### PR TITLE
Validation

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Arm Limited and Contributors
+# Copyright (c) 2019-2020, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -338,6 +338,10 @@ if(NOT MSVC)
     target_compile_options(${PROJECT_NAME} PUBLIC -fexceptions)
 endif()
 
+if(MSVC)
+    target_compile_options(${PROJECT_NAME} PUBLIC /MP)
+endif()
+
 if(${VKB_VALIDATION_LAYERS})
     target_compile_definitions(${PROJECT_NAME} PUBLIC VKB_VALIDATION_LAYERS)
 endif()
@@ -347,7 +351,7 @@ if(${VKB_WARNINGS_AS_ERRORS})
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         target_compile_options(${PROJECT_NAME} PRIVATE -Werror)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-        target_compile_options(${PROJECT_NAME} PRIVATE /W3 /WX /MP)
+        target_compile_options(${PROJECT_NAME} PRIVATE /W3 /WX)
     endif()
 endif()
 

--- a/framework/core/swapchain.h
+++ b/framework/core/swapchain.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -79,7 +79,7 @@ class Swapchain
 	          const uint32_t                        image_count       = 3,
 	          const VkSurfaceTransformFlagBitsKHR   transform         = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
 	          const VkPresentModeKHR                present_mode      = VK_PRESENT_MODE_FIFO_KHR,
-	          const std::set<VkImageUsageFlagBits> &image_usage_flags = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_SRC_BIT});
+	          const std::set<VkImageUsageFlagBits> &image_usage_flags = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_DST_BIT});
 
 	/**
 	 * @brief Constructor to create a swapchain from the old swapchain
@@ -92,7 +92,7 @@ class Swapchain
 	          const uint32_t                        image_count       = 3,
 	          const VkSurfaceTransformFlagBitsKHR   transform         = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
 	          const VkPresentModeKHR                present_mode      = VK_PRESENT_MODE_FIFO_KHR,
-	          const std::set<VkImageUsageFlagBits> &image_usage_flags = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_SRC_BIT});
+	          const std::set<VkImageUsageFlagBits> &image_usage_flags = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_DST_BIT});
 
 	Swapchain(const Swapchain &) = delete;
 

--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2020, Arm Limited and Contributors
  * Copyright (c) 2019, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -317,7 +317,7 @@ inline void upload_image_to_gpu(CommandBuffer &command_buffer, core::Buffer &sta
 		ImageMemoryBarrier memory_barrier{};
 		memory_barrier.old_layout      = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 		memory_barrier.new_layout      = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		memory_barrier.src_access_mask = 0;
+		memory_barrier.src_access_mask = VK_ACCESS_TRANSFER_WRITE_BIT;
 		memory_barrier.dst_access_mask = VK_ACCESS_SHADER_READ_BIT;
 		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
 		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;


### PR DESCRIPTION
## Description

Fixes #29

Switches the default image usage flag bits for the swapchain images to use `VK_IMAGE_USAGE_TRANSFER_DST_BIT` instead of `VK_IMAGE_USAGE_TRANSFER_SRC_BIT`.  

Fixes #30 

In both the hello_triangle example and the common instance.cpp code, the `VkDebugReportCallbackCreateInfoEXT` structure is used to populate the `pNext` member of the `VkInstanceCreateInfo` when validation is enabled.

Fixes #33 

Both the hello_triangle and common instance.cpp now attempt to use the recommended validation layer `VK_LAYER_KHRONOS_validation`, before falling back to `VK_LAYER_LUNARG_standard_validation`, which in turn will fall back to the list of explicit validation layers.  This should ensure the examples work with validation across a broad range of versions of Vulkan drivers. Relying on the list included in hello_triangle will fail on modern drivers as reported in the linked issue.  On the other hand, older Vulkan drivers may not recognize the newer `VK_LAYER_KHRONOS_validation`, so a set of fallbacks is preferable to the fixed approach. 


Fixes #37 

The `/MP` compile option should be added regardless of whether warnings are being treated as errors.

Fixes #38 

Fixed invalid source access mask in post-image-upload barrier in the GLTF loader.

Tested on http://vulkan.gpuinfo.org/displayreport.php?id=7266



## Checklist:

Do not submit your PR without all of the below being checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have tested my sample on at least one compliant Vulkan implementation
- [X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [X] If my sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [X] My changes do not add any new compiler warnings
- [X] Vulkan validation layer output is clean on at least one compliant implementation
- [X] Any dependent changes (e.g. assets) have been merged and published in downstream modules
- [X] I have used existing framework/helper functions where possible
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [X] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
