### PR TITLE
Fixed a bug where RenderFrames are being destroyed

### DIFF
--- a/samples/performance/render_subpasses/render_subpasses.cpp
+++ b/samples/performance/render_subpasses/render_subpasses.cpp
@@ -178,7 +178,7 @@ void RenderSubpasses::update(float delta_time)
 		// Reset frames, their synchronization objects and their command buffers
 		for (auto &frame : get_render_context().get_render_frames())
 		{
-			frame.reset();
+			frame->reset();
 		}
 	}
 
@@ -225,7 +225,7 @@ void RenderSubpasses::update(float delta_time)
 		// Reset frames, their synchronization objects and their command buffers
 		for (auto &frame : get_render_context().get_render_frames())
 		{
-			frame.reset();
+			frame->reset();
 		}
 
 		LOGI("Recreating render target");


### PR DESCRIPTION
## Description

Introduced here: https://github.com/KhronosGroup/Vulkan-Samples/commit/53489c85dd8f83e2da38752188d22700c1ccb416

Now that `RenderFrame` is a `unique_ptr` any time a setting was changed in the Render Subpasses sample, the frames were being completely destroyed

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)