### PR TITLE
Alternative fix for invalid move constructors

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2019-2020, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -792,7 +792,7 @@ void ApiVulkanSample::create_swapchain_buffers()
 		swapchain_buffers.resize(frames.size());
 		for (uint32_t i = 0; i < frames.size(); i++)
 		{
-			auto &image_view = *frames[i].get_render_target().get_views().begin();
+			auto &image_view = *frames[i]->get_render_target().get_views().begin();
 
 			swapchain_buffers[i].image = image_view.get_image().get_handle();
 			swapchain_buffers[i].view  = image_view.get_handle();

--- a/framework/fence_pool.h
+++ b/framework/fence_pool.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -30,7 +30,7 @@ class FencePool
 
 	FencePool(const FencePool &) = delete;
 
-	FencePool(FencePool &&other) = default;
+	FencePool(FencePool &&other) = delete;
 
 	~FencePool();
 

--- a/framework/gui.h
+++ b/framework/gui.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2020, Arm Limited and Contributors
  * Copyright (c) 2019, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -163,7 +163,6 @@ class Drawer
 	/**
 	 * @brief Adds a label to the gui
 	 * @param formatstr The format string
-	 * @returns True if adding item was successful
 	 */
 	void text(const char *formatstr, ...);
 

--- a/framework/rendering/render_context.h
+++ b/framework/rendering/render_context.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -69,7 +69,7 @@ class RenderContext
 
 	RenderContext(const RenderContext &) = delete;
 
-	RenderContext(RenderContext &&) = default;
+	RenderContext(RenderContext &&) = delete;
 
 	virtual ~RenderContext() = default;
 
@@ -214,7 +214,7 @@ class RenderContext
 
 	uint32_t get_active_frame_index() const;
 
-	std::vector<RenderFrame> &get_render_frames();
+	std::vector<std::unique_ptr<RenderFrame>> &get_render_frames();
 
 	/**
 	 * @brief Handles surface changes, only applicable if the render_context makes use of a swapchain
@@ -246,7 +246,7 @@ class RenderContext
 	    {VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
 	    {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
 
-	std::vector<RenderFrame> frames;
+	std::vector<std::unique_ptr<RenderFrame>> frames;
 
 	VkSemaphore acquired_semaphore;
 

--- a/framework/rendering/render_frame.cpp
+++ b/framework/rendering/render_frame.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,7 +22,7 @@
 
 namespace vkb
 {
-RenderFrame::RenderFrame(Device &device, RenderTarget &&render_target, size_t thread_count) :
+RenderFrame::RenderFrame(Device &device, std::unique_ptr<RenderTarget> &&render_target, size_t thread_count) :
     device{device},
     fence_pool{device},
     semaphore_pool{device},
@@ -58,7 +58,7 @@ Device &RenderFrame::get_device()
 	return device;
 }
 
-void RenderFrame::update_render_target(RenderTarget &&render_target)
+void RenderFrame::update_render_target(std::unique_ptr<RenderTarget> &&render_target)
 {
 	swapchain_render_target = std::move(render_target);
 }
@@ -148,12 +148,12 @@ VkSemaphore RenderFrame::request_semaphore()
 
 RenderTarget &RenderFrame::get_render_target()
 {
-	return swapchain_render_target;
+	return *swapchain_render_target;
 }
 
 const RenderTarget &RenderFrame::get_render_target_const() const
 {
-	return swapchain_render_target;
+	return *swapchain_render_target;
 }
 
 CommandBuffer &RenderFrame::request_command_buffer(const Queue &queue, CommandBuffer::ResetMode reset_mode, VkCommandBufferLevel level, size_t thread_index)

--- a/framework/rendering/render_frame.h
+++ b/framework/rendering/render_frame.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -60,11 +60,11 @@ class RenderFrame
 	 */
 	static constexpr uint32_t BUFFER_POOL_BLOCK_SIZE = 256;
 
-	RenderFrame(Device &device, RenderTarget &&render_target, size_t thread_count = 1);
+	RenderFrame(Device &device, std::unique_ptr<RenderTarget> &&render_target, size_t thread_count = 1);
 
 	RenderFrame(const RenderFrame &) = delete;
 
-	RenderFrame(RenderFrame &&) = default;
+	RenderFrame(RenderFrame &&) = delete;
 
 	RenderFrame &operator=(const RenderFrame &) = delete;
 
@@ -86,7 +86,7 @@ class RenderFrame
 	 * @brief Called when the swapchain changes
 	 * @param render_target A new render target with updated images
 	 */
-	void update_render_target(RenderTarget &&render_target);
+	void update_render_target(std::unique_ptr<RenderTarget> &&render_target);
 
 	RenderTarget &get_render_target();
 
@@ -155,7 +155,7 @@ class RenderFrame
 
 	size_t thread_count;
 
-	RenderTarget swapchain_render_target;
+	std::unique_ptr<RenderTarget> swapchain_render_target;
 
 	BufferAllocationStrategy buffer_allocation_strategy{BufferAllocationStrategy::MultipleAllocationsPerBuffer};
 

--- a/framework/rendering/render_target.cpp
+++ b/framework/rendering/render_target.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -38,7 +38,7 @@ Attachment::Attachment(VkFormat format, VkSampleCountFlagBits samples, VkImageUs
     usage{usage}
 {
 }
-const RenderTarget::CreateFunc RenderTarget::DEFAULT_CREATE_FUNC = [](core::Image &&swapchain_image) -> RenderTarget {
+const RenderTarget::CreateFunc RenderTarget::DEFAULT_CREATE_FUNC = [](core::Image &&swapchain_image) -> std::unique_ptr<RenderTarget> {
 	VkFormat depth_format;
 	VkBool32 is_format_supported = get_supported_depth_format(swapchain_image.get_device().get_physical_device(), &depth_format);
 	assert(is_format_supported && "No suitable format found for depth attachment");
@@ -52,29 +52,8 @@ const RenderTarget::CreateFunc RenderTarget::DEFAULT_CREATE_FUNC = [](core::Imag
 	images.push_back(std::move(swapchain_image));
 	images.push_back(std::move(depth_image));
 
-	return RenderTarget{std::move(images)};
+	return std::make_unique<RenderTarget>(std::move(images));
 };
-
-RenderTarget &RenderTarget::operator=(RenderTarget &&other) noexcept
-{
-	if (this != &other)
-	{
-		assert(&device == &other.device && "Cannot move assign with a render target created with a different device");
-
-		// Update those descriptor sets referring to old views
-		for (size_t i = 0; i < views.size(); ++i)
-		{
-			device.get_resource_cache().update_descriptor_sets(views, other.views);
-		}
-
-		std::swap(extent, other.extent);
-		std::swap(images, other.images);
-		std::swap(views, other.views);
-		std::swap(attachments, other.attachments);
-		std::swap(output_attachments, other.output_attachments);
-	}
-	return *this;
-}
 
 vkb::RenderTarget::RenderTarget(std::vector<core::Image> &&images) :
     device{images.back().get_device()},

--- a/framework/rendering/render_target.h
+++ b/framework/rendering/render_target.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -55,7 +55,7 @@ struct Attachment
 class RenderTarget
 {
   public:
-	using CreateFunc = std::function<RenderTarget(core::Image &&)>;
+	using CreateFunc = std::function<std::unique_ptr<RenderTarget>(core::Image &&)>;
 
 	static const CreateFunc DEFAULT_CREATE_FUNC;
 
@@ -63,11 +63,11 @@ class RenderTarget
 
 	RenderTarget(const RenderTarget &) = delete;
 
-	RenderTarget(RenderTarget &&) = default;
+	RenderTarget(RenderTarget &&) = delete;
 
 	RenderTarget &operator=(const RenderTarget &other) noexcept = delete;
 
-	RenderTarget &operator=(RenderTarget &&other) noexcept;
+	RenderTarget &operator=(RenderTarget &&other) noexcept = delete;
 
 	const VkExtent2D &get_extent() const;
 

--- a/framework/semaphore_pool.h
+++ b/framework/semaphore_pool.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -31,7 +31,7 @@ class SemaphorePool
 
 	SemaphorePool(const SemaphorePool &) = delete;
 
-	SemaphorePool(SemaphorePool &&other) = default;
+	SemaphorePool(SemaphorePool &&other) = delete;
 
 	~SemaphorePool();
 

--- a/framework/utils/graphs.cpp
+++ b/framework/utils/graphs.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -196,17 +196,18 @@ bool debug_graphs(RenderContext &context, sg::Scene &scene)
 	auto        frame_it = frames.begin();
 	while (frame_it != frames.end())
 	{
-		size_t frame_id = framework_graph.create_node<FrameworkNode>(*frame_it, "Render Frame");
+		auto & frame_ref = *frame_it;
+		size_t frame_id  = framework_graph.create_node<FrameworkNode>(*frame_ref, "Render Frame");
 		framework_graph.add_edge(render_context_id, frame_id);
 
-		size_t semaphore_pool_id = framework_graph.create_node<FrameworkNode>(frame_it->get_semaphore_pool());
-		size_t fence_pool_id     = framework_graph.create_node<FrameworkNode>(frame_it->get_fence_pool());
-		size_t render_target_id  = framework_graph.create_node<FrameworkNode>(frame_it->get_render_target_const());
+		size_t semaphore_pool_id = framework_graph.create_node<FrameworkNode>(frame_ref->get_semaphore_pool());
+		size_t fence_pool_id     = framework_graph.create_node<FrameworkNode>(frame_ref->get_fence_pool());
+		size_t render_target_id  = framework_graph.create_node<FrameworkNode>(frame_ref->get_render_target_const());
 		framework_graph.add_edge(frame_id, semaphore_pool_id);
 		framework_graph.add_edge(frame_id, fence_pool_id);
 		framework_graph.add_edge(frame_id, render_target_id);
 
-		for (const auto &view : frame_it->get_render_target_const().get_views())
+		for (const auto &view : frame_ref->get_render_target_const().get_views())
 		{
 			size_t      image_view_id = framework_graph.create_node<FrameworkNode>(view);
 			const auto &image         = view.get_image();

--- a/samples/performance/render_subpasses/render_subpasses.cpp
+++ b/samples/performance/render_subpasses/render_subpasses.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -50,7 +50,7 @@ RenderSubpasses::RenderSubpasses()
 	config.insert<vkb::IntSetting>(3, configs[Config::GBufferSize].value, 1);
 }
 
-vkb::RenderTarget RenderSubpasses::create_render_target(vkb::core::Image &&swapchain_image)
+std::unique_ptr<vkb::RenderTarget> RenderSubpasses::create_render_target(vkb::core::Image &&swapchain_image)
 {
 	auto &device = swapchain_image.get_device();
 	auto &extent = swapchain_image.get_extent();
@@ -93,7 +93,7 @@ vkb::RenderTarget RenderSubpasses::create_render_target(vkb::core::Image &&swapc
 	// Attachment 3
 	images.push_back(std::move(normal_image));
 
-	return vkb::RenderTarget{std::move(images)};
+	return std::make_unique<vkb::RenderTarget>(std::move(images));
 }
 
 void RenderSubpasses::prepare_render_context()

--- a/samples/performance/render_subpasses/render_subpasses.h
+++ b/samples/performance/render_subpasses/render_subpasses.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -71,7 +71,7 @@ class RenderSubpasses : public vkb::VulkanSample
 
 	void draw_renderpass(vkb::CommandBuffer &command_buffer, vkb::RenderTarget &render_target) override;
 
-	vkb::RenderTarget create_render_target(vkb::core::Image &&swapchain_image);
+	std::unique_ptr<vkb::RenderTarget> create_render_target(vkb::core::Image &&swapchain_image);
 
 	/// Good pipeline with two subpasses within one render pass
 	std::unique_ptr<vkb::RenderPipeline> render_pipeline{};


### PR DESCRIPTION

## Description

This is an alternative fix for #36.  Unlike the other fix in #40, this does not attempt to create valid move contructors for `SemaphorePool`, `FencePool`, `RenderTarget` and `RenderFrame`.  Instead it changes the move constructors for all of them from `= default` to `= delete`, and changes the `RenderContext` class to encapsulate frames in a `std::vector<std::unique_ptr<RenderFrame>>` instead of a ``std::vector<RenderFrame>`

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
