### PR TITLE
Add option to request a custom Vulkan API version

### DIFF
--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -371,7 +371,6 @@ class ApiVulkanSample : public vkb::VulkanSample
 
 	std::string title       = "Vulkan Example";
 	std::string name        = "vulkanExample";
-	uint32_t    api_version = VK_API_VERSION_1_0;
 
 	struct
 	{

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -132,7 +132,8 @@ std::vector<const char *> get_optimal_validation_layers(const std::vector<VkLaye
 Instance::Instance(const std::string &                           application_name,
                    const std::unordered_map<const char *, bool> &required_extensions,
                    const std::vector<const char *> &             required_validation_layers,
-                   bool                                          headless)
+                   bool                                          headless,
+                   uint32_t                                      api_version)
 {
 	VkResult result = volkInitialize();
 	if (result)
@@ -260,7 +261,7 @@ Instance::Instance(const std::string &                           application_nam
 	app_info.applicationVersion = 0;
 	app_info.pEngineName        = "Vulkan Samples";
 	app_info.engineVersion      = 0;
-	app_info.apiVersion         = VK_MAKE_VERSION(1, 0, 0);
+	app_info.apiVersion         = api_version;
 
 	VkInstanceCreateInfo instance_info = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
 

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -45,12 +45,14 @@ class Instance
 	 * @param required_extensions The extensions requested to be enabled
 	 * @param required_validation_layers The validation layers to be enabled
 	 * @param headless Whether the application is requesting a headless setup or not
+	 * @param api_version The Vulkan API version that the instance will be using
 	 * @throws runtime_error if the required extensions and validation layers are not found
 	 */
 	Instance(const std::string &                           application_name,
 	         const std::unordered_map<const char *, bool> &required_extensions        = {},
 	         const std::vector<const char *> &             required_validation_layers = {},
-	         bool                                          headless                   = false);
+	         bool                                          headless                   = false,
+	         uint32_t                                      api_version                = VK_API_VERSION_1_0);
 
 	/**
 	 * @brief Queries the GPUs of a VkInstance that is already created

--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -87,7 +87,7 @@ bool VulkanSample::prepare(Platform &platform)
 
 	// Creating the vulkan instance
 	add_instance_extension(platform.get_surface_extension());
-	instance = std::make_unique<Instance>(get_name(), get_instance_extensions(), get_validation_layers(), is_headless());
+	instance = std::make_unique<Instance>(get_name(), get_instance_extensions(), get_validation_layers(), is_headless(), api_version);
 
 	// Getting a valid vulkan surface from the platform
 	surface = platform.get_window().create_surface(*instance);
@@ -460,6 +460,11 @@ void VulkanSample::add_device_extension(const char *extension, bool optional)
 void VulkanSample::add_instance_extension(const char *extension, bool optional)
 {
 	instance_extensions[extension] = optional;
+}
+
+void VulkanSample::set_api_version(uint32_t requested_api_vrsion)
+{
+	api_version = requested_api_vrsion;
 }
 
 void VulkanSample::request_gpu_features(PhysicalDevice &gpu)

--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -462,9 +462,9 @@ void VulkanSample::add_instance_extension(const char *extension, bool optional)
 	instance_extensions[extension] = optional;
 }
 
-void VulkanSample::set_api_version(uint32_t requested_api_vrsion)
+void VulkanSample::set_api_version(uint32_t requested_api_version)
 {
-	api_version = requested_api_vrsion;
+	api_version = requested_api_version;
 }
 
 void VulkanSample::request_gpu_features(PhysicalDevice &gpu)

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -248,6 +248,11 @@ class VulkanSample : public Application
 	void add_instance_extension(const char *extension, bool optional = false);
 
 	/**
+	 * @brief Set he Vulkan API version to request at instance creation time
+	 */
+	void set_api_version(uint32_t requested_api_vrsion);
+
+	/**
 	 * @brief Request features from the gpu based on what is supported
 	 */
 	virtual void request_gpu_features(PhysicalDevice &gpu);
@@ -297,5 +302,8 @@ class VulkanSample : public Application
 
 	/** @brief Set of instance extensions to be enabled for this example and whether they are optional (must be set in the derived constructor) */
 	std::unordered_map<const char *, bool> instance_extensions;
+
+	/** @brief The Vulkan API version to request for this sample at instance creation time */
+	uint32_t api_version = VK_API_VERSION_1_0;
 };
 }        // namespace vkb

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -248,7 +248,7 @@ class VulkanSample : public Application
 	void add_instance_extension(const char *extension, bool optional = false);
 
 	/**
-	 * @brief Set he Vulkan API version to request at instance creation time
+	 * @brief Set the Vulkan API version to request at instance creation time
 	 */
 	void set_api_version(uint32_t requested_api_version);
 

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -250,7 +250,7 @@ class VulkanSample : public Application
 	/**
 	 * @brief Set he Vulkan API version to request at instance creation time
 	 */
-	void set_api_version(uint32_t requested_api_vrsion);
+	void set_api_version(uint32_t requested_api_version);
 
 	/**
 	 * @brief Request features from the gpu based on what is supported


### PR DESCRIPTION
Allows requesting Vulkan API versions per sample and replaces the fixed 1.0 version limitation

## Description

The API version in the samples base class was fixed to `VK_MAKE_VERSION(1, 0, 0)`, making it impossible to request an instance with higher version. The API sample base class actually had a property to override this, but it was never passed down to instance creation.

This PR fixes this, and introduces an api version setter to the sample base class that allows a sample to request different versions:

```cpp
SomeSample::SomeSample()
{
	title = "Some Sample";
	set_api_version(VK_API_VERSION_1_2);
}
```

The default value (if the setter is not called) remains at Vulkan 1.0, so no existing samples are affected.

This change is required for samples that want to use Vulkan core features above version 1.0.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making