### PR TITLE
Implementing Reversed Depth Buffer - Solution for z-fighting artifacts

### DIFF
--- a/framework/camera.h
+++ b/framework/camera.h
@@ -17,15 +17,13 @@
 
 #pragma once
 
-#ifndef GLM_FORCE_RADIANS
-#	define GLM_FORCE_RADIANS
-#endif
-#ifndef GLM_FORCE_DEPTH_ZERO_TO_ONE
-#	define GLM_FORCE_DEPTH_ZERO_TO_ONE
-#endif
-#include <glm/glm.hpp>
+#include "common/error.h"
+
+VKBP_DISABLE_WARNINGS()
+#include "common/glm_common.h"
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
+VKBP_ENABLE_WARNINGS()
 
 namespace vkb
 {

--- a/framework/common/glm_common.h
+++ b/framework/common/glm_common.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2019, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GLM_FORCE_RADIANS
+#	define GLM_FORCE_RADIANS
+#endif
+#ifndef GLM_FORCE_DEPTH_ZERO_TO_ONE
+#	define GLM_FORCE_DEPTH_ZERO_TO_ONE
+#endif
+#include <glm/glm.hpp>
+#include <glm/gtx/rotate_vector.hpp>
+#include <glm/gtx/transform.hpp>

--- a/framework/common/helpers.h
+++ b/framework/common/helpers.h
@@ -37,14 +37,8 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#define GLM_FORCE_DEPTH_ZERO_TO_ONE
-#include <glm/glm.hpp>
-#include <glm/gtc/constants.hpp>
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtc/type_ptr.hpp>
+#include "common/glm_common.h"
 #include <glm/gtx/hash.hpp>
-#include <glm/gtx/rotate_vector.hpp>
-#include <glm/gtx/transform.hpp>
 VKBP_ENABLE_WARNINGS()
 
 namespace vkb

--- a/framework/common/utils.h
+++ b/framework/common/utils.h
@@ -20,7 +20,8 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
+#include "glm/gtx/quaternion.hpp"
 VKBP_ENABLE_WARNINGS()
 
 #include "platform/filesystem.h"

--- a/framework/debug_info.h
+++ b/framework/debug_info.h
@@ -24,7 +24,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
 #include "common/helpers.h"

--- a/framework/geometry/frustum.h
+++ b/framework/geometry/frustum.h
@@ -20,8 +20,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#define GLM_FORCE_DEPTH_ZERO_TO_ONE
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
 namespace vkb

--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -25,7 +25,8 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
+#include <glm/gtc/type_ptr.hpp>
 VKBP_ENABLE_WARNINGS()
 
 #include "api_vulkan_sample.h"

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -24,7 +24,8 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
+#include <glm/gtc/matrix_transform.hpp>
 VKBP_ENABLE_WARNINGS()
 
 #include "buffer_pool.h"

--- a/framework/heightmap.cpp
+++ b/framework/heightmap.cpp
@@ -18,8 +18,13 @@
 #include "heightmap.h"
 
 #include <cstring>
-#include <glm/glm.hpp>
 #include <ktx.h>
+
+#include "common/error.h"
+
+VKBP_DISABLE_WARNINGS()
+#include "common/glm_common.h"
+VKBP_ENABLE_WARNINGS()
 
 #include "platform/filesystem.h"
 

--- a/framework/rendering/pipeline_state.h
+++ b/framework/rendering/pipeline_state.h
@@ -93,7 +93,8 @@ struct DepthStencilState
 
 	VkBool32 depth_write_enable{VK_TRUE};
 
-	VkCompareOp depth_compare_op{VK_COMPARE_OP_LESS_OR_EQUAL};
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
+	VkCompareOp depth_compare_op{VK_COMPARE_OP_GREATER};
 
 	VkBool32 depth_bounds_test_enable{VK_FALSE};
 

--- a/framework/rendering/render_pipeline.cpp
+++ b/framework/rendering/render_pipeline.cpp
@@ -38,7 +38,7 @@ RenderPipeline::RenderPipeline(std::vector<std::unique_ptr<Subpass>> &&subpasses
 	}
 	// Default clear value
 	clear_value[0].color        = {0.0f, 0.0f, 0.0f, 1.0f};
-	clear_value[1].depthStencil = {1.0f, ~0U};
+	clear_value[1].depthStencil = {0.0f, ~0U};
 }
 
 void RenderPipeline::add_subpass(std::unique_ptr<Subpass> &&subpass)

