### PR TITLE
OpenGL interop sample fixes

### DIFF
--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -322,7 +322,7 @@ function(add_project)
         target_include_directories(${PROJECT_NAME} PUBLIC 
             $<TARGET_PROPERTY:${TARGET_ID},INCLUDE_DIRECTORIES>)
 
-        target_link_libraries(${PROJECT_NAME} PUBLIC framework)
+        target_link_libraries(${PROJECT_NAME} PUBLIC framework ${TARGET_LIBS})
 
         if(${TARGET_TYPE} STREQUAL "Test")
             target_link_libraries(${PROJECT_NAME} PUBLIC test_framework)

--- a/samples/extensions/open_gl_interop/open_gl_interop.cpp
+++ b/samples/extensions/open_gl_interop/open_gl_interop.cpp
@@ -171,7 +171,7 @@ void OpenGLInterop::prepare_shared_resources()
 
 		VkExportSemaphoreCreateInfo exportSemaphoreCreateInfo{
 		    VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO, nullptr,
-		    compatable_semaphore_type};
+		    VkExternalSemaphoreHandleTypeFlags(compatable_semaphore_type)};
 		VkSemaphoreCreateInfo semaphoreCreateInfo{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
 		                                          &exportSemaphoreCreateInfo};
 		VK_CHECK(vkCreateSemaphore(deviceHandle, &semaphoreCreateInfo, nullptr,


### PR DESCRIPTION
## Description

The OpenGL interop sample fails to build with Clang 10 on Windows (MSVC 19.x), due to:

- An implicit type cast in an initializer list (flagged as an error by Clang).
- The framework's build system not linking a sample's `LIBS` to sample .exes (when `VKB_ENTRYPOINTS=ON`).

This small patch fixes the two issues.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)