### PR TITLE
Added support for spot lights

### DIFF
--- a/framework/common/strings.cpp
+++ b/framework/common/strings.cpp
@@ -1229,4 +1229,18 @@ const std::string color_component_to_string(VkColorComponentFlags flags)
 	                                            {VK_COLOR_COMPONENT_B_BIT, "B"},
 	                                            {VK_COLOR_COMPONENT_A_BIT, "A"}});
 }
+
+std::vector<std::string> split(const std::string &input, char delim)
+{
+	std::vector<std::string> tokens;
+
+	std::stringstream sstream(input);
+	std::string       token;
+	while (std::getline(sstream, token, delim))
+	{
+		tokens.push_back(token);
+	}
+
+	return tokens;
+}
 }        // namespace vkb

--- a/framework/common/strings.h
+++ b/framework/common/strings.h
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <volk.h>
 

--- a/framework/common/strings.h
+++ b/framework/common/strings.h
@@ -275,4 +275,12 @@ const std::string cull_mode_to_string(VkCullModeFlags bitmask);
  * @return The converted string to return
  */
 const std::string color_component_to_string(VkColorComponentFlags bitmask);
+
+/**
+ * @brief Helper function to split a single string into a vector of strings by a delimiter
+ * @param input The input string to be split
+ * @param delim The character to delimit by
+ * @return The vector of tokenized strings
+ */
+std::vector<std::string> split(const std::string &input, char delim);
 }        // namespace vkb

--- a/framework/common/utils.cpp
+++ b/framework/common/utils.cpp
@@ -283,6 +283,11 @@ sg::Light &add_directional_light(sg::Scene &scene, const glm::quat &rotation, co
 	return add_light(scene, sg::LightType::Directional, {}, rotation, props, parent_node);
 }
 
