### PR TITLE
Fix ShaderResource::size value for 8 bit types

### DIFF
--- a/framework/spirv_reflection.cpp
+++ b/framework/spirv_reflection.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -148,7 +148,7 @@ inline void read_resource_size(const spirv_cross::Compiler &    compiler,
 		case spirv_cross::SPIRType::BaseType::Int64:
 		case spirv_cross::SPIRType::BaseType::UInt64:
 		case spirv_cross::SPIRType::BaseType::Double:
-			shader_resource.size = 7;
+			shader_resource.size = 8;
 			break;
 		default:
 			shader_resource.size = 0;


### PR DESCRIPTION

## Description

The use of 7 looks like a simple typo that would easily go undetected until someone actually tried to use a double or other 64 bit type in a shader.

## Checklist:

I'm not spending my whole day on this.  
