### PR TITLE
Add Readme files for api and extension sample folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Additionally you may find the following links useful:
   - [Multi-threaded recording with secondary command buffers](./samples/performance/command_buffer_usage/command_buffer_usage_tutorial.md#Multi-threaded-recording)
 - **AFBC**
   - [Appropriate use of AFBC](./samples/performance/afbc/afbc_tutorial.md)
+- **API samples**
+  - [Overview for the API samples](./samples/api/README.md)
+- **Extension samples**
+  - [Overview for the extension samples](./samples/extensions/README.md)
 - **Misc**
   - [Driver version](./docs/misc.md#driver-version)
   - [Memory limits](./docs/memory_limits.md)

--- a/samples/api/README.md
+++ b/samples/api/README.md
@@ -23,6 +23,7 @@
 
 - [Introduction](#introduction)
 - [Tutorials](#tutorials)
+- [Samples](#samples)
 
 ## Introduction
 

--- a/samples/api/README.md
+++ b/samples/api/README.md
@@ -26,7 +26,7 @@
 
 ## Introduction
 
-This area of the repository contains samples that are meant to demonstrate Vulkan API usage. The goal of these samples is to demonstrate how to use a given feature at the API level without abstraction.
+This area of the repository contains samples that are meant to demonstrate Vulkan API usage. The goal of these samples is to demonstrate how to use a given feature at the API level with as little abstraction as possible.
 
 ## Tutorials
 - [Run-time mip-map generation](./texture_mipmap_generation/texture_mipmap_generation_tutorial.md)

--- a/samples/api/README.md
+++ b/samples/api/README.md
@@ -38,7 +38,7 @@ Compute shader example that uses two passes and shared compute shader memory for
 Dynamic uniform buffers are used for rendering multiple objects with separate matrices stored in a single uniform buffer object, that are addressed dynamically.
 - [High dynamic range](./hdr)<br/>
 Implements a high dynamic range rendering pipeline using 16/32 bit floating point precision for all calculations.
-- [Hello Triangle](./hellp_triangle)<br/>
+- [Hello Triangle](./hello_triangle)<br/>
 A self-contained (minimal use of framework) sample that illustrates the rendering of a triangle.
 - [Instancing](./instancing)<br/>
 Uses the instancing feature for rendering many instances of the same mesh from a single vertex buffer with variable parameters and textures.

--- a/samples/api/README.md
+++ b/samples/api/README.md
@@ -1,0 +1,51 @@
+<!--
+- Copyright (c) 2020, Arm Limited and Contributors
+-
+- SPDX-License-Identifier: Apache-2.0
+-
+- Licensed under the Apache License, Version 2.0 the "License";
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-
+-->
+
+# API samples <!-- omit in toc -->
+
+## Contents <!-- omit in toc -->
+
+- [Introduction](#introduction)
+- [Tutorials](#tutorials)
+
+## Introduction
+
+This area of the repository contains samples that are meant to demonstrate Vulkan API usage. The goal of these samples is to demonstrate how to use a given feature at the API level without abstraction.
+
+## Tutorials
+- [Run-time mip-map generation](./texture_mipmap_generation/texture_mipmap_generation_tutorial.md)
+
+## Samples
+- [Compute shader N-Body simulation](./compute_nbody)<br/>
+Compute shader example that uses two passes and shared compute shader memory for simulating a N-Body particle system.
+- [Dynamic Uniform buffers](./dynamic_uniform_buffers)<br/>
+Dynamic uniform buffers are used for rendering multiple objects with separate matrices stored in a single uniform buffer object, that are addressed dynamically.
+- [High dynamic range](./hdr)<br/>
+Implements a high dynamic range rendering pipeline using 16/32 bit floating point precision for all calculations.
+- [Hello Triangle](./hellp_triangle)<br/>
+A self-contained (minimal use of framework) sample that illustrates the rendering of a triangle.
+- [Instancing](./instancing)<br/>
+Uses the instancing feature for rendering many instances of the same mesh from a single vertex buffer with variable parameters and textures.
+- [Terrain Tessellation](./terrain_tessellation)<br/>
+Uses a tessellation shader for rendering a terrain with dynamic level-of-detail and frustum culling.
+- [Texture loading](./texture_loading)<br/>
+Loading and rendering of a 2D texture map from a file.
+- [Texture run-time mip-map generation](./texture_mipmap_generation)<br/>
+Generates a complete mip-chain for a texture at runtime instead of loading it from a file.
+

--- a/samples/extensions/README.md
+++ b/samples/extensions/README.md
@@ -22,6 +22,7 @@
 ## Contents <!-- omit in toc -->
 
 - [Introduction](#introduction)
+- [Samples](#samples)
 
 ## Introduction
 

--- a/samples/extensions/README.md
+++ b/samples/extensions/README.md
@@ -1,0 +1,42 @@
+<!--
+- Copyright (c) 2020, Arm Limited and Contributors
+-
+- SPDX-License-Identifier: Apache-2.0
+-
+- Licensed under the Apache License, Version 2.0 the "License";
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-
+-->
+
+# Extension samples <!-- omit in toc -->
+
+## Contents <!-- omit in toc -->
+
+- [Introduction](#introduction)
+
+## Introduction
+
+This area of the repository contains samples that are meant to demonstrate Vulkan extension. The goal of these samples is to demonstrate how to use a given extension at the API level with as little abstraction as possible.
+
+## Samples
+- [Conservative Rasterization](./conservative_rasterization)<br/>
+Extensions: [VK_EXT_conservative_rasterization](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_EXT_conservative_rasterization)<br/>
+Uses conservative rasterization to change the way fragments are generated. Enables overestimation to generate fragments for every pixel touched instead of only pixels that are fully covered.
+
+- [Push Descriptors](./push_descriptors)<br/>
+Extensions: [VK_KHR_push_descriptor](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_push_descriptor)<br/>
+Push descriptors apply the push constants concept to descriptor sets. Instead of creating per-object descriptor sets, this example passes descriptors at command buffer creation time.
+
+- [Basic Ray Tracing (NVIDIA)](./raytracing_basic)<br/>
+Extensions: [VK_NV_ray_tracing](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_NV_ray_tracing)<br/>
+Render a simple triangle using the Nvidia ray tracing extensions. Shows how to setup acceleration structures, ray tracing pipelines and the shaders required to do the actual ray tracing.
+

--- a/samples/extensions/README.md
+++ b/samples/extensions/README.md
@@ -29,14 +29,14 @@ This area of the repository contains samples that are meant to demonstrate Vulka
 
 ## Samples
 - [Conservative Rasterization](./conservative_rasterization)<br/>
-Extensions: [VK_EXT_conservative_rasterization](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_EXT_conservative_rasterization)<br/>
+**Extension**: [```VK_EXT_conservative_rasterization```](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_EXT_conservative_rasterization)<br/>
 Uses conservative rasterization to change the way fragments are generated. Enables overestimation to generate fragments for every pixel touched instead of only pixels that are fully covered.
 
 - [Push Descriptors](./push_descriptors)<br/>
-Extensions: [VK_KHR_push_descriptor](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_push_descriptor)<br/>
+**Extension**: [```VK_KHR_push_descriptor```](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_push_descriptor)<br/>
 Push descriptors apply the push constants concept to descriptor sets. Instead of creating per-object descriptor sets, this example passes descriptors at command buffer creation time.
 
 - [Basic Ray Tracing (NVIDIA)](./raytracing_basic)<br/>
-Extensions: [VK_NV_ray_tracing](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_NV_ray_tracing)<br/>
+**Extension**: [```VK_NV_ray_tracing```](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_NV_ray_tracing)<br/>
 Render a simple triangle using the Nvidia ray tracing extensions. Shows how to setup acceleration structures, ray tracing pipelines and the shaders required to do the actual ray tracing.
 


### PR DESCRIPTION
## Description

Adds dedicated readme files for the api and examples folders. The readme files contain a listing of the samples, along with a short description, and also links to tutorials (only one right now).

This also fixes #78.

## General Checklist:

Please ensure the following points are checked:

- n/a My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
-  n/a I have commented any added functions (in line with Doxygen)
-  n/a I have commented any code that could be hard to understand
-  n/a My changes do not add any new compiler warnings
-  n/a My changes do not add any new validation layer errors or warnings
-  n/a I have used existing framework/helper functions where possible
-  n/a My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)