### PR TITLE
Select image view aspect mask depending on whether format  is depth-only

### DIFF
--- a/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
+++ b/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
@@ -137,7 +137,7 @@ void ConservativeRasterization::prepare_offscreen()
 	sampler_info.borderColor         = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
 	VK_CHECK(vkCreateSampler(get_device().get_handle(), &sampler_info, nullptr, &offscreen_pass.sampler));
 
-	// Depth stencil attachment
+	// Depth attachment
 	image.format = framebuffer_depth_format;
 	image.usage  = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 
@@ -148,12 +148,15 @@ void ConservativeRasterization::prepare_offscreen()
 	VK_CHECK(vkAllocateMemory(get_device().get_handle(), &memory_allocation_info, nullptr, &offscreen_pass.depth.mem));
 	VK_CHECK(vkBindImageMemory(get_device().get_handle(), offscreen_pass.depth.image, offscreen_pass.depth.mem, 0));
 
+	// The depth format we get for the current device may not include a stencil part, which affects the aspect mask used by the image view
+	const VkImageAspectFlags aspect_mask = vkb::is_depth_only_format(framebuffer_depth_format) ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+
 	VkImageViewCreateInfo depth_stencil_view           = vkb::initializers::image_view_create_info();
 	depth_stencil_view.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
 	depth_stencil_view.format                          = framebuffer_depth_format;
 	depth_stencil_view.flags                           = 0;
 	depth_stencil_view.subresourceRange                = {};
-	depth_stencil_view.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+	depth_stencil_view.subresourceRange.aspectMask     = aspect_mask;
 	depth_stencil_view.subresourceRange.baseMipLevel   = 0;
 	depth_stencil_view.subresourceRange.levelCount     = 1;
 	depth_stencil_view.subresourceRange.baseArrayLayer = 0;


### PR DESCRIPTION
## Description

This PR for the conservative rasterization sample selects the aspect mask depending on whether the dynamically selected depth format has a stencil component or not. This fixes a validation error on implementations where the framework's depth format selection function returns a depth only format.

Fixes #128

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- n/a I have commented any added functions (in line with Doxygen)
- n/a I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)