### PR TITLE
Don't run clang-format on java files

### DIFF
--- a/.github/docker/scripts/clang_format.py
+++ b/.github/docker/scripts/clang_format.py
@@ -81,7 +81,6 @@ def main():
       'cu',  # CUDA
       # Other languages that clang-format supports
       'proto', 'protodevel',  # Protocol Buffers
-      'java',  # Java
       'js',  # JavaScript
       'ts',  # TypeScript
       ])

--- a/.github/docker/scripts/clang_format.py
+++ b/.github/docker/scripts/clang_format.py
@@ -73,16 +73,8 @@ def main():
     argv = argv[:idx]
 
   default_extensions = ','.join([
-      # From clang/lib/Frontend/FrontendOptions.cpp, all lower case
       'c', 'h',  # C
-      'm',  # ObjC
-      'mm',  # ObjC++
       'cc', 'cp', 'cpp', 'c++', 'cxx', 'hpp',  # C++
-      'cu',  # CUDA
-      # Other languages that clang-format supports
-      'proto', 'protodevel',  # Protocol Buffers
-      'js',  # JavaScript
-      'ts',  # TypeScript
       ])
 
   p = argparse.ArgumentParser(


### PR DESCRIPTION
## Description

Clang format 10 can not be run on java files yet the clang format script the CI uses allows this to happen. This causes clang format to throw an error and break pipelines on contributions that modify java files.

@marty-johnson59 this is needed to fix other PRs that are breaking on this issue.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
