### PR TITLE
Set the default Render Context configuration per Platform

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-- Copyright (c) 2019, Arm Limited and Contributors
+- Copyright (c) 2019-2021, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -28,10 +28,11 @@
 
 	<application android:label="@string/app_name"
 		android:allowBackup="false"
+		android:debuggable="true"
 		android:icon="@mipmap/ic_launcher"
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:theme="@style/AppTheme"
-		tools:ignore="GoogleAppIndexingWarning">
+		tools:ignore="GoogleAppIndexingWarning,HardcodedDebugMode">
 
 		<activity android:name="com.khronos.vulkan_samples.SampleLauncherActivity">
 			<intent-filter>

--- a/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
+++ b/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import android.support.v7.widget.Toolbar;
 
@@ -69,6 +70,10 @@ public class SampleLauncherActivity extends AppCompatActivity {
             File external_files_dir = getExternalFilesDir("");
             File temp_files_dir = getCacheDir();
             if (external_files_dir != null && temp_files_dir != null) {
+                // User no longer has permissions to access applications' storage, save files in
+                // top level (shared) external storage directory
+                String shared_storage = external_files_dir.getPath().split(Pattern.quote("Android"))[0];
+                external_files_dir = new File(shared_storage, getPackageName());
                 initFilePath(external_files_dir.toString(), temp_files_dir.toString());
             }
 

--- a/bldsys/cmake/android_package.cmake
+++ b/bldsys/cmake/android_package.cmake
@@ -1,5 +1,5 @@
 #[[
- Copyright (c) 2019, Arm Limited and Contributors
+ Copyright (c) 2019-2021, Arm Limited and Contributors
 
  SPDX-License-Identifier: Apache-2.0
 
@@ -113,7 +113,7 @@ function(android_sync_folder)
     set(SYNC_COMMAND ${CMAKE_COMMAND}
             -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
             -DFOLDER_DIR=${TARGET_PATH}/.
-            -DDEVICE_DIR=/sdcard/Android/data/com.khronos.${PROJECT_NAME}/files/${FOLDER_NAME}/
+            -DDEVICE_DIR=/sdcard/com.khronos.${PROJECT_NAME}/${FOLDER_NAME}/
             -P "${SCRIPT_DIR}/android_sync_folder.cmake")
 
     add_custom_target(

--- a/bldsys/cmake/template/entrypoint_main.cpp.in
+++ b/bldsys/cmake/template/entrypoint_main.cpp.in
@@ -57,7 +57,8 @@ int main(int argc, char *argv[])
 #endif
 		auto app = create_@TARGET_CREATE_FUNC@();
 		app->set_name("@TARGET_NAME@");
-		if (platform.initialize(std::move(app)))
+
+		if (platform.initialize(std::move(app)) && platform.prepare())
 		{
 			platform.main_loop();
 			platform.terminate(vkb::ExitCode::Success);

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -248,17 +248,17 @@ set(PLATFORM_FILES
     platform/application.h
     platform/platform.h
     platform/window.h
-    platform/headless_window.h
-    platform/glfw_window.h
     platform/filesystem.h
     platform/input_events.h
     platform/configuration.h
     platform/parser.h
+    platform/headless_window.h
+
     # Source Files
+    platform/headless_window.cpp
     platform/application.cpp
     platform/platform.cpp
     platform/window.cpp
-    platform/headless_window.cpp
     platform/filesystem.cpp
     platform/input_events.cpp
     platform/configuration.cpp

--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -164,9 +164,18 @@ vkb::Device &ApiVulkanSample::get_device()
 	return *device;
 }
 
+void ApiVulkanSample::create_render_context(vkb::Platform &platform)
+{
+	auto surface_priority_list = std::vector<VkSurfaceFormatKHR>{{VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	                                                             {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	                                                             {VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	                                                             {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
+
+	render_context = platform.create_render_context(*device.get(), surface, surface_priority_list);
+}
+
 void ApiVulkanSample::prepare_render_context()
 {
-	render_context->request_image_format(VK_FORMAT_B8G8R8A8_UNORM);
 	VulkanSample::prepare_render_context();
 }
 

--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -78,24 +78,6 @@ bool ApiVulkanSample::prepare(vkb::Platform &platform)
 	return true;
 }
 
-void ApiVulkanSample::prepare_render_context()
-{
-	get_render_context().set_present_mode_priority({VK_PRESENT_MODE_MAILBOX_KHR,
-	                                                VK_PRESENT_MODE_IMMEDIATE_KHR,
-	                                                VK_PRESENT_MODE_FIFO_KHR});
-
-	get_render_context().set_surface_format_priority({{VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                  {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                  {VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                  {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}});
-
-	get_render_context().request_present_mode(VK_PRESENT_MODE_MAILBOX_KHR);
-
-	get_render_context().request_image_format(VK_FORMAT_B8G8R8A8_UNORM);
-
-	get_render_context().prepare();
-}
-
 void ApiVulkanSample::update(float delta_time)
 {
 	if (view_updated)
@@ -180,6 +162,12 @@ void ApiVulkanSample::resize(const uint32_t, const uint32_t)
 vkb::Device &ApiVulkanSample::get_device()
 {
 	return *device;
+}
+
+void ApiVulkanSample::prepare_render_context()
+{
+	render_context->request_image_format(VK_FORMAT_B8G8R8A8_UNORM);
+	VulkanSample::prepare_render_context();
 }
 
 void ApiVulkanSample::input_event(const vkb::InputEvent &input_event)

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Sascha Willems
+/* Copyright (c) 2019-2021, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -102,6 +102,7 @@ class ApiVulkanSample : public vkb::VulkanSample
 	/// Stores the swapchain image buffers
 	std::vector<SwapchainBuffer> swapchain_buffers;
 
+	virtual void create_render_context(vkb::Platform &platform) override;
 	virtual void prepare_render_context() override;
 
 	// Handle to the device graphics queue that command buffers are submitted to
@@ -369,8 +370,8 @@ class ApiVulkanSample : public vkb::VulkanSample
 	glm::vec3 camera_pos = glm::vec3();
 	glm::vec2 mouse_pos;
 
-	std::string title       = "Vulkan Example";
-	std::string name        = "vulkanExample";
+	std::string title = "Vulkan Example";
+	std::string name  = "vulkanExample";
 
 	struct
 	{

--- a/framework/core/device.cpp
+++ b/framework/core/device.cpp
@@ -186,12 +186,6 @@ Device::Device(PhysicalDevice &gpu, VkSurfaceKHR surface, std::unordered_map<con
 
 		VkBool32 present_supported = gpu.is_present_supported(surface, queue_family_index);
 
-		// Only check if surface is valid to allow for headless applications
-		if (surface != VK_NULL_HANDLE)
-		{
-			VK_CHECK(vkGetPhysicalDeviceSurfaceSupportKHR(gpu.get_handle(), queue_family_index, surface, &present_supported));
-		}
-
 		for (uint32_t queue_index = 0U; queue_index < queue_family_property.queueCount; ++queue_index)
 		{
 			queues[queue_family_index].emplace_back(*this, queue_family_index, queue_family_property, present_supported, queue_index);

--- a/framework/core/swapchain.cpp
+++ b/framework/core/swapchain.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -482,11 +482,13 @@ VkImageUsageFlags Swapchain::get_usage() const
 
 void Swapchain::set_present_mode_priority(const std::vector<VkPresentModeKHR> &new_present_mode_priority_list)
 {
+	assert(!new_present_mode_priority_list.empty() && "Priority list must not be empty");
 	present_mode_priority_list = new_present_mode_priority_list;
 }
 
 void Swapchain::set_surface_format_priority(const std::vector<VkSurfaceFormatKHR> &new_surface_format_priority_list)
 {
+	assert(!new_surface_format_priority_list.empty() && "Priority list must not be empty");
 	surface_format_priority_list = new_surface_format_priority_list;
 }
 VkPresentModeKHR Swapchain::get_present_mode() const

--- a/framework/platform/android/android_platform.cpp
+++ b/framework/platform/android/android_platform.cpp
@@ -503,9 +503,9 @@ android_app *AndroidPlatform::get_android_app()
 	return app;
 }
 
-std::unique_ptr<RenderContext> AndroidPlatform::create_render_context(Device &device, VkSurfaceKHR surface) const
+std::unique_ptr<RenderContext> AndroidPlatform::create_render_context(Device &device, VkSurfaceKHR surface, const std::vector<VkSurfaceFormatKHR> &surface_format_priority) const
 {
-	auto context = Platform::create_render_context(device, surface);
+	auto context = Platform::create_render_context(device, surface, surface_format_priority);
 
 	context->set_present_mode_priority({VK_PRESENT_MODE_FIFO_KHR,
 	                                    VK_PRESENT_MODE_MAILBOX_KHR,

--- a/framework/platform/android/android_platform.h
+++ b/framework/platform/android/android_platform.h
@@ -56,7 +56,7 @@ class AndroidPlatform : public Platform
 
 	ANativeActivity *get_activity();
 
-	virtual std::unique_ptr<RenderContext> create_render_context(Device &device, VkSurfaceKHR surface) const override;
+	virtual std::unique_ptr<RenderContext> create_render_context(Device &device, VkSurfaceKHR surface, const std::vector<VkSurfaceFormatKHR> &surface_format_priority) const override;
 
 	void set_surface_ready();
 

--- a/framework/platform/android/android_platform.h
+++ b/framework/platform/android/android_platform.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -56,6 +56,10 @@ class AndroidPlatform : public Platform
 
 	ANativeActivity *get_activity();
 
+	virtual std::unique_ptr<RenderContext> create_render_context(Device &device, VkSurfaceKHR surface) const override;
+
+	void set_surface_ready();
+
   private:
 	void poll_events();
 
@@ -64,5 +68,7 @@ class AndroidPlatform : public Platform
 	std::string log_output;
 
 	virtual std::vector<spdlog::sink_ptr> get_platform_sinks() override;
+
+	bool surface_ready{false};
 };
 }        // namespace vkb

--- a/framework/platform/glfw_window.h
+++ b/framework/platform/glfw_window.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/platform/headless_window.cpp
+++ b/framework/platform/headless_window.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/platform/headless_window.h
+++ b/framework/platform/headless_window.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -154,16 +154,15 @@ void Platform::run()
 	}
 }
 
-std::unique_ptr<RenderContext> Platform::create_render_context(Device &device, VkSurfaceKHR surface) const
+std::unique_ptr<RenderContext> Platform::create_render_context(Device &device, VkSurfaceKHR surface, const std::vector<VkSurfaceFormatKHR> &surface_format_priority) const
 {
+	assert(!surface_format_priority.empty() && "Surface format priority list must contain atleast one preffered surface format");
+
 	auto context = std::make_unique<RenderContext>(device, surface, window->get_width(), window->get_height());
 
-	context->set_surface_format_priority({{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                      {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                      {VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                      {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}});
+	context->set_surface_format_priority(surface_format_priority);
 
-	context->request_image_format(VK_FORMAT_R8G8B8A8_SRGB);
+	context->request_image_format(surface_format_priority[0].format);
 
 	context->set_present_mode_priority({
 	    VK_PRESENT_MODE_MAILBOX_KHR,

--- a/framework/platform/platform.h
+++ b/framework/platform/platform.h
@@ -27,6 +27,7 @@
 #include "platform/filesystem.h"
 #include "platform/parser.h"
 #include "platform/window.h"
+#include "rendering/render_context.h"
 
 namespace vkb
 {
@@ -98,6 +99,8 @@ class Platform
 	 * @return The VkInstance extension name for the platform
 	 */
 	virtual const char *get_surface_extension() = 0;
+
+	virtual std::unique_ptr<RenderContext> create_render_context(Device &device, VkSurfaceKHR surface) const;
 
 	Window &get_window() const;
 

--- a/framework/platform/platform.h
+++ b/framework/platform/platform.h
@@ -100,7 +100,7 @@ class Platform
 	 */
 	virtual const char *get_surface_extension() = 0;
 
-	virtual std::unique_ptr<RenderContext> create_render_context(Device &device, VkSurfaceKHR surface) const;
+	virtual std::unique_ptr<RenderContext> create_render_context(Device &device, VkSurfaceKHR surface, const std::vector<VkSurfaceFormatKHR> &surface_format_priority) const;
 
 	Window &get_window() const;
 

--- a/framework/platform/unix/direct_window.h
+++ b/framework/platform/unix/direct_window.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/platform/unix/unix_d2d_platform.cpp
+++ b/framework/platform/unix/unix_d2d_platform.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -61,11 +61,6 @@ UnixD2DPlatform::UnixD2DPlatform(int argc, char **argv)
 	Platform::set_temp_directory(get_temp_path_from_environment());
 }
 
-bool UnixD2DPlatform::initialize(std::unique_ptr<Application> &&app)
-{
-	return Platform::initialize(std::move(app)) && prepare();
-}
-
 void UnixD2DPlatform::create_window()
 {
 	if (active_app->is_headless())
@@ -81,12 +76,5 @@ void UnixD2DPlatform::create_window()
 const char *UnixD2DPlatform::get_surface_extension()
 {
 	return VK_KHR_DISPLAY_EXTENSION_NAME;
-}
-
-std::vector<spdlog::sink_ptr> UnixD2DPlatform::get_platform_sinks()
-{
-	std::vector<spdlog::sink_ptr> sinks;
-	sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
-	return sinks;
 }
 }        // namespace vkb

--- a/framework/platform/unix/unix_d2d_platform.h
+++ b/framework/platform/unix/unix_d2d_platform.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -28,13 +28,8 @@ class UnixD2DPlatform : public Platform
 
 	virtual ~UnixD2DPlatform() = default;
 
-	virtual bool initialize(std::unique_ptr<Application> &&app) override;
-
 	virtual void create_window() override;
 
 	virtual const char *get_surface_extension() override;
-
-  private:
-	virtual std::vector<spdlog::sink_ptr> get_platform_sinks() override;
 };
 }        // namespace vkb

--- a/framework/platform/unix/unix_platform.cpp
+++ b/framework/platform/unix/unix_platform.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -19,13 +19,13 @@
 
 #include "common/error.h"
 
+#include "platform/glfw_window.h"
+#include "platform/headless_window.h"
+
 VKBP_DISABLE_WARNINGS()
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 VKBP_ENABLE_WARNINGS()
-
-#include "platform/glfw_window.h"
-#include "platform/headless_window.h"
 
 #ifndef VK_MVK_MACOS_SURFACE_EXTENSION_NAME
 #	define VK_MVK_MACOS_SURFACE_EXTENSION_NAME "VK_MVK_macos_surface"
@@ -70,11 +70,6 @@ UnixPlatform::UnixPlatform(const UnixType &type, int argc, char **argv) :
 	Platform::set_temp_directory(get_temp_path_from_environment());
 }
 
-bool UnixPlatform::initialize(std::unique_ptr<Application> &&app)
-{
-	return Platform::initialize(std::move(app)) && prepare();
-}
-
 void UnixPlatform::create_window()
 {
 	if (active_app->is_headless())
@@ -97,12 +92,5 @@ const char *UnixPlatform::get_surface_extension()
 	{
 		return VK_KHR_XCB_SURFACE_EXTENSION_NAME;
 	}
-}
-
-std::vector<spdlog::sink_ptr> UnixPlatform::get_platform_sinks()
-{
-	std::vector<spdlog::sink_ptr> sinks;
-	sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
-	return sinks;
 }
 }        // namespace vkb

--- a/framework/platform/unix/unix_platform.h
+++ b/framework/platform/unix/unix_platform.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -34,15 +34,11 @@ class UnixPlatform : public Platform
 
 	virtual ~UnixPlatform() = default;
 
-	virtual bool initialize(std::unique_ptr<Application> &&app) override;
-
 	virtual void create_window() override;
 
 	virtual const char *get_surface_extension() override;
 
   private:
 	UnixType type;
-
-	virtual std::vector<spdlog::sink_ptr> get_platform_sinks() override;
 };
 }        // namespace vkb

--- a/framework/platform/windows/windows_platform.cpp
+++ b/framework/platform/windows/windows_platform.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,13 +24,13 @@
 
 #include "common/error.h"
 
+#include "platform/glfw_window.h"
+#include "platform/headless_window.h"
+
 VKBP_DISABLE_WARNINGS()
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 VKBP_ENABLE_WARNINGS()
-
-#include "platform/glfw_window.h"
-#include "platform/headless_window.h"
 
 namespace vkb
 {
@@ -121,11 +121,6 @@ WindowsPlatform::WindowsPlatform(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	Platform::set_temp_directory(get_temp_path_from_environment());
 }
 
-bool WindowsPlatform::initialize(std::unique_ptr<Application> &&app)
-{
-	return Platform::initialize(std::move(app)) && prepare();
-}
-
 void WindowsPlatform::create_window()
 {
 	if (active_app->is_headless())
@@ -138,28 +133,8 @@ void WindowsPlatform::create_window()
 	}
 }
 
-void WindowsPlatform::terminate(ExitCode code)
-{
-	Platform::terminate(code);
-
-	if (code != ExitCode::Success || benchmark_mode)
-	{
-		std::cout << "Press enter to close...\n";
-		std::cin.get();
-	}
-
-	FreeConsole();
-}
-
 const char *WindowsPlatform::get_surface_extension()
 {
 	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
-
-std::vector<spdlog::sink_ptr> WindowsPlatform::get_platform_sinks()
-{
-	std::vector<spdlog::sink_ptr> sinks;
-	sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
-	return sinks;
 }
 }        // namespace vkb

--- a/framework/platform/windows/windows_platform.h
+++ b/framework/platform/windows/windows_platform.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,15 +29,8 @@ class WindowsPlatform : public Platform
 
 	virtual ~WindowsPlatform() = default;
 
-	virtual bool initialize(std::unique_ptr<Application> &&app) override;
-
 	virtual void create_window() override;
 
-	virtual void terminate(ExitCode code) override;
-
 	virtual const char *get_surface_extension() override;
-
-  private:
-	virtual std::vector<spdlog::sink_ptr> get_platform_sinks() override;
 };
 }        // namespace vkb

--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -97,12 +97,14 @@ void RenderContext::prepare(size_t thread_count, RenderTarget::CreateFunc create
 
 void RenderContext::set_present_mode_priority(const std::vector<VkPresentModeKHR> &new_present_mode_priority_list)
 {
-	this->present_mode_priority_list = new_present_mode_priority_list;
+	assert(!new_present_mode_priority_list.empty() && "Priority list must not be empty");
+	present_mode_priority_list = new_present_mode_priority_list;
 }
 
 void RenderContext::set_surface_format_priority(const std::vector<VkSurfaceFormatKHR> &new_surface_format_priority_list)
 {
-	this->surface_format_priority_list = new_surface_format_priority_list;
+	assert(!new_surface_format_priority_list.empty() && "Priority list must not be empty");
+	surface_format_priority_list = new_surface_format_priority_list;
 }
 
 VkFormat RenderContext::get_format()

--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -114,14 +114,7 @@ bool VulkanSample::prepare(Platform &platform)
 	device = std::make_unique<vkb::Device>(gpu, surface, get_device_extensions());
 
 	// Preparing render context for rendering
-	render_context = std::make_unique<vkb::RenderContext>(*device, surface, platform.get_window().get_width(), platform.get_window().get_height());
-	render_context->set_present_mode_priority({VK_PRESENT_MODE_FIFO_KHR,
-	                                           VK_PRESENT_MODE_MAILBOX_KHR});
-
-	render_context->set_surface_format_priority({{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                             {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                             {VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                             {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}});
+	render_context = platform.create_render_context(*device, surface);
 
 	prepare_render_context();
 

--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -113,14 +113,22 @@ bool VulkanSample::prepare(Platform &platform)
 
 	device = std::make_unique<vkb::Device>(gpu, surface, get_device_extensions());
 
-	// Preparing render context for rendering
-	render_context = platform.create_render_context(*device, surface);
-
+	create_render_context(platform);
 	prepare_render_context();
 
 	stats = std::make_unique<vkb::Stats>(*render_context);
 
 	return true;
+}
+
+void VulkanSample::create_render_context(Platform &platform)
+{
+	auto surface_priority_list = std::vector<VkSurfaceFormatKHR>{{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	                                                             {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	                                                             {VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	                                                             {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
+
+	render_context = platform.create_render_context(*device, surface, surface_priority_list);
 }
 
 void VulkanSample::prepare_render_context()

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -258,6 +258,11 @@ class VulkanSample : public Application
 	virtual void request_gpu_features(PhysicalDevice &gpu);
 
 	/** 
+	 * @brief Override this to customise the creation of the render_context
+	 */
+	virtual void create_render_context(Platform &platform);
+
+	/** 
 	 * @brief Override this to customise the creation of the swapchain and render_context
 	 */
 	virtual void prepare_render_context();


### PR DESCRIPTION
## Description

Currently all platforms running the samples have the same default render context configuration. API Samples force `VK_PRESENT_MODE_MAILBOX` and performance samples force `VK_PRESENT_MODE_FIFO`.

This PR proposes to set the default render context behaviour by what platform the application is being assumed that it is running on. Hence when the application runs on platforms presumed to be on desktop we prefer `VK_PRESENT_MODE_MAILBOX` to show discrepancy in framerate using different techniques and when using Android we prefer `VK_PRESENT_MODE_FIFO` which benefits are outlined in [this article](https://developer.samsung.com/sdp/blog/en-us/2019/07/26/vulkan-mobile-best-practice-how-to-configure-your-vulkan-swapchain)

Samples still have access to the `prepare_render_context` method where they can customize the context further. This change only targets the present mode default.

This PR helps solve part of #266 but does not include overriding the "vsync" through the CLI

## Notes

I have reintroduced the "Desktop Platform" under the justification that the code written in the later specialised platforms are already presumably running in a desktop environment. I understand that this hit a road bump before on the naming but I still see this as a useful place to remove duplication for these platforms.

Open to a discussion :)

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist (Does not apply)

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
