### PR TITLE
Fix memory leak in buffer allocation

### DIFF
--- a/framework/buffer_pool.cpp
+++ b/framework/buffer_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -89,9 +89,9 @@ BufferPool::BufferPool(Device &device, VkDeviceSize block_size, VkBufferUsageFla
 BufferBlock &BufferPool::request_buffer_block(const VkDeviceSize minimum_size)
 {
 	// Find the first block in the range of the inactive blocks
-	// which size is greater than the minimum size
+	// which can fit the minimum size
 	auto it = std::upper_bound(buffer_blocks.begin() + active_buffer_block_count, buffer_blocks.end(), minimum_size,
-	                           [](const VkDeviceSize &a, const std::unique_ptr<BufferBlock> &b) -> bool { return a < b->get_size(); });
+	                           [](const VkDeviceSize &a, const std::unique_ptr<BufferBlock> &b) -> bool { return a <= b->get_size(); });
 
 	if (it != buffer_blocks.end())
 	{


### PR DESCRIPTION
## Description

When allocating a buffer from the render frame of exactly the same size as the buffer pool block size, rather than reusing an inactive block, a new one was being allocated. Fix this by requiring blocks to be greater than or equal to the minimum size, as opposed to only greater than.

This leak was not observed in any existing samples but was encountered when allocating a 512K storage buffer in some code I was writing for learning purposes.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
