### PR TITLE
Removed sampler warning from GLTF Loader

### DIFF
--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -564,7 +564,6 @@ sg::Scene GLTFLoader::load_scene(int scene_index)
 				gltf_texture.name = images.at(gltf_texture.source)->get_name();
 			}
 
-			LOGW("Sampler not found for texture {}, possible GLTF error", gltf_texture.name);
 			texture->set_sampler(*default_sampler);
 		}
 


### PR DESCRIPTION
## Description

Removed a warning from the GLTF Loader

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)