### PR TITLE
Added panning camera to AFBC sample to help show delta

### DIFF
--- a/samples/performance/afbc/afbc.h
+++ b/samples/performance/afbc/afbc.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -19,6 +19,7 @@
 
 #include "rendering/render_pipeline.h"
 #include "scene_graph/components/camera.h"
+#include "timer.h"
 #include "vulkan_sample.h"
 
 /**
@@ -45,6 +46,8 @@ class AFBCSample : public vkb::VulkanSample
 	bool afbc_enabled_last_value{false};
 
 	bool afbc_enabled{false};
+
+	std::chrono::system_clock::time_point start_time;
 };
 
 std::unique_ptr<vkb::VulkanSample> create_afbc();

--- a/samples/performance/afbc/afbc_tutorial.md
+++ b/samples/performance/afbc/afbc_tutorial.md
@@ -59,7 +59,7 @@ In addition to this, your `VkImage` needs to adhere to the following flags:
 
 The sample presents the user with Sponza, with a graph displaying bandwidth at the top and a configuration window at the bottom. There is a back-and-forth oscillating camera to disable any GPU optimisations for frames that are identical.
 
-The configuration itself is simple. There is one checkbox (labelled "AFBC") that will reload the swapchain when its value is changed.
+The configuration itself is simple. There is one checkbox (labelled "Enable AFBC") that will reload the swapchain when its value is changed.
 
 ![Sponza AFBC off](images/afbc_disabled.jpg)
 

--- a/samples/performance/afbc/afbc_tutorial.md
+++ b/samples/performance/afbc/afbc_tutorial.md
@@ -57,7 +57,7 @@ In addition to this, your `VkImage` needs to adhere to the following flags:
 
 ## The AFBC Sample
 
-The sample presents the user with Sponza, with a graph displaying bandwidth at the top and a configuration window at the bottom.
+The sample presents the user with Sponza, with a graph displaying bandwidth at the top and a configuration window at the bottom. There is a back-and-forth oscillating camera to disable any GPU optimisations for frames that are identical.
 
 The configuration itself is simple. There is one checkbox (labelled "AFBC") that will reload the swapchain when its value is changed.
 


### PR DESCRIPTION
## Description

The AFBC sample now pans the camera to disable any transaction elimination that may occur on tile based GPUs. This helps show the bandwidth savings (and a larger delta) that you would make in a normal game scenario.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules