### PR TITLE
Improve semantics and fixed the incorrect type of return value 

### DIFF
--- a/framework/core/descriptor_pool.cpp
+++ b/framework/core/descriptor_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -184,7 +184,7 @@ std::uint32_t DescriptorPool::find_available_pool(std::uint32_t search_index)
 
 		if (result != VK_SUCCESS)
 		{
-			return VK_NULL_HANDLE;
+			return 0;
 		}
 
 		// Store internally the Vulkan handle

--- a/framework/core/device.cpp
+++ b/framework/core/device.cpp
@@ -417,7 +417,7 @@ uint32_t Device::get_queue_family_index(VkQueueFlagBits queue_flag)
 	{
 		for (uint32_t i = 0; i < static_cast<uint32_t>(queue_family_properties.size()); i++)
 		{
-			if ((queue_family_properties[i].queueFlags & queue_flag) && ((queue_family_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0))
+			if ((queue_family_properties[i].queueFlags & queue_flag) && !(queue_family_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT))
 			{
 				return i;
 				break;
@@ -431,7 +431,7 @@ uint32_t Device::get_queue_family_index(VkQueueFlagBits queue_flag)
 	{
 		for (uint32_t i = 0; i < static_cast<uint32_t>(queue_family_properties.size()); i++)
 		{
-			if ((queue_family_properties[i].queueFlags & queue_flag) && ((queue_family_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0) && ((queue_family_properties[i].queueFlags & VK_QUEUE_COMPUTE_BIT) == 0))
+			if ((queue_family_properties[i].queueFlags & queue_flag) && !(queue_family_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) && !(queue_family_properties[i].queueFlags & VK_QUEUE_COMPUTE_BIT))
 			{
 				return i;
 				break;


### PR DESCRIPTION
## Description

1. Use NOT operator here instead of equaling zero could improve semantics to understand easily we want to select the exact queue family here.
2. The VK_NULL_HANDLE is identical to nullptr in MSCV, which did not match the return type of the function. The problem here leads the compiling in MSVC to be failed. Return zero to match the type of int32_t instead of a null pointer. NULL might be cast to zero implicitly, though, cplusplus has a more strict type check.

## Tested Environments
Windows 10
Visual Studio 2022 (v143)
C++ Language Standard: 17
Vulkan version: 1.2.176

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
