### PR TITLE
FIx incorrect barrier when resolving the depth attachment on writebac…

### DIFF
--- a/framework/core/sampled_image.cpp
+++ b/framework/core/sampled_image.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020, Arm Limited and Contributors
+/* Copyright (c) 2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/core/sampled_image.cpp
+++ b/framework/core/sampled_image.cpp
@@ -27,21 +27,24 @@ SampledImage::SampledImage(const core::ImageView &image_view, Sampler *sampler) 
     image_view{&image_view},
     target_attachment{0},
     render_target{nullptr},
-    sampler{sampler}
+    sampler{sampler},
+    isDepthResolve{false}
 {}
 
-SampledImage::SampledImage(uint32_t target_attachment, RenderTarget *render_target, Sampler *sampler) :
+SampledImage::SampledImage(uint32_t target_attachment, RenderTarget *render_target, Sampler *sampler, bool isDepthResolve) :
     image_view{nullptr},
     target_attachment{target_attachment},
     render_target{render_target},
-    sampler{sampler}
+    sampler{sampler},
+    isDepthResolve{isDepthResolve}
 {}
 
 SampledImage::SampledImage(const SampledImage &to_copy) :
     image_view{to_copy.image_view},
     target_attachment{to_copy.target_attachment},
     render_target{to_copy.render_target},
-    sampler{to_copy.sampler}
+    sampler{to_copy.sampler},
+    isDepthResolve{false}
 {}
 
 SampledImage &SampledImage::operator=(const SampledImage &to_copy)
@@ -50,6 +53,7 @@ SampledImage &SampledImage::operator=(const SampledImage &to_copy)
 	target_attachment = to_copy.target_attachment;
 	render_target     = to_copy.render_target;
 	sampler           = to_copy.sampler;
+	isDepthResolve    = to_copy.isDepthResolve;
 	return *this;
 }
 
@@ -57,7 +61,8 @@ SampledImage::SampledImage(SampledImage &&to_move) :
     image_view{std::move(to_move.image_view)},
     target_attachment{std::move(to_move.target_attachment)},
     render_target{std::move(to_move.render_target)},
-    sampler{std::move(to_move.sampler)}
+    sampler{std::move(to_move.sampler)},
+    isDepthResolve{std::move(to_move.isDepthResolve)}
 {}
 
 SampledImage &SampledImage::operator=(SampledImage &&to_move)
@@ -66,6 +71,7 @@ SampledImage &SampledImage::operator=(SampledImage &&to_move)
 	target_attachment = std::move(to_move.target_attachment);
 	render_target     = std::move(to_move.render_target);
 	sampler           = std::move(to_move.sampler);
+	isDepthResolve    = std::move(to_move.isDepthResolve);
 	return *this;
 }
 

--- a/framework/core/sampled_image.h
+++ b/framework/core/sampled_image.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020, Arm Limited and Contributors
+/* Copyright (c) 2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -136,7 +136,7 @@ class SampledImage
 	uint32_t         target_attachment;
 	RenderTarget *   render_target;
 	Sampler *        sampler;
-	bool			 isDepthResolve;
+	bool             isDepthResolve;
 };
 
 }        // namespace core

--- a/framework/core/sampled_image.h
+++ b/framework/core/sampled_image.h
@@ -45,7 +45,7 @@ class SampledImage
 	* @remarks If the render target is null, the default is assumed.
 	*          If the sampler is null, a default sampler is used.
 	*/
-	SampledImage(uint32_t target_attachment, RenderTarget *render_target = nullptr, Sampler *sampler = nullptr);
+	SampledImage(uint32_t target_attachment, RenderTarget *render_target = nullptr, Sampler *sampler = nullptr, bool isDepthResolve = false);
 
 	SampledImage(const SampledImage &to_copy);
 	SampledImage &operator=(const SampledImage &to_copy);
@@ -126,11 +126,17 @@ class SampledImage
 		render_target = std::move(new_render_target);
 	}
 
+	inline bool is_depth_resolve() const
+	{
+		return isDepthResolve;
+	}
+
   private:
 	const ImageView *image_view;
 	uint32_t         target_attachment;
 	RenderTarget *   render_target;
 	Sampler *        sampler;
+	bool			 isDepthResolve;
 };
 
 }        // namespace core

--- a/framework/rendering/postprocessing_renderpass.cpp
+++ b/framework/rendering/postprocessing_renderpass.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020, Arm Limited and Contributors
+/* Copyright (c) 2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -233,7 +233,7 @@ void PostProcessingRenderPass::update_load_stores(
 		                                     [&render_target, j](auto &pair) {
 			                                     // NOTE: if RT not set, default is the currently-active one
 			                                     auto *sampled_rt = pair.first ? pair.first : &render_target;
-												 // unpack attachment
+			                                     // unpack attachment
 			                                     uint32_t attachment = pair.second & 0x7fffffff;
 			                                     return attachment == j && sampled_rt == &render_target;
 		                                     }) != sampled_attachments.end();
@@ -354,10 +354,10 @@ void PostProcessingRenderPass::transition_attachments(
 		auto *     sampled_rt  = sampled.first ? sampled.first : &render_target;
 
 		// unpack depth resolve flag and attachment
-		bool       is_depth_resolve = sampled.second & 0x80000000;
-		uint32_t   attachment       = sampled.second & 0x7fffffff;
+		bool     is_depth_resolve = sampled.second & 0x80000000;
+		uint32_t attachment       = sampled.second & 0x7fffffff;
 
-		const auto prev_layout      = sampled_rt->get_layout(attachment);
+		const auto prev_layout = sampled_rt->get_layout(attachment);
 
 		if (prev_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
 		{
@@ -446,7 +446,7 @@ void PostProcessingRenderPass::prepare_draw(CommandBuffer &command_buffer, Rende
 			if (const uint32_t *sampled_attachment = it.second.get_target_attachment())
 			{
 				auto *image_rt = it.second.get_render_target();
-				auto packed_sampled_attachment = *sampled_attachment;
+				auto  packed_sampled_attachment = *sampled_attachment;
 
 				// pack sampled attachment
 				if (it.second.is_depth_resolve())

--- a/samples/performance/msaa/msaa.cpp
+++ b/samples/performance/msaa/msaa.cpp
@@ -581,7 +581,7 @@ void MSAASample::postprocessing(vkb::CommandBuffer &command_buffer, vkb::RenderT
 		postprocessing_subpass.get_fs_variant().add_define("MS_DEPTH");
 	}
 	postprocessing_subpass
-	    .bind_sampled_image(depth_sampler_name, depth_attachment)
+	    .bind_sampled_image(depth_sampler_name, {depth_attachment, nullptr, nullptr, depth_writeback_resolve_supported && resolve_depth_on_writeback})
 	    .bind_sampled_image("color_sampler", i_color_resolve);
 
 	// Second render pass

--- a/samples/performance/msaa/msaa.cpp
+++ b/samples/performance/msaa/msaa.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020, Arm Limited and Contributors
+/* Copyright (c) 2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
…k in MSAA sample

## Description

The resolving depth occurs in the COLOR_ATTACHMENT_OUT stage, not in the EARLY\LATE_FRAGMENT_TESTS stage
and the corresponding access mask is COLOR_ATTACHMENT_WRITE_BIT, not DEPTH_STENCIL_ATTACHMENT_WRITE_BIT.

Fixes #235 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
