### PR TITLE
Added slide up/down to freecamera.

### DIFF
--- a/framework/scene_graph/scripts/free_camera.cpp
+++ b/framework/scene_graph/scripts/free_camera.cpp
@@ -1,4 +1,5 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2020, Arm Limited and Contributors
+ * Copyright (c) 2020, Andrew Cox, Huawei Technologies Research & Development (UK) Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/scene_graph/scripts/free_camera.cpp
+++ b/framework/scene_graph/scripts/free_camera.cpp
@@ -72,6 +72,14 @@ void FreeCamera::update(float delta_time)
 	{
 		delta_translation.x += TRANSLATION_MOVE_STEP;
 	}
+	if (key_pressed[KeyCode::Q])
+	{
+		delta_translation.y -= TRANSLATION_MOVE_STEP;
+	}
+	if (key_pressed[KeyCode::E])
+	{
+		delta_translation.y += TRANSLATION_MOVE_STEP;
+	}
 	if (key_pressed[KeyCode::LeftControl])
 	{
 		mul_translation *= (1.0f * TRANSLATION_MOVE_SPEED);


### PR DESCRIPTION
Put slide down and up on Q and E, fitting in to the WSAD cluster to give the less common but still useful axis of translational control on the same hand.
Lets the models be navigated more freely.

Does not relate to any issue. Just a simple quality of life improvement.