### PR TITLE
Regroup Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ jobs:
   allow_failures:
     - name: "Snake Case (Optional)"
   include:
-
-jobs:
-  include:
     - stage: Check
       name: "Doxygen"
       script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,53 +30,38 @@ jobs:
   allow_failures:
     - name: "Snake Case (Optional)"
   include:
+
+jobs:
+  include:
     - stage: Check
-
-    - name: "Doxygen"
-      script:
-        - docker exec VKB sh -c "cd /home/vulkan-samples && mkdir -p doxygen && doxygen ./docs/doxygen/doxyfile"
-        - docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(stat -c%s ./doxygen/warnings.txt) -gt 0 ]; then cat ./doxygen/warnings.txt; exit 1; fi"
-
-    - name: "Copyright Headers"
-      script:
-        - docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/check_copyright_headers.py master"
-
-    - name: "Clang Format"
-      script:
-        - docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/clang_format.py -v --diff master > ./clang-format-report.txt"
-        - docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(grep -c 'clang-format did not modify any files' ./clang-format-report.txt) -eq 0  ] && [ $(grep -c 'no modified files to format' ./clang-format-report.txt) -eq 0  ]; then cat ./clang-format-report.txt; exit 1; fi"
-
-    - name: "Clang Tidy"
-      script:
-        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -H. -Bbuild/clang"
-        - docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/run-clang-tidy.py -j $(($(nproc)/2+1)) -p build/clang -clang-tidy-binary=clang-tidy-8 -header-filter=framework,samples,vulkan_samples -checks=-*,google-*,-google-runtime-references -quiet framework/* samples/* vulkan_samples/* tests/"
-
-    - name: "Snake Case (Optional)"
-      script:
-        - docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/snake_case.py master > ./snake-report.txt"
-        - docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(grep -c '@@' ./snake-report.txt) -gt 0 ]; then cat ./snake-report.txt; exit 1; fi"
+      name: "Doxygen"
+      script: docker exec VKB sh -c "cd /home/vulkan-samples && mkdir -p doxygen && doxygen ./docs/doxygen/doxyfile"
+      script: docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(stat -c%s ./doxygen/warnings.txt) -gt 0 ]; then cat ./doxygen/warnings.txt; exit 1; fi"
+    - script: docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/check_copyright_headers.py master"
+      name: "Copyright Headers"
+    - script: docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/clang_format.py -v --diff master > ./clang-format-report.txt"
+      script: docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(grep -c 'clang-format did not modify any files' ./clang-format-report.txt) -eq 0  ] && [ $(grep -c 'no modified files to format' ./clang-format-report.txt) -eq 0  ]; then cat ./clang-format-report.txt; exit 1; fi"
+      name: "Clang Format"
+    - script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -H. -Bbuild/clang"
+      script: docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/run-clang-tidy.py -j $(($(nproc)/2+1)) -p build/clang -clang-tidy-binary=clang-tidy-8 -header-filter=framework,samples,vulkan_samples -checks=-*,google-*,-google-runtime-references -quiet framework/* samples/* vulkan_samples/* tests/"
+      name: "Clang Tidy"
+    - script: docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/snake_case.py master > ./snake-report.txt"
+      script: docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(grep -c '@@' ./snake-report.txt) -gt 0 ]; then cat ./snake-report.txt; exit 1; fi"
+      name: "Snake Case (Optional)"
 
     - stage: Build
-
-    - name: "Windows"
+      name: Build Windows
       language: shell
       os: windows
-      script:
-
-        - cmake -G"Visual Studio 15 2017 Win64" -H. -Bbuild -DVKB_BUILD_TESTS:BOOL=ON -DVKB_BUILD_SAMPLES:BOOL=ON
-        - cmake --build build --target vulkan_samples --config Release
-
-    - name: "Unix"
+      script: cmake -G"Visual Studio 15 2017 Win64" -H. -Bbuild -DVKB_BUILD_TESTS:BOOL=ON -DVKB_BUILD_SAMPLES:BOOL=ON
+      script: cmake --build build --target vulkan_samples --config Release
+    - script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE=bldsys/toolchain/android_gradle.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
+      script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build --config Release --target vulkan_samples_package -- -j$(($(nproc)/2+1))"
+      name: Build Linux
       language: shell
       os: linux
-      script:
-      - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE=bldsys/toolchain/android_gradle.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
-      - docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build --config Release --target vulkan_samples_package -- -j$(($(nproc)/2+1))"
-
-    - name: "Android"
+    - script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
+      script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build/linux --target vulkan_samples --config Release -- -j$(($(nproc)/2+1))"
+      name: Build Android
       language: shell
-      os: linux
-      script:
-      - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
-      - docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build/linux --target vulkan_samples --config Release -- -j$(($(nproc)/2+1))"
-
+      os: linux 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,14 +62,14 @@ jobs:
         - cmake -G"Visual Studio 15 2017 Win64" -H. -Bbuild -DVKB_BUILD_TESTS:BOOL=ON -DVKB_BUILD_SAMPLES:BOOL=ON
         - cmake --build build --target vulkan_samples --config Release
     - script: 
-        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE=bldsys/toolchain/android_gradle.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
-        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build --config Release --target vulkan_samples_package -- -j$(($(nproc)/2+1))"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build/linux --target vulkan_samples --config Release -- -j$(($(nproc)/2+1))"
       name: Build Linux
       language: shell
       os: linux
     - script: 
-        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
-        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build/linux --target vulkan_samples --config Release -- -j$(($(nproc)/2+1))"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE=bldsys/toolchain/android_gradle.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build --config Release --target vulkan_samples_package -- -j$(($(nproc)/2+1))"
       name: Build Android
       language: shell
       os: linux 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,33 +35,41 @@ jobs:
   include:
     - stage: Check
       name: "Doxygen"
-      script: docker exec VKB sh -c "cd /home/vulkan-samples && mkdir -p doxygen && doxygen ./docs/doxygen/doxyfile"
-      script: docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(stat -c%s ./doxygen/warnings.txt) -gt 0 ]; then cat ./doxygen/warnings.txt; exit 1; fi"
-    - script: docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/check_copyright_headers.py master"
+      script: 
+        - docker exec VKB sh -c "cd /home/vulkan-samples && mkdir -p doxygen && doxygen ./docs/doxygen/doxyfile"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(stat -c%s ./doxygen/warnings.txt) -gt 0 ]; then cat ./doxygen/warnings.txt; exit 1; fi"
+    - script: 
+      -  docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/check_copyright_headers.py master"
       name: "Copyright Headers"
-    - script: docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/clang_format.py -v --diff master > ./clang-format-report.txt"
-      script: docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(grep -c 'clang-format did not modify any files' ./clang-format-report.txt) -eq 0  ] && [ $(grep -c 'no modified files to format' ./clang-format-report.txt) -eq 0  ]; then cat ./clang-format-report.txt; exit 1; fi"
+    - script: 
+        - docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/clang_format.py -v --diff master > ./clang-format-report.txt"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(grep -c 'clang-format did not modify any files' ./clang-format-report.txt) -eq 0  ] && [ $(grep -c 'no modified files to format' ./clang-format-report.txt) -eq 0  ]; then cat ./clang-format-report.txt; exit 1; fi"
       name: "Clang Format"
-    - script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -H. -Bbuild/clang"
-      script: docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/run-clang-tidy.py -j $(($(nproc)/2+1)) -p build/clang -clang-tidy-binary=clang-tidy-8 -header-filter=framework,samples,vulkan_samples -checks=-*,google-*,-google-runtime-references -quiet framework/* samples/* vulkan_samples/* tests/"
+    - script: 
+        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -H. -Bbuild/clang"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/run-clang-tidy.py -j $(($(nproc)/2+1)) -p build/clang -clang-tidy-binary=clang-tidy-8 -header-filter=framework,samples,vulkan_samples -checks=-*,google-*,-google-runtime-references -quiet framework/* samples/* vulkan_samples/* tests/"
       name: "Clang Tidy"
-    - script: docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/snake_case.py master > ./snake-report.txt"
-      script: docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(grep -c '@@' ./snake-report.txt) -gt 0 ]; then cat ./snake-report.txt; exit 1; fi"
+    - script: 
+        - docker exec VKB sh -c "cd /home/vulkan-samples && python3 /usr/local/bin/snake_case.py master > ./snake-report.txt"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && if [ $(grep -c '@@' ./snake-report.txt) -gt 0 ]; then cat ./snake-report.txt; exit 1; fi"
       name: "Snake Case (Optional)"
 
     - stage: Build
       name: Build Windows
       language: shell
       os: windows
-      script: cmake -G"Visual Studio 15 2017 Win64" -H. -Bbuild -DVKB_BUILD_TESTS:BOOL=ON -DVKB_BUILD_SAMPLES:BOOL=ON
-      script: cmake --build build --target vulkan_samples --config Release
-    - script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE=bldsys/toolchain/android_gradle.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
-      script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build --config Release --target vulkan_samples_package -- -j$(($(nproc)/2+1))"
+      script: 
+        - cmake -G"Visual Studio 15 2017 Win64" -H. -Bbuild -DVKB_BUILD_TESTS:BOOL=ON -DVKB_BUILD_SAMPLES:BOOL=ON
+        - cmake --build build --target vulkan_samples --config Release
+    - script: 
+        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE=bldsys/toolchain/android_gradle.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build --config Release --target vulkan_samples_package -- -j$(($(nproc)/2+1))"
       name: Build Linux
       language: shell
       os: linux
-    - script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
-      script: docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build/linux --target vulkan_samples --config Release -- -j$(($(nproc)/2+1))"
+    - script: 
+        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake -G \"Unix Makefiles\" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON"
+        - docker exec VKB sh -c "cd /home/vulkan-samples && cmake --build build/linux --target vulkan_samples --config Release -- -j$(($(nproc)/2+1))"
       name: Build Android
       language: shell
       os: linux 


### PR DESCRIPTION
## Description

This PR regroups the Travis CI yaml file and gets rid of the empty shell build steps.

## Checklist:

Do not submit your PR without all of the below being checked:

- n/a My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have performed a self-review of my own code
- n/a I have commented my code, particularly in hard-to-understand areas
- n/a I have made corresponding changes to the documentation
- n/a I have tested my sample on at least one compliant Vulkan implementation
- n/a I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- n/a My changes do not add any new compiler warnings
- n/a Vulkan validation layer output is clean on at least one compliant implementation
- n/a Any dependent changes (e.g. assets) have been merged and published in downstream modules
- n/a I have used existing framework/helper functions where possible
- n/a I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- n/a My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