+sg::Light &add_spot_light(sg::Scene &scene, const glm::vec3 &position, const glm::quat &rotation, const sg::LightProperties &props, sg::Node *parent_node)
+{
+	return add_light(scene, sg::LightType::Spot, position, rotation, props, parent_node);
+}
+
 sg::Node &add_free_camera(sg::Scene &scene, const std::string &node_name, VkExtent2D extent)
 {
 	auto camera_node = scene.find_node(node_name);

--- a/framework/common/utils.h
+++ b/framework/common/utils.h
@@ -84,6 +84,17 @@ sg::Light &add_point_light(sg::Scene &scene, const glm::vec3 &position, const sg
 sg::Light &add_directional_light(sg::Scene &scene, const glm::quat &rotation, const sg::LightProperties &props = {}, sg::Node *parent_node = nullptr);
 
 /**
+ * @brief Adds a spot light to the scene with the specified parameters
+ * @param scene The scene to add the light to
+ * @param position The position of the light
+ * @param rotation The rotation of the light
+ * @param props The light properties, such as color and intensity
+ * @param parent_node The parent node for the line, defaults to root
+ * @return The newly created light component
+ */
+sg::Light &add_spot_light(sg::Scene &scene, const glm::vec3 &position, const glm::quat &rotation, const sg::LightProperties &props = {}, sg::Node *parent_node = nullptr);
+
+/**
  * @brief Add free camera script to a node with a camera object.
  *        Fallback to the default_camera if node not found.
  * @param scene The scene to add the camera to

--- a/framework/common/vk_common.cpp
+++ b/framework/common/vk_common.cpp
@@ -340,7 +340,7 @@ VkShaderModule load_shader(const std::string &filename, VkDevice device, VkShade
 {
 	vkb::GLSLCompiler glsl_compiler;
 
-	auto buffer = vkb::fs::read_shader(filename);
+	auto buffer = vkb::fs::read_shader_binary(filename);
 
 	std::string file_ext = filename;
 

--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -296,6 +296,15 @@ void CommandBuffer::bind_index_buffer(const core::Buffer &buffer, VkDeviceSize o
 	vkCmdBindIndexBuffer(get_handle(), buffer.get_handle(), offset, index_type);
 }
 
+void CommandBuffer::bind_lighting(LightingState &lighting_state, uint32_t set, uint32_t binding)
+{
+	bind_buffer(lighting_state.light_buffer.get_buffer(), lighting_state.light_buffer.get_offset(), lighting_state.light_buffer.get_size(), set, binding, 0);
+
+	set_specialization_constant(0, lighting_state.directional_lights.size());
+	set_specialization_constant(1, lighting_state.point_lights.size());
+	set_specialization_constant(2, lighting_state.spot_lights.size());
+}
+
 void CommandBuffer::set_viewport_state(const ViewportState &state_info)
 {
 	pipeline_state.set_viewport_state(state_info);

--- a/framework/core/command_buffer.h
+++ b/framework/core/command_buffer.h
@@ -40,6 +40,7 @@ class PipelineLayout;
 class PipelineState;
 class RenderTarget;
 class Subpass;
+struct LightingState;
 
 /**
  * @brief Helper class to manage and record a command buffer, building and
@@ -159,6 +160,8 @@ class CommandBuffer
 	void bind_vertex_buffers(uint32_t first_binding, const std::vector<std::reference_wrapper<const vkb::core::Buffer>> &buffers, const std::vector<VkDeviceSize> &offsets);
 
 	void bind_index_buffer(const core::Buffer &buffer, VkDeviceSize offset, VkIndexType index_type);
+
+	void bind_lighting(LightingState &lighting_state, uint32_t set, uint32_t binding);
 
 	void set_viewport_state(const ViewportState &state_info);
 

--- a/framework/core/shader_module.h
+++ b/framework/core/shader_module.h
@@ -150,20 +150,20 @@ class ShaderSource
 
 	ShaderSource(const std::string &filename);
 
-	ShaderSource(std::vector<uint8_t> &&data);
-
 	size_t get_id() const;
 
 	const std::string &get_filename() const;
 
-	const std::vector<uint8_t> &get_data() const;
+	void set_source(const std::string &source);
+
+	const std::string &get_source() const;
 
   private:
 	size_t id;
 
 	std::string filename;
 
-	std::vector<uint8_t> data;
+	std::string source;
 };
 
 /**

--- a/framework/platform/filesystem.cpp
+++ b/framework/platform/filesystem.cpp
@@ -112,7 +112,24 @@ void create_path(const std::string &root, const std::string &path)
 	}
 }
 
-static std::vector<uint8_t> read_binary_file(const std::string &filename, const uint32_t count)
+std::string read_text_file(const std::string &filename)
+{
+	std::vector<std::string> data;
+
+	std::ifstream file;
+
+	file.open(filename, std::ios::in);
+
+	if (!file.is_open())
+	{
+		throw std::runtime_error("Failed to open file: " + filename);
+	}
+
+	return std::string{(std::istreambuf_iterator<char>(file)),
+	                   (std::istreambuf_iterator<char>())};
+}
+
+std::vector<uint8_t> read_binary_file(const std::string &filename, const uint32_t count)
 {
 	std::vector<uint8_t> data;
 
@@ -166,7 +183,12 @@ std::vector<uint8_t> read_asset(const std::string &filename, const uint32_t coun
 	return read_binary_file(path::get(path::Type::Assets) + filename, count);
 }
 
-std::vector<uint8_t> read_shader(const std::string &filename)
+std::string read_shader(const std::string &filename)
+{
+	return read_text_file(path::get(path::Type::Shaders) + filename);
+}
+
+std::vector<uint8_t> read_shader_binary(const std::string &filename)
 {
 	return read_binary_file(path::get(path::Type::Shaders) + filename, 0);
 }

--- a/framework/platform/filesystem.h
+++ b/framework/platform/filesystem.h
@@ -101,12 +101,20 @@ void create_path(const std::string &root, const std::string &path);
 std::vector<uint8_t> read_asset(const std::string &filename, const uint32_t count = 0);
 
 /**
+ * @brief Helper to read a shader file into a single string
+ *
+ * @param filename The path to the file (relative to the assets directory)
+ * @return A string of the text in the shader file
+ */
+std::string read_shader(const std::string &filename);
+
+/**
  * @brief Helper to read a shader file into a byte-array
  *
  * @param filename The path to the file (relative to the assets directory)
  * @return A vector filled with data read from the file
  */
-std::vector<uint8_t> read_shader(const std::string &filename);
+std::vector<uint8_t> read_shader_binary(const std::string &filename);
 
 /**
  * @brief Helper to read a temporary file into a byte-array

--- a/framework/platform/filesystem.h
+++ b/framework/platform/filesystem.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/rendering/subpass.cpp
+++ b/framework/rendering/subpass.cpp
@@ -134,4 +134,9 @@ void Subpass::set_sample_count(VkSampleCountFlagBits sample_count)
 {
 	this->sample_count = sample_count;
 }
+
+LightingState &Subpass::get_lighting_state()
+{
+	return lighting_state;
+}
 }        // namespace vkb

--- a/framework/rendering/subpass.h
+++ b/framework/rendering/subpass.h
@@ -169,6 +169,8 @@ class Subpass
 					spot_lights.push_back(light);
 					break;
 				}
+				default:
+					break;
 			}
 		}
 

--- a/framework/rendering/subpass.h
+++ b/framework/rendering/subpass.h
@@ -127,6 +127,7 @@ class Subpass
 	 * @brief Create a buffer allocation from scene graph lights to be bound to shaders
 	 * 
 	 * @tparam A light structure that has 'directional_lights', 'point_lights' and 'spot_light' array fields defined.
+	 * @param command_buffer The command buffer that the returned light buffer allocation will be bound to
 	 * @param scene_lights  Lights from the scene graph
 	 * @param max_lights MAX_FORWARD_LIGHT_COUNT / MAX_DEFERRED_LIGHT_COUNT
 	 * @return BufferAllocation A buffer allocation created for use in shaders

--- a/framework/rendering/subpass.h
+++ b/framework/rendering/subpass.h
@@ -140,10 +140,8 @@ class Subpass
 	 * @brief Prepares the lighting state to have its lights 
 	 * 
 	 * @tparam A light structure that has 'directional_lights', 'point_lights' and 'spot_light' array fields defined.
-	 * @param command_buffer The command buffer that the returned light buffer allocation will be bound to
 	 * @param scene_lights All of the light components from the scene graph
 	 * @param light_count The maximum amount of lights allowed for any given type of light.
-	 * @return BufferAllocation A buffer allocation created for use in shaders
 	 */
 	template <typename T>
 	void allocate_lights(const std::vector<sg::Light *> &scene_lights,

--- a/framework/rendering/subpasses/forward_subpass.cpp
+++ b/framework/rendering/subpasses/forward_subpass.cpp
@@ -59,8 +59,8 @@ void ForwardSubpass::prepare()
 
 void ForwardSubpass::draw(CommandBuffer &command_buffer)
 {
-	auto lights_buffer = allocate_lights<ForwardLights>(command_buffer, scene.get_components<sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
-	command_buffer.bind_buffer(lights_buffer.get_buffer(), lights_buffer.get_offset(), lights_buffer.get_size(), 0, 4, 0);
+	allocate_lights<ForwardLights>(scene.get_components<sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
+	command_buffer.bind_lighting(get_lighting_state(), 0, 4);
 
 	GeometrySubpass::draw(command_buffer);
 }

--- a/framework/rendering/subpasses/forward_subpass.cpp
+++ b/framework/rendering/subpasses/forward_subpass.cpp
@@ -47,7 +47,8 @@ void ForwardSubpass::prepare()
 			auto &variant = sub_mesh->get_mut_shader_variant();
 
 			// Same as Geometry except adds lighting definitions to sub mesh variants.
-			variant.add_definitions({"MAX_FORWARD_LIGHT_COUNT " + std::to_string(MAX_FORWARD_LIGHT_COUNT)});
+			variant.add_definitions({"MAX_LIGHT_COUNT " + std::to_string(MAX_FORWARD_LIGHT_COUNT)});
+
 			variant.add_definitions(light_type_definitions);
 
 			auto &vert_module = device.get_resource_cache().request_shader_module(VK_SHADER_STAGE_VERTEX_BIT, get_vertex_shader(), variant);

--- a/framework/rendering/subpasses/forward_subpass.cpp
+++ b/framework/rendering/subpasses/forward_subpass.cpp
@@ -58,7 +58,7 @@ void ForwardSubpass::prepare()
 
 void ForwardSubpass::draw(CommandBuffer &command_buffer)
 {
-	auto lights_buffer = allocate_lights<ForwardLights>(scene.get_components<sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
+	auto lights_buffer = allocate_lights<ForwardLights>(command_buffer, scene.get_components<sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
 	command_buffer.bind_buffer(lights_buffer.get_buffer(), lights_buffer.get_offset(), lights_buffer.get_size(), 0, 4, 0);
 
 	GeometrySubpass::draw(command_buffer);

--- a/framework/rendering/subpasses/forward_subpass.h
+++ b/framework/rendering/subpasses/forward_subpass.h
@@ -22,7 +22,8 @@
 #include "buffer_pool.h"
 #include "rendering/subpasses/geometry_subpass.h"
 
-#define MAX_FORWARD_LIGHT_COUNT 16
+// This value is per type of light that we feed into the shader
+#define MAX_FORWARD_LIGHT_COUNT 8
 
 namespace vkb
 {
@@ -37,7 +38,9 @@ class Camera;
 
 struct alignas(16) ForwardLights
 {
-	Light lights[MAX_FORWARD_LIGHT_COUNT];
+	Light directional_lights[MAX_FORWARD_LIGHT_COUNT];
+	Light point_lights[MAX_FORWARD_LIGHT_COUNT];
+	Light spot_lights[MAX_FORWARD_LIGHT_COUNT];
 };
 
 /**

--- a/framework/rendering/subpasses/forward_subpass.h
+++ b/framework/rendering/subpasses/forward_subpass.h
@@ -37,8 +37,7 @@ class Camera;
 
 struct alignas(16) ForwardLights
 {
-	uint32_t count;
-	Light    lights[MAX_FORWARD_LIGHT_COUNT];
+	Light lights[MAX_FORWARD_LIGHT_COUNT];
 };
 
 /**

--- a/framework/rendering/subpasses/lighting_subpass.cpp
+++ b/framework/rendering/subpasses/lighting_subpass.cpp
@@ -33,7 +33,8 @@ LightingSubpass::LightingSubpass(RenderContext &render_context, ShaderSource &&v
 
 void LightingSubpass::prepare()
 {
-	lighting_variant.add_definitions({"MAX_DEFERRED_LIGHT_COUNT " + std::to_string(MAX_DEFERRED_LIGHT_COUNT)});
+	lighting_variant.add_definitions({"MAX_LIGHT_COUNT " + std::to_string(MAX_DEFERRED_LIGHT_COUNT)});
+
 	lighting_variant.add_definitions(light_type_definitions);
 	// Build all shaders upfront
 	auto &resource_cache = render_context.get_device().get_resource_cache();

--- a/framework/rendering/subpasses/lighting_subpass.cpp
+++ b/framework/rendering/subpasses/lighting_subpass.cpp
@@ -44,8 +44,8 @@ void LightingSubpass::prepare()
 
 void LightingSubpass::draw(CommandBuffer &command_buffer)
 {
-	auto light_buffer = allocate_lights<DeferredLights>(command_buffer, scene.get_components<sg::Light>(), MAX_DEFERRED_LIGHT_COUNT);
-	command_buffer.bind_buffer(light_buffer.get_buffer(), light_buffer.get_offset(), light_buffer.get_size(), 0, 4, 0);
+	allocate_lights<DeferredLights>(scene.get_components<sg::Light>(), MAX_DEFERRED_LIGHT_COUNT);
+	command_buffer.bind_lighting(get_lighting_state(), 0, 4);
 
 	// Get shaders from cache
 	auto &resource_cache     = command_buffer.get_device().get_resource_cache();

--- a/framework/rendering/subpasses/lighting_subpass.cpp
+++ b/framework/rendering/subpasses/lighting_subpass.cpp
@@ -43,7 +43,7 @@ void LightingSubpass::prepare()
 
 void LightingSubpass::draw(CommandBuffer &command_buffer)
 {
-	auto light_buffer = allocate_lights<DeferredLights>(scene.get_components<sg::Light>(), MAX_DEFERRED_LIGHT_COUNT);
+	auto light_buffer = allocate_lights<DeferredLights>(command_buffer, scene.get_components<sg::Light>(), MAX_DEFERRED_LIGHT_COUNT);
 	command_buffer.bind_buffer(light_buffer.get_buffer(), light_buffer.get_offset(), light_buffer.get_size(), 0, 4, 0);
 
 	// Get shaders from cache

--- a/framework/rendering/subpasses/lighting_subpass.h
+++ b/framework/rendering/subpasses/lighting_subpass.h
@@ -24,7 +24,8 @@ VKBP_DISABLE_WARNINGS()
 #include "common/glm_common.h"
 VKBP_ENABLE_WARNINGS()
 
-#define MAX_DEFERRED_LIGHT_COUNT 100
+// This value is per type of light that we feed into the shader
+#define MAX_DEFERRED_LIGHT_COUNT 32
 
 namespace vkb
 {
@@ -48,7 +49,9 @@ struct alignas(16) LightUniform
 
 struct alignas(16) DeferredLights
 {
-	Light lights[MAX_DEFERRED_LIGHT_COUNT];
+	Light directional_lights[MAX_DEFERRED_LIGHT_COUNT];
+	Light point_lights[MAX_DEFERRED_LIGHT_COUNT];
+	Light spot_lights[MAX_DEFERRED_LIGHT_COUNT];
 };
 
 /**

--- a/framework/rendering/subpasses/lighting_subpass.h
+++ b/framework/rendering/subpasses/lighting_subpass.h
@@ -48,8 +48,7 @@ struct alignas(16) LightUniform
 
 struct alignas(16) DeferredLights
 {
-	uint32_t count;
-	Light    lights[MAX_DEFERRED_LIGHT_COUNT];
+	Light lights[MAX_DEFERRED_LIGHT_COUNT];
 };
 
 /**

--- a/framework/resource_record.cpp
+++ b/framework/resource_record.cpp
@@ -68,7 +68,7 @@ size_t ResourceRecord::register_shader_module(VkShaderStageFlagBits stage, const
 {
 	shader_module_indices.push_back(shader_module_indices.size());
 
-	write(stream, ResourceType::ShaderModule, stage, glsl_source.get_data(), entry_point, shader_variant.get_preamble());
+	write(stream, ResourceType::ShaderModule, stage, glsl_source.get_source(), entry_point, shader_variant.get_preamble());
 
 	write_processes(stream, shader_variant.get_processes());
 

--- a/framework/resource_replay.cpp
+++ b/framework/resource_replay.cpp
@@ -92,20 +92,21 @@ void ResourceReplay::play(ResourceCache &resource_cache, ResourceRecord &recorde
 void ResourceReplay::create_shader_module(ResourceCache &resource_cache, std::istringstream &stream)
 {
 	VkShaderStageFlagBits    stage{};
-	std::vector<uint8_t>     glsl_code;
+	std::string              glsl_source;
 	std::string              entry_point;
 	std::string              preamble;
 	std::vector<std::string> processes;
 
 	read(stream,
 	     stage,
-	     glsl_code,
+	     glsl_source,
 	     entry_point,
 	     preamble);
 
 	read_processes(stream, processes);
 
-	ShaderSource  shader_source(std::move(glsl_code));
+	ShaderSource shader_source{};
+	shader_source.set_source(std::move(glsl_source));
 	ShaderVariant shader_variant(std::move(preamble), std::move(processes));
 
 	auto &shader_module = resource_cache.request_shader_module(stage, shader_source, shader_variant);

--- a/framework/scene_graph/components/light.h
+++ b/framework/scene_graph/components/light.h
@@ -37,9 +37,11 @@ namespace sg
 {
 enum LightType
 {
-	Directional,
-	Point,
-	Spot
+	Directional = 0,
+	Point       = 1,
+	Spot        = 2,
+	// Insert new lightype here
+	Max
 };
 
 struct LightProperties

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -668,7 +668,7 @@ VkShaderModule HelloTriangle::load_shader_module(Context &context, const char *p
 {
 	vkb::GLSLCompiler glsl_compiler;
 
-	auto buffer = vkb::fs::read_shader(path);
+	auto buffer = vkb::fs::read_shader_binary(path);
 
 	std::string file_ext = path;
 

--- a/samples/extensions/debug_utils/debug_utils.cpp
+++ b/samples/extensions/debug_utils/debug_utils.cpp
@@ -209,7 +209,7 @@ VkPipelineShaderStageCreateInfo DebugUtils::debug_load_shader(const std::string 
 		// Name the sader (by file name)
 		set_object_name(VK_OBJECT_TYPE_SHADER_MODULE, (uint64_t) shader_stage.module, std::string("Shader " + file).c_str());
 
-		std::vector<uint8_t> buffer = vkb::fs::read_shader(file);
+		std::vector<uint8_t> buffer = vkb::fs::read_shader_binary(file);
 		// Pass the source GLSL shader code via an object tag
 		VkDebugUtilsObjectTagInfoEXT info = {VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_TAG_INFO_EXT};
 		info.objectType                   = VK_OBJECT_TYPE_SHADER_MODULE;

--- a/samples/performance/command_buffer_usage/command_buffer_usage.cpp
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.cpp
@@ -254,6 +254,7 @@ void CommandBufferUsage::ForwardSubpassSecondary::record_draw(vkb::CommandBuffer
 
 	command_buffer.set_depth_stencil_state(get_depth_stencil_state());
 
+	auto light_buffer = allocate_lights<vkb::ForwardLights>(command_buffer, scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
 	command_buffer.bind_buffer(light_buffer.get_buffer(), light_buffer.get_offset(), light_buffer.get_size(), 0, 4, 0);
 
 	for (uint32_t i = mesh_start; i < mesh_end; i++)
@@ -284,6 +285,7 @@ vkb::CommandBuffer *CommandBufferUsage::ForwardSubpassSecondary::record_draw_sec
 
 	return &secondary_command_buffer;
 }
+
 void CommandBufferUsage::ForwardSubpassSecondary::draw(vkb::CommandBuffer &primary_command_buffer)
 {
 	std::multimap<float, std::pair<vkb::sg::Node *, vkb::sg::SubMesh *>> opaque_nodes;
@@ -308,8 +310,6 @@ void CommandBufferUsage::ForwardSubpassSecondary::draw(vkb::CommandBuffer &prima
 		sorted_transparent_nodes.push_back(node_it->second);
 	}
 	const auto transparent_submeshes = vkb::to_u32(sorted_transparent_nodes.size());
-
-	light_buffer = allocate_lights<vkb::ForwardLights>(primary_command_buffer, scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
 
 	color_blend_attachment.blend_enable = VK_FALSE;
 	color_blend_state.attachments.resize(get_output_attachments().size());

--- a/samples/performance/command_buffer_usage/command_buffer_usage.cpp
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.cpp
@@ -309,7 +309,7 @@ void CommandBufferUsage::ForwardSubpassSecondary::draw(vkb::CommandBuffer &prima
 	}
 	const auto transparent_submeshes = vkb::to_u32(sorted_transparent_nodes.size());
 
-	light_buffer = allocate_lights<vkb::ForwardLights>(scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
+	light_buffer = allocate_lights<vkb::ForwardLights>(primary_command_buffer, scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
 
 	color_blend_attachment.blend_enable = VK_FALSE;
 	color_blend_state.attachments.resize(get_output_attachments().size());

--- a/samples/performance/command_buffer_usage/command_buffer_usage.cpp
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.cpp
@@ -254,8 +254,7 @@ void CommandBufferUsage::ForwardSubpassSecondary::record_draw(vkb::CommandBuffer
 
 	command_buffer.set_depth_stencil_state(get_depth_stencil_state());
 
-	auto light_buffer = allocate_lights<vkb::ForwardLights>(command_buffer, scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
-	command_buffer.bind_buffer(light_buffer.get_buffer(), light_buffer.get_offset(), light_buffer.get_size(), 0, 4, 0);
+	command_buffer.bind_lighting(get_lighting_state(), 0, 4);
 
 	for (uint32_t i = mesh_start; i < mesh_end; i++)
 	{
@@ -310,6 +309,8 @@ void CommandBufferUsage::ForwardSubpassSecondary::draw(vkb::CommandBuffer &prima
 		sorted_transparent_nodes.push_back(node_it->second);
 	}
 	const auto transparent_submeshes = vkb::to_u32(sorted_transparent_nodes.size());
+
+	allocate_lights<vkb::ForwardLights>(scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
 
 	color_blend_attachment.blend_enable = VK_FALSE;
 	color_blend_state.attachments.resize(get_output_attachments().size());

--- a/samples/performance/command_buffer_usage/command_buffer_usage.h
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/performance/command_buffer_usage/command_buffer_usage.h
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.h
@@ -119,8 +119,6 @@ class CommandBufferUsage : public vkb::VulkanSample
 		float avg_draws_per_buffer{0};
 
 		ctpl::thread_pool thread_pool;
-
-		vkb::BufferAllocation light_buffer;
 	};
 
   private:

--- a/samples/performance/constant_data/constant_data.cpp
+++ b/samples/performance/constant_data/constant_data.cpp
@@ -442,7 +442,7 @@ void ConstantData::BufferArraySubpass::draw(vkb::CommandBuffer &command_buffer)
 	// Reset the instance index back to 0 for each draw call
 	instance_index = 0;
 
-	auto lights_buffer = allocate_lights<vkb::ForwardLights>(scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
+	auto lights_buffer = allocate_lights<vkb::ForwardLights>(command_buffer, scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
 	command_buffer.bind_buffer(lights_buffer.get_buffer(), lights_buffer.get_offset(), lights_buffer.get_size(), 0, 4, 0);
 
 	GeometrySubpass::draw(command_buffer);

--- a/samples/performance/constant_data/constant_data.cpp
+++ b/samples/performance/constant_data/constant_data.cpp
@@ -294,7 +294,7 @@ void ConstantData::ConstantDataSubpass::prepare()
 
 			// Copied from vkb::ForwardSubpass
 			variant.add_definitions({"SCENE_MESH_COUNT " + std::to_string(scene.get_components<vkb::sg::SubMesh>().size())});
-			variant.add_definitions({"MAX_FORWARD_LIGHT_COUNT " + std::to_string(MAX_FORWARD_LIGHT_COUNT)});
+			variant.add_definitions({"MAX_LIGHT_COUNT " + std::to_string(MAX_FORWARD_LIGHT_COUNT)});
 			variant.add_definitions(vkb::light_type_definitions);
 
 			// If struct size is 256 we add a definition so the uniform has more values

--- a/samples/performance/constant_data/constant_data.cpp
+++ b/samples/performance/constant_data/constant_data.cpp
@@ -442,8 +442,8 @@ void ConstantData::BufferArraySubpass::draw(vkb::CommandBuffer &command_buffer)
 	// Reset the instance index back to 0 for each draw call
 	instance_index = 0;
 
-	auto lights_buffer = allocate_lights<vkb::ForwardLights>(command_buffer, scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
-	command_buffer.bind_buffer(lights_buffer.get_buffer(), lights_buffer.get_offset(), lights_buffer.get_size(), 0, 4, 0);
+	allocate_lights<vkb::ForwardLights>(scene.get_components<vkb::sg::Light>(), MAX_FORWARD_LIGHT_COUNT);
+	command_buffer.bind_lighting(get_lighting_state(), 0, 4);
 
 	GeometrySubpass::draw(command_buffer);
 }

--- a/samples/performance/layout_transitions/layout_transitions.cpp
+++ b/samples/performance/layout_transitions/layout_transitions.cpp
@@ -50,16 +50,16 @@ bool LayoutTransitions::prepare(vkb::Platform &platform)
 	auto &camera_node = vkb::add_free_camera(*scene, "main_camera", get_render_context().get_surface_extent());
 	camera            = &camera_node.get_component<vkb::sg::Camera>();
 
-	auto geometry_vs = vkb::ShaderSource{vkb::fs::read_shader("deferred/geometry.vert")};
-	auto geometry_fs = vkb::ShaderSource{vkb::fs::read_shader("deferred/geometry.frag")};
+	auto geometry_vs = vkb::ShaderSource{"deferred/geometry.vert"};
+	auto geometry_fs = vkb::ShaderSource{"deferred/geometry.frag"};
 
 	std::unique_ptr<vkb::Subpass> gbuffer_pass = std::make_unique<vkb::GeometrySubpass>(get_render_context(), std::move(geometry_vs), std::move(geometry_fs), *scene, *camera);
 	gbuffer_pass->set_output_attachments({1, 2, 3});
 	gbuffer_pipeline.add_subpass(std::move(gbuffer_pass));
 	gbuffer_pipeline.set_load_store(vkb::gbuffer::get_clear_store_all());
 
-	auto lighting_vs = vkb::ShaderSource{vkb::fs::read_shader("deferred/lighting.vert")};
-	auto lighting_fs = vkb::ShaderSource{vkb::fs::read_shader("deferred/lighting.frag")};
+	auto lighting_vs = vkb::ShaderSource{"deferred/lighting.vert"};
+	auto lighting_fs = vkb::ShaderSource{"deferred/lighting.frag"};
 
 	std::unique_ptr<vkb::Subpass> lighting_subpass = std::make_unique<vkb::LightingSubpass>(get_render_context(), std::move(lighting_vs), std::move(lighting_fs), *camera, *scene);
 	lighting_subpass->set_input_attachments({1, 2, 3});

--- a/samples/performance/msaa/msaa.cpp
+++ b/samples/performance/msaa/msaa.cpp
@@ -111,14 +111,14 @@ bool MSAASample::prepare(vkb::Platform &platform)
 	auto &camera_node = vkb::add_free_camera(*scene, "main_camera", get_render_context().get_surface_extent());
 	camera            = dynamic_cast<vkb::sg::PerspectiveCamera *>(&camera_node.get_component<vkb::sg::Camera>());
 
-	vkb::ShaderSource scene_vs(vkb::fs::read_shader("base.vert"));
-	vkb::ShaderSource scene_fs(vkb::fs::read_shader("base.frag"));
+	vkb::ShaderSource scene_vs("base.vert");
+	vkb::ShaderSource scene_fs("base.frag");
 	auto              scene_subpass = std::make_unique<vkb::ForwardSubpass>(get_render_context(), std::move(scene_vs), std::move(scene_fs), *scene, *camera);
 	scene_pipeline                  = std::make_unique<vkb::RenderPipeline>();
 	scene_pipeline->add_subpass(std::move(scene_subpass));
 
-	vkb::ShaderSource postprocessing_vs(vkb::fs::read_shader("postprocessing/postprocessing.vert"));
-	vkb::ShaderSource postprocessing_fs(vkb::fs::read_shader("postprocessing/outline.frag"));
+	vkb::ShaderSource postprocessing_vs("postprocessing/postprocessing.vert");
+	vkb::ShaderSource postprocessing_fs("postprocessing/outline.frag");
 	auto              postprocessing_subpass = std::make_unique<vkb::PostProcessingSubpass>(get_render_context(), std::move(postprocessing_vs), std::move(postprocessing_fs), *scene, *camera);
 	postprocessing_pipeline                  = std::make_unique<vkb::RenderPipeline>();
 	postprocessing_pipeline->add_subpass(std::move(postprocessing_subpass));

--- a/samples/performance/pipeline_barriers/pipeline_barriers.cpp
+++ b/samples/performance/pipeline_barriers/pipeline_barriers.cpp
@@ -84,16 +84,16 @@ bool PipelineBarriers::prepare(vkb::Platform &platform)
 	auto &camera_node = vkb::add_free_camera(*scene, "main_camera", get_render_context().get_surface_extent());
 	camera            = &camera_node.get_component<vkb::sg::Camera>();
 
-	auto geometry_vs = vkb::ShaderSource{vkb::fs::read_shader("deferred/geometry.vert")};
-	auto geometry_fs = vkb::ShaderSource{vkb::fs::read_shader("deferred/geometry.frag")};
+	auto geometry_vs = vkb::ShaderSource{"deferred/geometry.vert"};
+	auto geometry_fs = vkb::ShaderSource{"deferred/geometry.frag"};
 
 	auto gbuffer_pass = std::make_unique<vkb::GeometrySubpass>(get_render_context(), std::move(geometry_vs), std::move(geometry_fs), *scene, *camera);
 	gbuffer_pass->set_output_attachments({1, 2, 3});
 	gbuffer_pipeline.add_subpass(std::move(gbuffer_pass));
 	gbuffer_pipeline.set_load_store(vkb::gbuffer::get_clear_store_all());
 
-	auto lighting_vs = vkb::ShaderSource{vkb::fs::read_shader("deferred/lighting.vert")};
-	auto lighting_fs = vkb::ShaderSource{vkb::fs::read_shader("deferred/lighting.frag")};
+	auto lighting_vs = vkb::ShaderSource{"deferred/lighting.vert"};
+	auto lighting_fs = vkb::ShaderSource{"deferred/lighting.frag"};
 
 	auto lighting_subpass = std::make_unique<vkb::LightingSubpass>(get_render_context(), std::move(lighting_vs), std::move(lighting_fs), *camera, *scene);
 	lighting_subpass->set_input_attachments({1, 2, 3});

--- a/samples/performance/specialization_constants/specialization_constants.cpp
+++ b/samples/performance/specialization_constants/specialization_constants.cpp
@@ -72,7 +72,7 @@ void SpecializationConstants::ForwardSubpassCustomLights::prepare()
 			auto &variant = sub_mesh->get_mut_shader_variant();
 
 			// Same as Geometry except adds lighting definitions to sub mesh variants.
-			variant.add_definitions({"MAX_FORWARD_LIGHT_COUNT " + std::to_string(LIGHT_COUNT)});
+			variant.add_definitions({"MAX_LIGHT_COUNT " + std::to_string(LIGHT_COUNT)});
 			variant.add_definitions(vkb::light_type_definitions);
 
 			auto &vert_module = device.get_resource_cache().request_shader_module(VK_SHADER_STAGE_VERTEX_BIT, get_vertex_shader(), variant);

--- a/samples/performance/specialization_constants/specialization_constants.cpp
+++ b/samples/performance/specialization_constants/specialization_constants.cpp
@@ -105,8 +105,8 @@ void SpecializationConstants::render(vkb::CommandBuffer &command_buffer)
 std::unique_ptr<vkb::RenderPipeline> SpecializationConstants::create_specialization_renderpass()
 {
 	// Scene subpass
-	vkb::ShaderSource vert_shader(vkb::fs::read_shader("base.vert"));
-	vkb::ShaderSource frag_shader(vkb::fs::read_shader("specialization_constants/specialization_constants.frag"));
+	vkb::ShaderSource vert_shader{"base.vert"};
+	vkb::ShaderSource frag_shader{"specialization_constants/specialization_constants.frag"};
 	auto              scene_subpass = std::make_unique<ForwardSubpassCustomLights>(get_render_context(), std::move(vert_shader), std::move(frag_shader), *scene, *camera);
 
 	// Create specialization constants pipeline
@@ -121,8 +121,8 @@ std::unique_ptr<vkb::RenderPipeline> SpecializationConstants::create_specializat
 std::unique_ptr<vkb::RenderPipeline> SpecializationConstants::create_standard_renderpass()
 {
 	// Scene subpass
-	vkb::ShaderSource vert_shader(vkb::fs::read_shader("base.vert"));
-	vkb::ShaderSource frag_shader(vkb::fs::read_shader("specialization_constants/UBOs.frag"));
+	vkb::ShaderSource vert_shader{"base.vert"};
+	vkb::ShaderSource frag_shader{"specialization_constants/UBOs.frag"};
 	auto              scene_subpass = std::make_unique<ForwardSubpassCustomLights>(get_render_context(), std::move(vert_shader), std::move(frag_shader), *scene, *camera);
 
 	// Create base pipeline

--- a/samples/performance/specialization_constants/specialization_constants.cpp
+++ b/samples/performance/specialization_constants/specialization_constants.cpp
@@ -137,7 +137,7 @@ std::unique_ptr<vkb::RenderPipeline> SpecializationConstants::create_standard_re
 void SpecializationConstants::ForwardSubpassCustomLights::draw(vkb::CommandBuffer &command_buffer)
 {
 	// Override forward light subpass draw function to provide a custom number of lights
-	auto lights_buffer = allocate_set_num_lights<CustomForwardLights>(scene.get_components<vkb::sg::Light>(), static_cast<size_t>(LIGHT_COUNT));
+	auto lights_buffer = allocate_custom_lights<CustomForwardLights>(command_buffer, scene.get_components<vkb::sg::Light>(), LIGHT_COUNT);
 	command_buffer.bind_buffer(lights_buffer.get_buffer(), lights_buffer.get_offset(), lights_buffer.get_size(), 0, 4, 0);
 
 	vkb::GeometrySubpass::draw(command_buffer);

--- a/samples/performance/specialization_constants/specialization_constants.h
+++ b/samples/performance/specialization_constants/specialization_constants.h
@@ -65,6 +65,7 @@ class SpecializationConstants : public vkb::VulkanSample
 		 *		  Provides the specified number of lights, regardless of how many are within the scene
 		 *
 		 * @tparam T ForwardLights / DeferredLights
+		 * @param command_buffer The command buffer that the returned light buffer allocation will be bound to
 		 * @param scene_lights  Lights from the scene graph
 		 * @param light_count Number of lights to render
 		 * @return BufferAllocation A buffer allocation created for use in shaders

--- a/samples/performance/specialization_constants/specialization_constants.h
+++ b/samples/performance/specialization_constants/specialization_constants.h
@@ -20,6 +20,7 @@
 #include "buffer_pool.h"
 #include "rendering/render_pipeline.h"
 #include "rendering/subpasses/forward_subpass.h"
+#include "scene_graph/components/light.h"
 #include "scene_graph/components/mesh.h"
 #include "scene_graph/components/perspective_camera.h"
 #include "vulkan_sample.h"
@@ -58,6 +59,47 @@ class SpecializationConstants : public vkb::VulkanSample
 		virtual void prepare() override;
 
 		virtual void draw(vkb::CommandBuffer &command_buffer) override;
+
+		/**
+		 * @brief Create a buffer allocation from scene graph lights for the specialization constants sample
+		 *		  Provides the specified number of lights, regardless of how many are within the scene
+		 *
+		 * @tparam T ForwardLights / DeferredLights
+		 * @param scene_lights  Lights from the scene graph
+		 * @param light_count Number of lights to render
+		 * @return BufferAllocation A buffer allocation created for use in shaders
+		 */
+		template <typename T>
+		vkb::BufferAllocation allocate_custom_lights(vkb::CommandBuffer &command_buffer, const std::vector<vkb::sg::Light *> &scene_lights, size_t light_count)
+		{
+			T light_info;
+			light_info.count = vkb::to_u32(light_count);
+
+			std::vector<vkb::Light> lights;
+			for (auto &scene_light : scene_lights)
+			{
+				if (lights.size() < light_count)
+				{
+					const auto &properties = scene_light->get_properties();
+					auto &      transform  = scene_light->get_node()->get_transform();
+
+					vkb::Light light{{transform.get_translation(), static_cast<float>(scene_light->get_light_type())},
+					                 {properties.color, properties.intensity},
+					                 {transform.get_rotation() * properties.direction, properties.range},
+					                 {properties.inner_cone_angle, properties.outer_cone_angle}};
+
+					lights.push_back(light);
+				}
+			}
+
+			std::copy(lights.begin(), lights.end(), light_info.lights);
+
+			auto &                render_frame = get_render_context().get_active_frame();
+			vkb::BufferAllocation light_buffer = render_frame.allocate_buffer(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, sizeof(T));
+			light_buffer.update(light_info);
+
+			return light_buffer;
+		};
 	};
 
   private:

--- a/samples/performance/wait_idle/wait_idle.cpp
+++ b/samples/performance/wait_idle/wait_idle.cpp
@@ -54,8 +54,8 @@ bool WaitIdle::prepare(vkb::Platform &plat)
 	camera            = dynamic_cast<vkb::sg::PerspectiveCamera *>(&camera_node.get_component<vkb::sg::Camera>());
 
 	// Example Scene Render Pipeline
-	vkb::ShaderSource vert_shader(vkb::fs::read_shader("base.vert"));
-	vkb::ShaderSource frag_shader(vkb::fs::read_shader("base.frag"));
+	vkb::ShaderSource vert_shader("base.vert");
+	vkb::ShaderSource frag_shader("base.frag");
 	auto              scene_subpass   = std::make_unique<vkb::ForwardSubpass>(get_render_context(), std::move(vert_shader), std::move(frag_shader), *scene, *camera);
 	auto              render_pipeline = vkb::RenderPipeline();
 	render_pipeline.add_subpass(std::move(scene_subpass));

--- a/shaders/base.frag
+++ b/shaders/base.frag
@@ -87,6 +87,17 @@ vec3 apply_point_light(uint index, vec3 normal)
 	return ndotl * lights.light[index].color.w * atten * lights.light[index].color.rgb;
 }
 
+vec3 apply_spot_light(uint index, vec3 normal)
+{
+	vec3 light_to_pixel = normalize(in_pos.xyz - lights.light[index].position.xyz);
+
+	float theta = dot(light_to_pixel, normalize(lights.light[index].direction.xyz));
+
+	float intensity = (theta - lights.light[index].info.y) / (lights.light[index].info.x - lights.light[index].info.y);
+
+	return smoothstep(0.0, 1.0, intensity) * lights.light[index].color.w * lights.light[index].color.rgb;
+}
+
 void main(void)
 {
 	vec3 normal = normalize(in_normal);
@@ -102,6 +113,10 @@ void main(void)
 		if (lights.light[i].position.w == POINT_LIGHT)
 		{
 			light_contribution += apply_point_light(i, normal);
+		}
+		if (lights.light[i].position.w == SPOT_LIGHT)
+		{
+			light_contribution += apply_spot_light(i, normal);
 		}
 	}
 

--- a/shaders/base.frag
+++ b/shaders/base.frag
@@ -46,9 +46,11 @@ struct Light
 
 layout(set = 0, binding = 4) uniform LightsInfo
 {
-	Light light[MAX_FORWARD_LIGHT_COUNT];
+	Light directional_lights[MAX_FORWARD_LIGHT_COUNT];
+	Light point_lights[MAX_FORWARD_LIGHT_COUNT];
+	Light spot_lights[MAX_FORWARD_LIGHT_COUNT];
 }
-lights;
+lights_info;
 
 // Push constants come with a limitation in the size of data.
 // The standard requires at least 128 bytes
@@ -60,50 +62,39 @@ layout(push_constant, std430) uniform PBRMaterialUniform
 }
 pbr_material_uniform;
 
-layout (constant_id = 0) const uint LIGHT_COUNT = 0U;
-layout (constant_id = 1) const bool HAS_DIRECTIONAL_LIGHTS = false;
-layout (constant_id = 2) const bool HAS_POINT_LIGHTS = false;
-layout (constant_id = 3) const bool HAS_SPOT_LIGHTS = false;
+layout (constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
+layout (constant_id = 1) const uint POINT_LIGHT_COUNT = 0U;
+layout (constant_id = 2) const uint SPOT_LIGHT_COUNT = 0U;
 
 vec3 apply_directional_light(uint index, vec3 normal)
 {
-	vec3 world_to_light = -lights.light[index].direction.xyz;
-
+	Light light = lights_info.directional_lights[index];
+	vec3 world_to_light = -light.direction.xyz;
 	world_to_light = normalize(world_to_light);
-
 	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-
-	return ndotl * lights.light[index].color.w * lights.light[index].color.rgb;
+	return ndotl * light.color.w * light.color.rgb;
 }
 
 vec3 apply_point_light(uint index, vec3 normal)
 {
-	vec3 world_to_light = lights.light[index].position.xyz - in_pos.xyz;
-
+	Light light = lights_info.point_lights[index];
+	vec3 world_to_light = light.position.xyz - in_pos.xyz;
 	float dist = length(world_to_light);
-
 	float atten = 1.0 / (dist * dist);
-
 	world_to_light = normalize(world_to_light);
-
 	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-
-	return ndotl * lights.light[index].color.w * atten * lights.light[index].color.rgb;
+	return ndotl * light.color.w * atten * light.color.rgb;
 }
 
 vec3 apply_spot_light(uint index, vec3 normal)
 {
-	vec3 light_to_pixel = normalize(in_pos.xyz - lights.light[index].position.xyz);
-
-	float theta = dot(light_to_pixel, normalize(lights.light[index].direction.xyz));
-
-	float inner_cone_angle = lights.light[index].info.x;
-
-	float outer_cone_angle = lights.light[index].info.y;
-
+	Light light = lights_info.spot_lights[index];
+	vec3 light_to_pixel = normalize(in_pos.xyz - light.position.xyz);
+	float theta = dot(light_to_pixel, normalize(light.direction.xyz));
+	float inner_cone_angle = light.info.x;
+	float outer_cone_angle = light.info.y;
 	float intensity = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
-
-	return smoothstep(0.0, 1.0, intensity) * lights.light[index].color.w * lights.light[index].color.rgb;
+	return smoothstep(0.0, 1.0, intensity) * light.color.w * light.color.rgb;
 }
 
 void main(void)
@@ -112,20 +103,19 @@ void main(void)
 
 	vec3 light_contribution = vec3(0.0);
 
-	for (uint i = 0U; i < LIGHT_COUNT; i++)
+	for (uint i = 0U; i < DIRECTIONAL_LIGHT_COUNT; ++i)
 	{
-		if (HAS_DIRECTIONAL_LIGHTS && lights.light[i].position.w == DIRECTIONAL_LIGHT)
-		{
-			light_contribution += apply_directional_light(i, normal);
-		}
-		else if (HAS_POINT_LIGHTS && lights.light[i].position.w == POINT_LIGHT)
-		{
-			light_contribution += apply_point_light(i, normal);
-		}
-		else if (HAS_SPOT_LIGHTS && lights.light[i].position.w == SPOT_LIGHT)
-		{
-			light_contribution += apply_spot_light(i, normal);
-		}
+		light_contribution += apply_directional_light(i, normal);
+	}
+
+	for (uint i = 0U; i < POINT_LIGHT_COUNT; ++i)
+	{
+		light_contribution += apply_point_light(i, normal);
+	}
+
+	for (uint i = 0U; i < SPOT_LIGHT_COUNT; ++i)
+	{
+		light_contribution += apply_spot_light(i, normal);
 	}
 
 	vec4 base_color = vec4(1.0, 0.0, 0.0, 1.0);

--- a/shaders/base.frag
+++ b/shaders/base.frag
@@ -46,7 +46,6 @@ struct Light
 
 layout(set = 0, binding = 4) uniform LightsInfo
 {
-	uint  count;
 	Light light[MAX_FORWARD_LIGHT_COUNT];
 }
 lights;
@@ -60,6 +59,11 @@ layout(push_constant, std430) uniform PBRMaterialUniform
 	float roughness_factor;
 }
 pbr_material_uniform;
+
+layout (constant_id = 0) const uint LIGHT_COUNT = 0U;
+layout (constant_id = 1) const bool HAS_DIRECTIONAL_LIGHTS = false;
+layout (constant_id = 2) const bool HAS_POINT_LIGHTS = false;
+layout (constant_id = 3) const bool HAS_SPOT_LIGHTS = false;
 
 vec3 apply_directional_light(uint index, vec3 normal)
 {
@@ -108,17 +112,17 @@ void main(void)
 
 	vec3 light_contribution = vec3(0.0);
 
-	for (uint i = 0U; i < lights.count; i++)
+	for (uint i = 0U; i < LIGHT_COUNT; i++)
 	{
-		if (lights.light[i].position.w == DIRECTIONAL_LIGHT)
+		if (HAS_DIRECTIONAL_LIGHTS && lights.light[i].position.w == DIRECTIONAL_LIGHT)
 		{
 			light_contribution += apply_directional_light(i, normal);
 		}
-		if (lights.light[i].position.w == POINT_LIGHT)
+		else if (HAS_POINT_LIGHTS && lights.light[i].position.w == POINT_LIGHT)
 		{
 			light_contribution += apply_point_light(i, normal);
 		}
-		if (lights.light[i].position.w == SPOT_LIGHT)
+		else if (HAS_SPOT_LIGHTS && lights.light[i].position.w == SPOT_LIGHT)
 		{
 			light_contribution += apply_spot_light(i, normal);
 		}

--- a/shaders/base.frag
+++ b/shaders/base.frag
@@ -93,7 +93,11 @@ vec3 apply_spot_light(uint index, vec3 normal)
 
 	float theta = dot(light_to_pixel, normalize(lights.light[index].direction.xyz));
 
-	float intensity = (theta - lights.light[index].info.y) / (lights.light[index].info.x - lights.light[index].info.y);
+	float inner_cone_angle = lights.light[index].info.x;
+
+	float outer_cone_angle = lights.light[index].info.y;
+
+	float intensity = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
 
 	return smoothstep(0.0, 1.0, intensity) * lights.light[index].color.w * lights.light[index].color.rgb;
 }

--- a/shaders/base.frag
+++ b/shaders/base.frag
@@ -56,6 +56,10 @@ layout(set = 0, binding = 4) uniform LightsInfo
 }
 lights_info;
 
+layout(constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
+layout(constant_id = 1) const uint POINT_LIGHT_COUNT       = 0U;
+layout(constant_id = 2) const uint SPOT_LIGHT_COUNT        = 0U;
+
 void main(void)
 {
 	vec3 normal = normalize(in_normal);

--- a/shaders/constant_data/buffer_array.frag
+++ b/shaders/constant_data/buffer_array.frag
@@ -54,6 +54,10 @@ layout(set = 0, binding = 4) uniform LightsInfo
 }
 lights_info;
 
+layout(constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
+layout(constant_id = 1) const uint POINT_LIGHT_COUNT       = 0U;
+layout(constant_id = 2) const uint SPOT_LIGHT_COUNT        = 0U;
+
 void main(void)
 {
 	vec3 normal = normalize(in_normal);

--- a/shaders/constant_data/push_constant.frag
+++ b/shaders/constant_data/push_constant.frag
@@ -49,6 +49,10 @@ layout(set = 0, binding = 4) uniform LightsInfo
 }
 lights_info;
 
+layout(constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
+layout(constant_id = 1) const uint POINT_LIGHT_COUNT       = 0U;
+layout(constant_id = 2) const uint SPOT_LIGHT_COUNT        = 0U;
+
 void main(void)
 {
 	vec3 normal = normalize(in_normal);

--- a/shaders/constant_data/push_constant.frag
+++ b/shaders/constant_data/push_constant.frag
@@ -39,46 +39,15 @@ layout(push_constant, std430) uniform MVPUniform
 #endif
 } mvp_uniform;
 
-struct Light
-{
-	vec4 position;         // position.w represents type of light
-	vec4 color;            // color.w represents light intensity
-	vec4 direction;        // direction.w represents range
-	vec2 info;             // (only used for spot lights) info.x represents light inner cone angle, info.y represents light outer cone angle
-};
+#include "lighting.h"
 
 layout(set = 0, binding = 4) uniform LightsInfo
 {
-	uint  count;
-	Light light[MAX_FORWARD_LIGHT_COUNT];
+	Light directional_lights[MAX_LIGHT_COUNT];
+	Light point_lights[MAX_LIGHT_COUNT];
+	Light spot_lights[MAX_LIGHT_COUNT];
 }
-lights;
-
-vec3 apply_directional_light(uint index, vec3 normal)
-{
-	vec3 world_to_light = -lights.light[index].direction.xyz;
-
-	world_to_light = normalize(world_to_light);
-
-	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-
-	return ndotl * lights.light[index].color.w * lights.light[index].color.rgb;
-}
-
-vec3 apply_point_light(uint index, vec3 normal)
-{
-	vec3 world_to_light = lights.light[index].position.xyz - in_pos.xyz;
-
-	float dist = length(world_to_light);
-
-	float atten = 1.0 / (dist * dist);
-
-	world_to_light = normalize(world_to_light);
-
-	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-
-	return ndotl * lights.light[index].color.w * atten * lights.light[index].color.rgb;
-}
+lights_info;
 
 void main(void)
 {
@@ -86,16 +55,19 @@ void main(void)
 
 	vec3 light_contribution = vec3(0.0);
 
-	for (uint i = 0U; i < lights.count; i++)
+	for (uint i = 0U; i < DIRECTIONAL_LIGHT_COUNT; ++i)
 	{
-		if (lights.light[i].position.w == DIRECTIONAL_LIGHT)
-		{
-			light_contribution += apply_directional_light(i, normal);
-		}
-		if (lights.light[i].position.w == POINT_LIGHT)
-		{
-			light_contribution += apply_point_light(i, normal);
-		}
+		light_contribution += apply_directional_light(lights_info.directional_lights[i], normal);
+	}
+
+	for (uint i = 0U; i < POINT_LIGHT_COUNT; ++i)
+	{
+		light_contribution += apply_point_light(lights_info.point_lights[i], in_pos.xyz, normal);
+	}
+
+	for (uint i = 0U; i < SPOT_LIGHT_COUNT; ++i)
+	{
+		light_contribution += apply_spot_light(lights_info.spot_lights[i], in_pos.xyz, normal);
 	}
 
 	vec4 base_color = vec4(1.0, 0.0, 0.0, 1.0);

--- a/shaders/constant_data/ubo.frag
+++ b/shaders/constant_data/ubo.frag
@@ -49,6 +49,10 @@ layout(set = 0, binding = 4) uniform LightsInfo
 }
 lights_info;
 
+layout(constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
+layout(constant_id = 1) const uint POINT_LIGHT_COUNT       = 0U;
+layout(constant_id = 2) const uint SPOT_LIGHT_COUNT        = 0U;
+
 void main(void)
 {
 	vec3 normal = normalize(in_normal);

--- a/shaders/constant_data/ubo.frag
+++ b/shaders/constant_data/ubo.frag
@@ -39,46 +39,15 @@ layout(set = 0, binding = 1) uniform MVPUniform
 #endif
 } mvp_uniform;
 
-struct Light
-{
-	vec4 position;         // position.w represents type of light
-	vec4 color;            // color.w represents light intensity
-	vec4 direction;        // direction.w represents range
-	vec2 info;             // (only used for spot lights) info.x represents light inner cone angle, info.y represents light outer cone angle
-};
+#include "lighting.h"
 
 layout(set = 0, binding = 4) uniform LightsInfo
 {
-	uint  count;
-	Light light[MAX_FORWARD_LIGHT_COUNT];
+	Light directional_lights[MAX_LIGHT_COUNT];
+	Light point_lights[MAX_LIGHT_COUNT];
+	Light spot_lights[MAX_LIGHT_COUNT];
 }
-lights;
-
-vec3 apply_directional_light(uint index, vec3 normal)
-{
-	vec3 world_to_light = -lights.light[index].direction.xyz;
-
-	world_to_light = normalize(world_to_light);
-
-	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-
-	return ndotl * lights.light[index].color.w * lights.light[index].color.rgb;
-}
-
-vec3 apply_point_light(uint index, vec3 normal)
-{
-	vec3 world_to_light = lights.light[index].position.xyz - in_pos.xyz;
-
-	float dist = length(world_to_light);
-
-	float atten = 1.0 / (dist * dist);
-
-	world_to_light = normalize(world_to_light);
-
-	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-
-	return ndotl * lights.light[index].color.w * atten * lights.light[index].color.rgb;
-}
+lights_info;
 
 void main(void)
 {
@@ -86,16 +55,19 @@ void main(void)
 
 	vec3 light_contribution = vec3(0.0);
 
-	for (uint i = 0U; i < lights.count; i++)
+	for (uint i = 0U; i < DIRECTIONAL_LIGHT_COUNT; ++i)
 	{
-		if (lights.light[i].position.w == DIRECTIONAL_LIGHT)
-		{
-			light_contribution += apply_directional_light(i, normal);
-		}
-		if (lights.light[i].position.w == POINT_LIGHT)
-		{
-			light_contribution += apply_point_light(i, normal);
-		}
+		light_contribution += apply_directional_light(lights_info.directional_lights[i], normal);
+	}
+
+	for (uint i = 0U; i < POINT_LIGHT_COUNT; ++i)
+	{
+		light_contribution += apply_point_light(lights_info.point_lights[i], in_pos.xyz, normal);
+	}
+
+	for (uint i = 0U; i < SPOT_LIGHT_COUNT; ++i)
+	{
+		light_contribution += apply_spot_light(lights_info.spot_lights[i], in_pos.xyz, normal);
 	}
 
 	vec4 base_color = vec4(1.0, 0.0, 0.0, 1.0);

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -66,12 +66,12 @@ vec3 apply_point_light(uint index, vec3 pos, vec3 normal)
 
 vec3 apply_spot_light(uint index, vec3 pos, vec3 normal)
 {
-    vec3 light_to_pixel = normalize(pos - lights.light[index].position.xyz);
-    float theta = dot(light_to_pixel, normalize(lights.light[index].direction.xyz));
-    float inner_cone_angle = lights.light[index].info.x;
-    float outer_cone_angle = lights.light[index].info.y;
+    vec3 light_to_pixel = normalize(pos - lights.lights[index].position.xyz);
+    float theta = dot(light_to_pixel, normalize(lights.lights[index].direction.xyz));
+    float inner_cone_angle = lights.lights[index].info.x;
+    float outer_cone_angle = lights.lights[index].info.y;
     float intensity = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
-    return smoothstep(0.0, 1.0, intensity) * lights.light[index].color.w * lights.light[index].color.rgb;
+    return smoothstep(0.0, 1.0, intensity) * lights.lights[index].color.w * lights.lights[index].color.rgb;
 }
 
 void main()
@@ -99,7 +99,7 @@ void main()
         {
             L += apply_point_light(i, pos, normal);
         }
-        if (lights.light[i].position.w == SPOT_LIGHT)
+        if (lights.lights[i].position.w == SPOT_LIGHT)
         {
             L += apply_spot_light(i, pos, normal);
         }

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -41,10 +41,14 @@ struct Light
 
 layout(set = 0, binding = 4) uniform LightsInfo
 {
-    uint  count;
     Light lights[MAX_DEFERRED_LIGHT_COUNT];
 }
 lights;
+
+layout (constant_id = 0) const uint LIGHT_COUNT = 0U;
+layout (constant_id = 1) const bool HAS_DIRECTIONAL_LIGHTS = false;
+layout (constant_id = 2) const bool HAS_POINT_LIGHTS = false;
+layout (constant_id = 3) const bool HAS_SPOT_LIGHTS = false;
 
 vec3 apply_directional_light(uint index, vec3 normal)
 {
@@ -89,17 +93,17 @@ void main()
 
     // Calculate lighting
     vec3 L = vec3(0.0);
-    for (uint i = 0U; i < lights.count; i++)
+    for (uint i = 0U; i < LIGHT_COUNT; i++)
     {
-        if (lights.lights[i].position.w == DIRECTIONAL_LIGHT)
+        if (HAS_DIRECTIONAL_LIGHTS && lights.lights[i].position.w == DIRECTIONAL_LIGHT)
         {
             L += apply_directional_light(i, normal);
         }
-        if (lights.lights[i].position.w == POINT_LIGHT)
+        else if (HAS_POINT_LIGHTS && lights.lights[i].position.w == POINT_LIGHT)
         {
             L += apply_point_light(i, pos, normal);
         }
-        if (lights.lights[i].position.w == SPOT_LIGHT)
+        else if (HAS_SPOT_LIGHTS && lights.lights[i].position.w == SPOT_LIGHT)
         {
             L += apply_spot_light(i, pos, normal);
         }

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -64,6 +64,16 @@ vec3 apply_point_light(uint index, vec3 pos, vec3 normal)
     return ndotl * lights.lights[index].color.w * atten * lights.lights[index].color.rgb;
 }
 
+vec3 apply_spot_light(uint index, vec3 pos, vec3 normal)
+{
+    vec3 light_to_pixel = normalize(pos - lights.light[index].position.xyz);
+    float theta = dot(light_to_pixel, normalize(lights.light[index].direction.xyz));
+    float inner_cone_angle = lights.light[index].info.x;
+    float outer_cone_angle = lights.light[index].info.y;
+    float intensity = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
+    return smoothstep(0.0, 1.0, intensity) * lights.light[index].color.w * lights.light[index].color.rgb;
+}
+
 void main()
 {
     // Retrieve position from depth
@@ -88,6 +98,10 @@ void main()
         if (lights.lights[i].position.w == POINT_LIGHT)
         {
             L += apply_point_light(i, pos, normal);
+        }
+        if (lights.light[i].position.w == SPOT_LIGHT)
+        {
+            L += apply_spot_light(i, pos, normal);
         }
     }
 

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -41,6 +41,10 @@ layout(set = 0, binding = 4) uniform LightsInfo
 }
 lights_info;
 
+layout(constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
+layout(constant_id = 1) const uint POINT_LIGHT_COUNT       = 0U;
+layout(constant_id = 2) const uint SPOT_LIGHT_COUNT        = 0U;
+
 void main()
 {
 	// Retrieve position from depth

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -31,56 +31,15 @@ layout(set = 0, binding = 3) uniform GlobalUniform
 }
 global_uniform;
 
-struct Light
-{
-    vec4 position;         // position.w represents type of light
-    vec4 color;            // color.w represents light intensity
-    vec4 direction;        // direction.w represents range
-    vec2 info;             // (only used for spot lights) info.x represents light inner cone angle, info.y represents light outer cone angle
-};
+#include "lighting.h"
 
 layout(set = 0, binding = 4) uniform LightsInfo
 {
-	Light directional_lights[MAX_DEFERRED_LIGHT_COUNT];
-	Light point_lights[MAX_DEFERRED_LIGHT_COUNT];
-	Light spot_lights[MAX_DEFERRED_LIGHT_COUNT];
+	Light directional_lights[MAX_LIGHT_COUNT];
+	Light point_lights[MAX_LIGHT_COUNT];
+	Light spot_lights[MAX_LIGHT_COUNT];
 }
 lights_info;
-
-layout (constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
-layout (constant_id = 1) const uint POINT_LIGHT_COUNT = 0U;
-layout (constant_id = 2) const uint SPOT_LIGHT_COUNT = 0U;
-
-vec3 apply_directional_light(uint index, vec3 normal)
-{
-    Light light = lights_info.directional_lights[index];
-    vec3 world_to_light = -light.direction.xyz;
-    world_to_light = normalize(world_to_light);
-    float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-    return ndotl * light.color.w * light.color.rgb;
-}
-
-vec3 apply_point_light(uint index, vec3 pos, vec3 normal)
-{
-    Light light = lights_info.point_lights[index];
-    vec3 world_to_light = light.position.xyz - pos;
-    float dist = length(world_to_light) * 0.005;
-    float atten = 1.0 / (dist * dist);
-    world_to_light = normalize(world_to_light);
-    float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-    return ndotl * light.color.w * atten * light.color.rgb;
-}
-
-vec3 apply_spot_light(uint index, vec3 pos, vec3 normal)
-{
-    Light light = lights_info.spot_lights[index];
-    vec3 light_to_pixel = normalize(pos - light.position.xyz);
-    float theta = dot(light_to_pixel, normalize(light.direction.xyz));
-    float inner_cone_angle = light.info.x;
-    float outer_cone_angle = light.info.y;
-    float intensity = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
-    return smoothstep(0.0, 1.0, intensity) * light.color.w * light.color.rgb;
-}
 
 void main()
 {
@@ -100,17 +59,17 @@ void main()
 
     for (uint i = 0U; i < DIRECTIONAL_LIGHT_COUNT; ++i)
     {
-        L += apply_directional_light(i, normal);
+        L += apply_directional_light(lights_info.directional_lights[i], normal);
     }
 
     for (uint i = 0U; i < POINT_LIGHT_COUNT; ++i)
     {
-        L += apply_point_light(i, pos, normal);
+        L += apply_point_light(lights_info.point_lights[i], pos, normal);
     }
 
     for (uint i = 0U; i < SPOT_LIGHT_COUNT; ++i)
     {
-        L += apply_spot_light(i, pos, normal);
+        L += apply_spot_light(lights_info.spot_lights[i], pos, normal);
     }
 
     vec3 ambient_color = vec3(0.2) * albedo.xyz;

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -43,36 +43,29 @@ lights_info;
 
 void main()
 {
-    // Retrieve position from depth
-    vec4  clip         = vec4(in_uv * 2.0 - 1.0, subpassLoad(i_depth).x, 1.0);
-    highp vec4 world_w = global_uniform.inv_view_proj * clip;
-    highp vec3 pos     = world_w.xyz / world_w.w;
-
-    vec4 albedo = subpassLoad(i_albedo);
-
-    // Transform from [0,1] to [-1,1]
-    vec3 normal = subpassLoad(i_normal).xyz;
-    normal      = normalize(2.0 * normal - 1.0);
-
-    // Calculate lighting
-    vec3 L = vec3(0.0);
-
-    for (uint i = 0U; i < DIRECTIONAL_LIGHT_COUNT; ++i)
-    {
-        L += apply_directional_light(lights_info.directional_lights[i], normal);
-    }
-
-    for (uint i = 0U; i < POINT_LIGHT_COUNT; ++i)
-    {
-        L += apply_point_light(lights_info.point_lights[i], pos, normal);
-    }
-
-    for (uint i = 0U; i < SPOT_LIGHT_COUNT; ++i)
-    {
-        L += apply_spot_light(lights_info.spot_lights[i], pos, normal);
-    }
-
-    vec3 ambient_color = vec3(0.2) * albedo.xyz;
-    
-    o_color = vec4(ambient_color + L * albedo.xyz, 1.0);
+	// Retrieve position from depth
+	vec4  clip         = vec4(in_uv * 2.0 - 1.0, subpassLoad(i_depth).x, 1.0);
+	highp vec4 world_w = global_uniform.inv_view_proj * clip;
+	highp vec3 pos     = world_w.xyz / world_w.w;
+	vec4 albedo = subpassLoad(i_albedo);
+	// Transform from [0,1] to [-1,1]
+	vec3 normal = subpassLoad(i_normal).xyz;
+	normal      = normalize(2.0 * normal - 1.0);
+	// Calculate lighting
+	vec3 L = vec3(0.0);
+	for (uint i = 0U; i < DIRECTIONAL_LIGHT_COUNT; ++i)
+	{
+		L += apply_directional_light(lights_info.directional_lights[i], normal);
+	}
+	for (uint i = 0U; i < POINT_LIGHT_COUNT; ++i)
+	{
+		L += apply_point_light(lights_info.point_lights[i], pos, normal);
+	}
+	for (uint i = 0U; i < SPOT_LIGHT_COUNT; ++i)
+	{
+		L += apply_spot_light(lights_info.spot_lights[i], pos, normal);
+	}
+	vec3 ambient_color = vec3(0.2) * albedo.xyz;
+	
+	o_color = vec4(ambient_color + L * albedo.xyz, 1.0);
 }

--- a/shaders/lighting.h
+++ b/shaders/lighting.h
@@ -23,9 +23,9 @@ struct Light
 	vec2 info;             // (only used for spot lights) info.x represents light inner cone angle, info.y represents light outer cone angle
 };
 
-layout (constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
-layout (constant_id = 1) const uint POINT_LIGHT_COUNT = 0U;
-layout (constant_id = 2) const uint SPOT_LIGHT_COUNT = 0U;
+layout(constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
+layout(constant_id = 1) const uint POINT_LIGHT_COUNT       = 0U;
+layout(constant_id = 2) const uint SPOT_LIGHT_COUNT        = 0U;
 
 vec3 apply_directional_light(Light light, vec3 normal)
 {
@@ -37,17 +37,17 @@ vec3 apply_directional_light(Light light, vec3 normal)
 
 vec3 apply_point_light(Light light, vec3 pos, vec3 normal)
 {
-	vec3 world_to_light = light.position.xyz - pos;
-	float dist          = length(world_to_light) * 0.005;
-	float atten         = 1.0 / (dist * dist);
-	world_to_light      = normalize(world_to_light);
-	float ndotl         = clamp(dot(normal, world_to_light), 0.0, 1.0);
+	vec3  world_to_light = light.position.xyz - pos;
+	float dist           = length(world_to_light) * 0.005;
+	float atten          = 1.0 / (dist * dist);
+	world_to_light       = normalize(world_to_light);
+	float ndotl          = clamp(dot(normal, world_to_light), 0.0, 1.0);
 	return ndotl * light.color.w * atten * light.color.rgb;
 }
 
 vec3 apply_spot_light(Light light, vec3 pos, vec3 normal)
 {
-	vec3 light_to_pixel    = normalize(pos - light.position.xyz);
+	vec3  light_to_pixel   = normalize(pos - light.position.xyz);
 	float theta            = dot(light_to_pixel, normalize(light.direction.xyz));
 	float inner_cone_angle = light.info.x;
 	float outer_cone_angle = light.info.y;

--- a/shaders/lighting.h
+++ b/shaders/lighting.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2020, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+ struct Light
+{
+	vec4 position;         // position.w represents type of light
+	vec4 color;            // color.w represents light intensity
+	vec4 direction;        // direction.w represents range
+	vec2 info;             // (only used for spot lights) info.x represents light inner cone angle, info.y represents light outer cone angle
+};
+
+layout (constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
+layout (constant_id = 1) const uint POINT_LIGHT_COUNT = 0U;
+layout (constant_id = 2) const uint SPOT_LIGHT_COUNT = 0U;
+
+vec3 apply_directional_light(Light light, vec3 normal)
+{
+    vec3 world_to_light = -light.direction.xyz;
+    world_to_light = normalize(world_to_light);
+    float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
+    return ndotl * light.color.w * light.color.rgb;
+}
+
+vec3 apply_point_light(Light light, vec3 pos, vec3 normal)
+{
+    vec3 world_to_light = light.position.xyz - pos;
+    float dist = length(world_to_light) * 0.005;
+    float atten = 1.0 / (dist * dist);
+    world_to_light = normalize(world_to_light);
+    float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
+    return ndotl * light.color.w * atten * light.color.rgb;
+}
+
+vec3 apply_spot_light(Light light, vec3 pos, vec3 normal)
+{
+    vec3 light_to_pixel = normalize(pos - light.position.xyz);
+    float theta = dot(light_to_pixel, normalize(light.direction.xyz));
+    float inner_cone_angle = light.info.x;
+    float outer_cone_angle = light.info.y;
+    float intensity = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
+    return smoothstep(0.0, 1.0, intensity) * light.color.w * light.color.rgb;
+}

--- a/shaders/lighting.h
+++ b/shaders/lighting.h
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
- struct Light
+
+struct Light
 {
 	vec4 position;         // position.w represents type of light
 	vec4 color;            // color.w represents light intensity
@@ -29,28 +29,28 @@ layout (constant_id = 2) const uint SPOT_LIGHT_COUNT = 0U;
 
 vec3 apply_directional_light(Light light, vec3 normal)
 {
-    vec3 world_to_light = -light.direction.xyz;
-    world_to_light = normalize(world_to_light);
-    float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-    return ndotl * light.color.w * light.color.rgb;
+	vec3 world_to_light = -light.direction.xyz;
+	world_to_light = normalize(world_to_light);
+	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
+	return ndotl * light.color.w * light.color.rgb;
 }
 
 vec3 apply_point_light(Light light, vec3 pos, vec3 normal)
 {
-    vec3 world_to_light = light.position.xyz - pos;
-    float dist = length(world_to_light) * 0.005;
-    float atten = 1.0 / (dist * dist);
-    world_to_light = normalize(world_to_light);
-    float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
-    return ndotl * light.color.w * atten * light.color.rgb;
+	vec3 world_to_light = light.position.xyz - pos;
+	float dist = length(world_to_light) * 0.005;
+	float atten = 1.0 / (dist * dist);
+	world_to_light = normalize(world_to_light);
+	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
+	return ndotl * light.color.w * atten * light.color.rgb;
 }
 
 vec3 apply_spot_light(Light light, vec3 pos, vec3 normal)
 {
-    vec3 light_to_pixel = normalize(pos - light.position.xyz);
-    float theta = dot(light_to_pixel, normalize(light.direction.xyz));
-    float inner_cone_angle = light.info.x;
-    float outer_cone_angle = light.info.y;
-    float intensity = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
-    return smoothstep(0.0, 1.0, intensity) * light.color.w * light.color.rgb;
+	vec3 light_to_pixel = normalize(pos - light.position.xyz);
+	float theta = dot(light_to_pixel, normalize(light.direction.xyz));
+	float inner_cone_angle = light.info.x;
+	float outer_cone_angle = light.info.y;
+	float intensity = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
+	return smoothstep(0.0, 1.0, intensity) * light.color.w * light.color.rgb;
 }

--- a/shaders/lighting.h
+++ b/shaders/lighting.h
@@ -23,10 +23,6 @@ struct Light
 	vec2 info;             // (only used for spot lights) info.x represents light inner cone angle, info.y represents light outer cone angle
 };
 
-layout(constant_id = 0) const uint DIRECTIONAL_LIGHT_COUNT = 0U;
-layout(constant_id = 1) const uint POINT_LIGHT_COUNT       = 0U;
-layout(constant_id = 2) const uint SPOT_LIGHT_COUNT        = 0U;
-
 vec3 apply_directional_light(Light light, vec3 normal)
 {
 	vec3 world_to_light = -light.direction.xyz;

--- a/shaders/lighting.h
+++ b/shaders/lighting.h
@@ -30,27 +30,27 @@ layout (constant_id = 2) const uint SPOT_LIGHT_COUNT = 0U;
 vec3 apply_directional_light(Light light, vec3 normal)
 {
 	vec3 world_to_light = -light.direction.xyz;
-	world_to_light = normalize(world_to_light);
-	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
+	world_to_light      = normalize(world_to_light);
+	float ndotl         = clamp(dot(normal, world_to_light), 0.0, 1.0);
 	return ndotl * light.color.w * light.color.rgb;
 }
 
 vec3 apply_point_light(Light light, vec3 pos, vec3 normal)
 {
 	vec3 world_to_light = light.position.xyz - pos;
-	float dist = length(world_to_light) * 0.005;
-	float atten = 1.0 / (dist * dist);
-	world_to_light = normalize(world_to_light);
-	float ndotl = clamp(dot(normal, world_to_light), 0.0, 1.0);
+	float dist          = length(world_to_light) * 0.005;
+	float atten         = 1.0 / (dist * dist);
+	world_to_light      = normalize(world_to_light);
+	float ndotl         = clamp(dot(normal, world_to_light), 0.0, 1.0);
 	return ndotl * light.color.w * atten * light.color.rgb;
 }
 
 vec3 apply_spot_light(Light light, vec3 pos, vec3 normal)
 {
-	vec3 light_to_pixel = normalize(pos - light.position.xyz);
-	float theta = dot(light_to_pixel, normalize(light.direction.xyz));
+	vec3 light_to_pixel    = normalize(pos - light.position.xyz);
+	float theta            = dot(light_to_pixel, normalize(light.direction.xyz));
 	float inner_cone_angle = light.info.x;
 	float outer_cone_angle = light.info.y;
-	float intensity = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
+	float intensity        = (theta - outer_cone_angle) / (inner_cone_angle - outer_cone_angle);
 	return smoothstep(0.0, 1.0, intensity) * light.color.w * light.color.rgb;
 }

--- a/shaders/specialization_constants/UBOs.frag
+++ b/shaders/specialization_constants/UBOs.frag
@@ -47,7 +47,7 @@ struct Light
 layout(set = 0, binding = 4) uniform LightsInfo
 {
 	uint  count;
-	Light light[MAX_FORWARD_LIGHT_COUNT];
+	Light light[MAX_LIGHT_COUNT];
 }
 lights;
 

--- a/shaders/specialization_constants/specialization_constants.frag
+++ b/shaders/specialization_constants/specialization_constants.frag
@@ -47,7 +47,7 @@ struct Light
 layout(set = 0, binding = 4) uniform LightsInfo
 {
 	uint  count;
-	Light light[MAX_FORWARD_LIGHT_COUNT];
+	Light light[MAX_LIGHT_COUNT];
 }
 lights;
 


### PR DESCRIPTION
## Description

* Added support in the shaders for spot lights, and added a utility function to add a spot light to the scene graph.
* Removed dynamic branching, shaders should now see a speed up in performance
* Added pre-compilation of shaders. You can now use #includes to include common code inside your shaders.

![image (2)](https://user-images.githubusercontent.com/46324550/86242366-87736380-bb9c-11ea-96a3-6c56c6846ecc.png)

Code example:

```
auto &spot_light = vkb::add_spot_light(*scene, camera_node.get_transform().get_translation(), camera_node.get_transform().get_rotation());
spot_light.set_properties({
	{0.0f, 0.0f, -1.0f},                     // Direction
	{1.0f, 0.95f, 0.7f},                    // Color (yellowish white)
	1.0f,                                        // intensity
	5.0f,                                        // range
	glm::cos(glm::radians(12.5f)), // inner cone angle (required for spot lights)
	glm::cos(glm::radians(15.5f))  // outer cone angle (required for spot lights)
});
```

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)