### PR TITLE
Make descriptor set layout cache requests depend on shader modules

### DIFF
--- a/framework/core/descriptor_set_layout.h
+++ b/framework/core/descriptor_set_layout.h
@@ -24,6 +24,7 @@ namespace vkb
 {
 class DescriptorPool;
 class Device;
+class ShaderModule;
 
 struct ShaderResource;
 
@@ -38,9 +39,13 @@ class DescriptorSetLayout
 	 * @brief Creates a descriptor set layout from a set of resources
 	 * @param device A valid Vulkan device
 	 * @param set_index The descriptor set index this layout maps to
+	 * @param shader_modules The shader modules this set layout will be used for
 	 * @param resource_set A grouping of shader resources belonging to the same set
 	 */
-	DescriptorSetLayout(Device &device, const uint32_t set_index, const std::vector<ShaderResource> &resource_set);
+	DescriptorSetLayout(Device &                           device,
+	                    const uint32_t                     set_index,
+	                    const std::vector<ShaderModule *> &shader_modules,
+	                    const std::vector<ShaderResource> &resource_set);
 
 	DescriptorSetLayout(const DescriptorSetLayout &) = delete;
 
@@ -66,6 +71,8 @@ class DescriptorSetLayout
 
 	VkDescriptorBindingFlagsEXT get_layout_binding_flag(const uint32_t binding_index) const;
 
+	const std::vector<ShaderModule *> &get_shader_modules() const;
+
   private:
 	Device &device;
 
@@ -82,5 +89,7 @@ class DescriptorSetLayout
 	std::unordered_map<uint32_t, VkDescriptorBindingFlagsEXT> binding_flags_lookup;
 
 	std::unordered_map<std::string, uint32_t> resources_lookup;
+
+	std::vector<ShaderModule *> shader_modules;
 };
 }        // namespace vkb

--- a/framework/core/pipeline_layout.cpp
+++ b/framework/core/pipeline_layout.cpp
@@ -81,7 +81,7 @@ PipelineLayout::PipelineLayout(Device &device, const std::vector<ShaderModule *>
 	// Create a descriptor set layout for each shader set in the shader modules
 	for (auto &shader_set_it : shader_sets)
 	{
-		descriptor_set_layouts.emplace_back(&device.get_resource_cache().request_descriptor_set_layout(shader_set_it.first, shader_set_it.second));
+		descriptor_set_layouts.emplace_back(&device.get_resource_cache().request_descriptor_set_layout(shader_set_it.first, shader_modules, shader_set_it.second));
 	}
 
 	// Collect all the descriptor set layout handles, maintaining set order

--- a/framework/resource_cache.cpp
+++ b/framework/resource_cache.cpp
@@ -68,9 +68,11 @@ PipelineLayout &ResourceCache::request_pipeline_layout(const std::vector<ShaderM
 	return request_resource(device, recorder, pipeline_layout_mutex, state.pipeline_layouts, shader_modules);
 }
 
-DescriptorSetLayout &ResourceCache::request_descriptor_set_layout(const uint32_t set_index, const std::vector<ShaderResource> &set_resources)
+DescriptorSetLayout &ResourceCache::request_descriptor_set_layout(const uint32_t                     set_index,
+                                                                  const std::vector<ShaderModule *> &shader_modules,
+                                                                  const std::vector<ShaderResource> &set_resources)
 {
-	return request_resource(device, recorder, descriptor_set_layout_mutex, state.descriptor_set_layouts, set_index, set_resources);
+	return request_resource(device, recorder, descriptor_set_layout_mutex, state.descriptor_set_layouts, set_index, shader_modules, set_resources);
 }
 
 GraphicsPipeline &ResourceCache::request_graphics_pipeline(PipelineState &pipeline_state)

--- a/framework/resource_cache.h
+++ b/framework/resource_cache.h
@@ -99,7 +99,9 @@ class ResourceCache
 
 	PipelineLayout &request_pipeline_layout(const std::vector<ShaderModule *> &shader_modules);
 
-	DescriptorSetLayout &request_descriptor_set_layout(const uint32_t set_index, const std::vector<ShaderResource> &set_resources);
+	DescriptorSetLayout &request_descriptor_set_layout(const uint32_t                     set_index,
+	                                                   const std::vector<ShaderModule *> &shader_modules,
+	                                                   const std::vector<ShaderResource> &set_resources);
 
 	GraphicsPipeline &request_graphics_pipeline(PipelineState &pipeline_state);
 


### PR DESCRIPTION
## Description

This patch prevents the framework from recycling descriptor sets across different shader modules. It does so by also considering the combined hash of all `ShaderModule` handles when requesting a descriptor set layout from the cache.

If this patch is not applied, there can be situations where two completely different shaders are considered identical by the resource cache because they have the same descriptor layout (e.g. 1 sampled image + 1 storage image). This causes the `name -> binding` maps (`resources_lookup`) to become nonsensical when the second shader is used.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making