### PR TITLE
Use updated permissions model when building the docker image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,28 +1,38 @@
 name: "Update Docker Image"
 
+# Adaptation of https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio
+
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Specify tag to use with image"
-        required: true
-        default: "latest"
+
+env:
+  IMAGE_NAME: vulkan-samples
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:
-      - name: Login to GitHub Container Registry
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+    permissions:
+      packages: write
+      contents: read
 
+    steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
       - name: Build Image
-        run: cd .github/docker && docker build -t ghcr.io/khronosgroup/vulkan-samples:${{ github.event.inputs.tag }} .
+        run: cd .github/docker && docker build --tag $IMAGE_NAME .
+
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push Image
-        run: docker image push ghcr.io/khronosgroup/vulkan-samples:${{ github.event.inputs.tag }}
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          echo IMAGE_ID=$IMAGE_ID
 
-      - name: Logout
-        run: docker logout ghcr.io
+          VERSION=latest
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
## Description

GitHub recently updated the permission model to allow granular permissions inherited from the repository instead of a single Personal Access Token. This was not available when the work for this PR was originally carried out however it is the better option.

This has been tested in a personal organisation first