### PR TITLE
Fix segfault if instance creation fails

### DIFF
--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -134,7 +134,10 @@ VulkanSample::~VulkanSample()
 	}
 
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	vkDestroyDebugReportCallbackEXT(instance, debug_report_callback, nullptr);
+	if (debug_report_callback != VK_NULL_HANDLE)
+	{
+		vkDestroyDebugReportCallbackEXT(instance, debug_report_callback, nullptr);
+	}
 #endif
 
 	if (instance != VK_NULL_HANDLE)


### PR DESCRIPTION
* vkDestroyDebugReportCallbackEXT can be NULL if instance creation fails. Add branch to avoid segfault.

<!--
- Copyright (c) 2019, Arm Limited and Contributors
-
- SPDX-License-Identifier: Apache-2.0
-
- Licensed under the Apache License, Version 2.0 the "License";
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-
-->

# Pull Request Template

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](../CONTRIBUTING.md)

## Checklist:

Do not submit your PR without all of the below being checked:

- [x] My code follows the [coding style](../CONTRIBUTING.md/#Code-Style)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my sample on at least one compliant Vulkan implementation
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] My changes do not add any new compiler warnings
= [x] Vulkan validation layer output is clean on at least one compliant implementation
- [x] Any dependent changes (e.g. assets) have been merged and published in downstream modules
- [x] I have used existing framework/helper functions where possible
- [x] I have reviewed file [licenses](../CONTRIBUTING.md/#Copyright-Notice-and-License-Template)
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](../CONTRIBUTING.md/#General-Requirements)
