### PR TITLE
Remove dead code in compute_nbody

### DIFF
--- a/samples/api/compute_nbody/compute_nbody.cpp
+++ b/samples/api/compute_nbody/compute_nbody.cpp
@@ -425,15 +425,7 @@ void ComputeNBody::prepare_graphics()
 
 void ComputeNBody::prepare_compute()
 {
-	// Create a compute capable device queue
-	// The VulkanDevice::createLogicalDevice functions finds a compute capable queue and prefers queue families that only support compute
-	// Depending on the implementation this may result in different queue family indices for graphics and computes,
-	// requiring proper synchronization (see the memory barriers in build_compute_command_buffer)
-	VkDeviceQueueCreateInfo queue_create_info = {};
-	queue_create_info.sType                   = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-	queue_create_info.pNext                   = NULL;
-	queue_create_info.queueFamilyIndex        = get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT);
-	queue_create_info.queueCount              = 1;
+	// Get compute queue
 	vkGetDeviceQueue(get_device().get_handle(), get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT), 0, &compute.queue);
 
 	// Create compute pipeline


### PR DESCRIPTION
<!--
- Copyright (c) 2019, Arm Limited and Contributors
-
- SPDX-License-Identifier: Apache-2.0
-
- Licensed under the Apache License, Version 2.0 the "License";
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-
-->

# Pull Request Template

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](../CONTRIBUTING.md)

## Checklist:

Do not submit your PR without all of the below being checked:

- [x] My code follows the [coding style](../CONTRIBUTING.md/#Code-Style)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my sample on at least one compliant Vulkan implementation
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] My changes do not add any new compiler warnings
= [x] Vulkan validation layer output is clean on at least one compliant implementation
- [x] Any dependent changes (e.g. assets) have been merged and published in downstream modules
- [x] I have used existing framework/helper functions where possible
- [x] I have reviewed file [licenses](../CONTRIBUTING.md/#Copyright-Notice-and-License-Template)
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](../CONTRIBUTING.md/#General-Requirements)
