### PR TITLE
Framework improvements 6: Implemented Update after bind descriptor sets

### DIFF
--- a/framework/common/resource_caching.h
+++ b/framework/common/resource_caching.h
@@ -208,6 +208,7 @@ struct hash<vkb::ShaderResource>
 		vkb::hash_combine(result, shader_resource.set);
 		vkb::hash_combine(result, shader_resource.binding);
 		vkb::hash_combine(result, static_cast<std::underlying_type<vkb::ShaderResourceType>::type>(shader_resource.type));
+		vkb::hash_combine(result, shader_resource.mode);
 
 		return result;
 	}
@@ -405,9 +406,9 @@ struct hash<vkb::PipelineState>
 
 		vkb::hash_combine(result, pipeline_state.get_subpass_index());
 
-		for (auto stage : pipeline_state.get_pipeline_layout().get_shader_modules())
+		for (auto shader_module : pipeline_state.get_pipeline_layout().get_shader_modules())
 		{
-			vkb::hash_combine(result, stage->get_id());
+			vkb::hash_combine(result, shader_module->get_id());
 		}
 
 		// VkPipelineVertexInputStateCreateInfo

--- a/framework/core/command_buffer.h
+++ b/framework/core/command_buffer.h
@@ -215,6 +215,8 @@ class CommandBuffer
 
 	const State get_state() const;
 
