### PR TITLE
Added GLTF animation support

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -166,9 +166,11 @@ set(SCENE_GRAPH_SCRIPTS_FILES
     # Header Files
     scene_graph/scripts/free_camera.h
     scene_graph/scripts/node_animation.h
+    scene_graph/scripts/animation.h
     # Source Files
     scene_graph/scripts/free_camera.cpp
-    scene_graph/scripts/node_animation.cpp)
+    scene_graph/scripts/node_animation.cpp
+    scene_graph/scripts/animation.cpp)
 
 set(STATS_FILES
     # Header Files

--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -151,8 +151,7 @@ inline VkFormat get_attribute_format(const tinygltf::Model *model, uint32_t acce
 
 	switch (accessor.componentType)
 	{
-		case TINYGLTF_COMPONENT_TYPE_BYTE:
-		{
+		case TINYGLTF_COMPONENT_TYPE_BYTE: {
 			static const std::map<int, VkFormat> mapped_format = {{TINYGLTF_TYPE_SCALAR, VK_FORMAT_R8_SINT},
 			                                                      {TINYGLTF_TYPE_VEC2, VK_FORMAT_R8G8_SINT},
 			                                                      {TINYGLTF_TYPE_VEC3, VK_FORMAT_R8G8B8_SINT},
@@ -162,8 +161,7 @@ inline VkFormat get_attribute_format(const tinygltf::Model *model, uint32_t acce
 
 			break;
 		}
-		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
-		{
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE: {
 			static const std::map<int, VkFormat> mapped_format = {{TINYGLTF_TYPE_SCALAR, VK_FORMAT_R8_UINT},
 			                                                      {TINYGLTF_TYPE_VEC2, VK_FORMAT_R8G8_UINT},
 			                                                      {TINYGLTF_TYPE_VEC3, VK_FORMAT_R8G8B8_UINT},
@@ -185,8 +183,7 @@ inline VkFormat get_attribute_format(const tinygltf::Model *model, uint32_t acce
 
 			break;
 		}
-		case TINYGLTF_COMPONENT_TYPE_SHORT:
-		{
+		case TINYGLTF_COMPONENT_TYPE_SHORT: {
 			static const std::map<int, VkFormat> mapped_format = {{TINYGLTF_TYPE_SCALAR, VK_FORMAT_R8_SINT},
 			                                                      {TINYGLTF_TYPE_VEC2, VK_FORMAT_R8G8_SINT},
 			                                                      {TINYGLTF_TYPE_VEC3, VK_FORMAT_R8G8B8_SINT},
@@ -196,8 +193,7 @@ inline VkFormat get_attribute_format(const tinygltf::Model *model, uint32_t acce
 
 			break;
 		}
-		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
-		{
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT: {
 			static const std::map<int, VkFormat> mapped_format = {{TINYGLTF_TYPE_SCALAR, VK_FORMAT_R16_UINT},
 			                                                      {TINYGLTF_TYPE_VEC2, VK_FORMAT_R16G16_UINT},
 			                                                      {TINYGLTF_TYPE_VEC3, VK_FORMAT_R16G16B16_UINT},
@@ -219,8 +215,7 @@ inline VkFormat get_attribute_format(const tinygltf::Model *model, uint32_t acce
 
 			break;
 		}
-		case TINYGLTF_COMPONENT_TYPE_INT:
-		{
+		case TINYGLTF_COMPONENT_TYPE_INT: {
 			static const std::map<int, VkFormat> mapped_format = {{TINYGLTF_TYPE_SCALAR, VK_FORMAT_R32_SINT},
 			                                                      {TINYGLTF_TYPE_VEC2, VK_FORMAT_R32G32_SINT},
 			                                                      {TINYGLTF_TYPE_VEC3, VK_FORMAT_R32G32B32_SINT},
@@ -230,8 +225,7 @@ inline VkFormat get_attribute_format(const tinygltf::Model *model, uint32_t acce
 
 			break;
 		}
-		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
-		{
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT: {
 			static const std::map<int, VkFormat> mapped_format = {{TINYGLTF_TYPE_SCALAR, VK_FORMAT_R32_UINT},
 			                                                      {TINYGLTF_TYPE_VEC2, VK_FORMAT_R32G32_UINT},
 			                                                      {TINYGLTF_TYPE_VEC3, VK_FORMAT_R32G32B32_UINT},
@@ -241,8 +235,7 @@ inline VkFormat get_attribute_format(const tinygltf::Model *model, uint32_t acce
 
 			break;
 		}
-		case TINYGLTF_COMPONENT_TYPE_FLOAT:
-		{
+		case TINYGLTF_COMPONENT_TYPE_FLOAT: {
 			static const std::map<int, VkFormat> mapped_format = {{TINYGLTF_TYPE_SCALAR, VK_FORMAT_R32_SFLOAT},
 			                                                      {TINYGLTF_TYPE_VEC2, VK_FORMAT_R32G32_SFLOAT},
 			                                                      {TINYGLTF_TYPE_VEC3, VK_FORMAT_R32G32B32_SFLOAT},
@@ -252,8 +245,7 @@ inline VkFormat get_attribute_format(const tinygltf::Model *model, uint32_t acce
 
 			break;
 		}
-		default:
-		{
+		default: {
 			format = VK_FORMAT_UNDEFINED;
 			break;
 		}
@@ -806,8 +798,7 @@ sg::Scene GLTFLoader::load_scene(int scene_index)
 
 			switch (output_accessor.type)
 			{
-				case TINYGLTF_TYPE_VEC3:
-				{
+				case TINYGLTF_TYPE_VEC3: {
 					const glm::vec3 *data = reinterpret_cast<const glm::vec3 *>(output_accessor_data.data());
 					for (size_t i = 0; i < output_accessor.count; ++i)
 					{
@@ -815,8 +806,7 @@ sg::Scene GLTFLoader::load_scene(int scene_index)
 					}
 					break;
 				}
-				case TINYGLTF_TYPE_VEC4:
-				{
+				case TINYGLTF_TYPE_VEC4: {
 					const glm::vec4 *data = reinterpret_cast<const glm::vec4 *>(output_accessor_data.data());
 					for (size_t i = 0; i < output_accessor.count; ++i)
 					{
@@ -824,8 +814,7 @@ sg::Scene GLTFLoader::load_scene(int scene_index)
 					}
 					break;
 				}
-				default:
-				{
+				default: {
 					LOGW("Gltf animation sampler #{} has unknown output data type", sampler_index);
 					continue;
 				}
@@ -1064,23 +1053,19 @@ std::unique_ptr<sg::SubMesh> GLTFLoader::load_model(uint32_t index)
 
 		switch (format)
 		{
-			case VK_FORMAT_R32_UINT:
-			{
+			case VK_FORMAT_R32_UINT: {
 				// Correct format
 				break;
 			}
-			case VK_FORMAT_R16_UINT:
-			{
+			case VK_FORMAT_R16_UINT: {
 				index_data = convert_underlying_data_stride(index_data, 2, 4);
 				break;
 			}
-			case VK_FORMAT_R8_UINT:
-			{
+			case VK_FORMAT_R8_UINT: {
 				index_data = convert_underlying_data_stride(index_data, 1, 4);
 				break;
 			}
-			default:
-			{
+			default: {
 				break;
 			}
 		}

--- a/framework/scene_graph/script.cpp
+++ b/framework/scene_graph/script.cpp
@@ -21,9 +21,8 @@ namespace vkb
 {
 namespace sg
 {
-Script::Script(Node &node, const std::string &name) :
-    Component{name},
-    node{node}
+Script::Script(const std::string &name) :
+    Component{name}
 {}
 
 std::type_index Script::get_type()
@@ -39,7 +38,13 @@ void Script::resize(uint32_t /*width*/, uint32_t /*height*/)
 {
 }
 
-Node &Script::get_node()
+NodeScript::NodeScript(Node &node, const std::string &name) :
+    Script{name},
+    node{node}
+{
+}
+
+Node &NodeScript::get_node()
 {
 	return node;
 }

--- a/framework/scene_graph/script.cpp
+++ b/framework/scene_graph/script.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/scene_graph/script.h
+++ b/framework/scene_graph/script.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/scene_graph/script.h
+++ b/framework/scene_graph/script.h
@@ -36,7 +36,7 @@ namespace sg
 class Script : public Component
 {
   public:
-	Script(Node &node, const std::string &name = "");
+	Script(const std::string &name = "");
 
 	virtual ~Script() = default;
 
@@ -50,6 +50,14 @@ class Script : public Component
 	virtual void input_event(const InputEvent &input_event);
 
 	virtual void resize(uint32_t width, uint32_t height);
+};
+
+class NodeScript : public Script
+{
+  public:
+	NodeScript(Node &node, const std::string &name = "");
+
+	virtual ~NodeScript() = default;
 
 	Node &get_node();
 

--- a/framework/scene_graph/scripts/animation.cpp
+++ b/framework/scene_graph/scripts/animation.cpp
@@ -60,15 +60,13 @@ void Animation::update(float delta_time)
 				{
 					switch (channel.target)
 					{
-						case Translation:
-						{
+						case Translation: {
 							transform.set_translation(glm::vec3(glm::mix(channel.sampler.outputs[i],
 							                                             channel.sampler.outputs[i + 1],
 							                                             time)));
 							break;
 						}
-						case Rotation:
-						{
+						case Rotation: {
 							glm::quat q1;
 							q1.x = channel.sampler.outputs[i].x;
 							q1.y = channel.sampler.outputs[i].y;
@@ -85,8 +83,7 @@ void Animation::update(float delta_time)
 							break;
 						}
 
-						case Scale:
-						{
+						case Scale: {
 							transform.set_scale(glm::vec3(glm::mix(channel.sampler.outputs[i],
 							                                       channel.sampler.outputs[i + 1],
 							                                       time)));
@@ -97,13 +94,11 @@ void Animation::update(float delta_time)
 				{
 					switch (channel.target)
 					{
-						case Translation:
-						{
+						case Translation: {
 							transform.set_translation(glm::vec3(channel.sampler.outputs[i]));
 							break;
 						}
-						case Rotation:
-						{
+						case Rotation: {
 							glm::quat q1;
 							q1.x = channel.sampler.outputs[i].x;
 							q1.y = channel.sampler.outputs[i].y;
@@ -114,8 +109,7 @@ void Animation::update(float delta_time)
 							break;
 						}
 
-						case Scale:
-						{
+						case Scale: {
 							transform.set_scale(glm::vec3(channel.sampler.outputs[i]));
 						}
 					}
@@ -137,13 +131,11 @@ void Animation::update(float delta_time)
 
 					switch (channel.target)
 					{
-						case Translation:
-						{
+						case Translation: {
 							transform.set_translation(glm::vec3(result));
 							break;
 						}
-						case Rotation:
-						{
+						case Rotation: {
 							glm::quat q1;
 							q1.x = result.x;
 							q1.y = result.y;
@@ -154,8 +146,7 @@ void Animation::update(float delta_time)
 							break;
 						}
 
-						case Scale:
-						{
+						case Scale: {
 							transform.set_scale(glm::vec3(result));
 						}
 					}

--- a/framework/scene_graph/scripts/animation.cpp
+++ b/framework/scene_graph/scripts/animation.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020, Arm Limited and Contributors
+/* Copyright (c) 2020-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/scene_graph/scripts/animation.cpp
+++ b/framework/scene_graph/scripts/animation.cpp
@@ -1,0 +1,181 @@
+/* Copyright (c) 2020, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "animation.h"
+
+#include "scene_graph/node.h"
+
+namespace vkb
+{
+namespace sg
+{
+Animation::Animation(const std::string &name) :
+    Script{name}
+{
+}
+
+Animation::Animation(const Animation &other) :
+    channels{other.channels}
+{
+}
+
+void Animation::add_channel(Node &node, const AnimationTarget &target, const AnimationSampler &sampler)
+{
+	channels.push_back({node, target, sampler});
+}
+
+void Animation::update(float delta_time)
+{
+	current_time += delta_time;
+	if (current_time > end_time)
+	{
+		current_time -= end_time;
+	}
+
+	for (auto &channel : channels)
+	{
+		for (size_t i = 0; i < channel.sampler.inputs.size() - 1; ++i)
+		{
+			if ((current_time >= channel.sampler.inputs[i]) && (current_time <= channel.sampler.inputs[i + 1]))
+			{
+				float time = (current_time - channel.sampler.inputs[i]) / (channel.sampler.inputs[i + 1] - channel.sampler.inputs[i]);
+
+				auto &transform = channel.node.get_transform();
+
+				if (channel.sampler.type == AnimationType::Linear)
+				{
+					switch (channel.target)
+					{
+						case Translation:
+						{
+							transform.set_translation(glm::vec3(glm::mix(channel.sampler.outputs[i],
+							                                             channel.sampler.outputs[i + 1],
+							                                             time)));
+							break;
+						}
+						case Rotation:
+						{
+							glm::quat q1;
+							q1.x = channel.sampler.outputs[i].x;
+							q1.y = channel.sampler.outputs[i].y;
+							q1.z = channel.sampler.outputs[i].z;
+							q1.w = channel.sampler.outputs[i].w;
+
+							glm::quat q2;
+							q2.x = channel.sampler.outputs[i + 1].x;
+							q2.y = channel.sampler.outputs[i + 1].y;
+							q2.z = channel.sampler.outputs[i + 1].z;
+							q2.w = channel.sampler.outputs[i + 1].w;
+
+							transform.set_rotation(glm::normalize(glm::slerp(q1, q2, time)));
+							break;
+						}
+
+						case Scale:
+						{
+							transform.set_scale(glm::vec3(glm::mix(channel.sampler.outputs[i],
+							                                       channel.sampler.outputs[i + 1],
+							                                       time)));
+						}
+					}
+				}
+				else if (channel.sampler.type == AnimationType::Step)
+				{
+					switch (channel.target)
+					{
+						case Translation:
+						{
+							transform.set_translation(glm::vec3(channel.sampler.outputs[i]));
+							break;
+						}
+						case Rotation:
+						{
+							glm::quat q1;
+							q1.x = channel.sampler.outputs[i].x;
+							q1.y = channel.sampler.outputs[i].y;
+							q1.z = channel.sampler.outputs[i].z;
+							q1.w = channel.sampler.outputs[i].w;
+
+							transform.set_rotation(glm::normalize(q1));
+							break;
+						}
+
+						case Scale:
+						{
+							transform.set_scale(glm::vec3(channel.sampler.outputs[i]));
+						}
+					}
+				}
+				else if (channel.sampler.type == AnimationType::CubicSpline)
+				{
+					float delta = channel.sampler.inputs[i + 1] - channel.sampler.inputs[i];
+
+					glm::vec4 p0 = channel.sampler.outputs[i * 3 + 1];              // Starting point
+					glm::vec4 p1 = channel.sampler.outputs[(i + 1) * 3 + 1];        // Ending point
+
+					glm::vec4 m0 = delta * channel.sampler.outputs[i * 3 + 2];              // Delta time * out tangent
+					glm::vec4 m1 = delta * channel.sampler.outputs[(i + 1) * 3 + 0];        // Delta time * in tangent of next point
+
+					// This equation is taken from the GLTF 2.0 specification Appendix C (https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#appendix-c-spline-interpolation)
+					glm::vec4 result = (2.0f * glm::pow(time, 3.0f) - 3.0f * glm::pow(time, 2.0f) + 1.0f) * p0 + (glm::pow(time, 3.0f) - 2.0f * glm::pow(time, 2.0f) + time) * m0 + (-2.0f * glm::pow(time, 3.0f) + 3.0f * glm::pow(time, 2.0f)) * p1 + (glm::pow(time, 3.0f) - glm::pow(time, 2.0f)) * m1;
+
+					auto &transform = channel.node.get_transform();
+
+					switch (channel.target)
+					{
+						case Translation:
+						{
+							transform.set_translation(glm::vec3(result));
+							break;
+						}
+						case Rotation:
+						{
+							glm::quat q1;
+							q1.x = result.x;
+							q1.y = result.y;
+							q1.z = result.z;
+							q1.w = result.w;
+
+							transform.set_rotation(glm::normalize(q1));
+							break;
+						}
+
+						case Scale:
+						{
+							transform.set_scale(glm::vec3(result));
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+void Animation::update_times(float new_start_time, float new_end_time)
+{
+	if (new_start_time < start_time)
+	{
+		start_time = new_start_time;
+	}
+	if (new_end_time > end_time)
+	{
+		end_time = new_end_time;
+	}
+}
+
+}        // namespace sg
+}        // namespace vkb

--- a/framework/scene_graph/scripts/animation.h
+++ b/framework/scene_graph/scripts/animation.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020, Arm Limited and Contributors
+/* Copyright (c) 2020-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/scene_graph/scripts/free_camera.cpp
+++ b/framework/scene_graph/scripts/free_camera.cpp
@@ -47,7 +47,7 @@ const float FreeCamera::TRANSLATION_MOVE_STEP = 50.0f;
 const uint32_t FreeCamera::TRANSLATION_MOVE_SPEED = 4;
 
 FreeCamera::FreeCamera(Node &node) :
-    Script{node, "FreeCamera"}
+    NodeScript{node, "FreeCamera"}
 {}
 
 void FreeCamera::update(float delta_time)

--- a/framework/scene_graph/scripts/free_camera.cpp
+++ b/framework/scene_graph/scripts/free_camera.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
- * Copyright (c) 2020, Andrew Cox, Huawei Technologies Research & Development (UK) Limited
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
+ * Copyright (c) 2020-2021, Andrew Cox, Huawei Technologies Research & Development (UK) Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/scene_graph/scripts/free_camera.h
+++ b/framework/scene_graph/scripts/free_camera.h
@@ -35,7 +35,7 @@ namespace vkb
 {
 namespace sg
 {
-class FreeCamera : public Script
+class FreeCamera : public NodeScript
 {
   public:
 	static const float TOUCH_DOWN_MOVE_FORWARD_WAIT_TIME;

--- a/framework/scene_graph/scripts/free_camera.h
+++ b/framework/scene_graph/scripts/free_camera.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/scene_graph/scripts/node_animation.cpp
+++ b/framework/scene_graph/scripts/node_animation.cpp
@@ -34,7 +34,7 @@ namespace vkb
 namespace sg
 {
 NodeAnimation::NodeAnimation(Node &node, TransformAnimFn animation_fn) :
-    Script{node, ""},
+    NodeScript{node, ""},
     animation_fn{animation_fn}
 {
 }

--- a/framework/scene_graph/scripts/node_animation.cpp
+++ b/framework/scene_graph/scripts/node_animation.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/scene_graph/scripts/node_animation.h
+++ b/framework/scene_graph/scripts/node_animation.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -35,6 +35,7 @@ VKBP_ENABLE_WARNINGS()
 #include "platform/window.h"
 #include "scene_graph/components/camera.h"
 #include "scene_graph/script.h"
+#include "scene_graph/scripts/animation.h"
 #include "scene_graph/scripts/free_camera.h"
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
@@ -146,6 +147,17 @@ void VulkanSample::update_scene(float delta_time)
 			for (auto script : scripts)
 			{
 				script->update(delta_time);
+			}
+		}
+
+		//Update animations
+		if (scene->has_component<sg::Animation>())
+		{
+			auto animations = scene->get_components<sg::Animation>();
+
+			for (auto animation : animations)
+			{
+				animation->update(delta_time);
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Added in GLTF animation support for Linear, Step and Cubic Spline animations using the GLTF 2.0 specifications.

GLTF Loader now automatically loads in animations that are embedded into GLTF files.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