--- a/framework/rendering/subpasses/geometry_subpass.h
+++ b/framework/rendering/subpasses/geometry_subpass.h
@@ -20,7 +20,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
 #include "rendering/subpass.h"

--- a/framework/scene_graph/components/aabb.h
+++ b/framework/scene_graph/components/aabb.h
@@ -25,7 +25,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
 #include "scene_graph/component.h"

--- a/framework/scene_graph/components/camera.h
+++ b/framework/scene_graph/components/camera.h
@@ -25,7 +25,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
 #include "common/helpers.h"

--- a/framework/scene_graph/components/image/astc.cpp
+++ b/framework/scene_graph/components/image/astc.cpp
@@ -22,7 +22,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 #if defined(_WIN32) || defined(_WIN64)
 // Windows.h defines IGNORE, so we must #undef it to avoid clashes with astc header
 #	undef IGNORE

--- a/framework/scene_graph/components/material.h
+++ b/framework/scene_graph/components/material.h
@@ -26,7 +26,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
 #include "scene_graph/component.h"

--- a/framework/scene_graph/components/pbr_material.h
+++ b/framework/scene_graph/components/pbr_material.h
@@ -26,7 +26,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
 #include "scene_graph/components/material.h"

--- a/framework/scene_graph/components/perspective_camera.cpp
+++ b/framework/scene_graph/components/perspective_camera.cpp
@@ -17,6 +17,10 @@
 
 #include "perspective_camera.h"
 
+VKBP_DISABLE_WARNINGS()
+#include <glm/gtc/matrix_transform.hpp>
+VKBP_ENABLE_WARNINGS()
+
 namespace vkb
 {
 namespace sg
@@ -60,7 +64,8 @@ float PerspectiveCamera::get_aspect_ratio()
 
 glm::mat4 PerspectiveCamera::get_projection()
 {
-	return glm::perspective(get_field_of_view(), aspect_ratio, near_plane, far_plane);
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
+	return glm::perspective(get_field_of_view(), aspect_ratio, far_plane, near_plane);
 }
 }        // namespace sg
 }        // namespace vkb

--- a/framework/scene_graph/components/perspective_camera.h
+++ b/framework/scene_graph/components/perspective_camera.h
@@ -26,7 +26,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
 #include "scene_graph/components/camera.h"

--- a/framework/scene_graph/components/transform.cpp
+++ b/framework/scene_graph/components/transform.cpp
@@ -20,7 +20,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 #include <glm/gtx/matrix_decompose.hpp>
 VKBP_ENABLE_WARNINGS()
 

--- a/framework/scene_graph/components/transform.h
+++ b/framework/scene_graph/components/transform.h
@@ -25,8 +25,8 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
-#include <glm/gtc/quaternion.hpp>
+#include "common/glm_common.h"
+#include <glm/gtx/quaternion.hpp>
 VKBP_ENABLE_WARNINGS()
 
 #include "scene_graph/component.h"

--- a/framework/scene_graph/scripts/free_camera.cpp
+++ b/framework/scene_graph/scripts/free_camera.cpp
@@ -20,7 +20,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 #include <glm/gtx/euler_angles.hpp>
 #include <glm/gtx/quaternion.hpp>
 VKBP_ENABLE_WARNINGS()

--- a/framework/scene_graph/scripts/free_camera.h
+++ b/framework/scene_graph/scripts/free_camera.h
@@ -26,7 +26,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
 #include "scene_graph/script.h"

--- a/framework/scene_graph/scripts/node_animation.cpp
+++ b/framework/scene_graph/scripts/node_animation.cpp
@@ -20,7 +20,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 #include <glm/gtx/euler_angles.hpp>
 #include <glm/gtx/quaternion.hpp>
 VKBP_ENABLE_WARNINGS()

--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -20,7 +20,7 @@
 #include "common/error.h"
 
 VKBP_DISABLE_WARNINGS()
