### PR TITLE
Small MRT fixes

### DIFF
--- a/framework/rendering/render_pipeline.cpp
+++ b/framework/rendering/render_pipeline.cpp
@@ -94,7 +94,7 @@ void RenderPipeline::draw(CommandBuffer &command_buffer, RenderTarget &render_ta
 
 		auto &subpass = subpasses[i];
 
-		subpass->update_render_target_attachments();
+		subpass->update_render_target_attachments(render_target);
 
 		if (i == 0)
 		{

--- a/framework/rendering/subpass.cpp
+++ b/framework/rendering/subpass.cpp
@@ -42,10 +42,8 @@ Subpass::Subpass(RenderContext &render_context, ShaderSource &&vertex_source, Sh
 {
 }
 
-void Subpass::update_render_target_attachments()
+void Subpass::update_render_target_attachments(RenderTarget &render_target)
 {
-	auto &render_target = render_context.get_active_frame().get_render_target();
-
 	render_target.set_input_attachments(input_attachments);
 	render_target.set_output_attachments(output_attachments);
 }

--- a/framework/rendering/subpass.h
+++ b/framework/rendering/subpass.h
@@ -81,7 +81,7 @@ class Subpass
 	 *        This function is called by the RenderPipeline before beginning the render
 	 *        pass and before proceeding with a new subpass.
 	 */
-	void update_render_target_attachments();
+	void update_render_target_attachments(RenderTarget &render_target);
 
 	/**
 	 * @brief Draw virtual function

--- a/framework/rendering/subpasses/geometry_subpass.cpp
+++ b/framework/rendering/subpasses/geometry_subpass.cpp
@@ -114,7 +114,10 @@ void GeometrySubpass::draw(CommandBuffer &command_buffer)
 
 	ColorBlendState color_blend_state{};
 	color_blend_state.attachments.resize(get_output_attachments().size());
-	color_blend_state.attachments[0] = color_blend_attachment;
+	for (auto &it : color_blend_state.attachments)
+	{
+		it = color_blend_attachment;
+	}
 	command_buffer.set_color_blend_state(color_blend_state);
 
 	command_buffer.set_depth_stencil_state(get_depth_stencil_state());


### PR DESCRIPTION
## Description

This branch adds two small fixes to the framework to make working with different `RenderTarget`s possible:

- Input/output descriptors are updated for the `RenderTarget` passed to `draw()` (instead of the sample's own).  
  This is so a second `RenderTarget` can potentially be used for a `RenderPipeline`.
- Color blend states are made to be identical for all output attachments of `GeometrySubpass`.  
  This is required if a second output (e.g., normals) is to be rendered in that subpass.
  If you have more than one color output attachment, and this patch is not applied, validation complains:
  > [error] [tance.cpp:41] 0 - VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605: Invalid Pipeline CreateInfo: If independent blend feature not enabled, all elements of pAttachments must be identical. The Vulkan spec states: If the independent blending feature is not enabled, all elements of pAttachments must be identical (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605)

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Tested on Windows and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)