+	void set_update_after_bind(bool update_after_bind_);
+
 	/**
 	 * @brief Reset the command buffer to a state where it can be recorded to
 	 * @param reset_mode How to reset the buffer, should match the one used by the pool to allocate it
@@ -239,6 +241,10 @@ class CommandBuffer
 	VkExtent2D last_framebuffer_extent{};
 
 	VkExtent2D last_render_area_extent{};
+
+	// If true, it becomes the responsibility of the caller to update ANY descriptor bindings
+	// that contain update after bind, as they wont be implicitly updated
+	bool update_after_bind{false};
 
 	std::unordered_map<uint32_t, DescriptorSetLayout *> descriptor_set_layout_binding_state;
 

--- a/framework/core/descriptor_pool.cpp
+++ b/framework/core/descriptor_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -102,16 +102,15 @@ VkDescriptorSet DescriptorPool::allocate()
 
 	VkDescriptorSetLayout set_layout = get_descriptor_set_layout().get_handle();
 
-	VkDescriptorSetAllocateInfo allocInfo{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
-
-	allocInfo.descriptorPool     = pools[pool_index];
-	allocInfo.descriptorSetCount = 1;
-	allocInfo.pSetLayouts        = &set_layout;
+	VkDescriptorSetAllocateInfo alloc_info{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+	alloc_info.descriptorPool     = pools[pool_index];
+	alloc_info.descriptorSetCount = 1;
+	alloc_info.pSetLayouts        = &set_layout;
 
 	VkDescriptorSet handle = VK_NULL_HANDLE;
 
 	// Allocate a new descriptor set from the current pool
-	auto result = vkAllocateDescriptorSets(device.get_handle(), &allocInfo, &handle);
+	auto result = vkAllocateDescriptorSets(device.get_handle(), &alloc_info, &handle);
 
 	if (result != VK_SUCCESS)
 	{
@@ -161,11 +160,22 @@ std::uint32_t DescriptorPool::find_available_pool(std::uint32_t search_index)
 	{
 		VkDescriptorPoolCreateInfo create_info{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
 
-		// We do not set FREE_DESCRIPTOR_SET_BIT as we do not need to free individual descriptor sets
-		create_info.flags         = 0;
 		create_info.poolSizeCount = to_u32(pool_sizes.size());
 		create_info.pPoolSizes    = pool_sizes.data();
 		create_info.maxSets       = pool_max_sets;
+
+		// We do not set FREE_DESCRIPTOR_SET_BIT as we do not need to free individual descriptor sets
+		create_info.flags = 0;
+
+		// Check descriptor set layout and enable the required flags
+		auto &binding_flags = descriptor_set_layout->get_binding_flags();
+		for (auto binding_flag : binding_flags)
+		{
+			if (binding_flag & VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT)
+			{
+				create_info.flags |= VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT_EXT;
+			}
+		}
 
 		VkDescriptorPool handle = VK_NULL_HANDLE;
 

--- a/framework/core/descriptor_set.cpp
+++ b/framework/core/descriptor_set.cpp
@@ -32,50 +32,69 @@ DescriptorSet::DescriptorSet(Device &                                  device,
     device{device},
     descriptor_set_layout{descriptor_set_layout},
     descriptor_pool{descriptor_pool},
+    buffer_infos{buffer_infos},
+    image_infos{image_infos},
     handle{descriptor_pool.allocate()}
 {
-	if (!buffer_infos.empty() || !image_infos.empty())
-	{
-		update(buffer_infos, image_infos);
-	}
+	prepare();
 }
 
-void DescriptorSet::update(const BindingMap<VkDescriptorBufferInfo> &buffer_infos, const BindingMap<VkDescriptorImageInfo> &image_infos)
+void DescriptorSet::reset(const BindingMap<VkDescriptorBufferInfo> &new_buffer_infos, const BindingMap<VkDescriptorImageInfo> &new_image_infos)
 {
-	this->buffer_infos = buffer_infos;
-	this->image_infos  = image_infos;
+	if (!new_buffer_infos.empty() || !new_image_infos.empty())
+	{
+		buffer_infos = new_buffer_infos;
+		image_infos  = new_image_infos;
+	}
+	else
+	{
+		LOGW("Calling reset on Descriptor Set with no new buffer infos and no new image infos.");
+	}
 
-	std::vector<VkWriteDescriptorSet> set_updates;
+	this->write_descriptor_sets.clear();
+	this->updated_bindings.clear();
+
+	prepare();
+}
+
+void DescriptorSet::prepare()
+{
+	// We don't want to prepare twice during the life cycle of a Descriptor Set
+	if (!write_descriptor_sets.empty())
+	{
+		LOGW("Trying to prepare a Descriptor Set that has already been prepared, skipping.");
+		return;
+	}
 
 	// Iterate over all buffer bindings
 	for (auto &binding_it : buffer_infos)
 	{
-		auto  binding         = binding_it.first;
+		auto  binding_index   = binding_it.first;
 		auto &buffer_bindings = binding_it.second;
 
-		if (auto binding_info = descriptor_set_layout.get_layout_binding(binding))
+		if (auto binding_info = descriptor_set_layout.get_layout_binding(binding_index))
 		{
 			// Iterate over all binding buffers in array
 			for (auto &element_it : buffer_bindings)
 			{
-				auto  arrayElement = element_it.first;
-				auto &buffer_info  = element_it.second;
+				auto  array_element = element_it.first;
+				auto &buffer_info   = element_it.second;
 
 				VkWriteDescriptorSet write_descriptor_set{VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
 
-				write_descriptor_set.dstBinding      = binding;
+				write_descriptor_set.dstBinding      = binding_index;
 				write_descriptor_set.descriptorType  = binding_info->descriptorType;
 				write_descriptor_set.pBufferInfo     = &buffer_info;
 				write_descriptor_set.dstSet          = handle;
-				write_descriptor_set.dstArrayElement = arrayElement;
+				write_descriptor_set.dstArrayElement = array_element;
 				write_descriptor_set.descriptorCount = 1;
 
-				set_updates.push_back(write_descriptor_set);
+				write_descriptor_sets.push_back(write_descriptor_set);
 			}
 		}
 		else
 		{
-			LOGE("Shader layout set does not use buffer binding at #{}", binding);
+			LOGE("Shader layout set does not use buffer binding at #{}", binding_index);
 		}
 	}
 
@@ -90,8 +109,8 @@ void DescriptorSet::update(const BindingMap<VkDescriptorBufferInfo> &buffer_info
 			// Iterate over all binding images in array
 			for (auto &element_it : binding_resources)
 			{
-				auto  arrayElement = element_it.first;
-				auto &image_info   = element_it.second;
+				auto  array_element = element_it.first;
+				auto &image_info    = element_it.second;
 
 				VkWriteDescriptorSet write_descriptor_set{VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
 
@@ -99,10 +118,10 @@ void DescriptorSet::update(const BindingMap<VkDescriptorBufferInfo> &buffer_info
 				write_descriptor_set.descriptorType  = binding_info->descriptorType;
 				write_descriptor_set.pImageInfo      = &image_info;
 				write_descriptor_set.dstSet          = handle;
-				write_descriptor_set.dstArrayElement = arrayElement;
+				write_descriptor_set.dstArrayElement = array_element;
 				write_descriptor_set.descriptorCount = 1;
 
-				set_updates.push_back(write_descriptor_set);
+				write_descriptor_sets.push_back(write_descriptor_set);
 			}
 		}
 		else
@@ -110,8 +129,52 @@ void DescriptorSet::update(const BindingMap<VkDescriptorBufferInfo> &buffer_info
 			LOGE("Shader layout set does not use image binding at #{}", binding_index);
 		}
 	}
+}
 
-	vkUpdateDescriptorSets(device.get_handle(), to_u32(set_updates.size()), set_updates.data(), 0, nullptr);
+void DescriptorSet::update(const std::vector<uint32_t> &bindings_to_update)
+{
+	std::vector<VkWriteDescriptorSet> write_operations;
+
+	// If the 'bindings_to_update' vector is empty, we want to write to all the bindings (skipping those that haven't already been written)
+	if (bindings_to_update.empty())
+	{
+		for (auto &write_operation : write_descriptor_sets)
+		{
+			if (std::find(updated_bindings.begin(), updated_bindings.end(), write_operation.dstBinding) == updated_bindings.end())
+			{
+				write_operations.push_back(write_operation);
+			}
+		}
+	}
+	else
+	{
+		// Otherwise we want to update the binding indices present in the 'bindings_to_update' vector.
+		// (Again skipping those that have already been written)
+		for (auto &write_operation : write_descriptor_sets)
+		{
+			if (std::find(bindings_to_update.begin(), bindings_to_update.end(), write_operation.dstBinding) != bindings_to_update.end() &&
+			    std::find(updated_bindings.begin(), updated_bindings.end(), write_operation.dstBinding) == updated_bindings.end())
+			{
+				write_operations.push_back(write_operation);
+			}
+		}
+	}
+
+	// Perform the Vulkan call to update the DescriptorSet by executing the write operations
+	if (!write_operations.empty())
+	{
+		vkUpdateDescriptorSets(device.get_handle(),
+		                       to_u32(write_operations.size()),
+		                       write_operations.data(),
+		                       0,
+		                       nullptr);
+	}
+
+	// Store the bindings from the write operations that were executed by vkUpdateDescriptorSets to prevent overwriting by future calls to "update()"
+	for (auto &write_op : write_operations)
+	{
+		updated_bindings.push_back(write_op.dstBinding);
+	}
 }
 
 DescriptorSet::DescriptorSet(DescriptorSet &&other) :
@@ -120,7 +183,9 @@ DescriptorSet::DescriptorSet(DescriptorSet &&other) :
     descriptor_pool{other.descriptor_pool},
     buffer_infos{std::move(other.buffer_infos)},
     image_infos{std::move(other.image_infos)},
-    handle{other.handle}
+    handle{other.handle},
+    write_descriptor_sets{std::move(other.write_descriptor_sets)},
+    updated_bindings{std::move(other.updated_bindings)}
 {
 	other.handle = VK_NULL_HANDLE;
 }

--- a/framework/core/descriptor_set.h
+++ b/framework/core/descriptor_set.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,10 +29,21 @@ class DescriptorPool;
 /**
  * @brief A descriptor set handle allocated from a \ref DescriptorPool.
  *        Destroying the handle has no effect, as the pool manages the lifecycle of its descriptor sets.
+ *
+ *        Keeps track of what bindings were written to prevent a double write.
  */
 class DescriptorSet
 {
   public:
+	/**
+	 * @brief Constructs a descriptor set from buffer infos and image infos
+	 *        Implicitly calls prepare()
+	 * @param device A valid Vulkan device
+	 * @param descriptor_set_layout The Vulkan descriptor set layout this descriptor set has
+	 * @param descriptor_pool The Vulkan descriptor pool the descriptor set is allocated from
+	 * @param buffer_infos The descriptors that describe buffer data
+	 * @param image_infos The descriptors that describe image data
+	 */
 	DescriptorSet(Device &                                  device,
 	              DescriptorSetLayout &                     descriptor_set_layout,
 	              DescriptorPool &                          descriptor_pool,
@@ -43,15 +54,27 @@ class DescriptorSet
 
 	DescriptorSet(DescriptorSet &&other);
 
-	// The descriptor set handle will be destroyed when the pool is reset
+	// The descriptor set handle is managed by the pool, and will be destroyed when the pool is reset
 	~DescriptorSet() = default;
 
 	DescriptorSet &operator=(const DescriptorSet &) = delete;
 
 	DescriptorSet &operator=(DescriptorSet &&) = delete;
 
-	void update(const BindingMap<VkDescriptorBufferInfo> &buffer_infos,
-	            const BindingMap<VkDescriptorImageInfo> & image_infos);
+	/**
+	 * @brief Resets the DescriptorSet state 
+	 *        Optionally prepares a new set of buffer infos and/or image infos
+	 * @param new_buffer_infos A map of buffer descriptors and their respective bindings
+	 * @param new_image_infos A map of image descriptors and their respective bindings
+	 */
+	void reset(const BindingMap<VkDescriptorBufferInfo> &new_buffer_infos = {},
+	           const BindingMap<VkDescriptorImageInfo> & new_image_infos  = {});
+
+	/**
+	 * @brief Updates the contents of the DescriptorSet by performing the write operations
+	 * @param bindings_to_update If empty. we update all bindings. Otherwise, only write the specified bindings if they haven't already been written
+	 */
+	void update(const std::vector<uint32_t> &bindings_to_update = {});
 
 	const DescriptorSetLayout &get_layout() const;
 
@@ -60,6 +83,13 @@ class DescriptorSet
 	BindingMap<VkDescriptorBufferInfo> &get_buffer_infos();
 
 	BindingMap<VkDescriptorImageInfo> &get_image_infos();
+
+  protected:
+	/**
+	 * @brief Prepares the descriptor set to have its contents updated by loading a vector of write operations
+	 *        Cannot be called twice during the lifetime of a DescriptorSet
+	 */
+	void prepare();
 
   private:
 	Device &device;
@@ -73,5 +103,11 @@ class DescriptorSet
 	BindingMap<VkDescriptorImageInfo> image_infos;
 
 	VkDescriptorSet handle{VK_NULL_HANDLE};
+
+	// The list of write operations for the descriptor set
+	std::vector<VkWriteDescriptorSet> write_descriptor_sets;
+
+	// The bindings of the write descriptors that have had vkUpdateDescriptorSets since the last call to update()
+	std::vector<uint32_t> updated_bindings;
 };
 }        // namespace vkb

