### PR TITLE
Framework improvements 4: Update ASTC module (and CI caching update)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,14 +65,10 @@ Linux:
   artifacts:
     paths:
       - build/linux
-    expire_in: 1h
+    expire_in: 2h
   tags:
     - linux
     - docker
-  artifacts:
-    paths:
-      - build/linux
-    expire_in: 2h
   script:
     - cmake -G "Unix Makefiles" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON
     - cmake --build build/linux --target vulkan_samples --config Release -- -j$(($(nproc)/2+1))
@@ -81,13 +77,13 @@ Windows:
   stage: Build
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-  tags:
-    - gpu
-    - windows
   artifacts:
     paths:
       - build/windows
     expire_in: 2h
+  tags:
+    - gpu
+    - windows
   script:
     - cmake -G"Visual Studio 15 2017 Win64" -H. -Bbuild/windows -DVKB_BUILD_TESTS:BOOL=ON -DVKB_BUILD_SAMPLES:BOOL=ON
     - cmake --build build/windows --target vulkan_samples --config Release
@@ -97,13 +93,13 @@ Android:
   image: khronosgroup/vulkan-samples
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-  tags:
-    - linux
-    - docker
   artifacts:
     paths:
       - build/android
     expire_in: 2h
+  tags:
+    - linux
+    - docker
   script:
     - cmake -G "Unix Makefiles" -H. -Bbuild/android -DCMAKE_TOOLCHAIN_FILE=bldsys/toolchain/android_gradle.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON
     - cmake --build build/android --config Release --target vulkan_samples_package -- -j$(($(nproc)/2+1))
@@ -120,7 +116,7 @@ GenerateSample:
    - docker
   script:
    - cd tests/generate_sample
-   - python generate_sample_test.py
+   - python3 generate_sample_test.py
 
 SystemTest:
   stage: Test

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -225,7 +225,7 @@ set(ASTC_SOURCES
 
 add_library(astc ${ASTC_SOURCES})
 target_include_directories(astc PUBLIC ${ASTC_INCLUDE_DIR})
-target_compile_definitions(astc PRIVATE -D_USE_MATH_DEFINES)
+target_compile_definitions(astc PRIVATE -DNO_STB_IMAGE_IMPLEMENTATION)
 set_property(TARGET astc PROPERTY FOLDER "ThirdParty")
 
 if(ANDROID)


### PR DESCRIPTION
Update the ASTC module and guard the stb_image.h implementation
This fixes the Android build with NDK v21

Other changes:
- Update artefacts in Gitlab CI.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)