### PR TITLE
Fix UI scaling issues on Windows

### DIFF
--- a/framework/platform/glfw_window.cpp
+++ b/framework/platform/glfw_window.cpp
@@ -373,12 +373,15 @@ float GlfwWindow::get_dpi_factor() const
 
 float GlfwWindow::get_content_scale_factor() const
 {
-	float xscale, yscale;
-	glfwGetWindowContentScale(handle, &xscale, &yscale);
+	int fb_width, fb_height;
+	glfwGetFramebufferSize(handle, &fb_width, &fb_height);
+	int win_width, win_height;
+	glfwGetWindowSize(handle, &win_width, &win_height);
+
 	// We could return a 2D result here instead of a scalar,
 	// but non-uniform scaling is very unlikely, and would
 	// require significantly more changes in the IMGUI integration
-	return xscale;
+	return static_cast<float>(win_width) / fb_width;
 }
 
 }        // namespace vkb


### PR DESCRIPTION
## Description

UI scaling does not look correct if the screen scaling factor is above 100% on Windows.  
This patch modifies the Glfw window backend to try and resolve the issue.

Fixes #93 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)