### PR TITLE
Change render_passes to start without depth store

### DIFF
--- a/samples/performance/render_passes/render_passes.h
+++ b/samples/performance/render_passes/render_passes.h
@@ -73,7 +73,7 @@ class RenderPassesSample : public vkb::VulkanSample
 	RadioButtonGroup store{
 	    "Depth attachment store operation",
 	    {"Store", "Don't care"},
-	    0};
+	    1};
 
 	std::vector<RadioButtonGroup *> radio_buttons = {&load, &store};
 

--- a/samples/performance/render_passes/render_passes.h
+++ b/samples/performance/render_passes/render_passes.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
## Description

Trivial change to the startup mode of the render_passes sample to use depth DONT_CARE instead of STORE.

Since the depth buffer is marked as transient and is lazily allocated, this will mean that it won't actually get allocated on tile-based architectures until the STORE mode is selected.

Fixes #137
