### PR TITLE
Framework improvements 8: Add MSAA support

### DIFF
--- a/bldsys/cmake/template/sample/sample.cpp.in
+++ b/bldsys/cmake/template/sample/sample.cpp.in
@@ -25,10 +25,6 @@
 #include "rendering/subpasses/forward_subpass.h"
 #include "stats.h"
 
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#	include "platform/android/android_platform.h"
-#endif
-
 @SAMPLE_NAME@::@SAMPLE_NAME@()
 {
 }

--- a/framework/common/error.cpp
+++ b/framework/common/error.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,6 +22,7 @@
 namespace vkb
 {
 VulkanException::VulkanException(const VkResult result, const std::string &msg) :
+    result{result},
     std::runtime_error{msg}
 {
 	error_message = std::string(std::runtime_error::what()) + std::string{" : "} + to_string(result);

--- a/framework/common/error.h
+++ b/framework/common/error.h
@@ -73,6 +73,8 @@ class VulkanException : public std::runtime_error
 	 */
 	const char *what() const noexcept override;
 
+	VkResult result;
+
   private:
 	std::string error_message;
 };

--- a/framework/common/resource_caching.h
+++ b/framework/common/resource_caching.h
@@ -130,6 +130,8 @@ struct hash<vkb::Attachment>
 
 		vkb::hash_combine(result, static_cast<std::underlying_type<VkFormat>::type>(attachment.format));
 		vkb::hash_combine(result, static_cast<std::underlying_type<VkSampleCountFlagBits>::type>(attachment.samples));
+		vkb::hash_combine(result, attachment.usage);
+		vkb::hash_combine(result, static_cast<std::underlying_type<VkImageLayout>::type>(attachment.initial_layout));
 
 		return result;
 	}
@@ -165,6 +167,15 @@ struct hash<vkb::SubpassInfo>
 		{
 			vkb::hash_combine(result, input_attachment);
 		}
+
+		for (uint32_t resolve_attachment : subpass_info.color_resolve_attachments)
+		{
+			vkb::hash_combine(result, resolve_attachment);
+		}
+
+		vkb::hash_combine(result, subpass_info.disable_depth_stencil_attachment);
+		vkb::hash_combine(result, subpass_info.depth_stencil_resolve_attachment);
+		vkb::hash_combine(result, subpass_info.depth_stencil_resolve_mode);
 
 		return result;
 	}

--- a/framework/common/vk_common.cpp
+++ b/framework/common/vk_common.cpp
@@ -124,12 +124,17 @@ bool is_depth_stencil_format(VkFormat format)
 	       is_depth_only_format(format);
 }
 
