### PR TITLE
Fix a crash when the GLTF loader does not find KHR_punctual_lights

### DIFF
--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -1227,8 +1227,12 @@ std::unique_ptr<sg::Camera> GLTFLoader::create_default_camera()
 
 std::vector<std::unique_ptr<sg::Light>> GLTFLoader::parse_khr_lights_punctual()
 {
-	if (is_extension_enabled(KHR_LIGHTS_PUNCTUAL_EXTENSION) && model.extensions.at(KHR_LIGHTS_PUNCTUAL_EXTENSION).Has("lights"))
+	if (is_extension_enabled(KHR_LIGHTS_PUNCTUAL_EXTENSION))
 	{
+		if (model.extensions.find(KHR_LIGHTS_PUNCTUAL_EXTENSION) == model.extensions.end() || !model.extensions.at(KHR_LIGHTS_PUNCTUAL_EXTENSION).Has("lights"))
+		{
+			return {};
+		}
 		auto &khr_lights = model.extensions.at(KHR_LIGHTS_PUNCTUAL_EXTENSION).Get("lights");
 
 		std::vector<std::unique_ptr<sg::Light>> light_components(khr_lights.ArrayLen());


### PR DESCRIPTION
## Description
Consider a GLTF 2.0 scene, exported directly from Blender, that only has a single plane geometry. It has no punctual lights. 
 
The GLTF loader currently crashes if the punctual lights extension is supported by the framework, but not declared in the file.   
This commit should fix the issue.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)