### PR TITLE
Fix validation when stencil is present in the image format

### DIFF
--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -443,11 +443,23 @@ void CommandBuffer::copy_buffer_to_image(const core::Buffer &buffer, const core:
 
 void CommandBuffer::image_memory_barrier(const core::ImageView &image_view, const ImageMemoryBarrier &memory_barrier)
 {
+	// Adjust barrier's subresource range for depth images
+	auto subresource_range = image_view.get_subresource_range();
+	auto format            = image_view.get_format();
+	if (is_depth_only_format(format))
+	{
+		subresource_range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+	}
+	else if (is_depth_stencil_format(format))
+	{
+		subresource_range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+	}
+
 	VkImageMemoryBarrier image_memory_barrier{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
 	image_memory_barrier.oldLayout        = memory_barrier.old_layout;
 	image_memory_barrier.newLayout        = memory_barrier.new_layout;
 	image_memory_barrier.image            = image_view.get_image().get_handle();
-	image_memory_barrier.subresourceRange = image_view.get_subresource_range();
+	image_memory_barrier.subresourceRange = subresource_range;
 	image_memory_barrier.srcAccessMask    = memory_barrier.src_access_mask;
 	image_memory_barrier.dstAccessMask    = memory_barrier.dst_access_mask;
 

--- a/framework/core/image_view.cpp
+++ b/framework/core/image_view.cpp
@@ -37,11 +37,7 @@ ImageView::ImageView(Image &img, VkImageViewType view_type, VkFormat format) :
 	subresource_range.levelCount = image->get_subresource().mipLevel;
 	subresource_range.layerCount = image->get_subresource().arrayLayer;
 
-	if (is_depth_only_format(format))
-	{
-		subresource_range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-	}
-	else if (is_depth_stencil_format(format))
+	if (is_depth_stencil_format(format))
 	{
 		subresource_range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
 	}


### PR DESCRIPTION
Fixes the validation error:
```
2019-06-22 16:00:53.789 24881-24969/? E/VulkanSamples: [error] [instance.cpp:35] Validation:  [ VUID-VkImageMemoryBarrier-image-01207 ] Object: 0xc (Type = 10) | vkCmdPipelineBarrier(): Image barrier pImageMemoryBarrier[0] references VkImage 0xc[] of format VK_FORMAT_D24_UNORM_S8_UINT that must have the depth and stencil aspects set, but its aspectMask is 0x2. The Vulkan spec states: If image has a depth/stencil format with both depth and stencil components, then the aspectMask member of subresourceRange must include both VK_IMAGE_ASPECT_DEPTH_BIT and VK_IMAGE_ASPECT_STENCIL_BIT (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkImageMemoryBarrier-image-01207)
```
Printed every frame on some devices (e.g. S8 with Adreno 540) where a format including stencil is selected by https://github.com/KhronosGroup/Vulkan-Samples/blob/6c03a9db17a8829da5a90e26354d52cf05ea36a7/framework/common/vk_common.h#L64

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)