### PR TITLE
Fix resize crash on intel based GPUs

### DIFF
--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -301,15 +301,13 @@ VkSemaphore RenderContext::begin_frame()
 
 	if (swapchain)
 	{
-		auto fence = prev_frame.request_fence();
-
-		auto result = swapchain->acquire_next_image(active_frame_index, aquired_semaphore, fence);
+		auto result = swapchain->acquire_next_image(active_frame_index, aquired_semaphore, VK_NULL_HANDLE);
 
 		if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR)
 		{
 			handle_surface_changes();
 
-			result = swapchain->acquire_next_image(active_frame_index, aquired_semaphore, fence);
+			result = swapchain->acquire_next_image(active_frame_index, aquired_semaphore, VK_NULL_HANDLE);
 		}
 
 		if (result != VK_SUCCESS)
@@ -323,6 +321,7 @@ VkSemaphore RenderContext::begin_frame()
 	// Now the frame is active again
 	frame_active = true;
 
+	// Wait on all resource to be freed from the previous render to this frame
 	wait_frame();
 
 	return aquired_semaphore;


### PR DESCRIPTION
## Description

When resizing on specific Intel based laptop GPU's the application will crash when waiting on fences. This may of been due to a driver bug.

The fence that seems to cause the crash was used when acquiring the next swap chain image. This fence is actually redundant as we do not need to synchronize the CPU with this resource, the semaphore locks this image until it is presented. Removing this fence fixes the issue.

Fixes #171 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