--- a/framework/core/descriptor_set_layout.cpp
+++ b/framework/core/descriptor_set_layout.cpp
@@ -68,6 +68,91 @@ inline VkDescriptorType find_descriptor_type(ShaderResourceType resource_type, b
 			break;
 	}
 }
+
+inline bool validate_binding(const VkDescriptorSetLayoutBinding &binding, const std::vector<VkDescriptorType> &blacklist)
+{
+	return !(std::find_if(blacklist.begin(), blacklist.end(), [binding](const VkDescriptorType &type) { return type == binding.descriptorType; }) != blacklist.end());
+}
+
+inline bool validate_flags(const PhysicalDevice &gpu, const std::vector<VkDescriptorSetLayoutBinding> &bindings, const std::vector<VkDescriptorBindingFlagsEXT> &flags)
+{
+	// Assume bindings are valid if there are no flags
+	if (flags.empty())
+	{
+		return true;
+	}
+
+	// Binding count has to equal flag count as its a 1:1 mapping
+	if (bindings.size() != flags.size())
+	{
+		LOGE("Binding count has to be equal to flag count.");
+		return false;
+	}
+
+	auto &extended_features = gpu.get_descriptor_indexing_features();
+
+	for (size_t i = 0; i < bindings.size(); ++i)
+	{
+		if (flags[i] == VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT)
+		{
+			if (extended_features.descriptorBindingUniformBufferUpdateAfterBind == 0)
+			{
+				if (!validate_binding(bindings[i], {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER}))
+				{
+					LOGE("If VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingUniformBufferUpdateAfterBind is not enabled, all bindings with descriptor type VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER must not use VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT");
+					return false;
+				}
+			}
+
+			if (extended_features.descriptorBindingSampledImageUpdateAfterBind == 0)
+			{
+				if (!validate_binding(bindings[i], {VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE}))
+				{
+					LOGE("If VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingSampledImageUpdateAfterBind is not enabled, all bindings with descriptor type VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, or VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE must not use VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT");
+					return false;
+				}
+			}
+
+			if (extended_features.descriptorBindingStorageImageUpdateAfterBind == 0)
+			{
+				if (!validate_binding(bindings[i], {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE}))
+				{
+					LOGE("If VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingStorageImageUpdateAfterBind is not enabled, all bindings with descriptor type VK_DESCRIPTOR_TYPE_STORAGE_IMAGE must not use VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT");
+					return false;
+				}
+			}
+
+			if (extended_features.descriptorBindingStorageBufferUpdateAfterBind == 0)
+			{
+				if (!validate_binding(bindings[i], {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER}))
+				{
+					LOGE("If VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingStorageBufferUpdateAfterBind is not enabled, all bindings with descriptor type VK_DESCRIPTOR_TYPE_STORAGE_BUFFER must not use VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT");
+					return false;
+				}
+			}
+
+			if (extended_features.descriptorBindingUniformTexelBufferUpdateAfterBind == 0)
+			{
+				if (!validate_binding(bindings[i], {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER}))
+				{
+					LOGE("If VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingUniformTexelBufferUpdateAfterBind is not enabled, all bindings with descriptor type VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER must not use VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT");
+					return false;
+				}
+			}
+
+			if (extended_features.descriptorBindingStorageTexelBufferUpdateAfterBind == 0)
+			{
+				if (!validate_binding(bindings[i], {VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER}))
+				{
+					LOGE("If VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingStorageTexelBufferUpdateAfterBind is not enabled, all bindings with descriptor type VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER must not use VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT");
+					return false;
+				}
+			}
+		}
+	}
+
+	return true;
+}
 }        // namespace
 
 DescriptorSetLayout::DescriptorSetLayout(Device &device, const std::vector<ShaderResource> &resource_set) :
