### PR TITLE
Fix lighting consts on 64-bit platforms

### DIFF
--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -300,9 +300,9 @@ void CommandBuffer::bind_lighting(LightingState &lighting_state, uint32_t set, u
 {
 	bind_buffer(lighting_state.light_buffer.get_buffer(), lighting_state.light_buffer.get_offset(), lighting_state.light_buffer.get_size(), set, binding, 0);
 
-	set_specialization_constant(0, lighting_state.directional_lights.size());
-	set_specialization_constant(1, lighting_state.point_lights.size());
-	set_specialization_constant(2, lighting_state.spot_lights.size());
+	set_specialization_constant(0, to_u32(lighting_state.directional_lights.size()));
+	set_specialization_constant(1, to_u32(lighting_state.point_lights.size()));
+	set_specialization_constant(2, to_u32(lighting_state.spot_lights.size()));
 }
 
 void CommandBuffer::set_viewport_state(const ViewportState &state_info)


### PR DESCRIPTION
vector::size() doesn't always return a 32-bit value so ensure we cast it to what the shader expects (a uint32).

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making