### PR TITLE
OpenGL interop sample fix (#205)

### DIFF
--- a/samples/extensions/open_gl_interop/open_gl_interop.cpp
+++ b/samples/extensions/open_gl_interop/open_gl_interop.cpp
@@ -795,7 +795,7 @@ OpenGLInterop::~OpenGLInterop()
 	{
 		device->wait_idle();
 		auto deviceHandle = device->get_handle();
-		vkDestroySemaphore(deviceHandle, sharedSemaphores.gl_complete, nullptr);
+		vkDestroySemaphore(deviceHandle, sharedSemaphores.gl_ready, nullptr);
 		vkDestroySemaphore(deviceHandle, sharedSemaphores.gl_complete, nullptr);
 		vkDestroyImage(deviceHandle, sharedTexture.image, nullptr);
 		vkDestroySampler(deviceHandle, sharedTexture.sampler, nullptr);


### PR DESCRIPTION
## Description

* Fixed typo on gl_complete -> gl_ready to avoid destroying the same
  semaphore twice

Fixes #205 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules