### PR TITLE
Update glslang

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -141,6 +141,7 @@ option(ENABLE_GLSLANG_BINARIES OFF)
 option(ENABLE_HLSL OFF)
 option(ENABLE_OPT OFF)
 option(BUILD_TESTING OFF)
+option(BUILD_EXTERNAL OFF)
 
 add_subdirectory(glslang)
 


### PR DESCRIPTION
## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md)

Updated the glslang submodule as required by #105
set BUILD_EXTERNAL OFF so that we do not have a dependency on python 3+