@@ -85,7 +170,19 @@ DescriptorSetLayout::DescriptorSetLayout(Device &device, const std::vector<Shade
 		}
 
 		// Convert from ShaderResourceType to VkDescriptorType.
-		auto descriptor_type = find_descriptor_type(resource.type, resource.dynamic);
+		auto descriptor_type = find_descriptor_type(resource.type, resource.mode == ShaderResourceMode::Dynamic);
+
+		if (resource.mode == ShaderResourceMode::UpdateAfterBind)
+		{
+			binding_flags.push_back(VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT);
+		}
+		else
+		{
+			// When creating a descriptor set layout, if we give a structure to create_info.pNext, each binding needs to have a binding flag
+			// (pBindings[i] uses the flags in pBindingFlags[i])
+			// Adding 0 ensures the bindings that dont use any flags are mapped correctly.
+			binding_flags.push_back(0);
+		}
 
 		// Convert ShaderResource to VkDescriptorSetLayoutBinding
 		VkDescriptorSetLayoutBinding layout_binding{};
@@ -100,13 +197,39 @@ DescriptorSetLayout::DescriptorSetLayout(Device &device, const std::vector<Shade
 		// Store mapping between binding and the binding point
 		bindings_lookup.emplace(resource.binding, layout_binding);
 
+		binding_flags_lookup.emplace(resource.binding, binding_flags.back());
+
 		resources_lookup.emplace(resource.name, resource.binding);
 	}
 
 	VkDescriptorSetLayoutCreateInfo create_info{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
-
+	create_info.flags        = 0;
 	create_info.bindingCount = to_u32(bindings.size());
 	create_info.pBindings    = bindings.data();
+
+	// Handle update-after-bind extensions
+	if (std::find_if(resource_set.begin(), resource_set.end(),
+	                 [](const ShaderResource &shader_resource) { return shader_resource.mode == ShaderResourceMode::UpdateAfterBind; }) != resource_set.end())
+	{
+		// Spec states you can't have ANY dynamic resources if you have one of the bindings set to update-after-bind
+		if (std::find_if(resource_set.begin(), resource_set.end(),
+		                 [](const ShaderResource &shader_resource) { return shader_resource.mode == ShaderResourceMode::Dynamic; }) != resource_set.end())
+		{
+			throw std::runtime_error("Cannot create descriptor set layout, dynamic resources are not allowed if at least one resource is update-after-bind.");
+		}
+
+		if (!validate_flags(device.get_gpu(), bindings, binding_flags))
+		{
+			throw std::runtime_error("Invalid binding set up, couldn't create descriptor set layout.");
+		}
+
+		VkDescriptorSetLayoutBindingFlagsCreateInfoEXT binding_flags_create_info{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT};
+		binding_flags_create_info.bindingCount  = to_u32(binding_flags.size());
+		binding_flags_create_info.pBindingFlags = binding_flags.data();
+
+		create_info.pNext = &binding_flags_create_info;
+		create_info.flags |= std::find(binding_flags.begin(), binding_flags.end(), VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT) != binding_flags.end() ? VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT : 0;
+	}
 
 	// Create the Vulkan descriptor set layout handle
 	VkResult result = vkCreateDescriptorSetLayout(device.get_handle(), &create_info, nullptr, &handle);
@@ -121,7 +244,9 @@ DescriptorSetLayout::DescriptorSetLayout(DescriptorSetLayout &&other) :
     device{other.device},
     handle{other.handle},
     bindings{std::move(other.bindings)},
+    binding_flags{std::move(other.binding_flags)},
     bindings_lookup{std::move(other.bindings_lookup)},
+    binding_flags_lookup{std::move(other.binding_flags_lookup)},
     resources_lookup{std::move(other.resources_lookup)}
 {
 	other.handle = VK_NULL_HANDLE;
@@ -144,6 +269,11 @@ VkDescriptorSetLayout DescriptorSetLayout::get_handle() const
 const std::vector<VkDescriptorSetLayoutBinding> &DescriptorSetLayout::get_bindings() const
 {
 	return bindings;
+}
+
+const std::vector<VkDescriptorBindingFlagsEXT> &DescriptorSetLayout::get_binding_flags() const
+{
+	return binding_flags;
 }
 
 std::unique_ptr<VkDescriptorSetLayoutBinding> DescriptorSetLayout::get_layout_binding(uint32_t binding_index) const
@@ -169,4 +299,17 @@ std::unique_ptr<VkDescriptorSetLayoutBinding> DescriptorSetLayout::get_layout_bi
 
 	return get_layout_binding(it->second);
 }
+
+VkDescriptorBindingFlagsEXT DescriptorSetLayout::get_layout_binding_flag(const uint32_t binding_index) const
+{
+	auto it = binding_flags_lookup.find(binding_index);
+
+	if (it == binding_flags_lookup.end())
+	{
+		return 0;
+	}
+
+	return it->second;
+}
+
 }        // namespace vkb