-#include <glm/glm.hpp>
+#include "common/glm_common.h"
 #include <imgui.h>
 VKBP_ENABLE_WARNINGS()
 

--- a/samples/api/compute_nbody/compute_nbody.cpp
+++ b/samples/api/compute_nbody/compute_nbody.cpp
@@ -25,7 +25,9 @@ ComputeNBody::ComputeNBody()
 {
 	title       = "Compute shader N-body system";
 	camera.type = vkb::CameraType::LookAt;
-	camera.set_perspective(60.0f, (float) width / (float) height, 0.1f, 512.0f);
+
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
+	camera.set_perspective(60.0f, (float) width / (float) height, 512.0f, 0.1f);
 	camera.set_rotation(glm::vec3(-26.0f, 75.0f, 0.0f));
 	camera.set_translation(glm::vec3(0.0f, 0.0f, -14.0f));
 	camera.translation_speed = 2.5f;
@@ -85,7 +87,7 @@ void ComputeNBody::build_command_buffers()
 
 	VkClearValue clear_values[2];
 	clear_values[0].color        = {{0.0f, 0.0f, 0.0f, 1.0f}};
-	clear_values[1].depthStencil = {1.0f, 0};
+	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
 	render_pass_begin_info.renderPass               = render_pass;

--- a/samples/api/dynamic_uniform_buffers/dynamic_uniform_buffers.cpp
+++ b/samples/api/dynamic_uniform_buffers/dynamic_uniform_buffers.cpp
@@ -81,7 +81,7 @@ void DynamicUniformBuffers::build_command_buffers()
 
 	VkClearValue clear_values[2];
 	clear_values[0].color        = default_clear_color;
-	clear_values[1].depthStencil = {1.0f, 0};
+	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
 	render_pass_begin_info.renderPass               = render_pass;
@@ -307,11 +307,12 @@ void DynamicUniformBuffers::prepare_pipelines()
 	        1,
 	        &blend_attachment_state);
 
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
 	VkPipelineDepthStencilStateCreateInfo depth_stencil_state =
 	    vkb::initializers::pipeline_depth_stencil_state_create_info(
 	        VK_TRUE,
 	        VK_TRUE,
-	        VK_COMPARE_OP_LESS_OR_EQUAL);
+	        VK_COMPARE_OP_GREATER);
 
 	VkPipelineViewportStateCreateInfo viewport_state =
 	    vkb::initializers::pipeline_viewport_state_create_info(1, 1, 0);
@@ -482,7 +483,9 @@ bool DynamicUniformBuffers::prepare(vkb::Platform &platform)
 	camera.type = vkb::CameraType::LookAt;
 	camera.set_position(glm::vec3(0.0f, 0.0f, -30.0f));
 	camera.set_rotation(glm::vec3(0.0f));
-	camera.set_perspective(60.0f, (float) width / (float) height, 0.1f, 256.0f);
+
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
+	camera.set_perspective(60.0f, (float) width / (float) height, 256.0f, 0.1f);
 
 	generate_cube();
 	prepare_uniform_buffers();

--- a/samples/api/hdr/hdr.cpp
+++ b/samples/api/hdr/hdr.cpp
@@ -80,7 +80,7 @@ void HDR::build_command_buffers()
 
 	VkClearValue clear_values[2];
 	clear_values[0].color        = {{0.0f, 0.0f, 0.0f, 0.0f}};
-	clear_values[1].depthStencil = {1.0f, 0};
+	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info = vkb::initializers::render_pass_begin_info();
 	render_pass_begin_info.renderPass            = render_pass;
@@ -101,7 +101,7 @@ void HDR::build_command_buffers()
 			std::array<VkClearValue, 3> clear_values;
 			clear_values[0].color        = {{0.0f, 0.0f, 0.0f, 0.0f}};
 			clear_values[1].color        = {{0.0f, 0.0f, 0.0f, 0.0f}};
-			clear_values[2].depthStencil = {1.0f, 0};
+			clear_values[2].depthStencil = {0.0f, 0};
 
 			VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
 			render_pass_begin_info.renderPass               = offscreen.render_pass;