-VkFormat get_suitable_depth_format(VkPhysicalDevice physical_device, const std::vector<VkFormat> &depth_format_priority_list)
+VkFormat get_suitable_depth_format(VkPhysicalDevice physical_device, bool depth_only, const std::vector<VkFormat> &depth_format_priority_list)
 {
 	VkFormat depth_format{VK_FORMAT_UNDEFINED};
 
 	for (auto &format : depth_format_priority_list)
 	{
+		if (depth_only && !is_depth_only_format(format))
+		{
+			continue;
+		}
+
 		VkFormatProperties properties;
 		vkGetPhysicalDeviceFormatProperties(physical_device, format, &properties);
 

--- a/framework/common/vk_common.h
+++ b/framework/common/vk_common.h
@@ -57,11 +57,13 @@ bool is_depth_stencil_format(VkFormat format);
 /**
  * @brief Helper function to determine a suitable supported depth format based on a priority list
  * @param physical_device The physical device to check the depth formats against
- * @param depth_format_priority_list The list of depth formats to prefer over one another
+ * @param depth_only (Optional) Wether to include the stencil component in the format or not
+ * @param depth_format_priority_list (Optional) The list of depth formats to prefer over one another
  *		  By default we start with the highest precision packed format
  * @return The valid suited depth format
  */
 VkFormat get_suitable_depth_format(VkPhysicalDevice             physical_device,
+                                   bool                         depth_only                 = false,
                                    const std::vector<VkFormat> &depth_format_priority_list = {
                                        VK_FORMAT_D32_SFLOAT,
                                        VK_FORMAT_D24_UNORM_S8_UINT,

--- a/framework/core/command_buffer.h
+++ b/framework/core/command_buffer.h
@@ -203,6 +203,8 @@ class CommandBuffer
 
 	void blit_image(const core::Image &src_img, const core::Image &dst_img, const std::vector<VkImageBlit> &regions);
 
+	void resolve_image(const core::Image &src_img, const core::Image &dst_img, const std::vector<VkImageResolve> &regions);
+
 	void copy_buffer(const core::Buffer &src_buffer, const core::Buffer &dst_buffer, VkDeviceSize size);
 
 	void copy_image(const core::Image &src_img, const core::Image &dst_img, const std::vector<VkImageCopy> &regions);

--- a/framework/core/image.cpp
+++ b/framework/core/image.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -122,13 +122,13 @@ Image::Image(Device &              device,
 	}
 }
 
-Image::Image(Device &device, VkImage handle, const VkExtent3D &extent, VkFormat format, VkImageUsageFlags image_usage) :
+Image::Image(Device &device, VkImage handle, const VkExtent3D &extent, VkFormat format, VkImageUsageFlags image_usage, VkSampleCountFlagBits sample_count) :
     device{device},
     handle{handle},
     type{find_image_type(extent)},
     extent{extent},
     format{format},
-    sample_count{VK_SAMPLE_COUNT_1_BIT},
+    sample_count{sample_count},
     usage{image_usage}
 {
 	subresource.mipLevel   = 1;

--- a/framework/core/image.h
+++ b/framework/core/image.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -32,11 +32,12 @@ class ImageView;
 class Image
 {
   public:
-	Image(Device &          device,
-	      VkImage           handle,
-	      const VkExtent3D &extent,
-	      VkFormat          format,
-	      VkImageUsageFlags image_usage);
+	Image(Device &              device,
+	      VkImage               handle,
+	      const VkExtent3D &    extent,
+	      VkFormat              format,
+	      VkImageUsageFlags     image_usage,
+	      VkSampleCountFlagBits sample_count = VK_SAMPLE_COUNT_1_BIT);
 
 	Image(Device &              device,
 	      const VkExtent3D &    extent,

--- a/framework/core/render_pass.cpp
+++ b/framework/core/render_pass.cpp
@@ -29,24 +29,103 @@ VkRenderPass RenderPass::get_handle() const
 	return handle;
 }
 
-RenderPass::RenderPass(Device &device, const std::vector<Attachment> &attachments, const std::vector<LoadStoreInfo> &load_store_infos, const std::vector<SubpassInfo> &subpasses) :
-    device{device},
-    subpass_count{std::max<size_t>(1, subpasses.size())},        // At least 1 subpass
-    input_attachments{subpass_count},
-    color_attachments{subpass_count},
-    depth_stencil_attachments{subpass_count}
+namespace
 {
-	uint32_t depth_stencil_attachment{VK_ATTACHMENT_UNUSED};
+inline void set_structure_type(VkAttachmentDescription &attachment)
+{
+	// VkAttachmentDescription has no sType field
+}
 
-	std::vector<VkAttachmentDescription> attachment_descriptions;
+inline void set_structure_type(VkAttachmentDescription2KHR &attachment)
+{
+	attachment.sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2_KHR;
+}
 
-	for (uint32_t i = 0U; i < attachments.size(); ++i)
+inline void set_structure_type(VkAttachmentReference &reference)
+{
+	// VkAttachmentReference has no sType field
+}
+
+inline void set_structure_type(VkAttachmentReference2KHR &reference)
+{
+	reference.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2_KHR;
+}
+
+inline void set_structure_type(VkRenderPassCreateInfo &create_info)
+{
+	create_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+}
+
+inline void set_structure_type(VkRenderPassCreateInfo2KHR &create_info)
+{
+	create_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2_KHR;
+}
+
+inline void set_structure_type(VkSubpassDescription &description)
+{
+	// VkSubpassDescription has no sType field
+}
+
+inline void set_structure_type(VkSubpassDescription2KHR &description)
+{
+	description.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2_KHR;
+}
+
+inline void set_pointer_next(VkSubpassDescription &subpass_description, VkSubpassDescriptionDepthStencilResolveKHR &depth_resolve, VkAttachmentReference &depth_resolve_attachment)
+{
+	// VkSubpassDescription cannot have pNext point to a VkSubpassDescriptionDepthStencilResolveKHR containing a VkAttachmentReference
+}
+
+inline void set_pointer_next(VkSubpassDescription2KHR &subpass_description, VkSubpassDescriptionDepthStencilResolveKHR &depth_resolve, VkAttachmentReference2KHR &depth_resolve_attachment)
+{
+	depth_resolve.pDepthStencilResolveAttachment = &depth_resolve_attachment;
+	subpass_description.pNext                    = &depth_resolve;
+}
+
+inline const VkAttachmentReference2KHR *get_depth_resolve_reference(const VkSubpassDescription &subpass_description)
+{
+	// VkSubpassDescription cannot have pNext point to a VkSubpassDescriptionDepthStencilResolveKHR containing a VkAttachmentReference2KHR
+	return nullptr;
+}
+
+inline const VkAttachmentReference2KHR *get_depth_resolve_reference(const VkSubpassDescription2KHR &subpass_description)
+{
+	auto description_depth_resolve = static_cast<const VkSubpassDescriptionDepthStencilResolveKHR *>(subpass_description.pNext);
+
+	const VkAttachmentReference2KHR *depth_resolve_attachment = nullptr;
+	if (description_depth_resolve)
 	{
-		VkAttachmentDescription attachment{};
+		depth_resolve_attachment = description_depth_resolve->pDepthStencilResolveAttachment;
+	}
 
-		attachment.format      = attachments[i].format;
-		attachment.samples     = attachments[i].samples;
-		attachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	return depth_resolve_attachment;
+}
+
+inline VkResult create_vk_renderpass(VkDevice device, VkRenderPassCreateInfo &create_info, VkRenderPass *handle)
+{
+	return vkCreateRenderPass(device, &create_info, nullptr, handle);
+}
+
+inline VkResult create_vk_renderpass(VkDevice device, VkRenderPassCreateInfo2KHR &create_info, VkRenderPass *handle)
+{
+	return vkCreateRenderPass2KHR(device, &create_info, nullptr, handle);
+}
+}        // namespace
+
+template <typename T>
+std::vector<T> get_attachment_descriptions(const std::vector<Attachment> &attachments, const std::vector<LoadStoreInfo> &load_store_infos)
+{
+	std::vector<T> attachment_descriptions;
+
+	for (size_t i = 0U; i < attachments.size(); ++i)
+	{
+		T attachment{};
+		set_structure_type(attachment);
+
+		attachment.format        = attachments[i].format;
+		attachment.samples       = attachments[i].samples;
+		attachment.initialLayout = attachments[i].initial_layout;
+		attachment.finalLayout   = is_depth_stencil_format(attachment.format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
 		if (i < load_store_infos.size())
 		{
@@ -56,102 +135,21 @@ RenderPass::RenderPass(Device &device, const std::vector<Attachment> &attachment
 			attachment.stencilStoreOp = load_store_infos[i].store_op;
 		}
 
-		if (is_depth_stencil_format(attachment.format))
-		{
-			depth_stencil_attachment = i;
-			attachment.finalLayout   = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-		}
-
 		attachment_descriptions.push_back(std::move(attachment));
 	}
 
-	std::vector<VkSubpassDescription> subpass_descriptions;
-	subpass_descriptions.reserve(subpass_count);
+	return attachment_descriptions;
+}
 
-	for (size_t i = 0; i < subpasses.size(); ++i)
-	{
-		auto &subpass = subpasses[i];
-
-		// Fill color/depth attachments references
-		for (auto o_attachment : subpass.output_attachments)
-		{
-			if (o_attachment != depth_stencil_attachment)
-			{
-				color_attachments[i].push_back({o_attachment, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL});
-			}
-		}
-
-		// Fill input attachments references
-		for (auto i_attachment : subpass.input_attachments)
-		{
-			if (is_depth_stencil_format(attachment_descriptions[i_attachment].format))
-			{
-				input_attachments[i].push_back({i_attachment, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL});
-			}
-			else
-			{
-				input_attachments[i].push_back({i_attachment, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL});
-			}
-		}
-
-		if (depth_stencil_attachment != VK_ATTACHMENT_UNUSED)
-		{
-			depth_stencil_attachments[i].push_back({depth_stencil_attachment, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL});
-		}
-	}
-
-	for (size_t i = 0; i < subpasses.size(); ++i)
-	{
-		auto &subpass = subpasses[i];
-
-		VkSubpassDescription subpass_description{};
-		subpass_description.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-
-		subpass_description.pInputAttachments    = input_attachments[i].empty() ? nullptr : input_attachments[i].data();
-		subpass_description.inputAttachmentCount = to_u32(input_attachments[i].size());
-
-		subpass_description.pColorAttachments    = color_attachments[i].empty() ? nullptr : color_attachments[i].data();
-		subpass_description.colorAttachmentCount = to_u32(color_attachments[i].size());
-
-		subpass_description.pDepthStencilAttachment = depth_stencil_attachments[i].empty() ? nullptr : depth_stencil_attachments[i].data();
-
-		subpass_descriptions.push_back(subpass_description);
-	}
-
-	// Default subpass
-	if (subpasses.empty())
-	{
-		VkSubpassDescription subpass_description{};
-		subpass_description.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-
-		for (uint32_t k = 0U; k < attachment_descriptions.size(); ++k)
-		{
-			if (k == depth_stencil_attachment)
-			{
-				continue;
-			}
-
-			color_attachments[0].push_back({k, VK_IMAGE_LAYOUT_GENERAL});
-		}
-
-		subpass_description.pColorAttachments = color_attachments[0].data();
-
-		if (depth_stencil_attachment != VK_ATTACHMENT_UNUSED)
-		{
-			depth_stencil_attachments[0].push_back({depth_stencil_attachment, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL});
-
-			subpass_description.pDepthStencilAttachment = depth_stencil_attachments[0].data();
-		}
-
-		subpass_descriptions.push_back(subpass_description);
-	}
-
+template <typename T_SubpassDescription, typename T_AttachmentDescription, typename T_AttachmentReference>
+void set_attachment_layouts(std::vector<T_SubpassDescription> &subpass_descriptions, std::vector<T_AttachmentDescription> &attachment_descriptions)
+{
 	// Make the initial layout same as in the first subpass using that attachment
 	for (auto &subpass : subpass_descriptions)
 	{
-		for (uint32_t k = 0U; k < subpass.colorAttachmentCount; ++k)
+		for (size_t k = 0U; k < subpass.colorAttachmentCount; ++k)
 		{
-			auto reference = subpass.pColorAttachments[k];
+			auto &reference = subpass.pColorAttachments[k];
 			// Set it only if not defined yet
 			if (attachment_descriptions[reference.attachment].initialLayout == VK_IMAGE_LAYOUT_UNDEFINED)
 			{
@@ -159,9 +157,9 @@ RenderPass::RenderPass(Device &device, const std::vector<Attachment> &attachment
 			}
 		}
 
-		for (uint32_t k = 0U; k < subpass.inputAttachmentCount; ++k)
+		for (size_t k = 0U; k < subpass.inputAttachmentCount; ++k)
 		{
-			auto reference = subpass.pInputAttachments[k];
+			auto &reference = subpass.pInputAttachments[k];
 			// Set it only if not defined yet
 			if (attachment_descriptions[reference.attachment].initialLayout == VK_IMAGE_LAYOUT_UNDEFINED)
 			{
@@ -171,11 +169,33 @@ RenderPass::RenderPass(Device &device, const std::vector<Attachment> &attachment
 
 		if (subpass.pDepthStencilAttachment)
 		{
-			auto reference = *subpass.pDepthStencilAttachment;
+			auto &reference = *subpass.pDepthStencilAttachment;
 			// Set it only if not defined yet
 			if (attachment_descriptions[reference.attachment].initialLayout == VK_IMAGE_LAYOUT_UNDEFINED)
 			{
 				attachment_descriptions[reference.attachment].initialLayout = reference.layout;
+			}
+		}
+
+		if (subpass.pResolveAttachments)
+		{
+			for (size_t k = 0U; k < subpass.colorAttachmentCount; ++k)
+			{
+				auto &reference = subpass.pResolveAttachments[k];
+				// Set it only if not defined yet
+				if (attachment_descriptions[reference.attachment].initialLayout == VK_IMAGE_LAYOUT_UNDEFINED)
+				{
+					attachment_descriptions[reference.attachment].initialLayout = reference.layout;
+				}
+			}
+		}
+
+		if (const auto depth_resolve = get_depth_resolve_reference(subpass))
+		{
+			// Set it only if not defined yet
+			if (attachment_descriptions[depth_resolve->attachment].initialLayout == VK_IMAGE_LAYOUT_UNDEFINED)
+			{
+				attachment_descriptions[depth_resolve->attachment].initialLayout = depth_resolve->layout;
 			}
 		}
 	}
@@ -184,21 +204,21 @@ RenderPass::RenderPass(Device &device, const std::vector<Attachment> &attachment
 	{
 		auto &subpass = subpass_descriptions.back();
 
-		for (uint32_t k = 0U; k < subpass.colorAttachmentCount; ++k)
+		for (size_t k = 0U; k < subpass.colorAttachmentCount; ++k)
 		{
 			const auto &reference = subpass.pColorAttachments[k];
 
 			attachment_descriptions[reference.attachment].finalLayout = reference.layout;
 		}
 
-		for (uint32_t k = 0U; k < subpass.inputAttachmentCount; ++k)
+		for (size_t k = 0U; k < subpass.inputAttachmentCount; ++k)
 		{
 			const auto &reference = subpass.pInputAttachments[k];
 
 			attachment_descriptions[reference.attachment].finalLayout = reference.layout;
 
 			// Do not use depth attachment if used as input
-			if (reference.attachment == depth_stencil_attachment)
+			if (is_depth_stencil_format(attachment_descriptions[reference.attachment].format))
 			{
 				subpass.pDepthStencilAttachment = nullptr;
 			}
@@ -210,14 +230,32 @@ RenderPass::RenderPass(Device &device, const std::vector<Attachment> &attachment
 
 			attachment_descriptions[reference.attachment].finalLayout = reference.layout;
 		}
-	}
 
-	// Set subpass dependencies
-	std::vector<VkSubpassDependency> dependencies(subpass_count - 1);
+		if (subpass.pResolveAttachments)
+		{
+			for (size_t k = 0U; k < subpass.colorAttachmentCount; ++k)
+			{
+				const auto &reference = subpass.pResolveAttachments[k];
+
+				attachment_descriptions[reference.attachment].finalLayout = reference.layout;
+			}
+		}
+
+		if (const auto depth_resolve = get_depth_resolve_reference(subpass))
+		{
+			attachment_descriptions[depth_resolve->attachment].finalLayout = depth_resolve->layout;
+		}
+	}
+}
+
+template <typename T>
+std::vector<T> get_subpass_dependencies(const size_t subpass_count)
+{
+	std::vector<T> dependencies(subpass_count - 1);
 
 	if (subpass_count > 1)
 	{
-		for (uint32_t i = 0; i < dependencies.size(); ++i)
+		for (uint32_t i = 0; i < to_u32(dependencies.size()); ++i)
 		{
 			// Transition input attachments from color attachment to shader read
 			dependencies[i].srcSubpass      = i;
@@ -230,31 +268,207 @@ RenderPass::RenderPass(Device &device, const std::vector<Attachment> &attachment
 		}
 	}
 
-	// Create render pass
-	VkRenderPassCreateInfo create_info{VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO};
+	return dependencies;
+}
 
+template <typename T>
+T get_attachment_reference(const uint32_t attachment, const VkImageLayout layout)
+{
+	T reference{};
+	set_structure_type(reference);
+
+	reference.attachment = attachment;
+	reference.layout     = layout;
+
+	return reference;
+}
+
+template <typename T_SubpassDescription, typename T_AttachmentDescription, typename T_AttachmentReference, typename T_SubpassDependency, typename T_RenderPassCreateInfo>
+void RenderPass::create_renderpass(const std::vector<Attachment> &attachments, const std::vector<LoadStoreInfo> &load_store_infos, const std::vector<SubpassInfo> &subpasses)
+{
+	auto attachment_descriptions = get_attachment_descriptions<T_AttachmentDescription>(attachments, load_store_infos);
+
+	// Store attachments for every subpass
+	std::vector<std::vector<T_AttachmentReference>> input_attachments{subpass_count};
+	std::vector<std::vector<T_AttachmentReference>> color_attachments{subpass_count};
+	std::vector<std::vector<T_AttachmentReference>> depth_stencil_attachments{subpass_count};
+	std::vector<std::vector<T_AttachmentReference>> color_resolve_attachments{subpass_count};
+	std::vector<std::vector<T_AttachmentReference>> depth_resolve_attachments{subpass_count};
+
+	for (size_t i = 0; i < subpasses.size(); ++i)
+	{
+		auto &subpass = subpasses[i];
+
+		// Fill color attachments references
+		for (auto o_attachment : subpass.output_attachments)
+		{
+			auto  initial_layout = attachments[o_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : attachments[o_attachment].initial_layout;
+			auto &description    = attachment_descriptions[o_attachment];
+			if (!is_depth_stencil_format(description.format))
+			{
+				color_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(o_attachment, initial_layout));
+			}
+		}
+
+		// Fill input attachments references
+		for (auto i_attachment : subpass.input_attachments)
+		{
+			auto default_layout = is_depth_stencil_format(attachment_descriptions[i_attachment].format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			auto initial_layout = attachments[i_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? default_layout : attachments[i_attachment].initial_layout;
+			input_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(i_attachment, initial_layout));
+		}
+
+		for (auto r_attachment : subpass.color_resolve_attachments)
+		{
+			auto initial_layout = attachments[r_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : attachments[r_attachment].initial_layout;
+			color_resolve_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(r_attachment, initial_layout));
+		}
+
+		if (!subpass.disable_depth_stencil_attachment)
+		{
+			// Assumption: depth stencil attachment appears in the list before any depth stencil resolve attachment
+			auto it = find_if(attachments.begin(), attachments.end(), [](const Attachment attachment) { return is_depth_stencil_format(attachment.format); });
+			if (it != attachments.end())
+			{
+				auto i_depth_stencil = vkb::to_u32(std::distance(attachments.begin(), it));
+				auto initial_layout  = it->initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : it->initial_layout;
+				depth_stencil_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(i_depth_stencil, initial_layout));
+
+				if (subpass.depth_stencil_resolve_mode != VK_RESOLVE_MODE_NONE)
+				{
+					auto i_depth_stencil_resolve = subpass.depth_stencil_resolve_attachment;
+					initial_layout               = attachments[i_depth_stencil_resolve].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : attachments[i_depth_stencil_resolve].initial_layout;
+					depth_resolve_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(i_depth_stencil_resolve, initial_layout));
+				}
+			}
+		}
+	}
+
+	std::vector<T_SubpassDescription> subpass_descriptions;
+	subpass_descriptions.reserve(subpass_count);
+	VkSubpassDescriptionDepthStencilResolveKHR depth_resolve{};
+	for (size_t i = 0; i < subpasses.size(); ++i)
+	{
+		auto &subpass = subpasses[i];
+
+		T_SubpassDescription subpass_description{};
+		set_structure_type(subpass_description);
+		subpass_description.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+
+		subpass_description.pInputAttachments    = input_attachments[i].empty() ? nullptr : input_attachments[i].data();
+		subpass_description.inputAttachmentCount = to_u32(input_attachments[i].size());
+
+		subpass_description.pColorAttachments    = color_attachments[i].empty() ? nullptr : color_attachments[i].data();
+		subpass_description.colorAttachmentCount = to_u32(color_attachments[i].size());
+
+		subpass_description.pResolveAttachments = color_resolve_attachments[i].empty() ? nullptr : color_resolve_attachments[i].data();
+
+		subpass_description.pDepthStencilAttachment = nullptr;
+		if (!depth_stencil_attachments[i].empty())
+		{
+			subpass_description.pDepthStencilAttachment = depth_stencil_attachments[i].data();
+
+			if (!depth_resolve_attachments[i].empty())
+			{
+				// If the pNext list of VkSubpassDescription2 includes a VkSubpassDescriptionDepthStencilResolve structure,
+				// then that structure describes multisample resolve operations for the depth/stencil attachment in a subpass
+				depth_resolve.sType            = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE_KHR;
+				depth_resolve.depthResolveMode = subpass.depth_stencil_resolve_mode;
+				set_pointer_next(subpass_description, depth_resolve, depth_resolve_attachments[i][0]);
+
+				auto &reference = depth_resolve_attachments[i][0];
+				// Set it only if not defined yet
+				if (attachment_descriptions[reference.attachment].initialLayout == VK_IMAGE_LAYOUT_UNDEFINED)
+				{
+					attachment_descriptions[reference.attachment].initialLayout = reference.layout;
+				}
+			}
+		}
+
+		subpass_descriptions.push_back(subpass_description);
+	}
+
+	// Default subpass
+	if (subpasses.empty())
+	{
+		T_SubpassDescription subpass_description{};
+		set_structure_type(subpass_description);
+		subpass_description.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+		uint32_t default_depth_stencil_attachment{VK_ATTACHMENT_UNUSED};
+
+		for (uint32_t k = 0U; k < to_u32(attachment_descriptions.size()); ++k)
+		{
+			if (is_depth_stencil_format(attachments[k].format))
+			{
+				if (default_depth_stencil_attachment == VK_ATTACHMENT_UNUSED)
+				{
+					default_depth_stencil_attachment = k;
+				}
+				continue;
+			}
+
+			color_attachments[0].push_back(get_attachment_reference<T_AttachmentReference>(k, VK_IMAGE_LAYOUT_GENERAL));
+		}
+
+		subpass_description.pColorAttachments = color_attachments[0].data();
+
+		if (default_depth_stencil_attachment != VK_ATTACHMENT_UNUSED)
+		{
+			depth_stencil_attachments[0].push_back(get_attachment_reference<T_AttachmentReference>(default_depth_stencil_attachment, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL));
+
+			subpass_description.pDepthStencilAttachment = depth_stencil_attachments[0].data();
+		}
+
+		subpass_descriptions.push_back(subpass_description);
+	}
+
+	set_attachment_layouts<T_SubpassDescription, T_AttachmentDescription, T_AttachmentReference>(subpass_descriptions, attachment_descriptions);
+
+	color_output_count.reserve(subpass_count);
+	for (size_t i = 0; i < subpass_count; i++)
+	{
+		color_output_count.push_back(to_u32(color_attachments[i].size()));
+	}
+
+	const auto &subpass_dependencies = get_subpass_dependencies<T_SubpassDependency>(subpass_count);
+
+	T_RenderPassCreateInfo create_info{};
+	set_structure_type(create_info);
 	create_info.attachmentCount = to_u32(attachment_descriptions.size());
 	create_info.pAttachments    = attachment_descriptions.data();
-	create_info.subpassCount    = to_u32(subpass_count);
+	create_info.subpassCount    = to_u32(subpass_descriptions.size());
 	create_info.pSubpasses      = subpass_descriptions.data();
-	create_info.dependencyCount = to_u32(dependencies.size());
-	create_info.pDependencies   = dependencies.data();
+	create_info.dependencyCount = to_u32(subpass_dependencies.size());
+	create_info.pDependencies   = subpass_dependencies.data();
 
-	auto result = vkCreateRenderPass(device.get_handle(), &create_info, nullptr, &handle);
+	auto result = create_vk_renderpass(device.get_handle(), create_info, &handle);
 
 	if (result != VK_SUCCESS)
 	{
 		throw VulkanException{result, "Cannot create RenderPass"};
 	}
-}        // namespace vkb
+}
+
+RenderPass::RenderPass(Device &device, const std::vector<Attachment> &attachments, const std::vector<LoadStoreInfo> &load_store_infos, const std::vector<SubpassInfo> &subpasses) :
+    device{device},
+    subpass_count{std::max<size_t>(1, subpasses.size())},        // At least 1 subpass
+    color_output_count{}
+{
+	if (device.is_enabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME))
+	{
+		create_renderpass<VkSubpassDescription2KHR, VkAttachmentDescription2KHR, VkAttachmentReference2KHR, VkSubpassDependency2KHR, VkRenderPassCreateInfo2KHR>(attachments, load_store_infos, subpasses);
+	}
+	else
+	{
+		create_renderpass<VkSubpassDescription, VkAttachmentDescription, VkAttachmentReference, VkSubpassDependency, VkRenderPassCreateInfo>(attachments, load_store_infos, subpasses);
+	}
+}
 
 RenderPass::RenderPass(RenderPass &&other) :
     device{other.device},
     handle{other.handle},
     subpass_count{other.subpass_count},
-    input_attachments{other.input_attachments},
-    color_attachments{other.color_attachments},
-    depth_stencil_attachments{other.depth_stencil_attachments}
+    color_output_count{other.color_output_count}
 {
 	other.handle = VK_NULL_HANDLE;
 }
@@ -270,7 +484,7 @@ RenderPass::~RenderPass()
 
 const uint32_t RenderPass::get_color_output_count(uint32_t subpass_index) const
 {
-	return to_u32(color_attachments[subpass_index].size());
+	return color_output_count[subpass_index];
 }
 
 const VkExtent2D RenderPass::get_render_area_granularity() const

--- a/framework/core/render_pass.h
+++ b/framework/core/render_pass.h
@@ -30,6 +30,14 @@ struct SubpassInfo
 	std::vector<uint32_t> input_attachments;
 
 	std::vector<uint32_t> output_attachments;
+
+	std::vector<uint32_t> color_resolve_attachments;
+
+	bool disable_depth_stencil_attachment;
+
+	uint32_t depth_stencil_resolve_attachment;
+
+	VkResolveModeFlagBits depth_stencil_resolve_mode;
 };
 
 class RenderPass
@@ -63,11 +71,9 @@ class RenderPass
 
 	size_t subpass_count;
 
-	// Store attachments for every subpass
-	std::vector<std::vector<VkAttachmentReference>> input_attachments;
+	template <typename T_SubpassDescription, typename T_AttachmentDescription, typename T_AttachmentReference, typename T_SubpassDependency, typename T_RenderPassCreateInfo>
+	void create_renderpass(const std::vector<Attachment> &attachments, const std::vector<LoadStoreInfo> &load_store_infos, const std::vector<SubpassInfo> &subpasses);
 
-	std::vector<std::vector<VkAttachmentReference>> color_attachments;
-
-	std::vector<std::vector<VkAttachmentReference>> depth_stencil_attachments;
+	std::vector<uint32_t> color_output_count;
 };
 }        // namespace vkb

--- a/framework/rendering/render_target.cpp
+++ b/framework/rendering/render_target.cpp
@@ -123,4 +123,9 @@ const std::vector<uint32_t> &RenderTarget::get_output_attachments() const
 	return output_attachments;
 }
 
+void RenderTarget::set_layout(uint32_t attachment, VkImageLayout layout)
+{
+	attachments[attachment].initial_layout = layout;
+}
+
 }        // namespace vkb

--- a/framework/rendering/render_target.h
+++ b/framework/rendering/render_target.h
@@ -38,6 +38,8 @@ struct Attachment
 
 	VkImageUsageFlags usage{VK_IMAGE_USAGE_SAMPLED_BIT};
 
+	VkImageLayout initial_layout{VK_IMAGE_LAYOUT_UNDEFINED};
+
 	Attachment() = default;
 
 	Attachment(VkFormat format, VkSampleCountFlagBits samples, VkImageUsageFlags usage);
@@ -92,6 +94,8 @@ class RenderTarget
 	void set_output_attachments(std::vector<uint32_t> &output);
 
 	const std::vector<uint32_t> &get_output_attachments() const;
+
+	void set_layout(uint32_t attachment, VkImageLayout layout);
 
   private:
 	Device &device;

--- a/framework/rendering/subpass.cpp
+++ b/framework/rendering/subpass.cpp
@@ -90,6 +90,51 @@ void Subpass::set_output_attachments(std::vector<uint32_t> output)
 	output_attachments = output;
 }
 
+const std::vector<uint32_t> &Subpass::get_color_resolve_attachments() const
+{
+	return color_resolve_attachments;
+}
+
+void Subpass::set_color_resolve_attachments(std::vector<uint32_t> color_resolve)
+{
+	color_resolve_attachments = color_resolve;
+}
+
+const bool &Subpass::get_disable_depth_stencil_attachment() const
+{
+	return disable_depth_stencil_attachment;
+}
+
+void Subpass::set_disable_depth_stencil_attachment(bool disable_depth_stencil)
+{
+	disable_depth_stencil_attachment = disable_depth_stencil;
+}
+
+const uint32_t &Subpass::get_depth_stencil_resolve_attachment() const
+{
+	return depth_stencil_resolve_attachment;
+}
+
+void Subpass::set_depth_stencil_resolve_attachment(uint32_t depth_stencil_resolve)
+{
+	depth_stencil_resolve_attachment = depth_stencil_resolve;
+}
+
+const VkResolveModeFlagBits Subpass::get_depth_stencil_resolve_mode() const
+{
+	return depth_stencil_resolve_mode;
+}
+
+void Subpass::set_depth_stencil_resolve_mode(VkResolveModeFlagBits mode)
+{
+	depth_stencil_resolve_mode = mode;
+}
+
+void Subpass::set_sample_count(VkSampleCountFlagBits sample_count)
+{
+	this->sample_count = sample_count;
+}
+
 void Subpass::clear_dynamic_resources()
 {
 	dynamic_resources.clear();

--- a/framework/rendering/subpass.h
+++ b/framework/rendering/subpass.h
@@ -109,6 +109,24 @@ class Subpass
 
 	void add_dynamic_resources(const std::vector<std::string> &dynamic_resources);
 
+	void set_sample_count(VkSampleCountFlagBits sample_count);
+
+	const std::vector<uint32_t> &get_color_resolve_attachments() const;
+
+	void set_color_resolve_attachments(std::vector<uint32_t> color_resolve);
+
+	const bool &get_disable_depth_stencil_attachment() const;
+
+	void set_disable_depth_stencil_attachment(bool disable_depth_stencil);
+
+	const uint32_t &get_depth_stencil_resolve_attachment() const;
+
+	void set_depth_stencil_resolve_attachment(uint32_t depth_stencil_resolve);
+
+	const VkResolveModeFlagBits get_depth_stencil_resolve_mode() const;
+
+	void set_depth_stencil_resolve_mode(VkResolveModeFlagBits mode);
+
 	/**
 	 * @brief Create a buffer allocation from scene graph lights to be bound to shaders
 	 * 
@@ -184,6 +202,8 @@ class Subpass
 
 	std::vector<std::string> dynamic_resources{};
 
+	VkSampleCountFlagBits sample_count{VK_SAMPLE_COUNT_1_BIT};
+
   private:
 	ShaderSource vertex_shader;
 
@@ -191,11 +211,30 @@ class Subpass
 
 	DepthStencilState depth_stencil_state{};
 
+	/**
+	 * @brief When creating the renderpass, pDepthStencilAttachment will
+	 *        be set to nullptr, which disables depth testing
+	 */
+	bool disable_depth_stencil_attachment{false};
+
+	/**
+	 * @brief When creating the renderpass, if not None, the resolve
+	 *        of the multisampled depth attachment will be enabled,
+	 *        with this mode, to depth_stencil_resolve_attachment
+	 */
+	VkResolveModeFlagBits depth_stencil_resolve_mode{VK_RESOLVE_MODE_NONE};
+
 	/// Default to no input attachments
 	std::vector<uint32_t> input_attachments = {};
 
 	/// Default to swapchain output attachment
 	std::vector<uint32_t> output_attachments = {0};
+
+	/// Default to no color resolve attachments
+	std::vector<uint32_t> color_resolve_attachments = {};
+
+	/// Default to no depth stencil resolve attachment
+	uint32_t depth_stencil_resolve_attachment{VK_ATTACHMENT_UNUSED};
 };
 
 }        // namespace vkb

--- a/framework/rendering/subpasses/geometry_subpass.cpp
+++ b/framework/rendering/subpasses/geometry_subpass.cpp
@@ -163,6 +163,10 @@ void GeometrySubpass::draw_submesh(CommandBuffer &command_buffer, sg::SubMesh &s
 
 	command_buffer.set_rasterization_state(rasterization_state);
 
+	MultisampleState multisample_state{};
+	multisample_state.rasterization_samples = sample_count;
+	command_buffer.set_multisample_state(multisample_state);
+
 	auto &vert_shader_module = device.get_resource_cache().request_shader_module(VK_SHADER_STAGE_VERTEX_BIT, get_vertex_shader(), sub_mesh.get_shader_variant());
 	auto &frag_shader_module = device.get_resource_cache().request_shader_module(VK_SHADER_STAGE_FRAGMENT_BIT, get_fragment_shader(), sub_mesh.get_shader_variant());
 

--- a/framework/scene_graph/components/perspective_camera.cpp
+++ b/framework/scene_graph/components/perspective_camera.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -34,9 +34,19 @@ void PerspectiveCamera::set_field_of_view(float new_fov)
 	fov = new_fov;
 }
 
+float PerspectiveCamera::get_far_plane() const
+{
+	return far_plane;
+}
+
 void PerspectiveCamera::set_far_plane(float zfar)
 {
 	far_plane = zfar;
+}
+
+float PerspectiveCamera::get_near_plane() const
+{
+	return near_plane;
 }
 
 void PerspectiveCamera::set_near_plane(float znear)

--- a/framework/scene_graph/components/perspective_camera.h
+++ b/framework/scene_graph/components/perspective_camera.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -46,7 +46,11 @@ class PerspectiveCamera : public Camera
 
 	void set_field_of_view(float fov);
 
+	float get_far_plane() const;
+
 	void set_far_plane(float zfar);
+
+	float get_near_plane() const;
 
 	void set_near_plane(float znear);
 


### PR DESCRIPTION
These changes are required for an upcoming MSAA performance sample.

- Add color and depth resolve parameters to Subpass
- Add resolve_image function to CommandBuffer
- Add sample_count parameter to images
- Add support for VkRenderPass2KHR if a sample enables VK_KHR_CREATE_RENDERPASS_2. This is a requirement for the VK_KHR_depth_stencil_resolve extension.
- Add support for color and depth resolve attachments
  when creating a RenderPass
- Add setter for RenderTarget image layouts
- Add Multisampling state to GeometrySubpass

Other changes
- Remove unnecessary include from new sample template
- Add getter for VulkanException result
- Add option to only consider depth formats when fiding a
  suitable depth stencil format
- Add getters for near and far plane of PerspectiveCamera

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)