### PR TITLE
Add syntax C++, GLSL and HLSL highlighting to recent tutorials

### DIFF
--- a/samples/performance/16bit_arithmetic/16bit_arithmetic_tutorial.md
+++ b/samples/performance/16bit_arithmetic/16bit_arithmetic_tutorial.md
@@ -72,7 +72,7 @@ completely isolate arithmetic throughput as the main bottleneck.
 
 Here, the critical arithmetic overhead is:
 
-```
+```glsl
 // This is very arbitrary. Expends a ton of arithmetic to compute
 // something that looks similar to a lens flare.
 vec4 compute_blob(vec2 pos, vec4 blob, float seed)
@@ -111,7 +111,7 @@ vec4 compute_blob(vec2 pos, vec4 blob, float seed)
 
 In this version, we rewrite `compute_blob` and the rest of the shader to be as pure FP16 as we can:
 
-```
+```glsl
 // Allows us to use float16_t for arithmetic purposes.
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 
@@ -119,7 +119,7 @@ In this version, we rewrite `compute_blob` and the rest of the shader to be as p
 #extension GL_EXT_shader_16bit_storage : require
 ```
 
-```
+```glsl
 // This is very arbitrary. Expends a ton of arithmetic to compute
 // something that looks similar to a lens flare.
 f16vec4 compute_blob(f16vec2 pos, f16vec4 blob, float16_t seed)

--- a/samples/performance/16bit_storage_input_output/16bit_storage_input_output_tutorial.md
+++ b/samples/performance/16bit_storage_input_output/16bit_storage_input_output_tutorial.md
@@ -67,7 +67,7 @@ shaders.
 
 The native 16-bit types can only be used when storing to the variable, or when loading from the variable.
 
-```
+```glsl
 // GL_EXT_16bit_storage would normally be used here, but that extension does not support input/output.
 // glslang enables SPIR-V capabilities as required.
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
@@ -77,7 +77,7 @@ vec4 arithmetic = blah(); // Arithmetic happens in FP32.
 Foo = f16vec4(arithmetic); // Narrowing store.
 ```
 
-```
+```glsl
 // GL_EXT_16bit_storage would normally be used here, but that extension does not support input/output.
 // glslang enables SPIR-V capabilities as required.
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
@@ -129,7 +129,7 @@ that the types used in vertex output and fragment input interfaces are as narrow
 In the first scenario, the vertex shader has 3 vec3 outputs,
 which is not a lot when considering modern rendering engines.
 
-```
+```glsl
 layout (location = 0) out vec3 o_vertex_color;
 layout (location = 1) out vec3 o_normal;
 layout (location = 2) out vec3 o_delta_pos;
@@ -167,7 +167,7 @@ bandwidth savings as explicit FP16 would, but the caveat is that you cannot be s
 you know the driver implementation details. The snippet below will work on any core Vulkan 1.0 implementation,
 but it may or may not give you true FP16 vertex outputs:
 
-```
+```glsl
 // Vertex
 layout(location = 0) out mediump vec3 o_normal;
 


### PR DESCRIPTION
## Description

This PR adds C++, GLSL and HLSL language information to code blocks in the tutorial markdowns for some of the more recent tutorials. This makes github display code blocks in these tutorials with language-based syntax highlighting:

Before:
![image](https://user-images.githubusercontent.com/10283127/115043572-eeb49700-9ed4-11eb-8c50-1ab6821d453e.png)

After:

![image](https://user-images.githubusercontent.com/10283127/115043585-f2481e00-9ed4-11eb-98a3-76976a309f82.png)

This is purely a documentation change.

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making