### PR TITLE
Framework improvements 3: Optional extensions

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -1179,13 +1179,3 @@ void ApiVulkanSample::draw_model(std::unique_ptr<vkb::sg::SubMesh> &model, VkCom
 	vkCmdBindIndexBuffer(command_buffer, index_buffer->get_handle(), 0, model->index_type);
 	vkCmdDrawIndexed(command_buffer, model->vertex_indices, 1, 0, 0, 0);
 }
-
-const std::vector<const char *> ApiVulkanSample::get_instance_extensions()
-{
-	return instance_extensions;
-}
-
-const std::vector<const char *> ApiVulkanSample::get_device_extensions()
-{
-	return device_extensions;
-}

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2019-2020, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -98,19 +98,9 @@ class ApiVulkanSample : public vkb::VulkanSample
 
 	vkb::Device &get_device();
 
-	const std::vector<const char *> get_instance_extensions() override;
-
-	const std::vector<const char *> get_device_extensions() override;
-
   protected:
 	/// Stores the swapchain image buffers
 	std::vector<SwapchainBuffer> swapchain_buffers;
-
-	/** @brief Set of device extensions to be enabled for this example (must be set in the derived constructor) */
-	std::vector<const char *> device_extensions;
-
-	/** @brief Set of instance extensions to be enabled for this example (must be set in the derived constructor) */
-	std::vector<const char *> instance_extensions;
 
 	virtual void prepare_render_context() override;
 

