### PR TITLE
Add a plugin to enable log output to a file

### DIFF
--- a/app/plugins/file_logger/file_logger.cpp
+++ b/app/plugins/file_logger/file_logger.cpp
@@ -1,0 +1,53 @@
+/* Copyright (c) 2021, Arm Limited and Contributors
+ * Copyright (c) 2021, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "file_logger.h"
+
+#include "apps.h"
+
+VKBP_DISABLE_WARNINGS()
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/spdlog.h>
+VKBP_ENABLE_WARNINGS()
+
+namespace plugins
+{
+FileLogger::FileLogger() :
+    FileLoggerTags("File Logger",
+                   "Enable log output to a file.",
+                   {}, {&log_file_flag})
+{
+}
+
+bool FileLogger::is_active(const vkb::CommandParser &parser)
+{
+	return parser.contains(&log_file_flag);
+}
+
+void FileLogger::init(const vkb::CommandParser &parser)
+{
+	if (parser.contains(&log_file_flag))
+	{
+		if (spdlog::default_logger())
+		{
+			std::string log_file_name = parser.as<std::string>(&log_file_flag);
+			spdlog::default_logger()->sinks().push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_file_name, true));
+		}
+	}
+}
+}        // namespace plugins

--- a/app/plugins/file_logger/file_logger.h
+++ b/app/plugins/file_logger/file_logger.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2020-2021, Arm Limited and Contributors
+ * Copyright (c) 2021, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "platform/plugins/plugin_base.h"
+
+namespace plugins
+{
+using FileLoggerTags = vkb::PluginBase<vkb::tags::Passive>;
+
+/**
+ * @brief File Logger
+ * 
+ * Enables writing log messages to a file
+ * 
+ * Usage: vulkan_sample --log-file filename.txt
+ * 
+ */
+class FileLogger : public FileLoggerTags
+{
+  public:
+	FileLogger();
+
+	virtual ~FileLogger() = default;
+
+	virtual bool is_active(const vkb::CommandParser &parser) override;
+
+	virtual void init(const vkb::CommandParser &parser) override;
+
+	vkb::FlagCommand log_file_flag = {vkb::FlagType::OneValue, "log-file", "", "Write log messages to the given file name"};
+};
+}        // namespace plugins


### PR DESCRIPTION
## Description

This PR adds a new plugin to the framework, which stores log messages to a file. This is done in addition to the default log output defined by the respective platform. So if you e.g. enable this on Windows, you still get the log messages in the separate console window, but also in a text file saved to disk.

Example usage:

```vulkan_samples.exe sample afbc --log-file afbc.txt```

Refs #372

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
