### PR TITLE
Change vkb::core::HPPBuffer from a facade over vkb::core::Buffer to a self-contained class, using vulkan.hpp.

### DIFF
--- a/framework/core/hpp_buffer.h
+++ b/framework/core/hpp_buffer.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <core/buffer.h>
 #include <core/hpp_device.h>
 #include <vulkan/vulkan.hpp>
 
@@ -26,11 +25,11 @@ namespace vkb
 namespace core
 {
 /**
- * @brief wrapper class for use with vulkan.hpp in the samples of this framework
+ * @brief vulkan.hpp version of the vkb::core::Buffer class
  *
  * See vkb::VulkanSample for documentation
  */
-class HPPBuffer : protected vkb::core::Buffer
+class HPPBuffer
 {
   public:
 	/**
@@ -47,6 +46,13 @@ class HPPBuffer : protected vkb::core::Buffer
 	          VmaMemoryUsage           memory_usage,
 	          VmaAllocationCreateFlags flags = VMA_ALLOCATION_CREATE_MAPPED_BIT);
 
+	HPPBuffer(const HPPBuffer &) = delete;
+	HPPBuffer(HPPBuffer &&rhs);
+	~HPPBuffer();
+
+	HPPBuffer &operator=(const HPPBuffer &) = delete;
+	HPPBuffer &operator                     =(HPPBuffer &&rhs);
+
 	/**
 	 * @brief Flushes memory if it is HOST_VISIBLE and not HOST_COHERENT
 	 */
@@ -58,6 +64,17 @@ class HPPBuffer : protected vkb::core::Buffer
 	 * @return The size of the buffer
 	 */
 	vk::DeviceSize get_size() const;
+
+	/**
+	 * @brief Maps vulkan memory if it isn't already mapped to an host visible address
+	 * @return Pointer to host visible memory
+	 */
+	uint8_t *map();
+
+	/**
+	 * @brief Unmaps vulkan memory from the host visible address
+	 */
+	void unmap();
 
 	/**
 	 * @brief Copies byte data into the buffer
@@ -85,6 +102,17 @@ class HPPBuffer : protected vkb::core::Buffer
 	{
 		update(reinterpret_cast<const uint8_t *>(&object), sizeof(T), offset);
 	}
+
+  private:
+	void destroy();
+
+  private:
+	vk::Buffer           handle = nullptr;
+	vk::BufferCreateInfo buffer_create_info;
+	uint8_t *            mapped_data   = nullptr;
+	bool                 persistent    = false;        /// Whether the buffer is persistently mapped or not
+	VmaAllocation        vmaAllocation = VK_NULL_HANDLE;
+	VmaAllocator         vmaAllocator  = VK_NULL_HANDLE;
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_device.h
+++ b/framework/core/hpp_device.h
@@ -26,6 +26,8 @@ namespace core
 {
 class HPPDevice : protected vkb::Device
 {
+  public:
+	using vkb::Device::get_memory_allocator;
 };
 }        // namespace core
 }        // namespace vkb


### PR DESCRIPTION
## Description

Making HPPBuffer a self-contained class, instead of just a facade over vkb::core::Buffer, shows how to interact between vulkan.hpp and VMA.
Built and tested on Windows 10, using VS2019.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
