### PR TITLE
Fix double destroy bug in semaphore pool

### DIFF
--- a/framework/fence_pool.cpp
+++ b/framework/fence_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,6 +24,14 @@ namespace vkb
 FencePool::FencePool(Device &device) :
     device{device}
 {
+}
+
+FencePool::FencePool(FencePool &&other) :
+    device{other.device},
+    active_fence_count{other.active_fence_count}
+{
+	fences.swap(other.fences);
+	other.active_fence_count = 0;
 }
 
 FencePool::~FencePool()

--- a/framework/fence_pool.h
+++ b/framework/fence_pool.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -30,7 +30,7 @@ class FencePool
 
 	FencePool(const FencePool &) = delete;
 
-	FencePool(FencePool &&other) = default;
+	FencePool(FencePool &&other);
 
 	~FencePool();
 

--- a/framework/rendering/render_target.cpp
+++ b/framework/rendering/render_target.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -54,6 +54,16 @@ const RenderTarget::CreateFunc RenderTarget::DEFAULT_CREATE_FUNC = [](core::Imag
 
 	return RenderTarget{std::move(images)};
 };
+
+RenderTarget::RenderTarget(RenderTarget &&other) :
+    device(other.device)
+{
+	std::swap(extent, other.extent);
+	std::swap(images, other.images);
+	std::swap(views, other.views);
+	std::swap(attachments, other.attachments);
+	std::swap(output_attachments, other.output_attachments);
+}
 
 RenderTarget &RenderTarget::operator=(RenderTarget &&other) noexcept
 {

--- a/framework/rendering/render_target.h
+++ b/framework/rendering/render_target.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -63,7 +63,7 @@ class RenderTarget
 
 	RenderTarget(const RenderTarget &) = delete;
 
-	RenderTarget(RenderTarget &&) = default;
+	RenderTarget(RenderTarget &&);
 
 	RenderTarget &operator=(const RenderTarget &other) noexcept = delete;
 

--- a/framework/semaphore_pool.cpp
+++ b/framework/semaphore_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,6 +24,14 @@ namespace vkb
 SemaphorePool::SemaphorePool(Device &device) :
     device{device}
 {
+}
+
+SemaphorePool::SemaphorePool(SemaphorePool &&other) :
+    device{other.device},
+    active_semaphore_count{other.active_semaphore_count}
+{
+	semaphores.swap(other.semaphores);
+	other.active_semaphore_count = 0;
 }
 
 SemaphorePool::~SemaphorePool()

--- a/framework/semaphore_pool.h
+++ b/framework/semaphore_pool.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -31,7 +31,7 @@ class SemaphorePool
 
 	SemaphorePool(const SemaphorePool &) = delete;
 
-	SemaphorePool(SemaphorePool &&other) = default;
+	SemaphorePool(SemaphorePool &&other);
 
 	~SemaphorePool();
 


### PR DESCRIPTION
## Description

Fix for #36 

Ensure that the `SemaphorePool` rvalue reference constructor clears the vector of `VkSemaphore` objects in the source instance.

## Checklist:

Do not submit your PR without all of the below being checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my sample on at least one compliant Vulkan implementation
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] If my sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any new compiler warnings
- [x] Vulkan validation layer output is clean on at least one compliant implementation
- [x] Any dependent changes (e.g. assets) have been merged and published in downstream modules
- [x] I have used existing framework/helper functions where possible
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
