### PR TITLE
Fix regression introduced by PR154 on some platforms

### DIFF
--- a/framework/core/shader_module.cpp
+++ b/framework/core/shader_module.cpp
@@ -42,9 +42,10 @@ inline std::vector<std::string> precompile_shader(const std::string &source)
 		{
 			// Include paths are relative to the base shader directory
 			std::string include_path = line.substr(10);
-			if (!include_path.empty() && include_path.back() == '"')
+			size_t last_delimiter = include_path.find("\"");
+			if (!include_path.empty() && last_delimiter != std::string::npos)
 			{
-				include_path.pop_back();
+				include_path = include_path.substr(0, last_delimiter);
 			}
 
 			auto include_file = precompile_shader(fs::read_shader(include_path));

--- a/framework/core/shader_module.cpp
+++ b/framework/core/shader_module.cpp
@@ -42,10 +42,10 @@ inline std::vector<std::string> precompile_shader(const std::string &source)
 		{
 			// Include paths are relative to the base shader directory
 			std::string include_path = line.substr(10);
-			size_t last_delimiter = include_path.find("\"");
-			if (!include_path.empty() && last_delimiter != std::string::npos)
+			size_t last_quote = include_path.find("\"");
+			if (!include_path.empty() && last_quote != std::string::npos)
 			{
-				include_path = include_path.substr(0, last_delimiter);
+				include_path = include_path.substr(0, last_quote);
 			}
 
 			auto include_file = precompile_shader(fs::read_shader(include_path));

--- a/framework/core/shader_module.cpp
+++ b/framework/core/shader_module.cpp
@@ -43,6 +43,7 @@ inline std::vector<std::string> precompile_shader(const std::string &source)
 			// Include paths are relative to the base shader directory
 			std::string include_path = line.substr(10);
 			size_t last_quote = include_path.find("\"");
+
 			if (!include_path.empty() && last_quote != std::string::npos)
 			{
 				include_path = include_path.substr(0, last_quote);

--- a/framework/core/shader_module.cpp
+++ b/framework/core/shader_module.cpp
@@ -42,8 +42,7 @@ inline std::vector<std::string> precompile_shader(const std::string &source)
 		{
 			// Include paths are relative to the base shader directory
 			std::string include_path = line.substr(10);
-			size_t last_quote = include_path.find("\"");
-
+			size_t      last_quote   = include_path.find("\"");
 			if (!include_path.empty() && last_quote != std::string::npos)
 			{
 				include_path = include_path.substr(0, last_quote);


### PR DESCRIPTION
On some platforms the last character is not a quotation mark but a carriage return. This was introducing a crash on the samples from the 'Performance' tab while trying to file.open the lighting.h header as shown below:
Abort message: 'terminating with uncaught exception of type std::runtime_erro': Failed to open file: /storage/emulated/0/Android/data/com.khronos.vulkan_samples/files/shaders/lighting.h"

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md)

Fixes #167 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules