### PR TITLE
Fixed typo in timer.h

### DIFF
--- a/framework/timer.h
+++ b/framework/timer.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -75,7 +75,7 @@ class Timer
 	/**
 	 * @brief Calculates the time difference between now and when the timer was started
 	 *        if lap() was called, then between now and when the timer was last lapped
-	 * @return The duration between the two time points (default in milliseconds)
+	 * @return The duration between the two time points (default in seconds)
 	 */
 	template <typename T = DefaultResolution>
 	double elapsed()


### PR DESCRIPTION
## Description

Fixed a typo in the documentation for the timer.h class.

Fixes https://github.com/KhronosGroup/Vulkan-Samples/issues/115 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)