### PR TITLE
constant_data sample - prevent end_render_pass() when it wasn't begun 

### DIFF
--- a/samples/performance/constant_data/constant_data.cpp
+++ b/samples/performance/constant_data/constant_data.cpp
@@ -210,9 +210,9 @@ void ConstantData::draw_renderpass(vkb::CommandBuffer &command_buffer, vkb::Rend
 		{
 			get_render_context().get_active_frame().update_descriptor_sets();
 		}
-	}
 
-	command_buffer.end_render_pass();
+		command_buffer.end_render_pass();
+	}
 }
 
 inline ConstantData::Method ConstantData::get_active_method()

--- a/samples/performance/constant_data/constant_data.cpp
+++ b/samples/performance/constant_data/constant_data.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: MIT
  *


### PR DESCRIPTION
## Description

If the batch config has disabled the render mode, `end_render_pass()` is being called without it being begun.

Moved the `end()` inside the same condition scope as the `begin()`.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android.  - _Only tested on Linux_ -
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly. - _Only affects one sample_ -
- [x] This PR describes the scope and expected impact of the changes I am making

