### PR TITLE
Framework fix for loading untextured glTF scenes

### DIFF
--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -537,8 +537,13 @@ sg::Scene GLTFLoader::load_scene()
 	scene.add_component(std::move(default_sampler));
 
 	// Load materials
-	auto textures = scene.get_components<sg::Texture>();
-
+	bool                            has_textures = scene.has_component<sg::Texture>();
+	std::vector<vkb::sg::Texture *> textures;
+	if (has_textures)
+	{
+		textures = scene.get_components<sg::Texture>();
+	}
+	
 	for (auto &gltf_material : model.materials)
 	{
 		auto material = parse_material(gltf_material);


### PR DESCRIPTION
<!--
- Copyright (c) 2019, Arm Limited and Contributors
-
- SPDX-License-Identifier: Apache-2.0
-
- Licensed under the Apache License, Version 2.0 the "License";
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-
-->

# Pull Request Template

## Description

This adds a fix to the glTF loader of the framework for scenes without textures. Without this fix, the loader will crash on such scenes as it expects that there are textures present in the scene.

This can be tested with an untextured scene like https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BoxAnimated

## Checklist:

Do not submit your PR without all of the below being checked:

- [x] My code follows the [coding style](../CONTRIBUTING.md/#Code-Style)
- [x] I have performed a self-review of my own code
- n/a I have commented my code, particularly in hard-to-understand areas
- n/a I have made corresponding changes to the documentation
- n/a I have tested my sample on at least one compliant Vulkan implementation
- n/a I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] My changes do not add any new compiler warnings
- n/a Vulkan validation layer output is clean on at least one compliant implementation
- n/a Any dependent changes (e.g. assets) have been merged and published in downstream modules
- n/a I have used existing framework/helper functions where possible
- [x] I have reviewed file [licenses](../CONTRIBUTING.md/#Copyright-Notice-and-License-Template)
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](../CONTRIBUTING.md/#General-Requirements)
