### PR TITLE
Fixed typo in debug window

### DIFF
--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -389,7 +389,7 @@ void VulkanSample::update_debug_window()
 
 	get_debug_info().insert<field::Static, std::string>("surface_format",
 	                                                    to_string(render_context->get_swapchain().get_format()) + " (" +
-	                                                        to_string(get_bits_per_pixel(render_context->get_swapchain().get_format())) + "bbp)");
+	                                                        to_string(get_bits_per_pixel(render_context->get_swapchain().get_format())) + "bpp)");
 
 	get_debug_info().insert<field::Static, uint32_t>("mesh_count", to_u32(scene->get_components<sg::SubMesh>().size()));
 


### PR DESCRIPTION
## Description

Changed the VkFormat bits per pixel unit text from "bbp" to "bpp".

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)