--- a/framework/core/descriptor_set_layout.h
+++ b/framework/core/descriptor_set_layout.h
@@ -55,9 +55,13 @@ class DescriptorSetLayout
 
 	const std::vector<VkDescriptorSetLayoutBinding> &get_bindings() const;
 
-	std::unique_ptr<VkDescriptorSetLayoutBinding> get_layout_binding(uint32_t binding_index) const;
+	std::unique_ptr<VkDescriptorSetLayoutBinding> get_layout_binding(const uint32_t binding_index) const;
 
 	std::unique_ptr<VkDescriptorSetLayoutBinding> get_layout_binding(const std::string &name) const;
+
+	const std::vector<VkDescriptorBindingFlagsEXT> &get_binding_flags() const;
+
+	VkDescriptorBindingFlagsEXT get_layout_binding_flag(const uint32_t binding_index) const;
 
   private:
 	Device &device;
@@ -66,7 +70,11 @@ class DescriptorSetLayout
 
 	std::vector<VkDescriptorSetLayoutBinding> bindings;
 
+	std::vector<VkDescriptorBindingFlagsEXT> binding_flags;
+
 	std::unordered_map<uint32_t, VkDescriptorSetLayoutBinding> bindings_lookup;
+
+	std::unordered_map<uint32_t, VkDescriptorBindingFlagsEXT> binding_flags_lookup;
 
 	std::unordered_map<std::string, uint32_t> resources_lookup;
 };

