### PR TITLE
Fix focus state in direct-2-display platform

### DIFF
--- a/framework/platform/unix/direct_window.cpp
+++ b/framework/platform/unix/direct_window.cpp
@@ -226,6 +226,8 @@ DirectWindow::DirectWindow(Platform &platform, uint32_t width, uint32_t height) 
 		if (tcsetattr(tty_fd, TCSANOW, &termio) == -1)
 			LOGW("Failed to set attribs for '/dev/tty'");
 	}
+
+	platform.set_focus(true);
 }
 
 DirectWindow::~DirectWindow()


### PR DESCRIPTION
D2D windows are always focused.
Without this change, the focus state remains uninitialized which can mean only the initial frame being rendered.
