### PR TITLE
Add ray tracing related helper classes and functions to the framework

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -210,6 +210,9 @@ set(CORE_FILES
     core/framebuffer.h
     core/render_pass.h
     core/query_pool.h
+    core/scratch_buffer.h
+    core/acceleration_structure.h
+    core/shader_binding_table.h
     # Source Files
     core/instance.cpp
     core/physical_device.cpp
@@ -233,7 +236,10 @@ set(CORE_FILES
     core/sampler.cpp
     core/framebuffer.cpp
     core/render_pass.cpp
-    core/query_pool.cpp)
+    core/query_pool.cpp
+    core/scratch_buffer.cpp
+    core/acceleration_structure.cpp
+    core/shader_binding_table.cpp)
 
 set(PLATFORM_FILES
     # Header Files

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, Arm Limited and Contributors
+# Copyright (c) 2019-2021, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/framework/core/acceleration_structure.cpp
+++ b/framework/core/acceleration_structure.cpp
@@ -1,0 +1,115 @@
+/* Copyright (c) 2021, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "acceleration_structure.h"
+
+#include "device.h"
+
+namespace vkb
+{
+namespace core
+{
+AccelerationStructure::AccelerationStructure(Device &                                    device,
+                                             VkAccelerationStructureTypeKHR              type,
+                                             VkAccelerationStructureBuildGeometryInfoKHR build_geometry_info,
+                                             uint32_t                                    primitive_count) :
+    device{device},
+    type{type}
+{
+	// Get required build sizes
+	build_sizes_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
+	vkGetAccelerationStructureBuildSizesKHR(
+	    device.get_handle(),
+	    VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
+	    &build_geometry_info,
+	    &primitive_count,
+	    &build_sizes_info);
+
+	// Create a buffer for the acceleration structure
+	buffer = std::make_unique<vkb::core::Buffer>(
+	    device,
+	    build_sizes_info.accelerationStructureSize,
+	    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+	    VMA_MEMORY_USAGE_GPU_ONLY);
+
+	VkAccelerationStructureCreateInfoKHR acceleration_structure_create_info{};
+	acceleration_structure_create_info.sType  = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR;
+	acceleration_structure_create_info.buffer = buffer->get_handle();
+	acceleration_structure_create_info.size   = build_sizes_info.accelerationStructureSize;
+	acceleration_structure_create_info.type   = type;
+	VkResult result                           = vkCreateAccelerationStructureKHR(device.get_handle(), &acceleration_structure_create_info, nullptr, &handle);
+
+	if (result != VK_SUCCESS)
+	{
+		throw VulkanException{result, "Could not create acceleration structure"};
+	}
+
+	// Get the acceleration structure's handle
+	VkAccelerationStructureDeviceAddressInfoKHR acceleration_device_address_info{};
+	acceleration_device_address_info.sType                 = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
+	acceleration_device_address_info.accelerationStructure = handle;
+	device_address                                         = vkGetAccelerationStructureDeviceAddressKHR(device.get_handle(), &acceleration_device_address_info);
+}
+AccelerationStructure::~AccelerationStructure()
+{
+	if (handle != VK_NULL_HANDLE)
+	{
+		vkDestroyAccelerationStructureKHR(device.get_handle(), handle, nullptr);
+	}
+}
+void AccelerationStructure::build(const std::vector<VkAccelerationStructureGeometryKHR> & geometries,
+                                  std::vector<VkAccelerationStructureBuildRangeInfoKHR *> build_range_infos,
+                                  VkQueue                                                 queue,
+                                  VkBuildAccelerationStructureFlagsKHR                    flags,
+                                  VkBuildAccelerationStructureModeKHR                     mode)
+{
+	// Create a scratch buffer as a temporary storage for the acceleration structure build
+	std::unique_ptr<vkb::core::ScratchBuffer> scratch_buffer = std::make_unique<vkb::core::ScratchBuffer>(device, build_sizes_info.buildScratchSize);
+
+	VkAccelerationStructureBuildGeometryInfoKHR acceleration_build_geometry_info{};
+	acceleration_build_geometry_info.sType                     = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
+	acceleration_build_geometry_info.type                      = type;
+	acceleration_build_geometry_info.flags                     = flags;
+	acceleration_build_geometry_info.mode                      = mode;
+	acceleration_build_geometry_info.dstAccelerationStructure  = handle;
+	acceleration_build_geometry_info.geometryCount             = static_cast<uint32_t>(geometries.size());
+	acceleration_build_geometry_info.pGeometries               = geometries.data();
+	acceleration_build_geometry_info.scratchData.deviceAddress = scratch_buffer->get_device_address();
+
+	// Build the acceleration structure on the device via a one-time command buffer submission
+	VkCommandBuffer command_buffer = device.create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+	vkCmdBuildAccelerationStructuresKHR(
+	    command_buffer,
+	    1,
+	    &acceleration_build_geometry_info,
+	    build_range_infos.data());
+	device.flush_command_buffer(command_buffer, queue);
+}
+VkAccelerationStructureKHR AccelerationStructure::get_handle() const
+{
+	return handle;
+}
+const VkAccelerationStructureKHR *AccelerationStructure::get() const
+{
+	return &handle;
+}
+uint64_t AccelerationStructure::get_device_address() const
+{
+	return device_address;
+}
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/acceleration_structure.cpp
+++ b/framework/core/acceleration_structure.cpp
@@ -23,20 +23,94 @@ namespace vkb
 {
 namespace core
 {
-AccelerationStructure::AccelerationStructure(Device &                                    device,
-                                             VkAccelerationStructureTypeKHR              type,
-                                             VkAccelerationStructureBuildGeometryInfoKHR build_geometry_info,
-                                             uint32_t                                    primitive_count) :
+AccelerationStructure::AccelerationStructure(Device &                       device,
+                                             VkAccelerationStructureTypeKHR type) :
     device{device},
     type{type}
 {
+}
+
+AccelerationStructure::~AccelerationStructure()
+{
+	if (handle != VK_NULL_HANDLE)
+	{
+		vkDestroyAccelerationStructureKHR(device.get_handle(), handle, nullptr);
+	}
+}
+
+void AccelerationStructure::add_triangle_geometry(std::unique_ptr<vkb::core::Buffer> &vertex_buffer, std::unique_ptr<vkb::core::Buffer> &index_buffer, std::unique_ptr<vkb::core::Buffer> &transform_buffer, uint32_t triangle_count, uint32_t max_vertex, VkDeviceSize vertex_stride, uint32_t transform_offset, VkFormat vertex_format, VkGeometryFlagsKHR flags)
+{
+	VkAccelerationStructureGeometryKHR geometry{};
+	geometry.sType                                          = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+	geometry.geometryType                                   = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
+	geometry.flags                                          = flags;
+	geometry.geometry.triangles.sType                       = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
+	geometry.geometry.triangles.vertexFormat                = vertex_format;
+	geometry.geometry.triangles.maxVertex                   = max_vertex;
+	geometry.geometry.triangles.vertexStride                = vertex_stride;
+	geometry.geometry.triangles.indexType                   = VK_INDEX_TYPE_UINT32;
+	geometry.geometry.triangles.vertexData.deviceAddress    = vertex_buffer->get_device_address();
+	geometry.geometry.triangles.indexData.deviceAddress     = index_buffer->get_device_address();
+	geometry.geometry.triangles.transformData.deviceAddress = transform_buffer->get_device_address();
+
+	geometries.push_back({geometry, triangle_count, transform_offset});
+}
+
+void AccelerationStructure::add_instance_geometry(std::unique_ptr<vkb::core::Buffer> &instance_buffer, uint32_t instance_count, uint32_t transform_offset, VkGeometryFlagsKHR flags)
+{
+	VkAccelerationStructureGeometryKHR geometry{};
+	geometry.sType                                 = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+	geometry.geometryType                          = VK_GEOMETRY_TYPE_INSTANCES_KHR;
+	geometry.flags                                 = flags;
+	geometry.geometry.instances.sType              = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
+	geometry.geometry.instances.arrayOfPointers    = VK_FALSE;
+	geometry.geometry.instances.data.deviceAddress = instance_buffer->get_device_address();
+
+	geometries.push_back({geometry, instance_count, transform_offset});
+}
+
+void AccelerationStructure::build(VkQueue queue, VkBuildAccelerationStructureFlagsKHR flags, VkBuildAccelerationStructureModeKHR mode)
+{
+	assert(!geometries.empty());
+
+	std::vector<VkAccelerationStructureGeometryKHR>         acceleration_structure_geometries;
+	std::vector<VkAccelerationStructureBuildRangeInfoKHR>   acceleration_structure_build_range_infos;
+	std::vector<VkAccelerationStructureBuildRangeInfoKHR *> pp_acceleration_structure_build_range_infos;
+	std::vector<uint32_t>                                   primitive_counts;
+	for (auto &geometry : geometries)
+	{
+		acceleration_structure_geometries.push_back(geometry.geometry);
+		// Infer build range info from geometry
+		VkAccelerationStructureBuildRangeInfoKHR build_range_info;
+		build_range_info.primitiveCount  = geometry.primitive_count;
+		build_range_info.primitiveOffset = 0;
+		build_range_info.firstVertex     = 0;
+		build_range_info.transformOffset = geometry.transform_offset;
+		acceleration_structure_build_range_infos.push_back(build_range_info);
+		primitive_counts.push_back(1);
+	}
+	for (size_t i = 0; i < acceleration_structure_build_range_infos.size(); i++)
+	{
+		pp_acceleration_structure_build_range_infos.push_back(&acceleration_structure_build_range_infos[i]);
+	}
+
+	VkAccelerationStructureBuildGeometryInfoKHR build_geometry_info{};
+	build_geometry_info.sType         = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
+	build_geometry_info.type          = type;
+	build_geometry_info.flags         = flags;
+	build_geometry_info.mode          = mode;
+	build_geometry_info.geometryCount = static_cast<uint32_t>(acceleration_structure_geometries.size());
+	build_geometry_info.pGeometries   = acceleration_structure_geometries.data();
+
+	uint32_t primitive_count = build_geometry_info.geometryCount;
+
 	// Get required build sizes
 	build_sizes_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
 	vkGetAccelerationStructureBuildSizesKHR(
 	    device.get_handle(),
 	    VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
 	    &build_geometry_info,
-	    &primitive_count,
+	    primitive_counts.data(),
 	    &build_sizes_info);
 
 	// Create a buffer for the acceleration structure
@@ -63,53 +137,37 @@ AccelerationStructure::AccelerationStructure(Device &                           
 	acceleration_device_address_info.sType                 = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
 	acceleration_device_address_info.accelerationStructure = handle;
 	device_address                                         = vkGetAccelerationStructureDeviceAddressKHR(device.get_handle(), &acceleration_device_address_info);
-}
-AccelerationStructure::~AccelerationStructure()
-{
-	if (handle != VK_NULL_HANDLE)
-	{
-		vkDestroyAccelerationStructureKHR(device.get_handle(), handle, nullptr);
-	}
-}
-void AccelerationStructure::build(const std::vector<VkAccelerationStructureGeometryKHR> & geometries,
-                                  std::vector<VkAccelerationStructureBuildRangeInfoKHR *> build_range_infos,
-                                  VkQueue                                                 queue,
-                                  VkBuildAccelerationStructureFlagsKHR                    flags,
-                                  VkBuildAccelerationStructureModeKHR                     mode)
-{
+
 	// Create a scratch buffer as a temporary storage for the acceleration structure build
 	std::unique_ptr<vkb::core::ScratchBuffer> scratch_buffer = std::make_unique<vkb::core::ScratchBuffer>(device, build_sizes_info.buildScratchSize);
 
-	VkAccelerationStructureBuildGeometryInfoKHR acceleration_build_geometry_info{};
-	acceleration_build_geometry_info.sType                     = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
-	acceleration_build_geometry_info.type                      = type;
-	acceleration_build_geometry_info.flags                     = flags;
-	acceleration_build_geometry_info.mode                      = mode;
-	acceleration_build_geometry_info.dstAccelerationStructure  = handle;
-	acceleration_build_geometry_info.geometryCount             = static_cast<uint32_t>(geometries.size());
-	acceleration_build_geometry_info.pGeometries               = geometries.data();
-	acceleration_build_geometry_info.scratchData.deviceAddress = scratch_buffer->get_device_address();
+	build_geometry_info.scratchData.deviceAddress = scratch_buffer->get_device_address();
+	build_geometry_info.dstAccelerationStructure  = handle;
 
 	// Build the acceleration structure on the device via a one-time command buffer submission
 	VkCommandBuffer command_buffer = device.create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 	vkCmdBuildAccelerationStructuresKHR(
 	    command_buffer,
 	    1,
-	    &acceleration_build_geometry_info,
-	    build_range_infos.data());
+	    &build_geometry_info,
+	    pp_acceleration_structure_build_range_infos.data());
 	device.flush_command_buffer(command_buffer, queue);
 }
+
 VkAccelerationStructureKHR AccelerationStructure::get_handle() const
 {
 	return handle;
 }
+
 const VkAccelerationStructureKHR *AccelerationStructure::get() const
 {
 	return &handle;
 }
+
 uint64_t AccelerationStructure::get_device_address() const
 {
 	return device_address;
 }
+
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/acceleration_structure.h
+++ b/framework/core/acceleration_structure.h
@@ -1,0 +1,76 @@
+/* Copyright (c) 2021, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "common/helpers.h"
+#include "common/vk_common.h"
+#include "core/buffer.h"
+#include "core/scratch_buffer.h"
+
+namespace vkb
+{
+class Device;
+
+namespace core
+{
+/**
+ * @brief Wraps setup and access for a ray tracing top- or bottom-level acceleration structure
+ */
+class AccelerationStructure
+{
+  public:
+	/**
+	 * @brief Creates a acceleration structure and the required buffer to store it's geometries
+	 * @param device A valid Vulkan device
+	 * @param type The type of the acceleration structure (top- or bottom-level)
+	 * @param build_size_info Size information for the acceleration structure build acquired via vkGetAccelerationStructureBuildSizesKHR
+	 */
+	AccelerationStructure(Device &                                    device,
+	                      VkAccelerationStructureTypeKHR              type,
+	                      VkAccelerationStructureBuildGeometryInfoKHR build_geometry_info,
+	                      uint32_t                                    primitive_count);
+
+	~AccelerationStructure();
+
+	void build(const std::vector<VkAccelerationStructureGeometryKHR> & geometries,
+	           std::vector<VkAccelerationStructureBuildRangeInfoKHR *> build_range_infos,
+	           VkQueue                                                 queue,
+	           VkBuildAccelerationStructureFlagsKHR                    flags = VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR,
+	           VkBuildAccelerationStructureModeKHR                     mode  = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
+
+	VkAccelerationStructureKHR get_handle() const;
+
+	const VkAccelerationStructureKHR *get() const;
+
+	uint64_t get_device_address() const;
+
+  private:
+	Device &device;
+
+	VkAccelerationStructureKHR handle{VK_NULL_HANDLE};
+
+	uint64_t device_address{0};
+
+	VkAccelerationStructureTypeKHR type{};
+
+	VkAccelerationStructureBuildSizesInfoKHR build_sizes_info{};
+
+	std::unique_ptr<vkb::core::Buffer> buffer{nullptr};
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/acceleration_structure.h
+++ b/framework/core/acceleration_structure.h
@@ -38,7 +38,8 @@ class AccelerationStructure
 	 * @brief Creates a acceleration structure and the required buffer to store it's geometries
 	 * @param device A valid Vulkan device
 	 * @param type The type of the acceleration structure (top- or bottom-level)
-	 * @param build_size_info Size information for the acceleration structure build acquired via vkGetAccelerationStructureBuildSizesKHR
+	 * @param build_geometry_info Geometry information for the acceleration structure build
+	 * @param primitive_count Number of primitives of this acceleration structure
 	 */
 	AccelerationStructure(Device &                                    device,
 	                      VkAccelerationStructureTypeKHR              type,

--- a/framework/core/buffer.cpp
+++ b/framework/core/buffer.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -146,6 +146,14 @@ void Buffer::flush() const
 void Buffer::update(const std::vector<uint8_t> &data, size_t offset)
 {
 	update(data.data(), data.size(), offset);
+}
+
+uint64_t Buffer::get_device_address()
+{
+	VkBufferDeviceAddressInfoKHR buffer_device_address_info{};
+	buffer_device_address_info.sType  = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+	buffer_device_address_info.buffer = handle;
+	return vkGetBufferDeviceAddressKHR(device.get_handle(), &buffer_device_address_info);
 }
 
 void Buffer::update(void *data, size_t size, size_t offset)

--- a/framework/core/buffer.h
+++ b/framework/core/buffer.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -122,6 +122,11 @@ class Buffer
 	{
 		update(reinterpret_cast<const uint8_t *>(&object), sizeof(T), offset);
 	}
+
+	/**
+	 * @return Return the buffer's device address (note: requires that the buffer has been created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT usage fla)
+	 */
+	uint64_t get_device_address();
 
   private:
 	Device &device;

--- a/framework/core/scratch_buffer.cpp
+++ b/framework/core/scratch_buffer.cpp
@@ -1,0 +1,74 @@
+/* Copyright (c) 2021, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "scratch_buffer.h"
+
+#include "device.h"
+
+namespace vkb
+{
+namespace core
+{
+ScratchBuffer::ScratchBuffer(Device &device, VkDeviceSize size) :
+    device{device},
+    size{size}
+{
+	VkBufferCreateInfo buffer_info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+	buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+	buffer_info.size  = size;
+
+	VmaAllocationCreateInfo memory_info{};
+	memory_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+
+	VmaAllocationInfo allocation_info{};
+	auto              result = vmaCreateBuffer(device.get_memory_allocator(),
+                                  &buffer_info, &memory_info,
+                                  &handle, &allocation,
+                                  &allocation_info);
+
+	if (result != VK_SUCCESS)
+	{
+		throw VulkanException{result, "Could not create Scratchbuffer"};
+	}
+
+	memory = allocation_info.deviceMemory;
+
+	VkBufferDeviceAddressInfoKHR buffer_device_address_info{};
+	buffer_device_address_info.sType  = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+	buffer_device_address_info.buffer = handle;
+	device_address                    = vkGetBufferDeviceAddressKHR(device.get_handle(), &buffer_device_address_info);
+}
+
+ScratchBuffer::~ScratchBuffer()
+{
+	if (handle != VK_NULL_HANDLE && allocation != VK_NULL_HANDLE)
+	{
+		vmaDestroyBuffer(device.get_memory_allocator(), handle, allocation);
+	}
+}
+
+VkBuffer ScratchBuffer::get_handle() const
+{
+	return handle;
+}
+
+uint64_t ScratchBuffer::get_device_address() const
+{
+	return device_address;
+}
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/scratch_buffer.h
+++ b/framework/core/scratch_buffer.h
@@ -1,0 +1,63 @@
+/* Copyright (c) 2021, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "common/helpers.h"
+#include "common/vk_common.h"
+
+namespace vkb
+{
+class Device;
+
+namespace core
+{
+/**
+ * @brief A simplied buffer class for creating temporary device local scratch buffers, used in e.g. ray tracing
+ */
+class ScratchBuffer
+{
+  public:
+	/**
+	 * @brief Creates a scratch buffer using VMA with pre-defined usage flags
+	 * @param device A valid Vulkan device
+	 * @param size The size in bytes of the buffer
+	 */
+	ScratchBuffer(Device &     device,
+	              VkDeviceSize size);
+
+	~ScratchBuffer();
+
+	VkBuffer get_handle() const;
+
+	uint64_t get_device_address() const;
+
+  private:
+	Device &device;
+
+	uint64_t device_address{0};
+
+	VkBuffer handle{VK_NULL_HANDLE};
+
+	VmaAllocation allocation{VK_NULL_HANDLE};
+
+	VkDeviceMemory memory{VK_NULL_HANDLE};
+
+	VkDeviceSize size{0};
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/shader_binding_table.cpp
+++ b/framework/core/shader_binding_table.cpp
@@ -1,0 +1,78 @@
+/* Copyright (c) 2021, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "shader_binding_table.h"
+
+namespace vkb
+{
+namespace core
+{
+ShaderBindingTable::ShaderBindingTable(Device &       device,
+                                       uint32_t       handle_count,
+                                       VkDeviceSize   handle_size_aligned,
+                                       VmaMemoryUsage memory_usage) :
+    device{device}
+{
+	VkBufferCreateInfo buffer_info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+	buffer_info.usage = VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+	buffer_info.size  = handle_count * handle_size_aligned;
+
+	VmaAllocationCreateInfo memory_info{};
+	memory_info.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
+	memory_info.usage = memory_usage;
+
+	VmaAllocationInfo allocation_info{};
+	auto              result = vmaCreateBuffer(device.get_memory_allocator(),
+                                  &buffer_info, &memory_info,
+                                  &handle, &allocation,
+                                  &allocation_info);
+
+	if (result != VK_SUCCESS)
+	{
+		throw VulkanException{result, "Could not create ShaderBindingTable"};
+	}
+
+	memory = allocation_info.deviceMemory;
+
+	VkBufferDeviceAddressInfoKHR buffer_device_address_info{};
+	buffer_device_address_info.sType            = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+	buffer_device_address_info.buffer           = handle;
+	strided_device_address_region.deviceAddress = vkGetBufferDeviceAddressKHR(device.get_handle(), &buffer_device_address_info);
+	strided_device_address_region.stride        = handle_size_aligned;
+	strided_device_address_region.size          = handle_count * handle_size_aligned;
+
+	mapped_data = static_cast<uint8_t *>(allocation_info.pMappedData);
+}
+
+ShaderBindingTable::~ShaderBindingTable()
+{
+	if (handle != VK_NULL_HANDLE && allocation != VK_NULL_HANDLE)
+	{
+		vmaDestroyBuffer(device.get_memory_allocator(), handle, allocation);
+	}
+}
+
+const VkStridedDeviceAddressRegionKHR *vkb::core::ShaderBindingTable::get_strided_device_address_region() const
+{
+	return &strided_device_address_region;
+}
+uint8_t *ShaderBindingTable::get_data() const
+{
+	return mapped_data;
+}
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/shader_binding_table.cpp
+++ b/framework/core/shader_binding_table.cpp
@@ -17,6 +17,8 @@
 
 #include "shader_binding_table.h"
 
+#include "device.h"
+
 namespace vkb
 {
 namespace core

--- a/framework/core/shader_binding_table.h
+++ b/framework/core/shader_binding_table.h
@@ -1,0 +1,69 @@
+/* Copyright (c) 2021, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "common/helpers.h"
+#include "common/vk_common.h"
+
+namespace vkb
+{
+class Device;
+
+namespace core
+{
+/**
+ * @brief Extended buffer class to simplify ray tracing shader binding table usage
+ */
+class ShaderBindingTable
+{
+  public:
+	/**
+	 * @brief Creates a shader binding table
+	 * @param device A valid Vulkan device
+	 * @param handle_count Shader group handle count
+	 * @param handle_size_aligned Aligned shader group handle size
+	 * @param memory_usage The memory usage of the shader binding table
+	 */
+	ShaderBindingTable(Device &       device,
+	                   uint32_t       handle_count,
+	                   VkDeviceSize   handle_size_aligned,
+	                   VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_CPU_TO_GPU);
+
+	~ShaderBindingTable();
+
+	const VkStridedDeviceAddressRegionKHR *get_strided_device_address_region() const;
+
+	uint8_t *get_data() const;
+
+  private:
+	Device &device;
+
+	VkStridedDeviceAddressRegionKHR strided_device_address_region{};
+
+	uint64_t device_address{0};
+
+	VkBuffer handle{VK_NULL_HANDLE};
+
+	VmaAllocation allocation{VK_NULL_HANDLE};
+
+	VkDeviceMemory memory{VK_NULL_HANDLE};
+
+	uint8_t *mapped_data{nullptr};
+};
+}        // namespace core
+}        // namespace vkb


### PR DESCRIPTION
## Description

This PR adds a new classes and minor changes to the framework to streamline development ray tracing samples. The aim of these changes is to reduce duplication of boiler plate code, as much of the ray tracing related functionality can be become quite verbose. For a basic ray tracing example, this saves around 300 lines of code.

New classes are added for:
- Acceleration structures
- Scratch buffers
- Shader binding tables

The scratch buffer and shader binding table classes are mostly just extended buffers with most of their properties like usage flags being preset in the classes to reduce boiler plate.

The acceleration structure class also hides away most of the boiler plate code and adds methods that simplify geometry setup and the build process.

Example:

```cpp
// Bottom level AS with multiple triangle geometries
bottom_level_acceleration_structure = std::make_unique<vkb::core::AccelerationStructure>(get_device(), VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR);
bottom_level_acceleration_structure->add_triangle_geometry(vertex_buffer, index_buffer, transform_data_buffer, 1, 2, sizeof(Vertex), 0);
bottom_level_acceleration_structure->add_triangle_geometry(vertex_buffer, index_buffer, transform_data_buffer, 1, 2, sizeof(Vertex), sizeof(VkTransformMatrixKHR));
bottom_level_acceleration_structure->add_triangle_geometry(vertex_buffer, index_buffer, transform_data_buffer, 1, 2, sizeof(Vertex), sizeof(VkTransformMatrixKHR) * 2);
bottom_level_acceleration_structure->build(queue);

// Top Level AS with single instance
top_level_acceleration_structure = std::make_unique<vkb::core::AccelerationStructure>(get_device(), VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
top_level_acceleration_structure->add_instance_geometry(instances_buffer, 1);
top_level_acceleration_structure->build(queue);
```

Changes to existing classes:
- Buffer

A function to retrieve the device address has been added to the buffer class. Ray tracing makes heavy use of device addresses, but device addresses are getting more and more common with newer Vulkan functionality, so this is more of a general addition. Note that this only works for buffers that have been created with the `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` usage flag.

Example:

```cpp
VkDeviceOrHostAddressConstKHR device_or_host_address{};
device_or_host_address.deviceAddress = vertex_buffer->get_device_address();
```

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making