### PR TITLE
Small copyright fix

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,3 +1,4 @@
+<!--
 - Copyright (c) 2020-2021, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Copyright comment was missing the opening tag
