### PR TITLE
Add D2D CI Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,18 +20,34 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
-
       - if: ${{ matrix.platform == 'ubuntu' }}
         name: Install RandR headers
         run: |
           sudo apt-get update
           sudo apt install xorg-dev libglu1-mesa-dev
-
       - name: Configure
         run: cmake -H"." -B"build/${{ matrix.platform }}" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON
-
       - name: "Build ${{ matrix.platform }} in ${{ matrix.build_type }}"
         run: cmake --build "build/${{ matrix.platform }}" --target vulkan_samples --config ${{ matrix.build_type }} ${{ env.PARALLEL }}
+
+
+  build_d2d:
+    name: "Build Ubuntu with Direct To Display"
+    env:
+      PARALLEL: -j 2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+      - name: Install RandR headers
+        run: |
+          sudo apt-get update
+          sudo apt install xorg-dev libglu1-mesa-dev
+      - name: Configure
+        run: cmake -H"." -B"build/ubuntu-latest-d2d" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DVKB_WSI_SELECTION=D2D
+      - name: "Build Ubuntu in Release with VKB_WSI_SELECTION=D2D"
+        run: cmake --build "build/ubuntu-latest-d2d" --target vulkan_samples --config Release ${{ env.PARALLEL }}
 
   build_android:
     name: "Build Android in ${{ matrix.build_type }}"


### PR DESCRIPTION
## Description

Add a D2D build to the CI [Example pipeline ran on my fork](https://github.com/TomAtkinsonArm/Vulkan-Samples/runs/3235737038?check_suite_focus=true)

Last time I attempted this I ran into a bunch of error messages about missing headers. This time seems to have passed without issue. 

`cmake -H"." -B"build/ubuntu-latest-d2d" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DVKB_WSI_SELECTION=D2D`

Is my configure command similar to what you would use @gary-sweet?

Fixes #309