### PR TITLE
Clang quality check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: alias clang-format="clang-format-10"
     - run: git fetch origin $TARGET_BRANCH:$TARGET_BRANCH
     - run: python3 /usr/local/bin/clang_format.py -v --diff $TARGET_BRANCH > clang-format-report.txt
     - run: if [ $(grep -c 'clang-format did not modify any files' clang-format-report.txt) -eq 0  ] && [ $(grep -c 'no modified files to format' clang-format-report.txt) -eq 0  ]; then cat clang-format-report.txt; exit 1; fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: alias clang-format="clang-format-10"
+    - run: git config clangFormat.binary "clang-format-10"
     - run: git fetch origin $TARGET_BRANCH:$TARGET_BRANCH
     - run: python3 /usr/local/bin/clang_format.py -v --diff $TARGET_BRANCH > clang-format-report.txt
     - run: if [ $(grep -c 'clang-format did not modify any files' clang-format-report.txt) -eq 0  ] && [ $(grep -c 'no modified files to format' clang-format-report.txt) -eq 0  ]; then cat clang-format-report.txt; exit 1; fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,3 +47,14 @@ jobs:
     - run: git fetch origin $TARGET_BRANCH:$TARGET_BRANCH
     - run: python3 /usr/local/bin/clang_format.py -v --diff $TARGET_BRANCH > clang-format-report.txt
     - run: if [ $(grep -c 'clang-format did not modify any files' clang-format-report.txt) -eq 0  ] && [ $(grep -c 'no modified files to format' clang-format-report.txt) -eq 0  ]; then cat clang-format-report.txt; exit 1; fi
+
+  clang_tidy:
+    name: Clang Tidy Check
+    container: khronosgroup/vulkan-samples
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: "recursive"
+    - run: cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -H. -Bbuild/clang
+    - run: python3 /usr/local/bin/run-clang-tidy.py -j $(($(nproc)/2+1)) -p build/clang -clang-tidy-binary=clang-tidy-10 -header-filter=framework,samples,vulkan_samples -checks=-*,google-*,-google-runtime-references -quiet framework/* samples/* vulkan_samples/* tests/*

--- a/framework/buffer_pool.cpp
+++ b/framework/buffer_pool.cpp
@@ -28,7 +28,7 @@ namespace vkb
 BufferBlock::BufferBlock(Device &device, VkDeviceSize size, VkBufferUsageFlags usage, VmaMemoryUsage memory_usage) :
     buffer{device, size, usage, memory_usage}
 {
-	if (usage == VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
+			if (usage == VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
 	{
 		alignment = device.get_gpu().get_properties().limits.minUniformBufferOffsetAlignment;
 	}

--- a/framework/buffer_pool.cpp
+++ b/framework/buffer_pool.cpp
@@ -28,7 +28,7 @@ namespace vkb
 BufferBlock::BufferBlock(Device &device, VkDeviceSize size, VkBufferUsageFlags usage, VmaMemoryUsage memory_usage) :
     buffer{device, size, usage, memory_usage}
 {
-			if (usage == VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
+	if (usage == VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
 	{
 		alignment = device.get_gpu().get_properties().limits.minUniformBufferOffsetAlignment;
 	}


### PR DESCRIPTION
The two scripts used for clang format and clang tidy displayed issues in GitHub Actions. They could not locate the clang-tidy and clang-format binaries. The fix was to point them to the binary locations