### PR TITLE
Add public function to access the extension feature chain

### DIFF
--- a/framework/core/physical_device.cpp
+++ b/framework/core/physical_device.cpp
@@ -101,6 +101,11 @@ void *PhysicalDevice::get_requested_extension_features() const
 	return last_requested_extension_feature;
 }
 
+void *&PhysicalDevice::get_mutable_requested_extension_features()
+{
+	return last_requested_extension_feature;
+}
+
 void PhysicalDevice::request_descriptor_indexing_features()
 {
 	// Request the relevant extension

--- a/framework/core/physical_device.h
+++ b/framework/core/physical_device.h
@@ -63,6 +63,9 @@ class PhysicalDevice
 
 	void *get_requested_extension_features() const;
 
+	// Returns the pointer to the extension feature chain to be used for enabling extension features
+	void *&get_mutable_requested_extension_features();
+
 	void request_descriptor_indexing_features();
 
 	const VkPhysicalDeviceDescriptorIndexingFeaturesEXT &get_descriptor_indexing_features() const;


### PR DESCRIPTION
## Description

This PR adds a public method to the ```PhysicalDevice``` class that allows examples to access the extension features pointer chain for enabling additional extension features e.g. from the ```request_gpu_features``` virtual function of the example base. This is required for making use of extensions that require the user to explicitly enable features along with the extension itself like ```VK_KHR_buffer_device_address``` or ```VK_KHR_ray_tracing```. 

Implementation is similar to enabling base features.

Usage-example:

```cpp
void SomeSample::request_gpu_features(vkb::PhysicalDevice &gpu)
{
	// device_buffer_device_address_features is declared as VkPhysicalDeviceBufferDeviceAddressFeatures in the sample's header
	device_buffer_device_address_features.sType               = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES;
	device_buffer_device_address_features.bufferDeviceAddress = VK_TRUE;
	gpu.get_mutable_requested_extension_features() = &device_buffer_device_address_features;
}
```

Fixes #95 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)