### PR TITLE
Make work group size for compute N-Body sample dynamic

### DIFF
--- a/samples/api/compute_nbody/compute_nbody.cpp
+++ b/samples/api/compute_nbody/compute_nbody.cpp
@@ -845,7 +845,7 @@ bool ComputeNBody::prepare(vkb::Platform &platform)
 	compute.queue_family_index  = get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT);
 
 	// Not all implementations support a work group size of 256, so we need to check with the device limits
-	work_group_size = std::min((uint32_t) 256, (uint32_t) get_device().get_gpu().get_properties().limits.maxComputeWorkGroupSize);
+	work_group_size = std::min((uint32_t) 256, (uint32_t) get_device().get_gpu().get_properties().limits.maxComputeWorkGroupSize[0]);
 	// Same for shared data size for passing data between shader invocations
 	shared_data_size = std::min((uint32_t) 1024, (uint32_t)(get_device().get_gpu().get_properties().limits.maxComputeSharedMemorySize / sizeof(glm::vec4)));
 

--- a/samples/api/compute_nbody/compute_nbody.h
+++ b/samples/api/compute_nbody/compute_nbody.h
@@ -34,7 +34,7 @@ class ComputeNBody : public ApiVulkanSample
 {
   public:
 	uint32_t num_particles;
-	uint32_t work_group_size = 128;
+	uint32_t work_group_size  = 128;
 	uint32_t shared_data_size = 1024;
 
 	struct

--- a/samples/api/compute_nbody/compute_nbody.h
+++ b/samples/api/compute_nbody/compute_nbody.h
@@ -34,6 +34,8 @@ class ComputeNBody : public ApiVulkanSample
 {
   public:
 	uint32_t num_particles;
+	uint32_t work_group_size = 128;
+	uint32_t shared_data_size = 1024;
 
 	struct
 	{

--- a/shaders/compute_nbody/particle_calculate.comp
+++ b/shaders/compute_nbody/particle_calculate.comp
@@ -34,10 +34,10 @@ layout (binding = 1) uniform UBO
 	int particleCount;
 } ubo;
 
-layout (constant_id = 1) const int SHARED_DATA_SIZE = 512;
+layout (constant_id = 1) const int SHARED_DATA_SIZE = 1024;
 layout (constant_id = 2) const float GRAVITY = 0.002;
 layout (constant_id = 3) const float POWER = 0.75;
-layout (constant_id = 4) const float SOFTEN = 0.0075;
+layout (constant_id = 4) const float SOFTEN = 0.05;
 
 layout (local_size_x_id = 0) in;
 

--- a/shaders/compute_nbody/particle_calculate.comp
+++ b/shaders/compute_nbody/particle_calculate.comp
@@ -1,5 +1,5 @@
 #version 450
-/* Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2019-2020, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/shaders/compute_nbody/particle_calculate.comp
+++ b/shaders/compute_nbody/particle_calculate.comp
@@ -28,18 +28,19 @@ layout(std140, binding = 0) buffer Pos
    Particle particles[ ];
 };
 
-layout (local_size_x = 256) in;
-
 layout (binding = 1) uniform UBO 
 {
 	float deltaT;
 	int particleCount;
 } ubo;
 
-layout (constant_id = 0) const int SHARED_DATA_SIZE = 512;
-layout (constant_id = 1) const float GRAVITY = 0.002;
-layout (constant_id = 2) const float POWER = 0.75;
-layout (constant_id = 3) const float SOFTEN = 0.0075;
+layout (constant_id = 0) const int WORKGROUP_SIZE = 128;
+layout (constant_id = 1) const int SHARED_DATA_SIZE = 512;
+layout (constant_id = 2) const float GRAVITY = 0.002;
+layout (constant_id = 3) const float POWER = 0.75;
+layout (constant_id = 4) const float SOFTEN = 0.0075;
+
+layout (local_size_x_id = 0) in;
 
 // Share data between computer shader invocations to speed up caluclations
 shared vec4 sharedData[SHARED_DATA_SIZE];

--- a/shaders/compute_nbody/particle_calculate.comp
+++ b/shaders/compute_nbody/particle_calculate.comp
@@ -34,7 +34,6 @@ layout (binding = 1) uniform UBO
 	int particleCount;
 } ubo;
 
-layout (constant_id = 0) const int WORKGROUP_SIZE = 128;
 layout (constant_id = 1) const int SHARED_DATA_SIZE = 512;
 layout (constant_id = 2) const float GRAVITY = 0.002;
 layout (constant_id = 3) const float POWER = 0.75;

--- a/shaders/compute_nbody/particle_integrate.comp
+++ b/shaders/compute_nbody/particle_integrate.comp
@@ -28,8 +28,6 @@ layout(std140, binding = 0) buffer Pos
    Particle particles[ ];
 };
 
-layout (constant_id = 0) const int WORKGROUP_SIZE = 128;
-
 layout (local_size_x_id = 0) in;
 
 layout (binding = 1) uniform UBO 

--- a/shaders/compute_nbody/particle_integrate.comp
+++ b/shaders/compute_nbody/particle_integrate.comp
@@ -28,7 +28,9 @@ layout(std140, binding = 0) buffer Pos
    Particle particles[ ];
 };
 
-layout (local_size_x = 256) in;
+layout (constant_id = 0) const int WORKGROUP_SIZE = 128;
+
+layout (local_size_x_id = 0) in;
 
 layout (binding = 1) uniform UBO 
 {

--- a/shaders/compute_nbody/particle_integrate.comp
+++ b/shaders/compute_nbody/particle_integrate.comp
@@ -1,5 +1,5 @@
 #version 450
-/* Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2019-2020, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
## Description

This PR replaces the fixed work group size of 256 for the compute shaders in the N-Body sample with dynamic values that consider the actual device limits. The work group size is then passed to the shaders using specialization constants.

Fixes #165

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)