### PR TITLE
Update Windows build instructions for newer CMake

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -134,7 +134,7 @@ adb shell setprop security.perf_harden 0
 
 ## Dependencies
 
-- CMake v3.10+ (known to work with 3.10.2)
+- CMake v3.10+ (known to work with 3.10.2 and 3.19.3)
 - Python 3
 - Visual Studio 2017 or above
 - [clang-format-8](#clang-format-and-visual-studio)
@@ -156,6 +156,11 @@ Go to the [LLVM downloads page](http://releases.llvm.org/download.html) to get c
 
 `Step 1.` The following command will generate the VS project
 
+```
+cmake -G"Visual Studio 15 2017 Win64" -S . -Bbuild/windows
+```
+
+(Prior to CMake v3.13)
 ```
 cmake -G"Visual Studio 15 2017 Win64" -H. -Bbuild/windows
 ```


### PR DESCRIPTION
## Description

The undocumented CMake `-H` option was removed in CMake 3.13 and replaced with `-S`
See https://cgold.readthedocs.io/en/latest/glossary/-S.html

I have only tested this on Windows, but I suspect the same changes need to apply to the other platforms as well.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
