### PR TITLE
Fix Subpasses sample on some platforms

### DIFF
--- a/framework/common/resource_caching.h
+++ b/framework/common/resource_caching.h
@@ -445,6 +445,7 @@ struct hash<vkb::RenderTarget>
 		for (auto &view : render_target.get_views())
 		{
 			vkb::hash_combine(result, view.get_handle());
+			vkb::hash_combine(result, view.get_image().get_handle());
 		}
 
 		return result;

--- a/framework/common/resource_caching.h
+++ b/framework/common/resource_caching.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, Arm Limited and Contributors
+/* Copyright (c) 2018-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -220,6 +220,8 @@ void RenderContext::recreate()
 
 		++frame_it;
 	}
+
+	device.get_resource_cache().clear_framebuffers();
 }
 
 void RenderContext::handle_surface_changes()


### PR DESCRIPTION
## Description

When toggling values in the 'Subpasses' sample, it recreates the render targets with the new parameters. The resource caching system was not taking into account that an ImageView that may have been destroyed and recreated with a different image could have the same ImageView handle in some platforms.

I believe the framework has a deeper issue since when a RenderContext gets recreated, it destroys the respective Image and ImageViews but does not remove them from the resource_cache. That may need to be addressed as well although I don't know where's the best place to do that and will leave it out of the scope of this fix. A possibility for this is to add a:
`device.get_resource_cache().clear_framebuffers();`
at the end of the void RenderContext::recreate() function but I'm not 100% sure that's the best place for it.

Fixes #94 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly. Tested on Adreno and Nvidia GPUs.
- [x] This PR describes the scope and expected impact of the changes I am making
