### PR TITLE
Adds Android release mode build instructions

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -266,15 +266,17 @@ For all dependencies set the following environment variables.
 
 ## Build with Gradle
 
-`Step 1.` Generate the gradle project using the internal script by running the following command
+### Generate the gradle project 
 
-##### Windows <!-- omit in toc -->
+Use the provided script for the platform you are building on by running the following command:
+
+#### Windows <!-- omit in toc -->
 
 ```
 bldsys\scripts\generate_android_gradle.bat
 ```
 
-##### Linux <!-- omit in toc -->
+#### Linux <!-- omit in toc -->
 
 ```
 ./bldsys/scripts/generate_android_gradle.sh
@@ -282,18 +284,42 @@ bldsys\scripts\generate_android_gradle.bat
 
 A new folder will be created in the root directory at `build\android_gradle`
 
-`Step 2.` Build the project
+### Build the project
+
+> Prefer a release build for better performance unless you want to actively debug the application.
 
 ```
 cd build/android_gradle
-gradle assembleDebug
 ```
 
-`Step 3.` You can now run the apk on a connected device
+For a release build:
+
+```
+gradle assembleRelease
+``` 
+
+For a debug build:
+
+```
+gradle assembleDebug
+``` 
+
+### Install the apk on the device
+
+You can now install the apk on a connected device using the Android Debug Bridge:
+
+For a release build:
+
+```
+adb install build/outputs/apk/release/vulkan_samples-release.apk
+```
+For a debug build:
 
 ```
 adb install build/outputs/apk/debug/vulkan_samples-debug.apk
 ```
+
+## Build with Android Studio
 
 > Alternatively, you may import the `build/android_gradle` folder in Android Studio and run the project from here
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -286,11 +286,12 @@ A new folder will be created in the root directory at `build\android_gradle`
 
 ### Build the project
 
-> Prefer a release build for better performance unless you want to actively debug the application.
 
 ```
 cd build/android_gradle
 ```
+
+> Prefer a release build for better performance unless you want to actively debug the application.
 
 For a release build:
 


### PR DESCRIPTION
## Description

As per today's call, this PR adds instructions on how to do a release build on Android using gradle. Release builds tend to be faster and should be preferred.

This is purely a documentation change.

Fixes #269 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making