--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
- * Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
+ * Copyright (c) 2019-2020, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -50,7 +50,14 @@ struct DriverVersion
 class Device
 {
   public:
-	Device(VkPhysicalDevice physical_device, VkSurfaceKHR surface, std::vector<const char *> requested_extensions = {}, VkPhysicalDeviceFeatures features = {});
+	/**
+	 * @brief Device constructor
+	 * @param physical_device The physical device
+	 * @param surface The surface
+	 * @param requested_extensions (Optional) List of required device extensions and whether support is optional or not
+	 * @param features (Optional) List of required device features
+	 */
+	Device(VkPhysicalDevice physical_device, VkSurfaceKHR surface, std::unordered_map<const char *, bool> requested_extensions = {}, VkPhysicalDeviceFeatures features = {});
 
 	Device(const Device &) = delete;
 
@@ -97,6 +104,8 @@ class Device
 	const Queue &get_suitable_graphics_queue();
 
 	bool is_extension_supported(const std::string &extension);
+
+	bool is_enabled(const char *extension);
 
 	uint32_t get_queue_family_index(VkQueueFlagBits queue_flag);
 
@@ -175,6 +184,8 @@ class Device
 
   private:
 	std::vector<VkExtensionProperties> device_extensions;
+
+	std::vector<const char *> enabled_extensions{};
 
 	VkPhysicalDevice physical_device{VK_NULL_HANDLE};
 

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -48,31 +48,6 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debug_callback(VkDebugReportFlagsEXT flags
 }
 #endif
 
-bool validate_extensions(const std::vector<const char *> &         required,
-                         const std::vector<VkExtensionProperties> &available)
-{
-	for (auto extension : required)
-	{
-		bool found = false;
-		for (auto &available_extension : available)
-		{
-			if (strcmp(available_extension.extensionName, extension) == 0)
-			{
-				found = true;
-				break;
-			}
-		}
-
-		if (!found)
-		{
-			LOGE("Extension {} not found", extension);
-			return false;
-		}
-	}
-
-	return true;
-}
-
 bool validate_layers(const std::vector<const char *> &     required,
                      const std::vector<VkLayerProperties> &available)
 {
@@ -135,11 +110,10 @@ std::vector<const char *> get_optimal_validation_layers(const std::vector<VkLaye
 	return {};
 }
 
-Instance::Instance(const std::string &              application_name,
-                   const std::vector<const char *> &required_extensions,
-                   const std::vector<const char *> &required_validation_layers,
-                   bool                             headless) :
-    extensions{required_extensions}
+Instance::Instance(const std::string &                           application_name,
+                   const std::unordered_map<const char *, bool> &required_extensions,
+                   const std::vector<const char *> &             required_validation_layers,
+                   bool                                          headless)
 {
 	VkResult result = volkInitialize();
 	if (result)
@@ -154,7 +128,7 @@ Instance::Instance(const std::string &              application_name,
 	VK_CHECK(vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, available_instance_extensions.data()));
 
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+	enabled_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 #endif
 
 	// Try to enable headless surface extension if it exists
@@ -167,7 +141,7 @@ Instance::Instance(const std::string &              application_name,
 			{
 				headless_extension = true;
 				LOGI("{} is available, enabling it", VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME);
-				extensions.push_back(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME);
+				enabled_extensions.push_back(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME);
 			}
 		}
 		if (!headless_extension)
@@ -177,10 +151,34 @@ Instance::Instance(const std::string &              application_name,
 	}
 	else
 	{
-		extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+		enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
 	}
 
-	if (!validate_extensions(extensions, available_instance_extensions))
+	auto extension_error = false;
+	for (auto extension : required_extensions)
+	{
+		auto extension_name        = extension.first;
+		auto extension_is_optional = extension.second;
+		if (std::find_if(available_instance_extensions.begin(), available_instance_extensions.end(),
+		                 [&extension_name](VkExtensionProperties available_extension) { return strcmp(available_extension.extensionName, extension_name) == 0; }) == available_instance_extensions.end())
+		{
+			if (extension_is_optional)
+			{
+				LOGW("Optional instance extension {} not available, some features may be disabled", extension_name);
+			}
+			else
+			{
+				LOGE("Required instance extension {} not available, cannot run", extension_name);
+			}
+			extension_error = !extension_is_optional;
+		}
+		else
+		{
+			enabled_extensions.push_back(extension_name);
+		}
+	}
+
+	if (extension_error)
 	{
 		throw std::runtime_error("Required instance extensions are missing.");
 	}
@@ -224,8 +222,8 @@ Instance::Instance(const std::string &              application_name,
 
 	instance_info.pApplicationInfo = &app_info;
 
-	instance_info.enabledExtensionCount   = to_u32(extensions.size());
-	instance_info.ppEnabledExtensionNames = extensions.data();
+	instance_info.enabledExtensionCount   = to_u32(enabled_extensions.size());
+	instance_info.ppEnabledExtensionNames = enabled_extensions.data();
 
 	instance_info.enabledLayerCount   = to_u32(requested_validation_layers.size());
 	instance_info.ppEnabledLayerNames = requested_validation_layers.data();
@@ -323,7 +321,7 @@ VkPhysicalDevice Instance::get_gpu()
 
 bool Instance::is_enabled(const char *extension)
 {
-	return std::find(extensions.begin(), extensions.end(), extension) != extensions.end();
+	return std::find_if(enabled_extensions.begin(), enabled_extensions.end(), [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) != enabled_extensions.end();
 }
 
 VkInstance Instance::get_handle()
@@ -333,6 +331,6 @@ VkInstance Instance::get_handle()
 
 const std::vector<const char *> &Instance::get_extensions()
 {
-	return extensions;
+	return enabled_extensions;
 }
 }        // namespace vkb

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -46,10 +46,10 @@ class Instance
 	 * @param headless Whether the application is requesting a headless setup or not
 	 * @throws runtime_error if the required extensions and validation layers are not found
 	 */
-	Instance(const std::string &              application_name,
-	         const std::vector<const char *> &required_extensions        = {},
-	         const std::vector<const char *> &required_validation_layers = {},
-	         bool                             headless                   = false);
+	Instance(const std::string &                           application_name,
+	         const std::unordered_map<const char *, bool> &required_extensions        = {},
+	         const std::vector<const char *> &             required_validation_layers = {},
+	         bool                                          headless                   = false);
 
 	/**
 	 * @brief Queries the GPUs of a VkInstance that is already created
@@ -97,7 +97,7 @@ class Instance
 	/**
 	 * @brief The enabled extensions
 	 */
-	std::vector<const char *> extensions;
+	std::vector<const char *> enabled_extensions;
 
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
 	/**

--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -86,9 +86,8 @@ bool VulkanSample::prepare(Platform &platform)
 	LOGI("Initializing Vulkan sample");
 
 	// Creating the vulkan instance
-	std::vector<const char *> requested_instance_extensions = get_instance_extensions();
-	requested_instance_extensions.push_back(platform.get_surface_extension());
-	instance = std::make_unique<Instance>(get_name(), requested_instance_extensions, get_validation_layers(), is_headless());
+	add_instance_extension(platform.get_surface_extension());
+	instance = std::make_unique<Instance>(get_name(), get_instance_extensions(), get_validation_layers(), is_headless());
 
 	// Getting a valid vulkan surface from the platform
 	surface = platform.get_window().create_surface(*instance);
@@ -100,13 +99,12 @@ bool VulkanSample::prepare(Platform &platform)
 	get_device_features();
 
 	// Creating vulkan device, specifying the swapchain extension always
-	std::vector<const char *> requested_device_extensions = get_device_extensions();
 	if (!is_headless() || instance->is_enabled(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME))
 	{
-		requested_device_extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+		add_device_extension(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 	}
 
-	device = std::make_unique<vkb::Device>(physical_device, surface, requested_device_extensions, requested_device_features);
+	device = std::make_unique<vkb::Device>(physical_device, surface, get_device_extensions(), requested_device_features);
 
 	// Preparing render context for rendering
 	render_context = std::make_unique<vkb::RenderContext>(*device, surface, platform.get_window().get_width(), platform.get_window().get_height());
@@ -431,14 +429,24 @@ const std::vector<const char *> VulkanSample::get_validation_layers()
 	return {};
 }
 
-std::vector<const char *> const VulkanSample::get_instance_extensions()
+const std::unordered_map<const char *, bool> VulkanSample::get_instance_extensions()
 {
-	return {};
+	return instance_extensions;
 }
 
-std::vector<const char *> const VulkanSample::get_device_extensions()
+const std::unordered_map<const char *, bool> VulkanSample::get_device_extensions()
 {
-	return {};
+	return device_extensions;
+}
+
+void VulkanSample::add_device_extension(const char *extension, bool optional)
+{
+	device_extensions[extension] = optional;
+}
+
+void VulkanSample::add_instance_extension(const char *extension, bool optional)
+{
+	instance_extensions[extension] = optional;
 }
 
 void VulkanSample::get_device_features()

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -228,16 +228,30 @@ class VulkanSample : public Application
 	/**
 	 * @brief Get sample-specific instance extensions.
 	 *
-	 * @return Vector of instance extensions. Default is empty vector.
+	 * @return Map of instance extensions and wether or not they are optional. Default is empty map.
 	 */
-	virtual const std::vector<const char *> get_instance_extensions();
+	const std::unordered_map<const char *, bool> get_instance_extensions();
 
 	/**
 	 * @brief Get sample-specific device extensions.
 	 *
-	 * @return Vector of device extensions. Default is empty vector.
+	 * @return Map of device extensions and whether or not they are optional. Default is empty map.
 	 */
-	virtual const std::vector<const char *> get_device_extensions();
+	const std::unordered_map<const char *, bool> get_device_extensions();
+
+	/**
+	 * @brief Add a sample-specific device extension
+	 * @param extension The extension name
+	 * @param optional (Optional) Wether the extension is optional
+	 */
+	void add_device_extension(const char *extension, bool optional = false);
+
+	/**
+	 * @brief Add a sample-specific instance extension
+	 * @param extension The extension name
+	 * @param optional (Optional) Wether the extension is optional
+	 */
+	void add_instance_extension(const char *extension, bool optional = false);
 
 	/**
 	 * @brief Populate `requested_device_features` with required sample-specific device features.
@@ -266,6 +280,16 @@ class VulkanSample : public Application
 	 */
 	virtual void update_debug_window();
 
+	/**
+	 * @brief Add free camera script to a node with a camera object.
+	 *        Fallback to the default_camera if node not found.
+	 *
+	 * @param node_name The scene node name
+	 *
+	 * @return Node where the script was attached as component
+	 */
+	sg::Node &add_free_camera(const std::string &node_name);
+
 	static constexpr float STATS_VIEW_RESET_TIME{10.0f};        // 10 seconds
 
 	/**
@@ -277,5 +301,12 @@ class VulkanSample : public Application
 	 * @brief The configuration of the sample
 	 */
 	Configuration configuration{};
+
+  private:
+	/** @brief Set of device extensions to be enabled for this example and wether they are optional (must be set in the derived constructor) */
+	std::unordered_map<const char *, bool> device_extensions;
+
+	/** @brief Set of instance extensions to be enabled for this example and whether they are optional (must be set in the derived constructor) */
+	std::unordered_map<const char *, bool> instance_extensions;
 };
 }        // namespace vkb

--- a/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
+++ b/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
@@ -33,10 +33,10 @@ ConservativeRasterization::ConservativeRasterization()
 	title = "Conservative rasterization";
 
 	// Reading device properties of conservative rasterization requires VK_KHR_get_physical_device_properties2 to be enabled
-	instance_extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+	add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
 	// Enable extension required for conservative rasterization
-	device_extensions.push_back(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
+	add_device_extension(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
 }
 
 ConservativeRasterization::~ConservativeRasterization()

--- a/samples/extensions/push_descriptors/push_descriptors.cpp
+++ b/samples/extensions/push_descriptors/push_descriptors.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2019-2020, Sascha Willems
 *
 * SPDX-License-Identifier: Apache-2.0
 *
@@ -36,8 +36,8 @@ PushDescriptors::PushDescriptors()
 	title = "Push descriptors";
 
 	// Enable extension required for push descriptors
-	instance_extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-	device_extensions.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
+	add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+	add_device_extension(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
 }
 
 PushDescriptors::~PushDescriptors()

--- a/samples/extensions/raytracing_basic/raytracing_basic.cpp
+++ b/samples/extensions/raytracing_basic/raytracing_basic.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2019-2020, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,9 +26,9 @@ RaytracingBasic::RaytracingBasic()
 	title = "VK_NV_ray_tracing";
 
 	// Enable instance and device extensions required to use VK_NV_ray_tracing
-	instance_extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-	device_extensions.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-	device_extensions.push_back(VK_NV_RAY_TRACING_EXTENSION_NAME);
+	add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+	add_device_extension(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+	add_device_extension(VK_NV_RAY_TRACING_EXTENSION_NAME);
 }
 
 RaytracingBasic::~RaytracingBasic()


### PR DESCRIPTION
Let the sample specify if a certain device/instance extension is optional (false by default).
If they are optional, do not crash if they are not supported (the sample can check if they are and act accordingly).

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)