--- a/framework/core/device.cpp
+++ b/framework/core/device.cpp
@@ -123,6 +123,9 @@ Device::Device(const PhysicalDevice &gpu, VkSurfaceKHR surface, std::unordered_m
 
 	VkDeviceCreateInfo create_info{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
 
+	// Latest requested feature will have the pNext's all set up for device creation.
+	create_info.pNext = gpu.get_requested_extension_features();
+
 	create_info.pQueueCreateInfos       = queue_create_infos.data();
 	create_info.queueCreateInfoCount    = to_u32(queue_create_infos.size());
 	const auto requested_gpu_features   = gpu.get_requested_features();

--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -28,6 +28,8 @@
 #include "core/framebuffer.h"
 #include "core/instance.h"
 #include "core/pipeline.h"
+
+#include "core/physical_device.h"
 #include "core/pipeline_layout.h"
 #include "core/queue.h"
 #include "core/render_pass.h"

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include "physical_device.h"
+
 #include "instance.h"
 
 #include <algorithm>

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -17,10 +17,12 @@
 
 #pragma once
 
-#include "core/physical_device.h"
+#include "common/helpers.h"
+#include "common/vk_common.h"
 
 namespace vkb
 {
+class PhysicalDevice;
 /**
  * @brief Returns a list of Khronos/LunarG supported validation layers
  *        Attempting to enable them in order of preference, starting with later Vulkan SDK versions

--- a/framework/core/physical_device.cpp
+++ b/framework/core/physical_device.cpp
@@ -17,8 +17,6 @@
 
 #include "physical_device.h"
 
-#include "core/instance.h"
-
 namespace vkb
 {
 PhysicalDevice::PhysicalDevice(const Instance &instance, VkPhysicalDevice physical_device) :
@@ -96,6 +94,31 @@ VkPhysicalDeviceFeatures &PhysicalDevice::get_mutable_requested_features()
 const VkPhysicalDeviceFeatures PhysicalDevice::get_requested_features() const
 {
 	return requested_features;
+}
+
+void *PhysicalDevice::get_requested_extension_features() const
+{
+	return last_requested_extension_feature;
+}
+
+void PhysicalDevice::request_descriptor_indexing_features()
+{
+	// Request the relevant extension
+	descriptor_indexing_features = request_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT);
+
+	// If an extension has already been requested, set that to the pNext element
+	if (last_requested_extension_feature)
+	{
+		descriptor_indexing_features.pNext = last_requested_extension_feature;
+	}
+
+	// Set the last requested extension to the pointer of the most recently requested extension
+	last_requested_extension_feature = &descriptor_indexing_features;
+}
+
+const VkPhysicalDeviceDescriptorIndexingFeaturesEXT &PhysicalDevice::get_descriptor_indexing_features() const
+{
+	return descriptor_indexing_features;
 }
 
 }        // namespace vkb

--- a/framework/core/physical_device.h
+++ b/framework/core/physical_device.h
@@ -17,8 +17,7 @@
 
 #pragma once
 
-#include "common/helpers.h"
-#include "common/vk_common.h"
+#include "core/instance.h"
 
 namespace vkb
 {
@@ -62,6 +61,31 @@ class PhysicalDevice
 
 	const VkPhysicalDeviceFeatures get_requested_features() const;
 
+	void *get_requested_extension_features() const;
+
+	void request_descriptor_indexing_features();
+
+	const VkPhysicalDeviceDescriptorIndexingFeaturesEXT &get_descriptor_indexing_features() const;
+
+  protected:
+	template <typename T>
+	const T request_extension_features(VkStructureType type)
+	{
+		if (!instance.is_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
+		{
+			return {};
+		}
+
+		VkPhysicalDeviceFeatures2KHR extended_features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR};
+		T                            ext{type};
+
+		extended_features.pNext = &ext;
+
+		vkGetPhysicalDeviceFeatures2KHR(handle, &extended_features);
+
+		return ext;
+	}
+
   private:
 	// Handle to the Vulkan instance
 	const Instance &instance;
@@ -83,5 +107,10 @@ class PhysicalDevice
 
 	// The features that will be requested to be enabled in the logical device
 	VkPhysicalDeviceFeatures requested_features{};
+
+	// The extension feature pointer
+	void *last_requested_extension_feature{nullptr};
+
+	VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptor_indexing_features{};
 };
 }        // namespace vkb

--- a/framework/core/shader_module.cpp
+++ b/framework/core/shader_module.cpp
@@ -112,19 +112,26 @@ const std::vector<uint32_t> &ShaderModule::get_binary() const
 	return spirv;
 }
 
-void ShaderModule::set_resource_dynamic(const std::string &resource_name)
+void ShaderModule::set_resource_mode(const ShaderResourceMode &mode, const std::string &resource_name)
 {
 	auto it = std::find_if(resources.begin(), resources.end(), [&resource_name](const ShaderResource &resource) { return resource.name == resource_name; });
 
 	if (it != resources.end())
 	{
-		if (it->type == ShaderResourceType::BufferUniform || it->type == ShaderResourceType::BufferStorage)
+		if (mode == ShaderResourceMode::Dynamic)
 		{
-			it->dynamic = true;
+			if (it->type == ShaderResourceType::BufferUniform || it->type == ShaderResourceType::BufferStorage)
+			{
+				it->mode = mode;
+			}
+			else
+			{
+				LOGW("Resource `{}` does not support dynamic.", resource_name);
+			}
 		}
 		else
 		{
-			LOGW("Resource `{}` does not support dynamic.", resource_name);
+			it->mode = mode;
 		}
 	}
 	else

--- a/framework/core/shader_module.h
+++ b/framework/core/shader_module.h
@@ -41,6 +41,14 @@ enum class ShaderResourceType
 	All
 };
 
+/// This determines the type and method of how descriptor set should be created and bound
+enum class ShaderResourceMode
+{
+	Static,
+	Dynamic,
+	UpdateAfterBind
+};
+
 /// Store shader resource data.
 /// Used by the shader module.
 struct ShaderResource
@@ -48,6 +56,8 @@ struct ShaderResource
 	VkShaderStageFlags stages;
 
 	ShaderResourceType type;
+
+	ShaderResourceMode mode;
 
 	uint32_t set;
 
@@ -68,8 +78,6 @@ struct ShaderResource
 	uint32_t size;
 
 	uint32_t constant_id;
-
-	bool dynamic;
 
 	std::string name;
 };
@@ -196,7 +204,7 @@ class ShaderModule
 
 	const std::vector<uint32_t> &get_binary() const;
 
-	void set_resource_dynamic(const std::string &resource_name);
+	void set_resource_mode(const ShaderResourceMode &mode, const std::string &resource_name);
 
   private:
 	Device &device;

--- a/framework/graphing/framework_graph.cpp
+++ b/framework/graphing/framework_graph.cpp
@@ -53,8 +53,8 @@ bool generate(RenderContext &context)
 		size_t pipeline_layouts_id = pipeline_layout_node(graph, it_pipeline_layouts->second);
 		graph.add_edge(resource_cache_id, pipeline_layouts_id);
 
-		auto &modules = it_pipeline_layouts->second.get_shader_modules();
-		for (const auto &shader_module : modules)
+		auto &shader_modules = it_pipeline_layouts->second.get_shader_modules();
+		for (const auto *shader_module : shader_modules)
 		{
 			size_t shader_modules_id = shader_module_node(graph, *shader_module);
 			graph.add_edge(pipeline_layouts_id, shader_modules_id);
@@ -390,7 +390,7 @@ size_t shader_resource_node(Graph &graph, const ShaderResource &shader_resource)
 	                       {"offset", shader_resource.offset},
 	                       {"size", shader_resource.size},
 	                       {"constant_id", shader_resource.constant_id},
-	                       {"dynamic", shader_resource.dynamic},
+	                       {"mode", shader_resource.mode},
 	                       {"name", shader_resource.name}};
 
 	return graph.create_node(label.c_str(), "Rendering", data);

--- a/framework/rendering/render_frame.cpp
+++ b/framework/rendering/render_frame.cpp
@@ -175,6 +175,15 @@ DescriptorSet &RenderFrame::request_descriptor_set(DescriptorSetLayout &descript
 	return request_resource(device, nullptr, *descriptor_sets.at(thread_index), descriptor_set_layout, descriptor_pool, buffer_infos, image_infos);
 }
 
+void RenderFrame::update_descriptor_sets(size_t thread_index)
+{
+	auto &thread_descriptor_sets = *descriptor_sets.at(thread_index);
+	for (auto &descriptor_set_it : thread_descriptor_sets)
+	{
+		descriptor_set_it.second.update();
+	}
+}
+
 void RenderFrame::clear_descriptors()
 {
 	for (auto &desc_sets_per_thread : descriptor_sets)

--- a/framework/rendering/render_frame.h
+++ b/framework/rendering/render_frame.h
@@ -128,6 +128,11 @@ class RenderFrame
 	 */
 	BufferAllocation allocate_buffer(VkBufferUsageFlags usage, VkDeviceSize size, size_t thread_index = 0);
 
+	/**
+	 * @brief Updates all the descriptor sets in the current frame at a specific thread index
+	 */
+	void update_descriptor_sets(size_t thread_index = 0);
+
   private:
 	Device &device;
 

--- a/framework/rendering/subpasses/forward_subpass.cpp
+++ b/framework/rendering/subpasses/forward_subpass.cpp
@@ -39,9 +39,6 @@ ForwardSubpass::ForwardSubpass(RenderContext &render_context, ShaderSource &&ver
 
 void ForwardSubpass::prepare()
 {
-	// By default use dynamic resources
-	dynamic_resources = {"GlobalUniform"};
-
 	auto &device = render_context.get_device();
 	for (auto &mesh : meshes)
 	{

--- a/framework/rendering/subpasses/geometry_subpass.cpp
+++ b/framework/rendering/subpasses/geometry_subpass.cpp
@@ -110,6 +110,7 @@ void GeometrySubpass::draw(CommandBuffer &command_buffer)
 	color_blend_attachment.blend_enable           = VK_TRUE;
 	color_blend_attachment.src_color_blend_factor = VK_BLEND_FACTOR_SRC_ALPHA;
 	color_blend_attachment.dst_color_blend_factor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+	color_blend_attachment.src_alpha_blend_factor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
 
 	ColorBlendState color_blend_state{};
 	color_blend_state.attachments.resize(get_output_attachments().size());
@@ -166,6 +167,12 @@ void GeometrySubpass::draw_submesh(CommandBuffer &command_buffer, sg::SubMesh &s
 	auto &frag_shader_module = device.get_resource_cache().request_shader_module(VK_SHADER_STAGE_FRAGMENT_BIT, get_fragment_shader(), sub_mesh.get_shader_variant());
 
 	std::vector<ShaderModule *> shader_modules{&vert_shader_module, &frag_shader_module};
+
+	// Set UBO to use dynamic indexing
+	for (auto &shader_module : shader_modules)
+	{
+		shader_module->set_resource_mode(ShaderResourceMode::Dynamic, "GlobalUniform");
+	}
 
 	auto &pipeline_layout = device.get_resource_cache().request_pipeline_layout(shader_modules);
 

--- a/framework/rendering/subpasses/geometry_subpass.cpp
+++ b/framework/rendering/subpasses/geometry_subpass.cpp
@@ -168,12 +168,6 @@ void GeometrySubpass::draw_submesh(CommandBuffer &command_buffer, sg::SubMesh &s
 
 	std::vector<ShaderModule *> shader_modules{&vert_shader_module, &frag_shader_module};
 
-	// Set UBO to use dynamic indexing
-	for (auto &shader_module : shader_modules)
-	{
-		shader_module->set_resource_mode(ShaderResourceMode::Dynamic, "GlobalUniform");
-	}
-
 	auto &pipeline_layout = device.get_resource_cache().request_pipeline_layout(shader_modules);
 
 	command_buffer.bind_pipeline_layout(pipeline_layout);


### PR DESCRIPTION
Add support for update-after-bind descriptor sets. This feature will be used in the upcoming Constant Data sample.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)