### PR TITLE
Add GLSL shader files to project structure via CMAKE

### DIFF
--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -150,6 +150,22 @@ function(add_sample)
         list(APPEND SRC_FILES ${TARGET_FILES})
     endif()
 
+    # Gather GLSL shader files
+    set(SHADER_DIR_GLSL "${PROJECT_SOURCE_DIR}/shaders/${TARGET_ID}")
+    file(GLOB SHADERS_GLSL 
+        "${SHADER_DIR_GLSL}/*.vert"
+        "${SHADER_DIR_GLSL}/*.frag"
+        "${SHADER_DIR_GLSL}/*.comp"
+        "${SHADER_DIR_GLSL}/*.geom"
+        "${SHADER_DIR_GLSL}/*.tesc"
+        "${SHADER_DIR_GLSL}/*.tese"
+        "${SHADER_DIR_GLSL}/*.mesh"
+        "${SHADER_DIR_GLSL}/*.task"
+        "${SHADER_DIR_GLSL}/*.rgen"
+        "${SHADER_DIR_GLSL}/*.rchit"
+        "${SHADER_DIR_GLSL}/*.rmiss"
+    )    
+
     add_project(
         TYPE "Sample"
         ID ${TARGET_ID}
@@ -162,7 +178,10 @@ function(add_sample)
         FILES
             ${SRC_FILES}
         LIBS
-            ${TARGET_LIBS})
+            ${TARGET_LIBS}
+        SHADERS_GLSL
+            ${SHADERS_GLSL})
+
 endfunction()
 
 function(add_sample_with_tags)
@@ -184,6 +203,21 @@ function(add_sample_with_tags)
         list(APPEND SRC_FILES ${TARGET_FILES})
     endif()
 
+    # Gather GLSL shader files
+    set(SHADER_DIR_GLSL "${PROJECT_SOURCE_DIR}/shaders/${TARGET_ID}")
+    file(GLOB SHADERS_GLSL 
+        "${SHADER_DIR_GLSL}/*.vert"
+        "${SHADER_DIR_GLSL}/*.frag"
+        "${SHADER_DIR_GLSL}/*.comp"
+        "${SHADER_DIR_GLSL}/*.geom"
+        "${SHADER_DIR_GLSL}/*.tesc"
+        "${SHADER_DIR_GLSL}/*.tese"
+        "${SHADER_DIR_GLSL}/*.mesh"
+        "${SHADER_DIR_GLSL}/*.task"
+        "${SHADER_DIR_GLSL}/*.rgen"
+        "${SHADER_DIR_GLSL}/*.rchit"
+        "${SHADER_DIR_GLSL}/*.rmiss"
+    )
 
     add_project(
         TYPE "Sample"
@@ -197,7 +231,9 @@ function(add_sample_with_tags)
         FILES
             ${SRC_FILES}
         LIBS
-            ${TARGET_LIBS})
+            ${TARGET_LIBS}
+            SHADERS_GLSL
+            ${SHADERS_GLSL})
 
 endfunction()
 
@@ -224,7 +260,7 @@ endfunction()
 function(add_project)
     set(options)  
     set(oneValueArgs TYPE ID CATEGORY AUTHOR NAME DESCRIPTION)
-    set(multiValueArgs TAGS FILES LIBS)
+    set(multiValueArgs TAGS FILES LIBS SHADERS_GLSL)
 
     cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -244,8 +280,13 @@ function(add_project)
 
     source_group("\\" FILES ${TARGET_FILES})
 
-    add_library(${PROJECT_NAME} STATIC ${TARGET_FILES})
-    
+    # Add shaders to project group
+    if(SHADERS_GLSL)
+        source_group("\\Shaders\\GLSL" FILES ${SHADERS_GLSL})
+    endif()
+
+    add_library(${PROJECT_NAME} STATIC ${TARGET_FILES} ${SHADERS_GLSL})
+   
     # inherit compile definitions from framework target
     target_compile_definitions(${PROJECT_NAME} PUBLIC $<TARGET_PROPERTY:framework,COMPILE_DEFINITIONS>)
 


### PR DESCRIPTION
## Description

This PR adds a function to the CMAKE build system that adds GLSL shader files to the sample projects where applicable. For every sample where the shaders are located in a folder with the same name as the samples (e.g. shaders\hdr). The CMAKE setup will now gather all GLSL files in that folder and adds them to the project structure. For samples without explicit shader folders, no shaders will be added to the project file. 

![image](https://user-images.githubusercontent.com/10283127/97839093-c7c92680-1ce1-11eb-9906-156af8068214.png)

This allows for easy access of the shaders directly from within the IDE.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [n/a] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [n/a] My changes do not add any new compiler warnings
- [n/a] My changes do not add any new validation layer errors or warnings
- [n/a ] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making