### PR TITLE
Fix focus on direct-2-display platforms

### DIFF
--- a/framework/platform/unix/direct_window.cpp
+++ b/framework/platform/unix/direct_window.cpp
@@ -227,6 +227,8 @@ DirectWindow::DirectWindow(Platform *platform, const Window::Properties &propert
 		if (tcsetattr(tty_fd, TCSANOW, &termio) == -1)
 			LOGW("Failed to set attribs for '/dev/tty'");
 	}
+
+	platform->set_focus(true);
 }
 
 DirectWindow::~DirectWindow()


### PR DESCRIPTION
Direct-2-display platforms always have focus, so make sure it's initialized.
