### PR TITLE
Remove unused explicit debug marker destruction

### DIFF
--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -266,13 +266,6 @@ Instance::Instance(VkInstance instance) :
 
 Instance::~Instance()
 {
-#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	if (debug_report_callback != VK_NULL_HANDLE)
-	{
-		vkDestroyDebugReportCallbackEXT(handle, debug_report_callback, nullptr);
-	}
-#endif
-
 	if (handle != VK_NULL_HANDLE)
 	{
 		vkDestroyInstance(handle, nullptr);

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -99,13 +99,6 @@ class Instance
 	 */
 	std::vector<const char *> extensions;
 
-#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	/**
-	 * @brief The debug report callback
-	 */
-	VkDebugReportCallbackEXT debug_report_callback{VK_NULL_HANDLE};
-#endif
-
 	/**
 	 * @brief The physical devices found on the machine
 	 */

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -1044,12 +1044,6 @@ void HelloTriangle::teardown(Context &context)
 		context.device = VK_NULL_HANDLE;
 	}
 
-	if (context.debug_callback != VK_NULL_HANDLE)
-	{
-		vkDestroyDebugReportCallbackEXT(context.instance, context.debug_callback, nullptr);
-		context.debug_callback = VK_NULL_HANDLE;
-	}
-
 	vk_instance.reset();
 }
 

--- a/samples/api/hello_triangle/hello_triangle.h
+++ b/samples/api/hello_triangle/hello_triangle.h
@@ -109,9 +109,6 @@ class HelloTriangle : public vkb::Application
 		 */
 		VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
 
-		/// The debug report callback.
-		VkDebugReportCallbackEXT debug_callback = VK_NULL_HANDLE;
-
 		/// A set of semaphores that can be reused.
 		std::vector<VkSemaphore> recycled_semaphores;
 


### PR DESCRIPTION
## Description

PR #60 made debug report callback construction implicit by adding it to the pNext structure of instance creation, removing the need to manually create the callback.

This results in some unused code and variables, as the explicit callback destruction is still there, but never actually called, as the variable for the debug marker callback is always NULL (see [this line](https://github.com/KhronosGroup/Vulkan-Samples/blob/d91d527366bdf6c48dc6f607c7cbc9ad47f84250/framework/core/instance.cpp#L267)).

This PR removes the unused code and variables in the framework and the hello triangle example.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- n/a I have commented any added functions (in line with Doxygen)
- n/a I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- n/a I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)