### PR TITLE
Replace NV shader stage enums with KHR version in the glsl compiler, add missing ray tracing shader stages

### DIFF
--- a/framework/common/vk_common.cpp
+++ b/framework/common/vk_common.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2020, Arm Limited and Contributors
- * Copyright (c) 2019-2020, Sascha Willems
+/* Copyright (c) 2018-2021, Arm Limited and Contributors
+ * Copyright (c) 2019-2021, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -96,15 +96,19 @@ VkShaderStageFlagBits find_shader_stage(const std::string &ext)
 	}
 	else if (ext == "rgen")
 	{
-		return VK_SHADER_STAGE_RAYGEN_BIT_NV;
+		return VK_SHADER_STAGE_RAYGEN_BIT_KHR;
 	}
 	else if (ext == "rmiss")
 	{
-		return VK_SHADER_STAGE_MISS_BIT_NV;
+		return VK_SHADER_STAGE_MISS_BIT_KHR;
 	}
 	else if (ext == "rchit")
 	{
-		return VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV;
+		return VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
+	}
+	else if (ext == "rcall")
+	{
+		return VK_SHADER_STAGE_CALLABLE_BIT_KHR;
 	}
 
 	throw std::runtime_error("File extension `" + ext + "` does not have a vulkan shader stage.");

--- a/framework/common/vk_common.cpp
+++ b/framework/common/vk_common.cpp
@@ -98,13 +98,21 @@ VkShaderStageFlagBits find_shader_stage(const std::string &ext)
 	{
 		return VK_SHADER_STAGE_RAYGEN_BIT_KHR;
 	}
-	else if (ext == "rmiss")
+	else if (ext == "rahit")
 	{
-		return VK_SHADER_STAGE_MISS_BIT_KHR;
+		return VK_SHADER_STAGE_ANY_HIT_BIT_KHR;
 	}
 	else if (ext == "rchit")
 	{
 		return VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
+	}
+	else if (ext == "rmiss")
+	{
+		return VK_SHADER_STAGE_MISS_BIT_KHR;
+	}
+	else if (ext == "rint")
+	{
+		return VK_SHADER_STAGE_INTERSECTION_BIT_KHR;
 	}
 	else if (ext == "rcall")
 	{

--- a/framework/glsl_compiler.cpp
+++ b/framework/glsl_compiler.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -51,14 +51,17 @@ inline EShLanguage FindShaderLanguage(VkShaderStageFlagBits stage)
 		case VK_SHADER_STAGE_COMPUTE_BIT:
 			return EShLangCompute;
 
-		case VK_SHADER_STAGE_RAYGEN_BIT_NV:
-			return EShLangRayGenNV;
+		case VK_SHADER_STAGE_RAYGEN_BIT_KHR:
+			return EShLangRayGen;
 
-		case VK_SHADER_STAGE_MISS_BIT_NV:
-			return EShLangMissNV;
+		case VK_SHADER_STAGE_MISS_BIT_KHR:
+			return EShLangMiss;
 
-		case VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV:
-			return EShLangClosestHitNV;
+		case VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR:
+			return EShLangClosestHit;
+
+		case VK_SHADER_STAGE_CALLABLE_BIT_KHR:
+			return EShLangCallable;
 
 		default:
 			return EShLangVertex;

--- a/framework/glsl_compiler.cpp
+++ b/framework/glsl_compiler.cpp
@@ -54,11 +54,17 @@ inline EShLanguage FindShaderLanguage(VkShaderStageFlagBits stage)
 		case VK_SHADER_STAGE_RAYGEN_BIT_KHR:
 			return EShLangRayGen;
 
-		case VK_SHADER_STAGE_MISS_BIT_KHR:
-			return EShLangMiss;
+		case VK_SHADER_STAGE_ANY_HIT_BIT_KHR:
+			return EShLangAnyHit;
 
 		case VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR:
 			return EShLangClosestHit;
+
+		case VK_SHADER_STAGE_MISS_BIT_KHR:
+			return EShLangMiss;
+
+		case VK_SHADER_STAGE_INTERSECTION_BIT_KHR:
+			return EShLangIntersect;
 
 		case VK_SHADER_STAGE_CALLABLE_BIT_KHR:
 			return EShLangCallable;


### PR DESCRIPTION
## Description

This PR replaces the the NV enums for shader stages used in the framework's glsl compiler. As the NV and KHR enums have the same values, this does not affect functionality and is more of a cosmetic clean-up.

It also adds the the missing shader stages for callable, intersection and anyhit ray tracing shaders.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making