### PR TITLE
Resolve gh_pages not building

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-slate
+exclude: third_party


### PR DESCRIPTION
## Description

Add `exclude: third_party` to _config.yml to ensure that gh_pages build correct. Warnings are still exhibited during build for binary files. 

Fixes #319

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