@@ -146,7 +146,7 @@ void HDR::build_command_buffers()
 		{
 			VkClearValue clear_values[2];
 			clear_values[0].color        = {{0.0f, 0.0f, 0.0f, 0.0f}};
-			clear_values[1].depthStencil = {1.0f, 0};
+			clear_values[1].depthStencil = {0.0f, 0};
 
 			// Bloom filter
 			VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
@@ -183,7 +183,7 @@ void HDR::build_command_buffers()
 		{
 			VkClearValue clear_values[2];
 			clear_values[0].color        = {{0.0f, 0.0f, 0.0f, 0.0f}};
-			clear_values[1].depthStencil = {1.0f, 0};
+			clear_values[1].depthStencil = {0.0f, 0};
 
 			// Final composition
 			VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
@@ -668,11 +668,12 @@ void HDR::prepare_pipelines()
 	        1,
 	        &blend_attachment_state);
 
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
 	VkPipelineDepthStencilStateCreateInfo depth_stencil_state =
 	    vkb::initializers::pipeline_depth_stencil_state_create_info(
 	        VK_FALSE,
 	        VK_FALSE,
-	        VK_COMPARE_OP_LESS_OR_EQUAL);
+	        VK_COMPARE_OP_GREATER);
 
 	VkPipelineViewportStateCreateInfo viewport_state =
 	    vkb::initializers::pipeline_viewport_state_create_info(1, 1, 0);
@@ -864,7 +865,9 @@ bool HDR::prepare(vkb::Platform &platform)
 	camera.type = vkb::CameraType::LookAt;
 	camera.set_position(glm::vec3(0.0f, 0.0f, -4.0f));
 	camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
-	camera.set_perspective(60.0f, (float) width / (float) height, 0.1f, 256.0f);
+
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
+	camera.set_perspective(60.0f, (float) width / (float) height, 256.0f, 0.1f);
 
 	load_assets();
 	prepare_uniform_buffers();

--- a/samples/api/instancing/instancing.cpp
+++ b/samples/api/instancing/instancing.cpp
@@ -70,7 +70,7 @@ void Instancing::build_command_buffers()
 
 	VkClearValue clear_values[2];
 	clear_values[0].color        = {{0.0f, 0.0f, 0.2f, 0.0f}};
-	clear_values[1].depthStencil = {1.0f, 0};
+	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
 	render_pass_begin_info.renderPass               = render_pass;
@@ -248,11 +248,12 @@ void Instancing::prepare_pipelines()
 	        1,
 	        &blend_attachment_state);
 
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
 	VkPipelineDepthStencilStateCreateInfo depth_stencil_state =
 	    vkb::initializers::pipeline_depth_stencil_state_create_info(
 	        VK_TRUE,
 	        VK_TRUE,
-	        VK_COMPARE_OP_LESS_OR_EQUAL);
+	        VK_COMPARE_OP_GREATER);
 
 	VkPipelineViewportStateCreateInfo viewport_state =
 	    vkb::initializers::pipeline_viewport_state_create_info(1, 1, 0);
@@ -486,8 +487,9 @@ bool Instancing::prepare(vkb::Platform &platform)
 		return false;
 	}
 
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
 	camera.type = vkb::CameraType::LookAt;
-	camera.set_perspective(60.0f, (float) width / (float) height, 0.1f, 256.0f);
+	camera.set_perspective(60.0f, (float) width / (float) height, 256.0f, 0.1f);
 	camera.set_rotation(glm::vec3(-17.2f, -4.7f, 0.0f));
 	camera.set_translation(glm::vec3(5.5f, -1.85f, -18.5f));
 

--- a/samples/api/terrain_tessellation/terrain_tessellation.cpp
+++ b/samples/api/terrain_tessellation/terrain_tessellation.cpp
@@ -206,7 +206,7 @@ void TerrainTessellation::build_command_buffers()
 
 	VkClearValue clear_values[2];
 	clear_values[0].color        = default_clear_color;
-	clear_values[1].depthStencil = {1.0f, 0};
+	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
 	render_pass_begin_info.renderPass               = render_pass;
