### PR TITLE
Adding console warning if desired stat is not available

### DIFF
--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -932,18 +932,18 @@ void Gui::show_stats(const Stats &stats)
 		float             avg = std::accumulate(graph_elements.begin(), graph_elements.end(), 0.0f) / graph_elements.size();
 
 		// Check if the stat is available in the current platform
-		if (!stats.is_available(stat_index))
+		if (stats.is_available(stat_index))
 		{
-			graph_label << graph_data.name << ": not available";
+			graph_label << fmt::format(graph_data.name + ": " + graph_data.format, avg * graph_data.scale_factor);
+			ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+			ImGui::PlotLines("", &graph_elements[0], static_cast<int>(graph_elements.size()), 0, graph_label.str().c_str(), graph_min, graph_max, graph_size);
+			ImGui::PopItemFlag();
 		}
 		else
 		{
-			graph_label << fmt::format(graph_data.name + ": " + graph_data.format, avg * graph_data.scale_factor);
+			graph_label << graph_data.name << ": not available";
+			ImGui::Text("%s", graph_label.str().c_str());
 		}
-
-		ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
-		ImGui::PlotLines("", &graph_elements[0], static_cast<int>(graph_elements.size()), 0, graph_label.str().c_str(), graph_min, graph_max, graph_size);
-		ImGui::PopItemFlag();
 	}
 }
 

--- a/framework/stats/stats.cpp
+++ b/framework/stats/stats.cpp
@@ -88,6 +88,14 @@ void Stats::request_stats(const std::set<StatIndex> &wanted_stats,
 		// Reduce smoothing for continuous sampling
 		alpha_smoothing = 0.6f;
 	}
+
+	for (const auto &stat_index : requested_stats)
+	{
+		if (!is_available(stat_index))
+		{
+			LOGW(vkb::StatsProvider::default_graph_data(stat_index).name + " : not available");
+		}
+	}
 }
 
 void Stats::resize(const size_t width)


### PR DESCRIPTION
Making UI less occupied if stat is not available.

![83022957-3237b580-a024-11ea-8413-1f5ebe790e82](https://user-images.githubusercontent.com/65225590/84666325-da9cb380-af18-11ea-96ef-fe27e8cf2406.png)

In case of some of the stats are available, it looks like this:
![83023105-63b08100-a024-11ea-8a9a-bde072c8c2c1](https://user-images.githubusercontent.com/65225590/84666386-e8eacf80-af18-11ea-8bd4-84e9ce64900d.JPG)

- [x] My code follows the coding style
- [x] I have reviewed file licenses
- [n/a] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [n/a] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [n/a] I have used existing framework/helper functions where possible
-My changes build and run on Windows, Linux and Android. I haven't tested it on macOS.