### PR TITLE
Fix incorrect usage of unordered_map in ShaderVariant

### DIFF
--- a/framework/core/shader_module.cpp
+++ b/framework/core/shader_module.cpp
@@ -175,11 +175,11 @@ void ShaderVariant::add_undefine(const std::string &undef)
 void ShaderVariant::add_runtime_array_size(const std::string &runtime_array_name, size_t size)
 {
 	if (runtime_array_sizes.find(runtime_array_name) == runtime_array_sizes.end())
-	{  // not found
+	{
 		runtime_array_sizes.insert({runtime_array_name, size});
 	}
 	else
-	{  // found
+	{
 		runtime_array_sizes[runtime_array_name] = size;
 	}
 }

--- a/framework/core/shader_module.cpp
+++ b/framework/core/shader_module.cpp
@@ -174,12 +174,12 @@ void ShaderVariant::add_undefine(const std::string &undef)
 
 void ShaderVariant::add_runtime_array_size(const std::string &runtime_array_name, size_t size)
 {
-	if (runtime_array_sizes.find(runtime_array_name) != runtime_array_sizes.end())
-	{
+	if (runtime_array_sizes.find(runtime_array_name) == runtime_array_sizes.end())
+	{  // not found
 		runtime_array_sizes.insert({runtime_array_name, size});
 	}
 	else
-	{
+	{  // found
 		runtime_array_sizes[runtime_array_name] = size;
 	}
 }


### PR DESCRIPTION
## Description

In the method implementation of `ShaderVariant::add_runtime_array_size`, a common `unordered_map` code pattern is used, but the if condition seems to be wrong.
This PR add a small fix to this problem.

## Checklist:

Do not submit your PR without all of the below being checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my sample on at least one compliant Vulkan implementation
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] If my sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any new compiler warnings
- [x] Vulkan validation layer output is clean on at least one compliant implementation
- [x] Any dependent changes (e.g. assets) have been merged and published in downstream modules
- [x] I have used existing framework/helper functions where possible
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