@@ -561,11 +561,12 @@ void TerrainTessellation::prepare_pipelines()
 	        1,
 	        &blend_attachment_state);
 
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
 	VkPipelineDepthStencilStateCreateInfo depth_stencil_state =
 	    vkb::initializers::pipeline_depth_stencil_state_create_info(
 	        VK_TRUE,
 	        VK_TRUE,
-	        VK_COMPARE_OP_LESS_OR_EQUAL);
+	        VK_COMPARE_OP_GREATER);
 
 	VkPipelineViewportStateCreateInfo viewport_state =
 	    vkb::initializers::pipeline_viewport_state_create_info(1, 1, 0);
@@ -737,8 +738,9 @@ bool TerrainTessellation::prepare(vkb::Platform &platform)
 		return false;
 	}
 
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
 	camera.type = vkb::CameraType::FirstPerson;
-	camera.set_perspective(60.0f, (float) width / (float) height, 0.1f, 512.0f);
+	camera.set_perspective(60.0f, (float) width / (float) height, 512.0f, 0.1f);
 	camera.set_rotation(glm::vec3(-12.0f, 159.0f, 0.0f));
 	camera.set_translation(glm::vec3(18.0f, 22.5f, 57.5f));
 	camera.translation_speed = 7.5f;

--- a/samples/api/texture_loading/texture_loading.cpp
+++ b/samples/api/texture_loading/texture_loading.cpp
@@ -410,7 +410,7 @@ void TextureLoading::build_command_buffers()
 
 	VkClearValue clear_values[2];
 	clear_values[0].color        = default_clear_color;
-	clear_values[1].depthStencil = {1.0f, 0};
+	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
 	render_pass_begin_info.renderPass               = render_pass;
@@ -611,11 +611,12 @@ void TextureLoading::prepare_pipelines()
 	        1,
 	        &blend_attachment_state);
 
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
 	VkPipelineDepthStencilStateCreateInfo depth_stencil_state =
 	    vkb::initializers::pipeline_depth_stencil_state_create_info(
 	        VK_TRUE,
 	        VK_TRUE,
-	        VK_COMPARE_OP_LESS_OR_EQUAL);
+	        VK_COMPARE_OP_GREATER);
 
 	VkPipelineViewportStateCreateInfo viewport_state =
 	    vkb::initializers::pipeline_viewport_state_create_info(1, 1, 0);

