### PR TITLE
Fix HWCPipe CPU counters

### DIFF
--- a/framework/stats/hwcpipe_stats_provider.cpp
+++ b/framework/stats/hwcpipe_stats_provider.cpp
@@ -172,7 +172,7 @@ StatsProvider::Counters HWCPipeStatsProvider::sample(float delta_time)
 		const StatData &data  = iter.second;
 
 		double d = 0.0;
-		if (m.cpu)
+		if (data.type == StatType::Cpu)
 		{
 			d = get_cpu_counter_value(m.cpu, data.cpu_counter);
 
@@ -189,7 +189,7 @@ StatsProvider::Counters HWCPipeStatsProvider::sample(float delta_time)
 					d = 0.0;
 			}
 		}
-		if (m.gpu)
+		else if (data.type == StatType::Gpu)
 		{
 			d = get_gpu_counter_value(m.gpu, data.gpu_counter);
 


### PR DESCRIPTION
Fixes an issue with the previous commit where CPU counters returned by HWCPipe were being rewritten with incorrect values.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)