### PR TITLE
Fix missing background in instancing sample

### DIFF
--- a/samples/api/instancing/instancing.cpp
+++ b/samples/api/instancing/instancing.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Sascha Willems
+/* Copyright (c) 2019-2021, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/api/instancing/instancing.cpp
+++ b/samples/api/instancing/instancing.cpp
@@ -351,6 +351,7 @@ void Instancing::prepare_pipelines()
 	// Star field pipeline
 	rasterization_state.cullMode         = VK_CULL_MODE_NONE;
 	depth_stencil_state.depthWriteEnable = VK_FALSE;
+	depth_stencil_state.depthTestEnable  = VK_FALSE;
 	shader_stages[0]                     = load_shader("instancing/starfield.vert", VK_SHADER_STAGE_VERTEX_BIT);
 	shader_stages[1]                     = load_shader("instancing/starfield.frag", VK_SHADER_STAGE_FRAGMENT_BIT);
 	// Vertices are generated in the vertex shader


### PR DESCRIPTION
## Description

Due to reverse Z, the background in the instancing sample was not displayed:

![image](https://user-images.githubusercontent.com/10283127/114267070-151c9300-99fa-11eb-9030-1be2e3652f64.png)

This PR disables depth testing for the background, making it visible again:

![image](https://user-images.githubusercontent.com/10283127/114267094-341b2500-99fa-11eb-8489-956d2fbb0749.png)


## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making