### PR TITLE
[Android] Check for external storage permissions

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -25,10 +25,13 @@
 
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+	                 tools:ignore="ScopedStorage" />
 
 	<application android:label="@string/app_name"
 		android:allowBackup="false"
 		android:debuggable="true"
+		android:requestLegacyExternalStorage="true"
 		android:icon="@mipmap/ic_launcher"
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:theme="@style/AppTheme"

--- a/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
+++ b/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
@@ -21,9 +21,14 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.os.Environment;
+import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -92,6 +97,18 @@ public class SampleLauncherActivity extends AppCompatActivity {
         } else {
             // Chain request permissions
             requestNextPermission();
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (!Environment.isExternalStorageManager())
+            {
+                // Prompt the user to "Allow access to all files"
+                Intent intent = new Intent();
+                                    intent.setAction(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+                                    Uri uri = Uri.fromParts("package", this.getPackageName(), null);
+                                    intent.setData(uri);
+                startActivity(intent);
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Request additional storage permissions for Android 11, and legacy permissions for previous versions

Tested on Samsung Galaxy S20 (Android 10) and S21 (Android 11)

Fixes #369 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [n/a] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
