### PR TITLE
Enable VK_KHR_Maintenance3 for ray tracing sample

### DIFF
--- a/samples/extensions/raytracing_basic/raytracing_basic.cpp
+++ b/samples/extensions/raytracing_basic/raytracing_basic.cpp
@@ -118,6 +118,7 @@ RaytracingBasic::RaytracingBasic()
 	title = "VK_KHR_ray_tracing";
 	// Enable instance and device extensions required to use VK_KHR_ray_tracing
 	add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+	add_device_extension(VK_KHR_MAINTENANCE3_EXTENSION_NAME);
 	add_device_extension(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
 	add_device_extension(VK_KHR_RAY_TRACING_EXTENSION_NAME);
 	add_device_extension(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);


### PR DESCRIPTION
## Description

This PR enables the VK_KHR_Maintenance3 extension, which is a requirement for using VK_KHR_Descriptor_Indexing, which itself is required to use the ray tracing extensions.

This resolves a validation layer error.

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- n/a I have commented any added functions (in line with Doxygen)
- n/a I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- n/a] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)