### PR TITLE
Fix vkb::screenshot()

### DIFF
--- a/framework/common/utils.cpp
+++ b/framework/common/utils.cpp
@@ -20,19 +20,11 @@
 #include <queue>
 #include <stdexcept>
 
-#include "core/pipeline_layout.h"
-#include "core/shader_module.h"
 #include "graphing/framework_graph.h"
 #include "graphing/scene_graph.h"
-#include "scene_graph/components/image.h"
 #include "scene_graph/components/material.h"
-#include "scene_graph/components/mesh.h"
-#include "scene_graph/components/pbr_material.h"
 #include "scene_graph/components/perspective_camera.h"
-#include "scene_graph/components/sampler.h"
 #include "scene_graph/components/sub_mesh.h"
-#include "scene_graph/components/texture.h"
-#include "scene_graph/components/transform.h"
 #include "scene_graph/node.h"
 #include "scene_graph/script.h"
 #include "scene_graph/scripts/free_camera.h"
@@ -52,7 +44,10 @@ std::string get_extension(const std::string &uri)
 
 void screenshot(RenderContext &render_context, const std::string &filename)
 {
-	VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+	assert(render_context.get_format() == VK_FORMAT_R8G8B8A8_UNORM ||
+	       render_context.get_format() == VK_FORMAT_B8G8R8A8_UNORM ||
+	       render_context.get_format() == VK_FORMAT_R8G8B8A8_SRGB ||
+	       render_context.get_format() == VK_FORMAT_B8G8R8A8_SRGB);
 
 	// We want the last completed frame since we don't want to be reading from an incomplete framebuffer
 	auto &frame          = render_context.get_last_rendered_frame();
@@ -96,11 +91,9 @@ void screenshot(RenderContext &render_context, const std::string &filename)
 		cmd_buf.image_memory_barrier(src_image_view, memory_barrier);
 	}
 
-	bool swizzle = false;
-
 	// Check if framebuffer images are in a BGR format
 	auto bgr_formats = {VK_FORMAT_B8G8R8A8_SRGB, VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_B8G8R8A8_SNORM};
-	swizzle          = std::find(bgr_formats.begin(), bgr_formats.end(), src_image_view.get_format()) != bgr_formats.end();
+	bool swizzle     = std::find(bgr_formats.begin(), bgr_formats.end(), src_image_view.get_format()) != bgr_formats.end();
 
 	// Copy framebuffer image memory
 	VkBufferImageCopy image_copy_region{};

--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -453,6 +453,12 @@ void CommandBuffer::copy_buffer_to_image(const core::Buffer &buffer, const core:
 	vkCmdCopyBufferToImage(get_handle(), buffer.get_handle(),
 	                       image.get_handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
 	                       to_u32(regions.size()), regions.data());
+}
+
+void CommandBuffer::copy_image_to_buffer(const core::Image &image, VkImageLayout image_layout, const core::Buffer &buffer, const std::vector<VkBufferImageCopy> &regions)
+{
+	vkCmdCopyImageToBuffer(get_handle(), image.get_handle(), image_layout,
+	                       buffer.get_handle(), to_u32(regions.size()), regions.data());
 }
 
 void CommandBuffer::image_memory_barrier(const core::ImageView &image_view, const ImageMemoryBarrier &memory_barrier)

--- a/framework/core/command_buffer.h
+++ b/framework/core/command_buffer.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -226,6 +226,8 @@ class CommandBuffer
 	void copy_image(const core::Image &src_img, const core::Image &dst_img, const std::vector<VkImageCopy> &regions);
 
 	void copy_buffer_to_image(const core::Buffer &buffer, const core::Image &image, const std::vector<VkBufferImageCopy> &regions);
+
+	void copy_image_to_buffer(const core::Image &image, VkImageLayout image_layout, const core::Buffer &buffer, const std::vector<VkBufferImageCopy> &regions);
 
 	void image_memory_barrier(const core::ImageView &image_view, const ImageMemoryBarrier &memory_barrier);
 

--- a/framework/platform/unix/direct_window.cpp
+++ b/framework/platform/unix/direct_window.cpp
@@ -161,16 +161,28 @@ static KeyCode map_multichar_key(int tty_fd, KeyCode initial)
 	static std::map<std::string, KeyCode> mc_map;        // Static for one-time-init
 	if (mc_map.size() == 0)
 	{
-		mc_map["[A"]  = KeyCode::Up;
-		mc_map["[B"]  = KeyCode::Down;
-		mc_map["[C"]  = KeyCode::Right;
-		mc_map["[D"]  = KeyCode::Left;
-		mc_map["[2~"] = KeyCode::Insert;
-		mc_map["[3~"] = KeyCode::DelKey;
-		mc_map["[5~"] = KeyCode::PageUp;
-		mc_map["[6~"] = KeyCode::PageDown;
-		mc_map["[H"]  = KeyCode::Home;
-		mc_map["[F"]  = KeyCode::End;
+		mc_map["[A"]   = KeyCode::Up;
+		mc_map["[B"]   = KeyCode::Down;
+		mc_map["[C"]   = KeyCode::Right;
+		mc_map["[D"]   = KeyCode::Left;
+		mc_map["[2~"]  = KeyCode::Insert;
+		mc_map["[3~"]  = KeyCode::DelKey;
+		mc_map["[5~"]  = KeyCode::PageUp;
+		mc_map["[6~"]  = KeyCode::PageDown;
+		mc_map["[H"]   = KeyCode::Home;
+		mc_map["[F"]   = KeyCode::End;
+		mc_map["OP"]   = KeyCode::F1;
+		mc_map["OQ"]   = KeyCode::F2;
+		mc_map["OR"]   = KeyCode::F3;
+		mc_map["OS"]   = KeyCode::F4;
+		mc_map["[15~"] = KeyCode::F5;
+		mc_map["[17~"] = KeyCode::F6;
+		mc_map["[18~"] = KeyCode::F7;
+		mc_map["[19~"] = KeyCode::F8;
+		mc_map["[20~"] = KeyCode::F9;
+		mc_map["[21~"] = KeyCode::F10;
+		mc_map["[23~"] = KeyCode::F11;
+		mc_map["[24~"] = KeyCode::F12;
 	}
 
 	char        key;

--- a/framework/platform/unix/direct_window.cpp
+++ b/framework/platform/unix/direct_window.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -333,7 +333,8 @@ void VulkanSample::input_event(const InputEvent &input_event)
 	if (input_event.get_source() == EventSource::Keyboard)
 	{
 		const auto &key_event = static_cast<const KeyInputEvent &>(input_event);
-		if (key_event.get_action() == KeyAction::Down && key_event.get_code() == KeyCode::PrintScreen)
+		if (key_event.get_action() == KeyAction::Down &&
+		    (key_event.get_code() == KeyCode::PrintScreen || key_event.get_code() == KeyCode::F12))
 		{
 			screenshot(*render_context, "screenshot-" + get_name());
 		}


### PR DESCRIPTION
## Description

Addresses the incorrect use of VK_IMAGE_USAGE_SAMPLED_BIT as described in issue #259.

Changes vkb::screenshot() to use VkCopyImageToBuffer  rather than VkCopyImage.

This simplifies the code, and I believe is a better practice that trying to read image data directly.
The previous code also didn't work for me. It either produced empty images, or images that started with a horizontal offset for me.

Tested only on Linux devices.

Fixes #259

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
