### PR TITLE
Move assets and shaders to shared storage and make app debuggable even in release builds

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-- Copyright (c) 2019, Arm Limited and Contributors
+- Copyright (c) 2019-2021, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -28,10 +28,11 @@
 
 	<application android:label="@string/app_name"
 		android:allowBackup="false"
+		android:debuggable="true"
 		android:icon="@mipmap/ic_launcher"
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:theme="@style/AppTheme"
-		tools:ignore="GoogleAppIndexingWarning">
+		tools:ignore="GoogleAppIndexingWarning,HardcodedDebugMode">
 
 		<activity android:name="com.khronos.vulkan_samples.SampleLauncherActivity">
 			<intent-filter>

--- a/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
+++ b/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import android.support.v7.widget.Toolbar;
 
@@ -69,6 +70,10 @@ public class SampleLauncherActivity extends AppCompatActivity {
             File external_files_dir = getExternalFilesDir("");
             File temp_files_dir = getCacheDir();
             if (external_files_dir != null && temp_files_dir != null) {
+                // User no longer has permissions to access applications' storage, save files in
+                // top level (shared) external storage directory
+                String shared_storage = external_files_dir.getPath().split(Pattern.quote("Android"))[0];
+                external_files_dir = new File(shared_storage, getPackageName());
                 initFilePath(external_files_dir.toString(), temp_files_dir.toString());
             }
 

--- a/bldsys/cmake/android_package.cmake
+++ b/bldsys/cmake/android_package.cmake
@@ -1,5 +1,5 @@
 #[[
- Copyright (c) 2019, Arm Limited and Contributors
+ Copyright (c) 2019-2021, Arm Limited and Contributors
 
  SPDX-License-Identifier: Apache-2.0
 

--- a/bldsys/cmake/android_package.cmake
+++ b/bldsys/cmake/android_package.cmake
@@ -113,7 +113,7 @@ function(android_sync_folder)
     set(SYNC_COMMAND ${CMAKE_COMMAND}
             -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
             -DFOLDER_DIR=${TARGET_PATH}/.
-            -DDEVICE_DIR=/sdcard/Android/data/com.khronos.${PROJECT_NAME}/files/${FOLDER_NAME}/
+            -DDEVICE_DIR=/sdcard/com.khronos.${PROJECT_NAME}/${FOLDER_NAME}/
             -P "${SCRIPT_DIR}/android_sync_folder.cmake")
 
     add_custom_target(


### PR DESCRIPTION
## Description

A contribution made by Emilio. Used in the Vsync changes so I have tested this change there.

Latest Android (e.g. on Galaxy S21) security policy means we can no longer access files within the application's external storage directory.

To work around this, save files in the shared storage directory. That is, rather than using:

`/sdcard/Android/data/com.khronos.vulkan_samples/files/`

we now use

`/sdcard/com.khronos.vulkan_samples/`

In addition to this, we can tag the application as 'debuggable' in the manifest, so that we can do performance analysis on release builds using Streamline (and also trace release builds using RenderDoc). This has no effect on performance.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
