### PR TITLE
Index buffer size is using vertex_buffer_size

### DIFF
--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2020, Arm Limited and Contributors
  * Copyright (c) 2019, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -404,7 +404,7 @@ bool Gui::update_buffers()
 		updated                = true;
 
 		index_buffer.reset();
-		index_buffer = std::make_unique<core::Buffer>(sample.get_render_context().get_device(), vertex_buffer_size,
+		index_buffer = std::make_unique<core::Buffer>(sample.get_render_context().get_device(), index_buffer_size,
 		                                              VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
 		                                              VMA_MEMORY_USAGE_GPU_TO_CPU);
 	}


### PR DESCRIPTION
## Description

Apparent simple copy paste error.  When creating the index buffer for the GUI, it uses `vertex_buffer_size` instead of `index_buffer_size`

## Checklist:

Ugh, seriously, guys, come on.  