### PR TITLE
Fix attachments spelling error in render_pass.h

### DIFF
--- a/framework/core/render_pass.h
+++ b/framework/core/render_pass.h
@@ -45,7 +45,7 @@ class RenderPass : public NonCopyable
 	VkRenderPass get_handle() const;
 
 	RenderPass(Device &                          device,
-	           const std::vector<Attachment> &   attachemnts,
+	           const std::vector<Attachment> &   attachments,
 	           const std::vector<LoadStoreInfo> &load_store_infos,
 	           const std::vector<SubpassInfo> &  subpasses);
 


### PR DESCRIPTION
## Description

Simple spelling correction in `render_pass.h` for one of the parameters that gets passed in.  

## Checklist:

Do not submit your PR without all of the below being checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have tested my sample on at least one compliant Vulkan implementation
- [X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [X] My changes do not add any new compiler warnings
- [X] Vulkan validation layer output is clean on at least one compliant implementation
- [X] Any dependent changes (e.g. assets) have been merged and published in downstream modules
- [X] I have used existing framework/helper functions where possible
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [X] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
