### PR TITLE
Framework improvements 2: Close Android platform correctly

### DIFF
--- a/bldsys/cmake/template/entrypoint_main.cpp.in
+++ b/bldsys/cmake/template/entrypoint_main.cpp.in
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/platform/android/android_platform.h
+++ b/framework/platform/android/android_platform.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -57,6 +57,8 @@ class AndroidPlatform : public Platform
 	ANativeActivity *get_activity();
 
   private:
+	void poll_events();
+
 	android_app *app{nullptr};
 
 	std::string log_output;

--- a/framework/platform/android/android_window.cpp
+++ b/framework/platform/android/android_window.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -48,13 +48,15 @@ VkSurfaceKHR AndroidWindow::create_surface(Instance &instance)
 
 bool AndroidWindow::should_close()
 {
-	return handle == nullptr;
+	return finish_called ? true : handle == nullptr;
 }
 
 void AndroidWindow::close()
 {
 	auto &android_platform = dynamic_cast<AndroidPlatform &>(platform);
-	ANativeActivity_finish(android_platform.get_android_app()->activity);
+	ANativeActivity_finish(android_platform.get_activity());
+
+	finish_called = true;
 }
 
 float AndroidWindow::get_dpi_factor() const

--- a/framework/platform/android/android_window.h
+++ b/framework/platform/android/android_window.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -59,5 +59,7 @@ class AndroidWindow : public Window
 
 	// If true, return a VK_NULL_HANDLE on create_surface()
 	bool headless;
+
+	bool finish_called{false};
 };
 }        // namespace vkb


### PR DESCRIPTION
Now the Android application does not shut down in case of an exception, it returns to the samples menu instead.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)