--- a/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
+++ b/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
@@ -257,7 +257,7 @@ void ConservativeRasterization::build_command_buffers()
 		{
 			VkClearValue clear_values[2];
 			clear_values[0].color        = {{0.25f, 0.25f, 0.25f, 0.0f}};
-			clear_values[1].depthStencil = {1.0f, 0};
+			clear_values[1].depthStencil = {0.0f, 0};
 
 			VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
 			render_pass_begin_info.renderPass               = offscreen_pass.render_pass;
@@ -293,7 +293,7 @@ void ConservativeRasterization::build_command_buffers()
 		{
 			VkClearValue clear_values[2];
 			clear_values[0].color        = {{0.25f, 0.25f, 0.25f, 0.25f}};
-			clear_values[1].depthStencil = {1.0f, 0};
+			clear_values[1].depthStencil = {0.0f, 0};
 
 			VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
 			render_pass_begin_info.framebuffer              = framebuffers[i];
@@ -448,8 +448,9 @@ void ConservativeRasterization::prepare_pipelines()
 	VkPipelineColorBlendStateCreateInfo color_blend_state =
 	    vkb::initializers::pipeline_color_blend_state_create_info(1, &blend_attachment_state);
 
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
 	VkPipelineDepthStencilStateCreateInfo depth_stencil_state =
-	    vkb::initializers::pipeline_depth_stencil_state_create_info(VK_FALSE, VK_FALSE, VK_COMPARE_OP_LESS_OR_EQUAL);
+	    vkb::initializers::pipeline_depth_stencil_state_create_info(VK_FALSE, VK_FALSE, VK_COMPARE_OP_GREATER);
 
 	VkPipelineViewportStateCreateInfo viewport_state =
 	    vkb::initializers::pipeline_viewport_state_create_info(1, 1, 0);
@@ -579,8 +580,9 @@ bool ConservativeRasterization::prepare(vkb::Platform &platform)
 		return false;
 	}
 
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
 	camera.type = vkb::CameraType::LookAt;
-	camera.set_perspective(60.0f, (float) width / (float) height, 0.1f, 512.0f);
+	camera.set_perspective(60.0f, (float) width / (float) height, 512.0f, 0.1f);
 	camera.set_rotation(glm::vec3(0.0f));
 	camera.set_translation(glm::vec3(0.0f, 0.0f, -2.0f));
 

--- a/samples/extensions/push_descriptors/push_descriptors.cpp
+++ b/samples/extensions/push_descriptors/push_descriptors.cpp
@@ -71,7 +71,7 @@ void PushDescriptors::build_command_buffers()
 
 	VkClearValue clear_values[2];
 	clear_values[0].color        = default_clear_color;
-	clear_values[1].depthStencil = {1.0f, 0};
+	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
 	render_pass_begin_info.renderPass               = render_pass;
@@ -195,8 +195,9 @@ void PushDescriptors::prepare_pipelines()
 	VkPipelineColorBlendStateCreateInfo color_blend_state =
 	    vkb::initializers::pipeline_color_blend_state_create_info(1, &blend_attachment_state);
 
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
 	VkPipelineDepthStencilStateCreateInfo depth_stencil_state =
-	    vkb::initializers::pipeline_depth_stencil_state_create_info(VK_TRUE, VK_TRUE, VK_COMPARE_OP_LESS_OR_EQUAL);
+	    vkb::initializers::pipeline_depth_stencil_state_create_info(VK_TRUE, VK_TRUE, VK_COMPARE_OP_GREATER);
 
 	VkPipelineViewportStateCreateInfo viewport_state =
 	    vkb::initializers::pipeline_viewport_state_create_info(1, 1, 0);
@@ -344,8 +345,9 @@ bool PushDescriptors::prepare(vkb::Platform &platform)
 		End of extension specific functions
 	*/
 
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
 	camera.type = vkb::CameraType::LookAt;
-	camera.set_perspective(60.0f, static_cast<float>(width) / height, 0.1f, 512.0f);
+	camera.set_perspective(60.0f, static_cast<float>(width) / height, 512.0f, 0.1f);
 	camera.set_rotation(glm::vec3(0.0f, 0.0f, 0.0f));
 	camera.set_translation(glm::vec3(0.0f, 0.0f, -5.0f));
 

--- a/samples/extensions/raytracing_basic/raytracing_basic.cpp
+++ b/samples/extensions/raytracing_basic/raytracing_basic.cpp
@@ -635,8 +635,9 @@ bool RaytracingBasic::prepare(vkb::Platform &platform)
 	vkGetRayTracingShaderGroupHandlesNV            = reinterpret_cast<PFN_vkGetRayTracingShaderGroupHandlesNV>(vkGetDeviceProcAddr(get_device().get_handle(), "vkGetRayTracingShaderGroupHandlesNV"));
 	vkCmdTraceRaysNV                               = reinterpret_cast<PFN_vkCmdTraceRaysNV>(vkGetDeviceProcAddr(get_device().get_handle(), "vkCmdTraceRaysNV"));
 
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
 	camera.type = vkb::CameraType::LookAt;
-	camera.set_perspective(60.0f, (float) width / (float) height, 0.1f, 512.0f);
+	camera.set_perspective(60.0f, (float) width / (float) height, 512.0f, 0.1f);
 	camera.set_rotation(glm::vec3(0.0f, 0.0f, 0.0f));
 	camera.set_translation(glm::vec3(0.0f, 0.0f, -2.5f));
 

--- a/samples/performance/render_subpasses/render_subpasses.cpp
+++ b/samples/performance/render_subpasses/render_subpasses.cpp
@@ -341,7 +341,7 @@ std::vector<VkClearValue> get_clear_value()
 	// Clear values
 	std::vector<VkClearValue> clear_value{4};
 	clear_value[0].color        = {{0.0f, 0.0f, 0.0f, 1.0f}};
-	clear_value[1].depthStencil = {1.0f, ~0U};
+	clear_value[1].depthStencil = {0.0f, ~0U};
 	clear_value[2].color        = {{0.0f, 0.0f, 0.0f, 1.0f}};
 	clear_value[3].color        = {{0.0f, 0.0f, 0.0f, 1.0f}};
 

--- a/samples/performance/surface_rotation/surface_rotation.cpp
+++ b/samples/performance/surface_rotation/surface_rotation.cpp
@@ -17,6 +17,7 @@
 
 #include "surface_rotation.h"
 
+#include "common/error.h"
 #include "core/device.h"
 #include "core/pipeline_layout.h"
 #include "core/shader_module.h"
@@ -29,9 +30,10 @@
 #include "scene_graph/components/pbr_material.h"
 #include "stats.h"
 
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#	include "platform/android/android_platform.h"
-#endif
+VKBP_DISABLE_WARNINGS()
+#include "common/glm_common.h"
+#include <glm/gtc/matrix_transform.hpp>
+VKBP_ENABLE_WARNINGS()
 
 SurfaceRotation::SurfaceRotation()
 {

--- a/tests/system_test/test_framework/gltf_loader_test.cpp
+++ b/tests/system_test/test_framework/gltf_loader_test.cpp
@@ -27,6 +27,11 @@
 #	include "platform/android/android_platform.h"
 #endif
 
+VKBP_DISABLE_WARNINGS()
+#include "common/glm_common.h"
+#include <glm/gtx/quaternion.hpp>
+VKBP_ENABLE_WARNINGS()
+
 namespace vkbtest
 {
 GLTFLoaderTest::GLTFLoaderTest(const std::string &scene_path) :


### PR DESCRIPTION
## Reversed Depth Buffer
Following on from issue #36 have now re-implemented the Reversed depth buffer for the latest master branch, including addition of brief comments in the code to explain what this does.
Personal tests conducted on:
* Windows - NVidia GTX 1070 (driver version 1.03.0038.0021)
* Android - Samsung Galaxy S10e Mali (G70FXXU1ASAT)

### Overview
This change replaces the standard depth buffer range from being 0..1 to 1..0. This ensures better distribution of precision across the entire depth range, rather than the conventional depth buffer which has a great deal of precision concentrated at the beginning of the depth range.

##### Default depth buffer precision distribution
![1](https://user-images.githubusercontent.com/46377927/70920266-32199f80-201a-11ea-8afc-7c6869ce2d42.png)

##### Reversed Depth precision distribution:
![2](https://user-images.githubusercontent.com/46377927/70920274-35ad2680-201a-11ea-99a5-0b09b97b10ad.png)

*(credit sources: https://developer.nvidia.com/content/depth-precision-visualized)*


### Results

##### Before (Existing depth buffer implementation):
![3](https://user-images.githubusercontent.com/46377927/70920283-3940ad80-201a-11ea-9beb-884629f3c925.png)


##### After (Reversed depth buffer):
![4](https://user-images.githubusercontent.com/46377927/70920292-3e056180-201a-11ea-97df-949924b69e97.png)


### Samples changes
* For all API and extension samples, the changes have been applied per sample, as each sample uniquely implements the camera and depth state:
   * Flipped znear and zfar parameters passed into glm::perspective (for construction of projection matrix)
   * Changed depth test from VK_COMPARE_OP_LESS_EQUALS to VK_COMPARE_OP_GREATER
   * Depth clear colour changed from 1.0 to 0.0. 

### Framework changes
* For the performance samples, these changes are made inside the framework (framework/camera.cpp) as all performance samples share a common camera setup.
* Depth clear value also modified separately in render_subpasses sample
* glm includes hoisted to common/glm_common.h to resolve  inconsistencies in compilation macro's between different include locations.

## Checklist:

* [x] My code follows the [coding style](/vulkan/vulkan-samples/master/../CONTRIBUTING.md#Code-Style)
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] I have tested my sample on at least one compliant Vulkan implementation - Android, Windows, macOS & Linux
* [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
* [x] My changes do not add any new compiler warnings
* [x] Vulkan validation layer output is clean on at least one compliant implementation (Android & Windows)
* [x] Any dependent changes (e.g. assets) have been merged and published in downstream modules - https://github.com/KhronosGroup/Vulkan-Samples-Assets/pull/3
* [x] I have used existing framework/helper functions where possible
* [x] I have reviewed file [licenses](/vulkan/vulkan-samples/master/../CONTRIBUTING.md#Copyright-Notice-and-License-Template)
* [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](/vulkan/vulkan-samples/master/../CONTRIBUTING.md#General-Requirements) 