### PR TITLE
Added 'glad' to ThirdParty property to keep solution explorer clean

### DIFF
--- a/samples/extensions/open_gl_interop/CMakeLists.txt
+++ b/samples/extensions/open_gl_interop/CMakeLists.txt
@@ -37,6 +37,7 @@ set(GLAD_SOURCES
 add_library(glad ${GLAD_SOURCES})
 target_sources(glad PRIVATE ${GLAD_SOURCES})
 target_include_directories(glad PUBLIC ${GLAD_DIR}/include)
+set_property(TARGET glad PROPERTY FOLDER "ThirdParty")
 
 # Only Compile on platforms that support glfw
 # Corresponds to the logic in framework/CMakeLists.txt near "if(VKB_DIRECT_2_DISPLAY)"


### PR DESCRIPTION
## Description

Tiny fix to keep visual studio solution explorer view clean.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)