### PR TITLE
Change vkb::HPPApiVulkanSample from a facade over vkb::ApiVulkanSample to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -39,6 +39,8 @@ set(FRAMEWORK_FILES
     timer.h
     camera.h
     hpp_api_vulkan_sample.h
+    hpp_gltf_loader.h
+    hpp_vulkan_sample.h
     # Source Files
     gui.cpp
     glsl_compiler.cpp
@@ -71,6 +73,7 @@ set(COMMON_FILES
     common/utils.h
     common/strings.h
     common/tags.h
+    common/hpp_vk_common.h
     # Source Files
     common/error.cpp
     common/vk_common.cpp
@@ -95,6 +98,7 @@ set(RENDERING_FILES
     rendering/render_pipeline.h
     rendering/render_target.h
     rendering/subpass.h
+    rendering/hpp_render_context.h
     # Source files
     rendering/pipeline_state.cpp
     rendering/postprocessing_pipeline.cpp
@@ -147,6 +151,8 @@ set(SCENE_GRAPH_COMPONENT_FILES
     scene_graph/components/image/astc.h
     scene_graph/components/image/ktx.h
     scene_graph/components/image/stb.h
+    scene_graph/components/hpp_image.h
+    scene_graph/components/hpp_sub_mesh.h
     # Source Files
     scene_graph/components/aabb.cpp
     scene_graph/components/camera.cpp
@@ -220,6 +226,11 @@ set(CORE_FILES
     core/shader_binding_table.h
     core/hpp_buffer.h
     core/hpp_device.h
+    core/hpp_image.h
+    core/hpp_instance.h
+    core/hpp_physical_device.h
+    core/hpp_queue.h
+    core/hpp_swapchain.h
     # Source Files
     core/instance.cpp
     core/physical_device.cpp
@@ -247,8 +258,7 @@ set(CORE_FILES
     core/scratch_buffer.cpp
     core/acceleration_structure.cpp
     core/shader_binding_table.cpp
-    core/hpp_buffer.cpp
-    core/hpp_device.cpp)
+    core/hpp_buffer.cpp)
 
 set(PLATFORM_FILES
     # Header Files
@@ -262,6 +272,7 @@ set(PLATFORM_FILES
     platform/headless_window.h
     platform/plugins/plugin.h
     platform/plugins/plugin_base.h
+    platform/hpp_platform.h
 
     # Source Files
     platform/headless_window.cpp

--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -1,0 +1,102 @@
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <common/vk_common.h>
+#include <vulkan/vulkan.hpp>
+
+namespace vkb
+{
+namespace common
+{
+/**
+ * @brief facade helper functions around the functions in common/vk_commmon, providing a vulkan.hpp-based interface
+ */
+vk::Format get_suitable_depth_format(vk::PhysicalDevice             physical_device,
+                                     bool                           depth_only                 = false,
+                                     const std::vector<vk::Format> &depth_format_priority_list = {
+                                         vk::Format::eD32Sfloat, vk::Format::eD24UnormS8Uint, vk::Format::eD16Unorm})
+{
+	std::vector<VkFormat> dfpl;
+	dfpl.reserve(depth_format_priority_list.size());
+	for (auto const &format : depth_format_priority_list)
+	{
+		dfpl.push_back(static_cast<VkFormat>(format));
+	}
+	return static_cast<vk::Format>(vkb::get_suitable_depth_format(physical_device, depth_only, dfpl));
+}
+
+bool is_depth_only_format(vk::Format format)
+{
+	return format == vk::Format::eD16Unorm || format == vk::Format::eD32Sfloat;
+}
+
+bool is_depth_stencil_format(vk::Format format)
+{
+	return format == vk::Format::eD16UnormS8Uint || format == vk::Format::eD24UnormS8Uint || format == vk::Format::eD32SfloatS8Uint ||
+	       is_depth_only_format(format);
+}
+
+vk::ShaderModule load_shader(const std::string &filename, vk::Device device, vk::ShaderStageFlagBits stage)
+{
+	return vkb::load_shader(filename, device, static_cast<VkShaderStageFlagBits>(stage));
+}
+
+vk::ImageLayout map_descriptor_type_to_image_layout(vk::DescriptorType descriptor_type, vk::Format format)
+{
+	switch (descriptor_type)
+	{
+		case vk::DescriptorType::eCombinedImageSampler:
+		case vk::DescriptorType::eInputAttachment:
+			if (is_depth_stencil_format(format))
+			{
+				return vk::ImageLayout::eDepthStencilReadOnlyOptimal;
+			}
+			else
+			{
+				return vk::ImageLayout::eShaderReadOnlyOptimal;
+			}
+			break;
+		case vk::DescriptorType::eStorageImage:
+			return vk::ImageLayout::eGeneral;
+			break;
+		default:
+			return vk::ImageLayout::eUndefined;
+			break;
+	}
+}
+
+void set_image_layout(vk::CommandBuffer         command_buffer,
+                      vk::Image                 image,
+                      vk::ImageLayout           old_layout,
+                      vk::ImageLayout           new_layout,
+                      vk::ImageSubresourceRange subresource_range,
+                      vk::PipelineStageFlags    src_mask = vk::PipelineStageFlagBits::eAllCommands,
+                      vk::PipelineStageFlags    dst_mask = vk::PipelineStageFlagBits::eAllCommands)
+{
+	vkb::set_image_layout(command_buffer,
+	                      image,
+	                      static_cast<VkImageLayout>(old_layout),
+	                      static_cast<VkImageLayout>(new_layout),
+	                      subresource_range,
+	                      static_cast<VkPipelineStageFlags>(src_mask),
+	                      static_cast<VkPipelineStageFlags>(dst_mask));
+}
+
+}        // namespace common
+}        // namespace vkb

--- a/framework/core/buffer.cpp
+++ b/framework/core/buffer.cpp
@@ -23,7 +23,7 @@ namespace vkb
 {
 namespace core
 {
-Buffer::Buffer(Device &device, VkDeviceSize size, VkBufferUsageFlags buffer_usage, VmaMemoryUsage memory_usage, VmaAllocationCreateFlags flags) :
+Buffer::Buffer(Device const &device, VkDeviceSize size, VkBufferUsageFlags buffer_usage, VmaMemoryUsage memory_usage, VmaAllocationCreateFlags flags) :
     device{device},
     size{size}
 {

--- a/framework/core/buffer.h
+++ b/framework/core/buffer.h
@@ -37,7 +37,7 @@ class Buffer
 	 * @param memory_usage The memory usage of the buffer
 	 * @param flags The allocation create flags
 	 */
-	Buffer(Device &                 device,
+	Buffer(Device const &           device,
 	       VkDeviceSize             size,
 	       VkBufferUsageFlags       buffer_usage,
 	       VmaMemoryUsage           memory_usage,
@@ -155,7 +155,7 @@ class Buffer
 	uint64_t get_device_address();
 
   private:
-	Device &device;
+	Device const &device;
 
 	VkBuffer handle{VK_NULL_HANDLE};
 

--- a/framework/core/device.cpp
+++ b/framework/core/device.cpp
@@ -332,7 +332,7 @@ bool Device::is_image_format_supported(VkFormat format) const
 	return result != VK_ERROR_FORMAT_NOT_SUPPORTED;
 }
 
-uint32_t Device::get_memory_type(uint32_t bits, VkMemoryPropertyFlags properties, VkBool32 *memory_type_found)
+uint32_t Device::get_memory_type(uint32_t bits, VkMemoryPropertyFlags properties, VkBool32 *memory_type_found) const
 {
 	for (uint32_t i = 0; i < gpu.get_memory_properties().memoryTypeCount; i++)
 	{
@@ -366,11 +366,11 @@ const Queue &Device::get_queue(uint32_t queue_family_index, uint32_t queue_index
 	return queues[queue_family_index][queue_index];
 }
 
-const Queue &Device::get_queue_by_flags(VkQueueFlags required_queue_flags, uint32_t queue_index)
+const Queue &Device::get_queue_by_flags(VkQueueFlags required_queue_flags, uint32_t queue_index) const
 {
 	for (uint32_t queue_family_index = 0U; queue_family_index < queues.size(); ++queue_family_index)
 	{
-		Queue &first_queue = queues[queue_family_index][0];
+		Queue const &first_queue = queues[queue_family_index][0];
 
 		VkQueueFlags queue_flags = first_queue.get_properties().queueFlags;
 		uint32_t     queue_count = first_queue.get_properties().queueCount;
@@ -384,11 +384,11 @@ const Queue &Device::get_queue_by_flags(VkQueueFlags required_queue_flags, uint3
 	throw std::runtime_error("Queue not found");
 }
 
-const Queue &Device::get_queue_by_present(uint32_t queue_index)
+const Queue &Device::get_queue_by_present(uint32_t queue_index) const
 {
 	for (uint32_t queue_family_index = 0U; queue_family_index < queues.size(); ++queue_family_index)
 	{
-		Queue &first_queue = queues[queue_family_index][0];
+		Queue const &first_queue = queues[queue_family_index][0];
 
 		uint32_t queue_count = first_queue.get_properties().queueCount;
 
@@ -452,11 +452,11 @@ uint32_t Device::get_queue_family_index(VkQueueFlagBits queue_flag)
 	throw std::runtime_error("Could not find a matching queue family index");
 }
 
-const Queue &Device::get_suitable_graphics_queue()
+const Queue &Device::get_suitable_graphics_queue() const
 {
 	for (uint32_t queue_family_index = 0U; queue_family_index < queues.size(); ++queue_family_index)
 	{
-		Queue &first_queue = queues[queue_family_index][0];
+		Queue const &first_queue = queues[queue_family_index][0];
 
 		uint32_t queue_count = first_queue.get_properties().queueCount;
 
@@ -549,7 +549,7 @@ VkCommandPool Device::create_command_pool(uint32_t queue_index, VkCommandPoolCre
 	return command_pool;
 }
 
-VkCommandBuffer Device::create_command_buffer(VkCommandBufferLevel level, bool begin)
+VkCommandBuffer Device::create_command_buffer(VkCommandBufferLevel level, bool begin) const
 {
 	assert(command_pool && "No command pool exists in the device");
 
@@ -573,7 +573,7 @@ VkCommandBuffer Device::create_command_buffer(VkCommandBufferLevel level, bool b
 	return command_buffer;
 }
 
-void Device::flush_command_buffer(VkCommandBuffer command_buffer, VkQueue queue, bool free, VkSemaphore signalSemaphore)
+void Device::flush_command_buffer(VkCommandBuffer command_buffer, VkQueue queue, bool free, VkSemaphore signalSemaphore) const
 {
 	if (command_buffer == VK_NULL_HANDLE)
 	{
@@ -613,27 +613,27 @@ void Device::flush_command_buffer(VkCommandBuffer command_buffer, VkQueue queue,
 	}
 }
 
-CommandPool &Device::get_command_pool()
+CommandPool &Device::get_command_pool() const
 {
 	return *command_pool;
 }
 
-FencePool &Device::get_fence_pool()
+FencePool &Device::get_fence_pool() const
 {
 	return *fence_pool;
 }
 
-CommandBuffer &Device::request_command_buffer()
+CommandBuffer &Device::request_command_buffer() const
 {
 	return command_pool->request_command_buffer();
 }
 
-VkFence Device::request_fence()
+VkFence Device::request_fence() const
 {
 	return fence_pool->request_fence();
 }
 
-VkResult Device::wait_idle()
+VkResult Device::wait_idle() const
 {
 	return vkDeviceWaitIdle(handle);
 }

--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -88,15 +88,15 @@ class Device
 
 	const Queue &get_queue(uint32_t queue_family_index, uint32_t queue_index);
 
-	const Queue &get_queue_by_flags(VkQueueFlags queue_flags, uint32_t queue_index);
+	const Queue &get_queue_by_flags(VkQueueFlags queue_flags, uint32_t queue_index) const;
 
-	const Queue &get_queue_by_present(uint32_t queue_index);
+	const Queue &get_queue_by_present(uint32_t queue_index) const;
 
 	/**
 	 * @brief Finds a suitable graphics queue to submit to
 	 * @return The first present supported queue, otherwise just any graphics queue
 	 */
-	const Queue &get_suitable_graphics_queue();
+	const Queue &get_suitable_graphics_queue() const;
 
 	bool is_extension_supported(const std::string &extension);
 
@@ -106,7 +106,7 @@ class Device
 
 	uint32_t get_num_queues_for_queue_family(uint32_t queue_family_index);
 
-	CommandPool &get_command_pool();
+	CommandPool &get_command_pool() const;
 
 	/**
 	 * @brief Checks that a given memory type is supported by the GPU
@@ -115,7 +115,7 @@ class Device
 	 * @param memory_type_found True if found, false if not found
 	 * @returns The memory type index of the found memory type
 	 */
-	uint32_t get_memory_type(uint32_t bits, VkMemoryPropertyFlags properties, VkBool32 *memory_type_found = nullptr);
+	uint32_t get_memory_type(uint32_t bits, VkMemoryPropertyFlags properties, VkBool32 *memory_type_found = nullptr) const;
 
 	/**
 	* @brief Creates a vulkan buffer
@@ -151,7 +151,7 @@ class Device
 	 * @param begin Whether the command buffer should be implictly started before it's returned
 	 * @returns A valid VkCommandBuffer
 	 */
-	VkCommandBuffer create_command_buffer(VkCommandBufferLevel level, bool begin = false);
+	VkCommandBuffer create_command_buffer(VkCommandBufferLevel level, bool begin = false) const;
 
 	/**
 	 * @brief Submits and frees up a given command buffer
@@ -160,23 +160,23 @@ class Device
 	 * @param free Whether the command buffer should be implictly freed up
 	 * @param signalSemaphore An optional semaphore to signal when the commands have been executed
 	 */
-	void flush_command_buffer(VkCommandBuffer command_buffer, VkQueue queue, bool free = true, VkSemaphore signalSemaphore = VK_NULL_HANDLE);
+	void flush_command_buffer(VkCommandBuffer command_buffer, VkQueue queue, bool free = true, VkSemaphore signalSemaphore = VK_NULL_HANDLE) const;
 
 	/**
 	 * @brief Requests a command buffer from the general command_pool
 	 * @return A new command buffer
 	 */
-	CommandBuffer &request_command_buffer();
+	CommandBuffer &request_command_buffer() const;
 
-	FencePool &get_fence_pool();
+	FencePool &get_fence_pool() const;
 
 	/**
 	 * @brief Requests a fence to the fence pool
 	 * @return A vulkan fence
 	 */
-	VkFence request_fence();
+	VkFence request_fence() const;
 
-	VkResult wait_idle();
+	VkResult wait_idle() const;
 
 	ResourceCache &get_resource_cache();
 

--- a/framework/core/hpp_buffer.cpp
+++ b/framework/core/hpp_buffer.cpp
@@ -21,11 +21,8 @@ namespace vkb
 {
 namespace core
 {
-HPPBuffer::HPPBuffer(vkb::core::HPPDevice &   device,
-                     vk::DeviceSize           size,
-                     vk::BufferUsageFlags     buffer_usage,
-                     VmaMemoryUsage           memory_usage,
-                     VmaAllocationCreateFlags flags) :
+HPPBuffer::HPPBuffer(
+    vkb::core::HPPDevice const &device, vk::DeviceSize size, vk::BufferUsageFlags buffer_usage, VmaMemoryUsage memory_usage, VmaAllocationCreateFlags flags) :
     buffer_create_info({}, size, buffer_usage), vmaAllocator(device.get_memory_allocator())
 {
 #ifdef VK_USE_PLATFORM_METAL_EXT
@@ -138,6 +135,11 @@ void HPPBuffer::update(uint8_t const *data, size_t size, size_t offset)
 void HPPBuffer::update(void *data, size_t size, size_t offset)
 {
 	update(reinterpret_cast<const uint8_t *>(data), size, offset);
+}
+
+void HPPBuffer::update(const std::vector<uint8_t> &data, size_t offset)
+{
+	update(data.data(), data.size(), offset);
 }
 
 void HPPBuffer::destroy()

--- a/framework/core/hpp_buffer.h
+++ b/framework/core/hpp_buffer.h
@@ -27,7 +27,7 @@ namespace core
 /**
  * @brief vulkan.hpp version of the vkb::core::Buffer class
  *
- * See vkb::VulkanSample for documentation
+ * See vkb::core::Buffer for documentation
  */
 class HPPBuffer
 {
@@ -40,11 +40,11 @@ class HPPBuffer
 	 * @param memory_usage The memory usage of the buffer
 	 * @param flags The allocation create flags
 	 */
-	HPPBuffer(vkb::core::HPPDevice &   device,
-	          vk::DeviceSize           size,
-	          vk::BufferUsageFlags     buffer_usage,
-	          VmaMemoryUsage           memory_usage,
-	          VmaAllocationCreateFlags flags = VMA_ALLOCATION_CREATE_MAPPED_BIT);
+	HPPBuffer(vkb::core::HPPDevice const &device,
+	          vk::DeviceSize              size,
+	          vk::BufferUsageFlags        buffer_usage,
+	          VmaMemoryUsage              memory_usage,
+	          VmaAllocationCreateFlags    flags = VMA_ALLOCATION_CREATE_MAPPED_BIT);
 
 	HPPBuffer(const HPPBuffer &) = delete;
 	HPPBuffer(HPPBuffer &&rhs);
@@ -91,6 +91,13 @@ class HPPBuffer
 	 * @param offset The offset to start the copying into the mapped data
 	 */
 	void update(void *data, size_t size, size_t offset = 0);
+
+	/**
+	 * @brief Copies a vector of bytes into the buffer
+	 * @param data The data vector to upload
+	 * @param offset The offset to start the copying into the mapped data
+	 */
+	void update(const std::vector<uint8_t> &data, size_t offset = 0);
 
 	/**
 	 * @brief Copies an object as byte data into the buffer

--- a/framework/core/hpp_device.h
+++ b/framework/core/hpp_device.h
@@ -18,16 +18,69 @@
 #pragma once
 
 #include <core/device.h>
+
+#include <core/hpp_physical_device.h>
+#include <core/hpp_queue.h>
 #include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
 namespace core
 {
+/**
+ * @brief facade class around vkb::Device, providing a vulkan.hpp-based interface
+ *
+ * See vkb::Device for documentation
+ */
 class HPPDevice : protected vkb::Device
 {
   public:
 	using vkb::Device::get_memory_allocator;
+
+	vk::CommandBuffer create_command_buffer(vk::CommandBufferLevel level, bool begin = false) const
+	{
+		return vkb::Device::create_command_buffer(static_cast<VkCommandBufferLevel>(level), begin);
+	}
+
+	void flush_command_buffer(vk::CommandBuffer command_buffer, vk::Queue queue, bool free = true, vk::Semaphore signalSemaphore = nullptr) const
+	{
+		vkb::Device::flush_command_buffer(command_buffer, queue, free, signalSemaphore);
+	}
+
+	vk::Device get_handle() const
+	{
+		return vkb::Device::get_handle();
+	}
+
+	vkb::core::HPPPhysicalDevice const &get_gpu() const
+	{
+		return reinterpret_cast<vkb::core::HPPPhysicalDevice const &>(vkb::Device::get_gpu());
+	}
+
+	uint32_t get_memory_type(uint32_t bits, vk::MemoryPropertyFlags properties, vk::Bool32 *memory_type_found = nullptr) const
+	{
+		return vkb::Device::get_memory_type(bits, static_cast<VkMemoryPropertyFlags>(properties), memory_type_found);
+	}
+
+	vkb::core::HPPQueue const &get_queue_by_flags(vk::QueueFlags queue_flags, uint32_t queue_index) const
+	{
+		return reinterpret_cast<vkb::core::HPPQueue const &>(vkb::Device::get_queue_by_flags(static_cast<VkQueueFlags>(queue_flags), queue_index));
+	}
+
+	vkb::core::HPPQueue const &get_queue_by_present(uint32_t queue_index) const
+	{
+		return reinterpret_cast<vkb::core::HPPQueue const &>(vkb::Device::get_queue_by_present(queue_index));
+	}
+
+	vkb::core::HPPQueue const &get_suitable_graphics_queue() const
+	{
+		return reinterpret_cast<vkb::core::HPPQueue const &>(vkb::Device::get_suitable_graphics_queue());
+	}
+
+	vk::Result wait_idle() const
+	{
+		return static_cast<vk::Result>(vkb::Device::wait_idle());
+	}
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_image.h
+++ b/framework/core/hpp_image.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -15,39 +15,26 @@
  * limitations under the License.
  */
 
-#include "sampler.h"
+#pragma once
 
-#include "device.h"
+#include <core/image.h>
 
 namespace vkb
 {
 namespace core
 {
-Sampler::Sampler(Device const &d, const VkSamplerCreateInfo &info) :
-    device{d}
+/**
+ * @brief facade class around vkb::core::Image, providing a vulkan.hpp-based interface
+ *
+ * See vkb::core::Image for documentation
+ */
+class HPPImage : protected Image
 {
-	VK_CHECK(vkCreateSampler(device.get_handle(), &info, nullptr, &handle));
-}
-
-Sampler::Sampler(Sampler &&other) :
-    device{other.device},
-    handle{other.handle}
-{
-	other.handle = VK_NULL_HANDLE;
-}
-
-Sampler::~Sampler()
-{
-	if (handle != VK_NULL_HANDLE)
+  public:
+	vk::Image get_handle() const
 	{
-		vkDestroySampler(device.get_handle(), handle, nullptr);
+		return Image::get_handle();
 	}
-}
-
-VkSampler Sampler::get_handle() const
-{
-	assert(handle != VK_NULL_HANDLE && "Sampler handle is invalid");
-	return handle;
-}
+};
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_instance.h
+++ b/framework/core/hpp_instance.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -15,39 +15,27 @@
  * limitations under the License.
  */
 
-#include "sampler.h"
+#pragma once
 
-#include "device.h"
+#include <core/instance.h>
+#include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
 namespace core
 {
-Sampler::Sampler(Device const &d, const VkSamplerCreateInfo &info) :
-    device{d}
+/**
+ * @brief facade class around vkb::Instance, providing a vulkan.hpp-based interface
+ *
+ * See vkb::Instance for documentation
+ */
+class HPPInstance : protected vkb::Instance
 {
-	VK_CHECK(vkCreateSampler(device.get_handle(), &info, nullptr, &handle));
-}
-
-Sampler::Sampler(Sampler &&other) :
-    device{other.device},
-    handle{other.handle}
-{
-	other.handle = VK_NULL_HANDLE;
-}
-
-Sampler::~Sampler()
-{
-	if (handle != VK_NULL_HANDLE)
+  public:
+	vk::Instance get_handle() const
 	{
-		vkDestroySampler(device.get_handle(), handle, nullptr);
+		return vkb::Instance::get_handle();
 	}
-}
-
-VkSampler Sampler::get_handle() const
-{
-	assert(handle != VK_NULL_HANDLE && "Sampler handle is invalid");
-	return handle;
-}
+};        // namespace Instance
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_physical_device.h
+++ b/framework/core/hpp_physical_device.h
@@ -15,11 +15,37 @@
  * limitations under the License.
  */
 
-#include <core/hpp_device.h>
+#pragma once
+
+#include <core/physical_device.h>
+#include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
 namespace core
 {
+/**
+ * @brief facade class around vkb::PhysicalDevice, providing a vulkan.hpp-based interface
+ *
+ * See vkb::PhysicalDevice for documentation
+ */
+class HPPPhysicalDevice : protected vkb::PhysicalDevice
+{
+  public:
+	vk::PhysicalDeviceFeatures const &get_features() const
+	{
+		return *reinterpret_cast<vk::PhysicalDeviceFeatures const *>(&vkb::PhysicalDevice::get_features());
+	}
+
+	vk::PhysicalDevice get_handle() const
+	{
+		return vkb::PhysicalDevice::get_handle();
+	}
+
+	vk::PhysicalDeviceProperties const &get_properties() const
+	{
+		return *reinterpret_cast<vk::PhysicalDeviceProperties const *>(&vkb::PhysicalDevice::get_properties());
+	}
+};
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_queue.h
+++ b/framework/core/hpp_queue.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -15,39 +15,38 @@
  * limitations under the License.
  */
 
-#include "sampler.h"
+#pragma once
 
-#include "device.h"
+#include <core/queue.h>
 
 namespace vkb
 {
 namespace core
 {
-Sampler::Sampler(Device const &d, const VkSamplerCreateInfo &info) :
-    device{d}
+/**
+ * @brief facade class around vkb::Queue, providing a vulkan.hpp-based interface
+ *
+ * See vkb::Queue for documentation
+ */
+class HPPQueue : protected vkb::Queue
 {
-	VK_CHECK(vkCreateSampler(device.get_handle(), &info, nullptr, &handle));
-}
+  public:
+	using vkb::Queue::get_family_index;
 
-Sampler::Sampler(Sampler &&other) :
-    device{other.device},
-    handle{other.handle}
-{
-	other.handle = VK_NULL_HANDLE;
-}
-
-Sampler::~Sampler()
-{
-	if (handle != VK_NULL_HANDLE)
+	vk::Queue get_handle() const
 	{
-		vkDestroySampler(device.get_handle(), handle, nullptr);
+		return vkb::Queue::get_handle();
 	}
-}
 
-VkSampler Sampler::get_handle() const
-{
-	assert(handle != VK_NULL_HANDLE && "Sampler handle is invalid");
-	return handle;
-}
+	vk::Result present(const vk::PresentInfoKHR &present_infos) const
+	{
+		return static_cast<vk::Result>(vkb::Queue::present(present_infos));
+	}
+
+	vk::Result wait_idle() const
+	{
+		return static_cast<vk::Result>(vkb::Queue::wait_idle());
+	}
+};
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_swapchain.h
+++ b/framework/core/hpp_swapchain.h
@@ -1,0 +1,60 @@
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <core/swapchain.h>
+
+namespace vkb
+{
+namespace core
+{
+/**
+ * @brief facade class around vkb::Swapchain, providing a vulkan.hpp-based interface
+ *
+ * See vkb::Swapchain for documentation
+ */
+class HPPSwapchain : protected vkb::Swapchain
+{
+  public:
+	vk::Result acquire_next_image(uint32_t &image_index, vk::Semaphore image_acquired_semaphore, vk::Fence fence = nullptr) const
+	{
+		return static_cast<vk::Result>(vkb::Swapchain::acquire_next_image(image_index, image_acquired_semaphore, fence));
+	}
+
+	vk::Format get_format() const
+	{
+		return static_cast<vk::Format>(vkb::Swapchain::get_format());
+	}
+
+	vk::SwapchainKHR get_handle() const
+	{
+		return vkb::Swapchain::get_handle();
+	}
+
+	std::vector<VkImage> const &get_images() const
+	{
+		return vkb::Swapchain::get_images();
+	}
+
+	vk::SurfaceKHR get_surface() const
+	{
+		return static_cast<vk::SurfaceKHR>(vkb::Swapchain::get_surface());
+	}
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/image.cpp
+++ b/framework/core/image.cpp
@@ -67,7 +67,7 @@ inline VkImageType find_image_type(VkExtent3D extent)
 
 namespace core
 {
-Image::Image(Device &              device,
+Image::Image(Device const &        device,
              const VkExtent3D &    extent,
              VkFormat              format,
              VkImageUsageFlags     image_usage,
@@ -131,7 +131,7 @@ Image::Image(Device &              device,
 	}
 }
 
-Image::Image(Device &device, VkImage handle, const VkExtent3D &extent, VkFormat format, VkImageUsageFlags image_usage, VkSampleCountFlagBits sample_count) :
+Image::Image(Device const &device, VkImage handle, const VkExtent3D &extent, VkFormat format, VkImageUsageFlags image_usage, VkSampleCountFlagBits sample_count) :
     device{device},
     handle{handle},
     type{find_image_type(extent)},
@@ -179,7 +179,7 @@ Image::~Image()
 	}
 }
 
-Device &Image::get_device()
+Device const &Image::get_device()
 {
 	return device;
 }

--- a/framework/core/image.h
+++ b/framework/core/image.h
@@ -32,14 +32,14 @@ class ImageView;
 class Image
 {
   public:
-	Image(Device &              device,
+	Image(Device const &        device,
 	      VkImage               handle,
 	      const VkExtent3D &    extent,
 	      VkFormat              format,
 	      VkImageUsageFlags     image_usage,
 	      VkSampleCountFlagBits sample_count = VK_SAMPLE_COUNT_1_BIT);
 
-	Image(Device &              device,
+	Image(Device const &        device,
 	      const VkExtent3D &    extent,
 	      VkFormat              format,
 	      VkImageUsageFlags     image_usage,
@@ -62,7 +62,7 @@ class Image
 
 	Image &operator=(Image &&) = delete;
 
-	Device &get_device();
+	Device const &get_device();
 
 	VkImage get_handle() const;
 
@@ -98,7 +98,7 @@ class Image
 	std::unordered_set<ImageView *> &get_views();
 
   private:
-	Device &device;
+	Device const &device;
 
 	VkImage handle{VK_NULL_HANDLE};
 

--- a/framework/core/image_view.h
+++ b/framework/core/image_view.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -59,7 +59,7 @@ class ImageView
 	VkImageSubresourceLayers get_subresource_layers() const;
 
   private:
-	Device &device;
+	Device const &device;
 
 	Image *image{};
 

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -464,7 +464,7 @@ bool Instance::is_enabled(const char *extension) const
 	return std::find_if(enabled_extensions.begin(), enabled_extensions.end(), [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) != enabled_extensions.end();
 }
 
-VkInstance Instance::get_handle()
+VkInstance Instance::get_handle() const
 {
 	return handle;
 }

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -94,7 +94,7 @@ class Instance
 	 */
 	bool is_enabled(const char *extension) const;
 
-	VkInstance get_handle();
+	VkInstance get_handle() const;
 
 	const std::vector<const char *> &get_extensions();
 

--- a/framework/core/physical_device.cpp
+++ b/framework/core/physical_device.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020, Arm Limited and Contributors
+/* Copyright (c) 2020-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -71,7 +71,7 @@ const VkPhysicalDeviceFeatures &PhysicalDevice::get_features() const
 	return features;
 }
 
-const VkPhysicalDeviceProperties PhysicalDevice::get_properties() const
+const VkPhysicalDeviceProperties &PhysicalDevice::get_properties() const
 {
 	return properties;
 }

--- a/framework/core/physical_device.h
+++ b/framework/core/physical_device.h
@@ -51,7 +51,7 @@ class PhysicalDevice
 
 	const VkPhysicalDeviceFeatures &get_features() const;
 
-	const VkPhysicalDeviceProperties get_properties() const;
+	const VkPhysicalDeviceProperties &get_properties() const;
 
 	const VkPhysicalDeviceMemoryProperties get_memory_properties() const;
 

--- a/framework/core/sampler.h
+++ b/framework/core/sampler.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -37,7 +37,7 @@ class Sampler
 	 * @param d The device to use
 	 * @param info Creation details
 	 */
-	Sampler(Device &d, const VkSamplerCreateInfo &info);
+	Sampler(Device const &d, const VkSamplerCreateInfo &info);
 
 	Sampler(const Sampler &) = delete;
 
@@ -55,7 +55,7 @@ class Sampler
 	VkSampler get_handle() const;
 
   private:
-	Device &device;
+	Device const &device;
 
 	VkSampler handle{VK_NULL_HANDLE};
 };

--- a/framework/core/swapchain.cpp
+++ b/framework/core/swapchain.cpp
@@ -450,7 +450,7 @@ SwapchainProperties &Swapchain::get_properties()
 	return properties;
 }
 
-VkResult Swapchain::acquire_next_image(uint32_t &image_index, VkSemaphore image_acquired_semaphore, VkFence fence)
+VkResult Swapchain::acquire_next_image(uint32_t &image_index, VkSemaphore image_acquired_semaphore, VkFence fence) const
 {
 	return vkAcquireNextImageKHR(device.get_handle(), handle, std::numeric_limits<uint64_t>::max(), image_acquired_semaphore, fence, &image_index);
 }

--- a/framework/core/swapchain.h
+++ b/framework/core/swapchain.h
@@ -114,7 +114,7 @@ class Swapchain
 
 	SwapchainProperties &get_properties();
 
-	VkResult acquire_next_image(uint32_t &image_index, VkSemaphore image_acquired_semaphore, VkFence fence = VK_NULL_HANDLE);
+	VkResult acquire_next_image(uint32_t &image_index, VkSemaphore image_acquired_semaphore, VkFence fence = VK_NULL_HANDLE) const;
 
 	const VkExtent2D &get_extent() const;
 

--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -323,7 +323,7 @@ inline void upload_image_to_gpu(CommandBuffer &command_buffer, core::Buffer &sta
 std::unordered_map<std::string, bool> GLTFLoader::supported_extensions = {
     {KHR_LIGHTS_PUNCTUAL_EXTENSION, false}};
 
-GLTFLoader::GLTFLoader(Device &device) :
+GLTFLoader::GLTFLoader(Device const &device) :
     device{device}
 {
 }
@@ -646,7 +646,7 @@ sg::Scene GLTFLoader::load_scene(int scene_index)
 
 				auto format = get_attribute_format(&model, gltf_primitive.indices);
 
-				auto index_data  = get_attribute_data(&model, gltf_primitive.indices);
+				auto index_data = get_attribute_data(&model, gltf_primitive.indices);
 
 				switch (format)
 				{

--- a/framework/gltf_loader.h
+++ b/framework/gltf_loader.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
- * Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2018-2021, Arm Limited and Contributors
+ * Copyright (c) 2019-2021, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -69,7 +69,7 @@ struct TypeCast
 class GLTFLoader
 {
   public:
-	GLTFLoader(Device &device);
+	GLTFLoader(Device const &device);
 
 	virtual ~GLTFLoader() = default;
 
@@ -122,7 +122,7 @@ class GLTFLoader
 	 */
 	tinygltf::Value *get_extension(tinygltf::ExtensionMap &tinygltf_extensions, const std::string &extension);
 
-	Device &device;
+	Device const &device;
 
 	tinygltf::Model model;
 

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -17,12 +17,16 @@
 
 #include <hpp_api_vulkan_sample.h>
 
+#include <common/hpp_vk_common.h>
+#include <core/hpp_buffer.h>
+#include <hpp_gltf_loader.h>
+
 // Instantiate the default dispatcher
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 
 bool HPPApiVulkanSample::prepare(vkb::Platform &platform)
 {
-	if (!ApiVulkanSample::prepare(platform))
+	if (!HPPVulkanSample::prepare(platform))
 	{
 		return false;
 	}
@@ -30,70 +34,1078 @@ bool HPPApiVulkanSample::prepare(vkb::Platform &platform)
 	// initialize function pointers for C++-bindings
 	static vk::DynamicLoader dl;
 	VULKAN_HPP_DEFAULT_DISPATCHER.init(dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr"));
-	VULKAN_HPP_DEFAULT_DISPATCHER.init(get_instance());
-	VULKAN_HPP_DEFAULT_DISPATCHER.init(get_device());
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(get_instance().get_handle());
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(get_device().get_handle());
+
+	depth_format = vkb::common::get_suitable_depth_format(get_device().get_gpu().get_handle());
+
+	// Create synchronization objects
+	// Create a semaphore used to synchronize image presentation
+	// Ensures that the current swapchain render target has completed presentation and has been released by the presentation engine, ready for rendering
+	semaphores.acquired_image_ready = get_device().get_handle().createSemaphore({});
+	// Create a semaphore used to synchronize command submission
+	// Ensures that the image is not presented until all commands have been sumbitted and executed
+	semaphores.render_complete = get_device().get_handle().createSemaphore({});
+
+	// Set up submit info structure
+	// Semaphores will stay the same during application lifetime
+	// Command buffer submission info is set by each example
+	submit_info                   = vk::SubmitInfo();
+	submit_info.pWaitDstStageMask = &submit_pipeline_stages;
+
+	if (platform.get_window().get_window_mode() != vkb::Window::Mode::Headless)
+	{
+		submit_info.setWaitSemaphores(semaphores.acquired_image_ready);
+		submit_info.setSignalSemaphores(semaphores.render_complete);
+	}
+
+	queue = get_device().get_suitable_graphics_queue().get_handle();
+
+	create_swapchain_buffers();
+	create_command_pool();
+	create_command_buffers();
+	create_synchronization_primitives();
+	setup_depth_stencil();
+	setup_render_pass();
+	create_pipeline_cache();
+	setup_framebuffer();
+
+	extent = get_render_context().get_surface_extent();
+
+	gui = std::make_unique<vkb::Gui>(*this, platform.get_window(), /*stats=*/nullptr, 15.0f, true);
+	gui->prepare(pipeline_cache,
+	             render_pass,
+	             {load_shader("uioverlay/uioverlay.vert", vk::ShaderStageFlagBits::eVertex),
+	              load_shader("uioverlay/uioverlay.frag", vk::ShaderStageFlagBits::eFragment)});
 
 	return true;
 }
 
-vk::CommandBuffer HPPApiVulkanSample::get_command_buffer(size_t index) const
+void HPPApiVulkanSample::update(float delta_time)
 {
-	return static_cast<vk::CommandBuffer>(draw_cmd_buffers[index]);
+	if (view_updated)
+	{
+		view_updated = false;
+		view_changed();
+	}
+
+	update_overlay(delta_time);
+
+	render(delta_time);
+	camera.update(delta_time);
+	if (camera.moving())
+	{
+		view_updated = true;
+	}
+
+	get_platform().on_post_draw(get_render_context());
 }
 
-size_t HPPApiVulkanSample::get_command_buffers_count() const
+void HPPApiVulkanSample::resize(const uint32_t, const uint32_t)
 {
-	return draw_cmd_buffers.size();
+	if (!prepared)
+	{
+		return;
+	}
+
+	get_render_context().handle_surface_changes();
+
+	// Don't recreate the swapchain if the dimensions haven't changed
+	if (extent == get_render_context().get_surface_extent())
+	{
+		return;
+	}
+
+	extent = get_render_context().get_surface_extent();
+
+	prepared = false;
+
+	// Ensure all operations on the device have been finished before destroying resources
+	get_device().wait_idle();
+
+	create_swapchain_buffers();
+
+	// Recreate the frame buffers
+	get_device().get_handle().destroyImageView(depth_stencil.view);
+	get_device().get_handle().destroyImage(depth_stencil.image);
+	get_device().get_handle().freeMemory(depth_stencil.mem);
+	setup_depth_stencil();
+	for (uint32_t i = 0; i < framebuffers.size(); i++)
+	{
+		get_device().get_handle().destroyFramebuffer(framebuffers[i]);
+		framebuffers[i] = nullptr;
+	}
+	setup_framebuffer();
+
+	if (extent.width && extent.height && gui)
+	{
+		gui->resize(extent.width, extent.height);
+	}
+
+	// Command buffers need to be recreated as they may store
+	// references to the recreated frame buffer
+	destroy_command_buffers();
+	create_command_buffers();
+	build_command_buffers();
+
+	get_device().wait_idle();
+
+	if (extent.width && extent.height)
+	{
+		camera.update_aspect_ratio((float) extent.width / (float) extent.height);
+	}
+
+	// Notify derived class
+	view_changed();
+
+	prepared = true;
 }
 
-vk::Device HPPApiVulkanSample::get_device() const
+void HPPApiVulkanSample::create_render_context(vkb::Platform &platform)
 {
-	return static_cast<vk::Device>(device->get_handle());
+	HPPVulkanSample::create_render_context(platform,
+	                                       {{vk::Format::eB8G8R8A8Unorm, vk::ColorSpaceKHR::eSrgbNonlinear},
+	                                        {vk::Format::eR8G8B8A8Unorm, vk::ColorSpaceKHR::eSrgbNonlinear},
+	                                        {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
+	                                        {vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}});
 }
 
-vk::ClearColorValue const &HPPApiVulkanSample::get_default_clear_color() const
+void HPPApiVulkanSample::prepare_render_context()
 {
-	return *reinterpret_cast<vk::ClearColorValue const *>(&default_clear_color);
+	HPPVulkanSample::prepare_render_context();
 }
 
-vk::DescriptorPool HPPApiVulkanSample::get_descriptor_pool() const
+void HPPApiVulkanSample::input_event(const vkb::InputEvent &input_event)
 {
-	return static_cast<vk::DescriptorPool>(descriptor_pool);
+	HPPVulkanSample::input_event(input_event);
+
+	bool gui_captures_event = false;
+
+	if (gui)
+	{
+		gui_captures_event = gui->input_event(input_event);
+	}
+
+	if (!gui_captures_event)
+	{
+		if (input_event.get_source() == vkb::EventSource::Mouse)
+		{
+			const auto &mouse_button = static_cast<const vkb::MouseButtonInputEvent &>(input_event);
+
+			handle_mouse_move(static_cast<int32_t>(mouse_button.get_pos_x()), static_cast<int32_t>(mouse_button.get_pos_y()));
+
+			if (mouse_button.get_action() == vkb::MouseAction::Down)
+			{
+				switch (mouse_button.get_button())
+				{
+					case vkb::MouseButton::Left:
+						mouse_buttons.left = true;
+						break;
+					case vkb::MouseButton::Right:
+						mouse_buttons.right = true;
+						break;
+					case vkb::MouseButton::Middle:
+						mouse_buttons.middle = true;
+						break;
+					default:
+						break;
+				}
+			}
+			else if (mouse_button.get_action() == vkb::MouseAction::Up)
+			{
+				switch (mouse_button.get_button())
+				{
+					case vkb::MouseButton::Left:
+						mouse_buttons.left = false;
+						break;
+					case vkb::MouseButton::Right:
+						mouse_buttons.right = false;
+						break;
+					case vkb::MouseButton::Middle:
+						mouse_buttons.middle = false;
+						break;
+					default:
+						break;
+				}
+			}
+		}
+		else if (input_event.get_source() == vkb::EventSource::Touchscreen)
+		{
+			const auto &touch_event = static_cast<const vkb::TouchInputEvent &>(input_event);
+
+			if (touch_event.get_action() == vkb::TouchAction::Down)
+			{
+				touch_down         = true;
+				touch_pos.x        = static_cast<int32_t>(touch_event.get_pos_x());
+				touch_pos.y        = static_cast<int32_t>(touch_event.get_pos_y());
+				mouse_pos.x        = touch_event.get_pos_x();
+				mouse_pos.y        = touch_event.get_pos_y();
+				mouse_buttons.left = true;
+			}
+			else if (touch_event.get_action() == vkb::TouchAction::Up)
+			{
+				touch_pos.x        = static_cast<int32_t>(touch_event.get_pos_x());
+				touch_pos.y        = static_cast<int32_t>(touch_event.get_pos_y());
+				touch_timer        = 0.0;
+				touch_down         = false;
+				camera.keys.up     = false;
+				mouse_buttons.left = false;
+			}
+			else if (touch_event.get_action() == vkb::TouchAction::Move)
+			{
+				bool handled = false;
+				if (gui)
+				{
+					ImGuiIO &io = ImGui::GetIO();
+					handled     = io.WantCaptureMouse;
+				}
+				if (!handled)
+				{
+					int32_t eventX = static_cast<int32_t>(touch_event.get_pos_x());
+					int32_t eventY = static_cast<int32_t>(touch_event.get_pos_y());
+
+					float deltaX = (float) (touch_pos.y - eventY) * rotation_speed * 0.5f;
+					float deltaY = (float) (touch_pos.x - eventX) * rotation_speed * 0.5f;
+
+					camera.rotate(glm::vec3(deltaX, 0.0f, 0.0f));
+					camera.rotate(glm::vec3(0.0f, -deltaY, 0.0f));
+
+					rotation.x += deltaX;
+					rotation.y -= deltaY;
+
+					view_changed();
+
+					touch_pos.x = eventX;
+					touch_pos.y = eventY;
+				}
+			}
+		}
+		else if (input_event.get_source() == vkb::EventSource::Keyboard)
+		{
+			const auto &key_button = static_cast<const vkb::KeyInputEvent &>(input_event);
+
+			if (key_button.get_action() == vkb::KeyAction::Down)
+			{
+				switch (key_button.get_code())
+				{
+					case vkb::KeyCode::W:
+						camera.keys.up = true;
+						break;
+					case vkb::KeyCode::S:
+						camera.keys.down = true;
+						break;
+					case vkb::KeyCode::A:
+						camera.keys.left = true;
+						break;
+					case vkb::KeyCode::D:
+						camera.keys.right = true;
+						break;
+					case vkb::KeyCode::P:
+						paused = !paused;
+						break;
+					default:
+						break;
+				}
+			}
+			else if (key_button.get_action() == vkb::KeyAction::Up)
+			{
+				switch (key_button.get_code())
+				{
+					case vkb::KeyCode::W:
+						camera.keys.up = false;
+						break;
+					case vkb::KeyCode::S:
+						camera.keys.down = false;
+						break;
+					case vkb::KeyCode::A:
+						camera.keys.left = false;
+						break;
+					case vkb::KeyCode::D:
+						camera.keys.right = false;
+						break;
+					default:
+						break;
+				}
+			}
+		}
+	}
 }
 
-vk::Framebuffer HPPApiVulkanSample::get_framebuffer(size_t index) const
+void HPPApiVulkanSample::handle_mouse_move(int32_t x, int32_t y)
 {
-	return static_cast<vk::Framebuffer>(framebuffers[index]);
+	int32_t dx = (int32_t) mouse_pos.x - x;
+	int32_t dy = (int32_t) mouse_pos.y - y;
+
+	bool handled = false;
+
+	if (gui)
+	{
+		ImGuiIO &io = ImGui::GetIO();
+		handled     = io.WantCaptureMouse;
+	}
+	mouse_moved((float) x, (float) y, handled);
+
+	if (handled)
+	{
+		mouse_pos = glm::vec2((float) x, (float) y);
+		return;
+	}
+
+	if (mouse_buttons.left)
+	{
+		rotation.x += dy * 1.25f * rotation_speed;
+		rotation.y -= dx * 1.25f * rotation_speed;
+		camera.rotate(glm::vec3(dy * camera.rotation_speed, -dx * camera.rotation_speed, 0.0f));
+		view_updated = true;
+	}
+	if (mouse_buttons.right)
+	{
+		zoom += dy * .005f * zoom_speed;
+		camera.translate(glm::vec3(-0.0f, 0.0f, dy * .005f * zoom_speed));
+		view_updated = true;
+	}
+	if (mouse_buttons.middle)
+	{
+		camera_pos.x -= dx * 0.01f;
+		camera_pos.y -= dy * 0.01f;
+		camera.translate(glm::vec3(-dx * 0.01f, -dy * 0.01f, 0.0f));
+		view_updated = true;
+	}
+	mouse_pos = glm::vec2((float) x, (float) y);
 }
 
-vk::Instance HPPApiVulkanSample::get_instance() const
+void HPPApiVulkanSample::mouse_moved(double x, double y, bool &handled)
+{}
+
+bool HPPApiVulkanSample::check_command_buffers()
 {
-	return static_cast<vk::Instance>(instance->get_handle());
+	for (auto &command_buffer : draw_cmd_buffers)
+	{
+		if (command_buffer)
+		{
+			return false;
+		}
+	}
+	return true;
 }
 
-vk::PhysicalDevice HPPApiVulkanSample::get_physical_device() const
+void HPPApiVulkanSample::create_command_buffers()
 {
-	return static_cast<vk::PhysicalDevice>(device->get_gpu().get_handle());
+	// Create one command buffer for each swap chain image and reuse for rendering
+	vk::CommandBufferAllocateInfo allocate_info(
+	    cmd_pool, vk::CommandBufferLevel::ePrimary, static_cast<uint32_t>(get_render_context().get_render_frames().size()));
+
+	draw_cmd_buffers = get_device().get_handle().allocateCommandBuffers(allocate_info);
 }
 
-vk::Queue HPPApiVulkanSample::get_queue() const
+void HPPApiVulkanSample::destroy_command_buffers()
 {
-	return static_cast<vk::Queue>(queue);
+	get_device().get_handle().freeCommandBuffers(cmd_pool, draw_cmd_buffers);
+}
+
+void HPPApiVulkanSample::create_pipeline_cache()
+{
+	pipeline_cache = get_device().get_handle().createPipelineCache({});
 }
 
 vk::PipelineShaderStageCreateInfo HPPApiVulkanSample::load_shader(const std::string &file, vk::ShaderStageFlagBits stage)
 {
-	return ApiVulkanSample::load_shader(file, static_cast<VkShaderStageFlagBits>(stage));
+	shader_modules.push_back(vkb::common::load_shader(file.c_str(), get_device().get_handle(), stage));
+	assert(shader_modules.back());
+	return vk::PipelineShaderStageCreateInfo({}, stage, shader_modules.back(), "main");
 }
 
-vk::SubmitInfo const &HPPApiVulkanSample::set_submit_info(vk::CommandBuffer const &command_buffer)
+void HPPApiVulkanSample::update_overlay(float delta_time)
 {
-	submit_info.commandBufferCount = 1;
-	submit_info.pCommandBuffers    = reinterpret_cast<VkCommandBuffer const *>(&command_buffer);
-	return *reinterpret_cast<vk::SubmitInfo const *>(&submit_info);
+	if (gui)
+	{
+		gui->show_simple_window(get_name(), vkb::to_u32(1.0f / delta_time), [this]() { on_update_ui_overlay(gui->get_drawer()); });
+
+		gui->update(delta_time);
+
+		if (gui->update_buffers() || gui->get_drawer().is_dirty())
+		{
+			build_command_buffers();
+			gui->get_drawer().clear();
+		}
+	}
 }
 
-vkb::core::HPPDevice &HPPApiVulkanSample::get_device_wrapper()
+void HPPApiVulkanSample::draw_ui(const vk::CommandBuffer command_buffer)
 {
-	return reinterpret_cast<vkb::core::HPPDevice &>(*device);
+	if (gui)
+	{
+		command_buffer.setViewport(0, vk::Viewport(0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f));
+		command_buffer.setScissor(0, vk::Rect2D({0, 0}, extent));
+
+		gui->draw(command_buffer);
+	}
+}
+
+void HPPApiVulkanSample::prepare_frame()
+{
+	if (get_render_context().has_swapchain())
+	{
+		handle_surface_changes();
+		// Acquire the next image from the swap chain
+		// Shows how to filter an error code from a vulkan function, which is mapped to an exception but should be handled here!
+		vk::Result result;
+		try
+		{
+			result = get_render_context().get_swapchain().acquire_next_image(current_buffer, semaphores.acquired_image_ready);
+		}
+		catch (const vk::SystemError &e)
+		{
+			if (e.code() == vk::Result::eErrorOutOfDateKHR)
+			{
+				result = vk::Result::eErrorOutOfDateKHR;
+			}
+			else
+			{
+				throw;
+			}
+		}
+		// Recreate the swapchain if it's no longer compatible with the surface (eErrorOutOfDateKHR) or no longer optimal for
+		// presentation (eSuboptimalKHR)
+		if ((result == vk::Result::eErrorOutOfDateKHR) || (result == vk::Result::eSuboptimalKHR))
+		{
+			resize(extent.width, extent.height);
+		}
+	}
+}
+
+void HPPApiVulkanSample::submit_frame()
+{
+	if (get_render_context().has_swapchain())
+	{
+		const auto &queue = get_device().get_queue_by_present(0);
+
+		vk::SwapchainKHR swapchain = get_render_context().get_swapchain().get_handle();
+
+		vk::PresentInfoKHR present_info({}, swapchain, current_buffer);
+		// Check if a wait semaphore has been specified to wait for before presenting the image
+		if (semaphores.render_complete)
+		{
+			present_info.setWaitSemaphores(semaphores.render_complete);
+		}
+
+		// Shows how to filter an error code from a vulkan function, which is mapped to an exception but should be handled here!
+		vk::Result present_result;
+		try
+		{
+			present_result = queue.present(present_info);
+		}
+		catch (const vk::SystemError &e)
+		{
+			if (e.code() == vk::Result::eErrorOutOfDateKHR)
+			{
+				// Swap chain is no longer compatible with the surface and needs to be recreated
+				resize(extent.width, extent.height);
+				return;
+			}
+			else
+			{
+				// rethrow this error
+				throw;
+			}
+		}
+	}
+
+	// DO NOT USE
+	// vkDeviceWaitIdle and vkQueueWaitIdle are extremely expensive functions, and are used here purely for demonstrating the vulkan API
+	// without having to concern ourselves with proper syncronization. These functions should NEVER be used inside the render loop like this (every frame).
+	get_device().get_queue_by_present(0).wait_idle();
+}
+
+HPPApiVulkanSample::~HPPApiVulkanSample()
+{
+	if (get_device().get_handle())
+	{
+		get_device().wait_idle();
+
+		// Clean up Vulkan resources
+		get_device().get_handle().destroyDescriptorPool(descriptor_pool);
+		destroy_command_buffers();
+		get_device().get_handle().destroyRenderPass(render_pass);
+		for (auto &framebuffer : framebuffers)
+		{
+			get_device().get_handle().destroyFramebuffer(framebuffer);
+		}
+
+		for (auto &swapchain_buffer : swapchain_buffers)
+		{
+			get_device().get_handle().destroyImageView(swapchain_buffer.view);
+		}
+
+		for (auto &shader_module : shader_modules)
+		{
+			get_device().get_handle().destroyShaderModule(shader_module);
+		}
+		get_device().get_handle().destroyImageView(depth_stencil.view);
+		get_device().get_handle().destroyImage(depth_stencil.image);
+		get_device().get_handle().freeMemory(depth_stencil.mem);
+
+		get_device().get_handle().destroyPipelineCache(pipeline_cache);
+
+		get_device().get_handle().destroyCommandPool(cmd_pool);
+
+		get_device().get_handle().destroySemaphore(semaphores.acquired_image_ready);
+		get_device().get_handle().destroySemaphore(semaphores.render_complete);
+		for (auto &fence : wait_fences)
+		{
+			get_device().get_handle().destroyFence(fence);
+		}
+	}
+
+	gui.reset();
+}
+
+void HPPApiVulkanSample::view_changed()
+{}
+
+void HPPApiVulkanSample::build_command_buffers()
+{}
+
+void HPPApiVulkanSample::create_synchronization_primitives()
+{
+	// Wait fences to sync command buffer access
+	vk::FenceCreateInfo fence_create_info(vk::FenceCreateFlagBits::eSignaled);
+	wait_fences.resize(draw_cmd_buffers.size());
+	for (auto &fence : wait_fences)
+	{
+		fence = get_device().get_handle().createFence(fence_create_info);
+	}
+}
+
+void HPPApiVulkanSample::create_command_pool()
+{
+	uint32_t                  queue_family_index = get_device().get_queue_by_flags(vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute, 0).get_family_index();
+	vk::CommandPoolCreateInfo command_pool_info(vk::CommandPoolCreateFlagBits::eResetCommandBuffer, queue_family_index);
+	cmd_pool = get_device().get_handle().createCommandPool(command_pool_info);
+}
+
+void HPPApiVulkanSample::setup_depth_stencil()
+{
+	vk::ImageCreateInfo image_create_info;
+	image_create_info.imageType   = vk::ImageType::e2D;
+	image_create_info.format      = depth_format;
+	image_create_info.extent      = vk::Extent3D(get_render_context().get_surface_extent().width, get_render_context().get_surface_extent().height, 1);
+	image_create_info.mipLevels   = 1;
+	image_create_info.arrayLayers = 1;
+	image_create_info.samples     = vk::SampleCountFlagBits::e1;
+	image_create_info.tiling      = vk::ImageTiling::eOptimal;
+	image_create_info.usage       = vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eTransferSrc;
+
+	depth_stencil.image            = get_device().get_handle().createImage(image_create_info);
+	vk::MemoryRequirements memReqs = get_device().get_handle().getImageMemoryRequirements(depth_stencil.image);
+
+	vk::MemoryAllocateInfo memory_allocation(memReqs.size, get_device().get_memory_type(memReqs.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
+	depth_stencil.mem = get_device().get_handle().allocateMemory(memory_allocation);
+	get_device().get_handle().bindImageMemory(depth_stencil.image, depth_stencil.mem, 0);
+
+	vk::ImageViewCreateInfo image_view_create_info;
+	image_view_create_info.viewType                        = vk::ImageViewType::e2D;
+	image_view_create_info.image                           = depth_stencil.image;
+	image_view_create_info.format                          = depth_format;
+	image_view_create_info.subresourceRange.baseMipLevel   = 0;
+	image_view_create_info.subresourceRange.levelCount     = 1;
+	image_view_create_info.subresourceRange.baseArrayLayer = 0;
+	image_view_create_info.subresourceRange.layerCount     = 1;
+	image_view_create_info.subresourceRange.aspectMask     = vk::ImageAspectFlagBits::eDepth;
+	// Stencil aspect should only be set on depth + stencil formats (vk::Format::eD16UnormS8Uint..vk::Format::eD32SfloatS8Uint
+	if (vk::Format::eD16UnormS8Uint <= depth_format)
+	{
+		image_view_create_info.subresourceRange.aspectMask |= vk::ImageAspectFlagBits::eStencil;
+	}
+	depth_stencil.view = get_device().get_handle().createImageView(image_view_create_info);
+}
+
+void HPPApiVulkanSample::setup_framebuffer()
+{
+	std::array<vk::ImageView, 2> attachments;
+
+	// Depth/Stencil attachment is the same for all frame buffers
+	attachments[1] = depth_stencil.view;
+
+	vk::FramebufferCreateInfo framebuffer_create_info(
+	    {}, render_pass, attachments, get_render_context().get_surface_extent().width, get_render_context().get_surface_extent().height, 1);
+
+	// Delete existing frame buffers
+	for (auto &framebuffer : framebuffers)
+	{
+		get_device().get_handle().destroyFramebuffer(framebuffer);
+	}
+	framebuffers.clear();
+
+	// Create frame buffers for every swap chain image
+	framebuffers.reserve(swapchain_buffers.size());
+	for (auto &buffer : swapchain_buffers)
+	{
+		attachments[0] = buffer.view;
+		framebuffers.push_back(get_device().get_handle().createFramebuffer(framebuffer_create_info));
+	}
+}
+
+void HPPApiVulkanSample::setup_render_pass()
+{
+	std::array<vk::AttachmentDescription, 2> attachments;
+	// Color attachment
+	attachments[0].format         = get_render_context().get_format();
+	attachments[0].samples        = vk::SampleCountFlagBits::e1;
+	attachments[0].loadOp         = vk::AttachmentLoadOp::eClear;
+	attachments[0].storeOp        = vk::AttachmentStoreOp::eStore;
+	attachments[0].stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
+	attachments[0].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+	attachments[0].initialLayout  = vk::ImageLayout::eUndefined;
+	attachments[0].finalLayout    = vk::ImageLayout::ePresentSrcKHR;
+	// Depth attachment
+	attachments[1].format         = depth_format;
+	attachments[1].samples        = vk::SampleCountFlagBits::e1;
+	attachments[1].loadOp         = vk::AttachmentLoadOp::eClear;
+	attachments[1].storeOp        = vk::AttachmentStoreOp::eDontCare;
+	attachments[1].stencilLoadOp  = vk::AttachmentLoadOp::eClear;
+	attachments[1].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+	attachments[1].initialLayout  = vk::ImageLayout::eUndefined;
+	attachments[1].finalLayout    = vk::ImageLayout::eDepthStencilAttachmentOptimal;
+
+	vk::AttachmentReference color_reference(0, vk::ImageLayout::eColorAttachmentOptimal);
+
+	vk::AttachmentReference depth_reference(1, vk::ImageLayout::eDepthStencilAttachmentOptimal);
+
+	vk::SubpassDescription subpass_description({}, vk::PipelineBindPoint::eGraphics, {}, color_reference, {}, &depth_reference);
+
+	// Subpass dependencies for layout transitions
+	std::array<vk::SubpassDependency, 2> dependencies;
+
+	dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
+	dependencies[0].dstSubpass      = 0;
+	dependencies[0].srcStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
+	dependencies[0].dstStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	dependencies[0].srcAccessMask   = vk::AccessFlagBits::eMemoryRead;
+	dependencies[0].dstAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
+	dependencies[0].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+
+	dependencies[1].srcSubpass      = 0;
+	dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
+	dependencies[1].srcStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	dependencies[1].dstStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
+	dependencies[1].srcAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
+	dependencies[1].dstAccessMask   = vk::AccessFlagBits::eMemoryRead;
+	dependencies[1].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+
+	vk::RenderPassCreateInfo render_pass_create_info({}, attachments, subpass_description, dependencies);
+
+	render_pass = get_device().get_handle().createRenderPass(render_pass_create_info);
+}
+
+void HPPApiVulkanSample::update_render_pass_flags(RenderPassCreateFlags flags)
+{
+	get_device().get_handle().destroyRenderPass(render_pass);
+
+	vk::AttachmentLoadOp color_attachment_load_op      = vk::AttachmentLoadOp::eClear;
+	vk::ImageLayout      color_attachment_image_layout = vk::ImageLayout::eUndefined;
+
+	// Samples can keep the color attachment contents, e.g. if they have previously written to the swap chain images
+	if (flags & RenderPassCreateFlags::ColorAttachmentLoad)
+	{
+		color_attachment_load_op      = vk::AttachmentLoadOp::eLoad;
+		color_attachment_image_layout = vk::ImageLayout::ePresentSrcKHR;
+	}
+
+	std::array<vk::AttachmentDescription, 2> attachments = {};
+	// Color attachment
+	attachments[0].format         = get_render_context().get_format();
+	attachments[0].samples        = vk::SampleCountFlagBits::e1;
+	attachments[0].loadOp         = color_attachment_load_op;
+	attachments[0].storeOp        = vk::AttachmentStoreOp::eStore;
+	attachments[0].stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
+	attachments[0].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+	attachments[0].initialLayout  = color_attachment_image_layout;
+	attachments[0].finalLayout    = vk::ImageLayout::ePresentSrcKHR;
+	// Depth attachment
+	attachments[1].format         = depth_format;
+	attachments[1].samples        = vk::SampleCountFlagBits::e1;
+	attachments[1].loadOp         = vk::AttachmentLoadOp::eClear;
+	attachments[1].storeOp        = vk::AttachmentStoreOp::eDontCare;
+	attachments[1].stencilLoadOp  = vk::AttachmentLoadOp::eClear;
+	attachments[1].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+	attachments[1].initialLayout  = vk::ImageLayout::eUndefined;
+	attachments[1].finalLayout    = vk::ImageLayout::eDepthStencilAttachmentOptimal;
+
+	vk::AttachmentReference color_reference(0, vk::ImageLayout::eColorAttachmentOptimal);
+
+	vk::AttachmentReference depth_reference(1, vk::ImageLayout::eDepthStencilAttachmentOptimal);
+
+	vk::SubpassDescription subpass_description({}, vk::PipelineBindPoint::eGraphics, {}, color_reference, {}, &depth_reference);
+
+	// Subpass dependencies for layout transitions
+	std::array<vk::SubpassDependency, 2> dependencies;
+
+	dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
+	dependencies[0].dstSubpass      = 0;
+	dependencies[0].srcStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
+	dependencies[0].dstStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	dependencies[0].srcAccessMask   = vk::AccessFlagBits::eMemoryWrite;
+	dependencies[0].dstAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
+	dependencies[0].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+
+	dependencies[1].srcSubpass      = 0;
+	dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
+	dependencies[1].srcStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	dependencies[1].dstStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
+	dependencies[1].srcAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
+	dependencies[1].dstAccessMask   = vk::AccessFlagBits::eMemoryRead;
+	dependencies[1].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+
+	vk::RenderPassCreateInfo render_pass_create_info({}, attachments, subpass_description, dependencies);
+
+	render_pass = get_device().get_handle().createRenderPass(render_pass_create_info);
+}
+
+void HPPApiVulkanSample::on_update_ui_overlay(vkb::Drawer &drawer)
+{}
+
+void HPPApiVulkanSample::create_swapchain_buffers()
+{
+	if (get_render_context().has_swapchain())
+	{
+		auto &images = get_render_context().get_swapchain().get_images();
+
+		// Get the swap chain buffers containing the image and imageview
+		for (auto &swapchain_buffer : swapchain_buffers)
+		{
+			get_device().get_handle().destroyImageView(swapchain_buffer.view);
+		}
+		swapchain_buffers.clear();
+		swapchain_buffers.reserve(images.size());
+		for (auto &image : images)
+		{
+			vk::ImageViewCreateInfo color_attachment_view;
+			color_attachment_view.image                           = image;
+			color_attachment_view.viewType                        = vk::ImageViewType::e2D;
+			color_attachment_view.format                          = get_render_context().get_swapchain().get_format();
+			color_attachment_view.components                      = {vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eG, vk::ComponentSwizzle::eB, vk::ComponentSwizzle::eA};
+			color_attachment_view.subresourceRange.aspectMask     = vk::ImageAspectFlagBits::eColor;
+			color_attachment_view.subresourceRange.baseMipLevel   = 0;
+			color_attachment_view.subresourceRange.levelCount     = 1;
+			color_attachment_view.subresourceRange.baseArrayLayer = 0;
+			color_attachment_view.subresourceRange.layerCount     = 1;
+
+			swapchain_buffers.push_back({image, get_device().get_handle().createImageView(color_attachment_view)});
+		}
+	}
+	else
+	{
+		auto &frames = get_render_context().get_render_frames();
+
+		// Get the swap chain buffers containing the image and imageview
+		swapchain_buffers.clear();
+		swapchain_buffers.reserve(frames.size());
+		for (auto &frame : frames)
+		{
+			auto &image_view = *frame->get_render_target().get_views().begin();
+			swapchain_buffers.push_back({image_view.get_image().get_handle(), image_view.get_handle()});
+		}
+	}
+}
+
+void HPPApiVulkanSample::update_swapchain_image_usage_flags(std::set<vk::ImageUsageFlagBits> const &image_usage_flags)
+{
+	get_render_context().update_swapchain(image_usage_flags);
+	create_swapchain_buffers();
+	setup_framebuffer();
+}
+
+void HPPApiVulkanSample::handle_surface_changes()
+{
+	vk::SurfaceCapabilitiesKHR surface_properties =
+	    get_device().get_gpu().get_handle().getSurfaceCapabilitiesKHR(get_render_context().get_swapchain().get_surface());
+
+	if (surface_properties.currentExtent != get_render_context().get_surface_extent())
+	{
+		resize(surface_properties.currentExtent.width, surface_properties.currentExtent.height);
+	}
+}
+
+HPPTexture HPPApiVulkanSample::load_texture(const std::string &file)
+{
+	HPPTexture texture;
+
+	texture.image = vkb::scene_graph::components::HPPImage::load(file, file);
+	texture.image->create_vk_image(get_device());
+
+	const auto &queue = get_device().get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);
+
+	vk::CommandBuffer command_buffer = get_device().create_command_buffer(vk::CommandBufferLevel::ePrimary, true);
+
+	vkb::core::HPPBuffer stage_buffer{get_device(), texture.image->get_data().size(), vk::BufferUsageFlagBits::eTransferSrc, VMA_MEMORY_USAGE_CPU_ONLY};
+
+	stage_buffer.update(texture.image->get_data());
+
+	// Setup buffer copy regions for each mip level
+	std::vector<vk::BufferImageCopy> bufferCopyRegions;
+
+	auto &mipmaps = texture.image->get_mipmaps();
+
+	for (size_t i = 0; i < mipmaps.size(); i++)
+	{
+		vk::BufferImageCopy buffer_copy_region;
+		buffer_copy_region.imageSubresource.aspectMask     = vk::ImageAspectFlagBits::eColor;
+		buffer_copy_region.imageSubresource.mipLevel       = vkb::to_u32(i);
+		buffer_copy_region.imageSubresource.baseArrayLayer = 0;
+		buffer_copy_region.imageSubresource.layerCount     = 1;
+		buffer_copy_region.imageExtent.width               = texture.image->get_extent().width >> i;
+		buffer_copy_region.imageExtent.height              = texture.image->get_extent().height >> i;
+		buffer_copy_region.imageExtent.depth               = 1;
+		buffer_copy_region.bufferOffset                    = mipmaps[i].offset;
+
+		bufferCopyRegions.push_back(buffer_copy_region);
+	}
+
+	vk::ImageSubresourceRange subresource_range(vk::ImageAspectFlagBits::eColor, 0, vkb::to_u32(mipmaps.size()), 0, 1);
+
+	// Image barrier for optimal image (target)
+	// Optimal image will be used as destination for the copy
+	vkb::common::set_image_layout(
+	    command_buffer, texture.image->get_vk_image().get_handle(), vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, subresource_range);
+
+	// Copy mip levels from staging buffer
+	command_buffer.copyBufferToImage(
+	    stage_buffer.get_handle(), texture.image->get_vk_image().get_handle(), vk::ImageLayout::eTransferDstOptimal, bufferCopyRegions);
+
+	// Change texture image layout to shader read after all mip levels have been copied
+	vkb::common::set_image_layout(command_buffer,
+	                              texture.image->get_vk_image().get_handle(),
+	                              vk::ImageLayout::eTransferDstOptimal,
+	                              vk::ImageLayout::eShaderReadOnlyOptimal,
+	                              subresource_range);
+
+	get_device().flush_command_buffer(command_buffer, queue.get_handle());
+
+	// Create a defaultsampler
+	vk::SamplerCreateInfo sampler_create_info;
+	sampler_create_info.magFilter    = vk::Filter::eLinear;
+	sampler_create_info.minFilter    = vk::Filter::eLinear;
+	sampler_create_info.mipmapMode   = vk::SamplerMipmapMode::eLinear;
+	sampler_create_info.addressModeU = vk::SamplerAddressMode::eRepeat;
+	sampler_create_info.addressModeV = vk::SamplerAddressMode::eRepeat;
+	sampler_create_info.addressModeW = vk::SamplerAddressMode::eRepeat;
+	sampler_create_info.mipLodBias   = 0.0f;
+	sampler_create_info.compareOp    = vk::CompareOp::eNever;
+	sampler_create_info.minLod       = 0.0f;
+	// Max level-of-detail should match mip level count
+	sampler_create_info.maxLod = static_cast<float>(mipmaps.size());
+	// Only enable anisotropic filtering if enabled on the device
+	// Note that for simplicity, we will always be using max. available anisotropy level for the current device
+	// This may have an impact on performance, esp. on lower-specced devices
+	// In a real-world scenario the level of anisotropy should be a user setting or e.g. lowered for mobile devices by default
+	sampler_create_info.maxAnisotropy =
+	    get_device().get_gpu().get_features().samplerAnisotropy ? (get_device().get_gpu().get_properties().limits.maxSamplerAnisotropy) : 1.0f;
+	sampler_create_info.anisotropyEnable = get_device().get_gpu().get_features().samplerAnisotropy;
+	sampler_create_info.borderColor      = vk::BorderColor::eFloatOpaqueWhite;
+	texture.sampler                      = get_device().get_handle().createSampler(sampler_create_info);
+
+	return texture;
+}
+
+HPPTexture HPPApiVulkanSample::load_texture_array(const std::string &file)
+{
+	HPPTexture texture{};
+
+	texture.image = vkb::scene_graph::components::HPPImage::load(file, file);
+	texture.image->create_vk_image(get_device(), vk::ImageViewType::e2DArray);
+
+	const auto &queue = get_device().get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);
+
+	vk::CommandBuffer command_buffer = get_device().create_command_buffer(vk::CommandBufferLevel::ePrimary, true);
+
+	vkb::core::HPPBuffer stage_buffer{get_device(), texture.image->get_data().size(), vk::BufferUsageFlagBits::eTransferSrc, VMA_MEMORY_USAGE_CPU_ONLY};
+
+	stage_buffer.update(texture.image->get_data());
+
+	// Setup buffer copy regions for each mip level
+	std::vector<vk::BufferImageCopy> buffer_copy_regions;
+
+	auto &      mipmaps = texture.image->get_mipmaps();
+	const auto &layers  = texture.image->get_layers();
+
+	auto &offsets = texture.image->get_offsets();
+
+	for (uint32_t layer = 0; layer < layers; layer++)
+	{
+		for (size_t i = 0; i < mipmaps.size(); i++)
+		{
+			vk::BufferImageCopy buffer_copy_region;
+			buffer_copy_region.imageSubresource.aspectMask     = vk::ImageAspectFlagBits::eColor;
+			buffer_copy_region.imageSubresource.mipLevel       = vkb::to_u32(i);
+			buffer_copy_region.imageSubresource.baseArrayLayer = layer;
+			buffer_copy_region.imageSubresource.layerCount     = 1;
+			buffer_copy_region.imageExtent.width               = texture.image->get_extent().width >> i;
+			buffer_copy_region.imageExtent.height              = texture.image->get_extent().height >> i;
+			buffer_copy_region.imageExtent.depth               = 1;
+			buffer_copy_region.bufferOffset                    = offsets[layer][i];
+
+			buffer_copy_regions.push_back(buffer_copy_region);
+		}
+	}
+
+	vk::ImageSubresourceRange subresource_range(vk::ImageAspectFlagBits::eColor, 0, vkb::to_u32(mipmaps.size()), 0, layers);
+
+	// Image barrier for optimal image (target)
+	// Optimal image will be used as destination for the copy
+	vkb::common::set_image_layout(
+	    command_buffer, texture.image->get_vk_image().get_handle(), vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, subresource_range);
+
+	// Copy mip levels from staging buffer
+	command_buffer.copyBufferToImage(
+	    stage_buffer.get_handle(), texture.image->get_vk_image().get_handle(), vk::ImageLayout::eTransferDstOptimal, buffer_copy_regions);
+
+	// Change texture image layout to shader read after all mip levels have been copied
+	vkb::common::set_image_layout(command_buffer,
+	                              texture.image->get_vk_image().get_handle(),
+	                              vk::ImageLayout::eTransferDstOptimal,
+	                              vk::ImageLayout::eShaderReadOnlyOptimal,
+	                              subresource_range);
+
+	get_device().flush_command_buffer(command_buffer, queue.get_handle());
+
+	// Create a defaultsampler
+	vk::SamplerCreateInfo sampler_create_info;
+	sampler_create_info.magFilter    = vk::Filter::eLinear;
+	sampler_create_info.minFilter    = vk::Filter::eLinear;
+	sampler_create_info.mipmapMode   = vk::SamplerMipmapMode::eLinear;
+	sampler_create_info.addressModeU = vk::SamplerAddressMode::eClampToEdge;
+	sampler_create_info.addressModeV = vk::SamplerAddressMode::eClampToEdge;
+	sampler_create_info.addressModeW = vk::SamplerAddressMode::eClampToEdge;
+	sampler_create_info.mipLodBias   = 0.0f;
+	sampler_create_info.compareOp    = vk::CompareOp::eNever;
+	sampler_create_info.minLod       = 0.0f;
+	// Max level-of-detail should match mip level count
+	sampler_create_info.maxLod = static_cast<float>(mipmaps.size());
+	// Only enable anisotropic filtering if enabled on the devicec
+	sampler_create_info.maxAnisotropy =
+	    get_device().get_gpu().get_features().samplerAnisotropy ? get_device().get_gpu().get_properties().limits.maxSamplerAnisotropy : 1.0f;
+	sampler_create_info.anisotropyEnable = get_device().get_gpu().get_features().samplerAnisotropy;
+	sampler_create_info.borderColor      = vk::BorderColor::eFloatOpaqueWhite;
+	texture.sampler                      = get_device().get_handle().createSampler(sampler_create_info);
+
+	return texture;
+}
+
+HPPTexture HPPApiVulkanSample::load_texture_cubemap(const std::string &file)
+{
+	HPPTexture texture{};
+
+	texture.image = vkb::scene_graph::components::HPPImage::load(file, file);
+	texture.image->create_vk_image(get_device(), vk::ImageViewType::eCube, vk::ImageCreateFlagBits::eCubeCompatible);
+
+	const auto &queue = get_device().get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);
+
+	vk::CommandBuffer command_buffer = get_device().create_command_buffer(vk::CommandBufferLevel::ePrimary, true);
+
+	vkb::core::HPPBuffer stage_buffer{get_device(), texture.image->get_data().size(), vk::BufferUsageFlagBits::eTransferSrc, VMA_MEMORY_USAGE_CPU_ONLY};
+
+	stage_buffer.update(texture.image->get_data());
+
+	// Setup buffer copy regions for each mip level
+	std::vector<vk::BufferImageCopy> buffer_copy_regions;
+
+	auto &      mipmaps = texture.image->get_mipmaps();
+	const auto &layers  = texture.image->get_layers();
+
+	auto &offsets = texture.image->get_offsets();
+
+	for (uint32_t layer = 0; layer < layers; layer++)
+	{
+		for (size_t i = 0; i < mipmaps.size(); i++)
+		{
+			vk::BufferImageCopy buffer_copy_region;
+			buffer_copy_region.imageSubresource.aspectMask     = vk::ImageAspectFlagBits::eColor;
+			buffer_copy_region.imageSubresource.mipLevel       = vkb::to_u32(i);
+			buffer_copy_region.imageSubresource.baseArrayLayer = layer;
+			buffer_copy_region.imageSubresource.layerCount     = 1;
+			buffer_copy_region.imageExtent.width               = texture.image->get_extent().width >> i;
+			buffer_copy_region.imageExtent.height              = texture.image->get_extent().height >> i;
+			buffer_copy_region.imageExtent.depth               = 1;
+			buffer_copy_region.bufferOffset                    = offsets[layer][i];
+
+			buffer_copy_regions.push_back(buffer_copy_region);
+		}
+	}
+
+	vk::ImageSubresourceRange subresource_range(vk::ImageAspectFlagBits::eColor, 0, vkb::to_u32(mipmaps.size()), 0, layers);
+
+	// Image barrier for optimal image (target)
+	// Optimal image will be used as destination for the copy
+	vkb::common::set_image_layout(
+	    command_buffer, texture.image->get_vk_image().get_handle(), vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, subresource_range);
+
+	// Copy mip levels from staging buffer
+	command_buffer.copyBufferToImage(
+	    stage_buffer.get_handle(), texture.image->get_vk_image().get_handle(), vk::ImageLayout::eTransferDstOptimal, buffer_copy_regions);
+
+	// Change texture image layout to shader read after all mip levels have been copied
+	vkb::common::set_image_layout(command_buffer,
+	                              texture.image->get_vk_image().get_handle(),
+	                              vk::ImageLayout::eTransferDstOptimal,
+	                              vk::ImageLayout::eShaderReadOnlyOptimal,
+	                              subresource_range);
+
+	get_device().flush_command_buffer(command_buffer, queue.get_handle());
+
+	// Create a defaultsampler
+	vk::SamplerCreateInfo sampler_create_info;
+	sampler_create_info.magFilter    = vk::Filter::eLinear;
+	sampler_create_info.minFilter    = vk::Filter::eLinear;
+	sampler_create_info.mipmapMode   = vk::SamplerMipmapMode::eLinear;
+	sampler_create_info.addressModeU = vk::SamplerAddressMode::eClampToEdge;
+	sampler_create_info.addressModeV = vk::SamplerAddressMode::eClampToEdge;
+	sampler_create_info.addressModeW = vk::SamplerAddressMode::eClampToEdge;
+	sampler_create_info.mipLodBias   = 0.0f;
+	sampler_create_info.compareOp    = vk::CompareOp::eNever;
+	sampler_create_info.minLod       = 0.0f;
+	// Max level-of-detail should match mip level count
+	sampler_create_info.maxLod = static_cast<float>(mipmaps.size());
+	// Only enable anisotropic filtering if enabled on the devicec
+	sampler_create_info.maxAnisotropy =
+	    get_device().get_gpu().get_features().samplerAnisotropy ? get_device().get_gpu().get_properties().limits.maxSamplerAnisotropy : 1.0f;
+	sampler_create_info.anisotropyEnable = get_device().get_gpu().get_features().samplerAnisotropy;
+	sampler_create_info.borderColor      = vk::BorderColor::eFloatOpaqueWhite;
+	texture.sampler                      = get_device().get_handle().createSampler(sampler_create_info);
+
+	return texture;
+}
+
+std::unique_ptr<vkb::scene_graph::components::HPPSubMesh> HPPApiVulkanSample::load_model(const std::string &file, uint32_t index)
+{
+	vkb::HPPGLTFLoader loader{get_device()};
+
+	std::unique_ptr<vkb::scene_graph::components::HPPSubMesh> model = loader.read_model_from_file(file, index);
+
+	if (!model)
+	{
+		LOGE("Cannot load model from file: {}", file.c_str());
+		throw std::runtime_error("Cannot load model from: " + file);
+	}
+
+	return model;
+}
+
+void HPPApiVulkanSample::draw_model(std::unique_ptr<vkb::scene_graph::components::HPPSubMesh> &model, vk::CommandBuffer command_buffer)
+{
+	vk::DeviceSize offset = 0;
+
+	const auto &vertex_buffer = model->get_vertex_buffer("vertex_buffer");
+	auto &      index_buffer  = model->get_index_buffer();
+
+	command_buffer.bindVertexBuffers(0, vertex_buffer.get_handle(), offset);
+	command_buffer.bindIndexBuffer(index_buffer.get_handle(), 0, model->get_index_type());
+	command_buffer.drawIndexed(model->vertex_indices, 1, 0, 0, 0);
+}
+
+void HPPApiVulkanSample::with_command_buffer(const std::function<void(vk::CommandBuffer command_buffer)> &f, vk::Semaphore signalSemaphore)
+{
+	vk::CommandBuffer command_buffer = get_device().create_command_buffer(vk::CommandBufferLevel::ePrimary, true);
+	f(command_buffer);
+	get_device().flush_command_buffer(command_buffer, queue, true, signalSemaphore);
 }

--- a/framework/hpp_api_vulkan_sample.h
+++ b/framework/hpp_api_vulkan_sample.h
@@ -17,30 +17,370 @@
 
 #pragma once
 
-#include <api_vulkan_sample.h>
-#include <core/hpp_device.h>
+#include <hpp_vulkan_sample.h>
+
+#include <camera.h>
+#include <scene_graph/components/hpp_image.h>
+#include <scene_graph/components/hpp_sub_mesh.h>
 
 /**
- * @brief wrapper class for use with vulkan.hpp in the samples of this framework
- *
- * See vkb::VulkanSample for documentation
+ * @brief A swapchain buffer
  */
-class HPPApiVulkanSample : public ApiVulkanSample
+struct HPPSwapchainBuffer
+{
+	vk::Image     image;
+	vk::ImageView view;
+};
+
+/**
+ * @brief A texture wrapper that owns its image data and links it with a sampler
+ */
+struct HPPTexture
+{
+	std::unique_ptr<vkb::scene_graph::components::HPPImage> image;
+	vk::Sampler                                             sampler;
+};
+
+/**
+ * @brief The structure of a vertex
+ */
+struct HPPVertex
+{
+	glm::vec3 pos;
+	glm::vec3 normal;
+	glm::vec2 uv;
+	glm::vec4 joint0;
+	glm::vec4 weight0;
+};
+
+/**
+ * @brief vulkan.hpp version of the vkb::ApiVulkanSample class
+ *
+ * See vkb::ApiVulkanSample for documentation
+ */
+class HPPApiVulkanSample : public vkb::HPPVulkanSample
 {
   public:
-	bool prepare(vkb::Platform &platform) override;
+	HPPApiVulkanSample() = default;
 
-	vk::CommandBuffer                 get_command_buffer(size_t index) const;
-	size_t                            get_command_buffers_count() const;
-	vk::Device                        get_device() const;
-	vk::ClearColorValue const &       get_default_clear_color() const;
-	vk::DescriptorPool                get_descriptor_pool() const;
-	vk::Framebuffer                   get_framebuffer(size_t index) const;
-	vk::Instance                      get_instance() const;
-	vk::PhysicalDevice                get_physical_device() const;
-	vk::Queue                         get_queue() const;
+	virtual ~HPPApiVulkanSample();
+
+	virtual bool prepare(vkb::Platform &platform) override;
+
+	virtual void input_event(const vkb::InputEvent &input_event) override;
+
+	virtual void update(float delta_time) override;
+
+	virtual void resize(const uint32_t width, const uint32_t height) override;
+
+	virtual void render(float delta_time) = 0;
+
+	enum RenderPassCreateFlags
+	{
+		ColorAttachmentLoad = 0x00000001
+	};
+
+  protected:
+	/// Stores the swapchain image buffers
+	std::vector<HPPSwapchainBuffer> swapchain_buffers;
+
+	virtual void create_render_context(vkb::Platform &platform) override;
+	virtual void prepare_render_context() override;
+
+	// Handle to the device graphics queue that command buffers are submitted to
+	vk::Queue queue;
+
+	// Depth buffer format (selected during Vulkan initialization)
+	vk::Format depth_format;
+
+	// Command buffer pool
+	vk::CommandPool cmd_pool;
+
+	/** @brief Pipeline stages used to wait at for graphics queue submissions */
+	vk::PipelineStageFlags submit_pipeline_stages = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+
+	// Contains command buffers and semaphores to be presented to the queue
+	vk::SubmitInfo submit_info;
+
+	// Command buffers used for rendering
+	std::vector<vk::CommandBuffer> draw_cmd_buffers;
+
+	// Global render pass for frame buffer writes
+	vk::RenderPass render_pass;
+
+	// List of available frame buffers (same as number of swap chain images)
+	std::vector<vk::Framebuffer> framebuffers;
+
+	// Active frame buffer index
+	uint32_t current_buffer = 0;
+
+	// Descriptor set pool
+	vk::DescriptorPool descriptor_pool;
+
+	// List of shader modules created (stored for cleanup)
+	std::vector<vk::ShaderModule> shader_modules;
+
+	// Pipeline cache object
+	vk::PipelineCache pipeline_cache;
+
+	// Synchronization semaphores
+	struct
+	{
+		// Swap chain image presentation
+		vk::Semaphore acquired_image_ready;
+
+		// Command buffer submission and execution
+		vk::Semaphore render_complete;
+	} semaphores;
+
+	// Synchronization fences
+	std::vector<vk::Fence> wait_fences;
+
+	/**
+   * @brief Populates the swapchain_buffers vector with the image and imageviews
+   */
+	void create_swapchain_buffers();
+
+	/**
+   * @brief Updates the swapchains image usage, if a swapchain exists and recreates all resources based on swapchain images
+   * @param image_usage_flags The usage flags the new swapchain images will have
+   */
+	void update_swapchain_image_usage_flags(std::set<vk::ImageUsageFlagBits> const &image_usage_flags);
+
+	/**
+   * @brief Handles changes to the surface, e.g. on resize
+   */
+	void handle_surface_changes();
+
+	/**
+   * @brief Loads in a ktx 2D texture
+   * @param file The filename of the texture to load
+   */
+	HPPTexture load_texture(const std::string &file);
+
+	/**
+   * @brief Laods in a ktx 2D texture array
+   * @param file The filename of the texture to load
+   */
+	HPPTexture load_texture_array(const std::string &file);
+
+	/**
+   * @brief Loads in a ktx 2D texture cubemap
+   * @param file The filename of the texture to load
+   */
+	HPPTexture load_texture_cubemap(const std::string &file);
+
+	/**
+   * @brief Loads in a single model from a GLTF file
+   * @param file The filename of the model to load
+   * @param index The index of the model to load from the GLTF file (default: 0)
+   */
+	std::unique_ptr<vkb::scene_graph::components::HPPSubMesh> load_model(const std::string &file, uint32_t index = 0);
+
+	/**
+   * @brief Records the necessary drawing commands to a command buffer
+   * @param model The model to draw
+   * @param command_buffer The command buffer to record to
+   */
+	void draw_model(std::unique_ptr<vkb::scene_graph::components::HPPSubMesh> &model, vk::CommandBuffer command_buffer);
+
+	/**
+   * @brief Synchronously execute a block code within a command buffer, then submit the command buffer and wait for completion.
+   * @param f a block of code which is passed a command buffer which is already in the begin state.
+   * @param signalSemaphore An optional semaphore to signal when the commands have completed execution.
+   */
+	void with_command_buffer(const std::function<void(vk::CommandBuffer command_buffer)> &f, vk::Semaphore signalSemaphore = nullptr);
+
+  public:
+	/**
+   * @brief Called when a view change occurs, can be overriden in derived samples to handle updating uniforms
+   */
+	virtual void view_changed();
+
+	/**
+   * @brief Called after the mouse cursor is moved and before internal events (like camera rotation) is handled
+   * @param x The width from the origin
+   * @param y The height from the origin
+   * @param handled Whether the event was handled
+   */
+	virtual void mouse_moved(double x, double y, bool &handled);
+
+	/**
+   * @brief To be overridden by the derived class. Records the relevant commands to the rendering command buffers
+   *        Called when the framebuffers need to be rebuilt
+   */
+	virtual void build_command_buffers() = 0;
+
+	/**
+   * @brief Creates the fences for rendering
+   */
+	void create_synchronization_primitives();
+
+	/**
+   * @brief Creates a new (graphics) command pool object storing command buffers
+   */
+	void create_command_pool();
+
+	/**
+   * @brief Setup default depth and stencil views
+   */
+	virtual void setup_depth_stencil();
+
+	/**
+   * @brief Create framebuffers for all requested swap chain images
+   *        Can be overriden in derived class to setup a custom framebuffer (e.g. for MSAA)
+   */
+	virtual void setup_framebuffer();
+
+	/**
+   * @brief Setup a default render pass
+   *        Can be overriden in derived class to setup a custom render pass (e.g. for MSAA)
+   */
+	virtual void setup_render_pass();
+
+	/**
+   * @brief Update flags for the default render pass and recreate it
+   * @param flags Optional flags for render pass creation
+   */
+	void update_render_pass_flags(RenderPassCreateFlags flags = {});
+
+	/**
+   * @brief Check if command buffers are valid (!= VK_NULL_HANDLE)
+   */
+	bool check_command_buffers();
+
+	/**
+   * @brief Create command buffers for drawing commands
+   */
+	void create_command_buffers();
+
+	/**
+   * @brief Destroy all command buffers, may be necessary during runtime if options are toggled
+   */
+	void destroy_command_buffers();
+
+	/**
+   * @brief Create a cache pool for rendering pipelines
+   */
+	void create_pipeline_cache();
+
+	/**
+   * @brief Load a SPIR-V shader
+   * @param file The file location of the shader relative to the shaders folder
+   * @param stage The shader stage
+   */
 	vk::PipelineShaderStageCreateInfo load_shader(const std::string &file, vk::ShaderStageFlagBits stage);
-	vk::SubmitInfo const &            set_submit_info(vk::CommandBuffer const &command_buffer);
 
-	vkb::core::HPPDevice &get_device_wrapper();
+	/**
+   * @brief Updates the overlay
+   * @param delta_time The time taken since the last frame
+   */
+	void update_overlay(float delta_time);
+
+	/**
+   * @brief If the gui is enabled, then record the drawing commands to a command buffer
+   * @param command_buffer A valid command buffer that is ready to be recorded to
+   */
+	void draw_ui(const vk::CommandBuffer command_buffer);
+
+	/**
+   * @brief Prepare the frame for workload submission, acquires the next image from the swap chain and
+   *        sets the default wait and signal semaphores
+   */
+	void prepare_frame();
+
+	/**
+   * @brief Submit the frames' workload
+   */
+	void submit_frame();
+
+	/**
+   * @brief Called when the UI overlay is updating, can be used to add custom elements to the overlay
+   * @param drawer The drawer from the gui to draw certain elements
+   */
+	virtual void on_update_ui_overlay(vkb::Drawer &drawer);
+
+  private:
+	/** brief Indicates that the view (position, rotation) has changed and buffers containing camera matrices need to be updated */
+	bool view_updated = false;
+	// Destination dimensions for resizing the window
+	vk::Extent2D dest_extent;
+	bool         resizing = false;
+
+	void handle_mouse_move(int32_t x, int32_t y);
+
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	/// The debug report callback
+	vk::DebugReportCallbackEXT debug_report_callback;
+#endif
+
+  public:
+	bool         prepared = false;
+	vk::Extent2D extent;
+
+	/** @brief Example settings that can be changed e.g. by command line arguments */
+	struct
+	{
+		/** @brief Set to true if fullscreen mode has been requested via command line */
+		bool fullscreen = false;
+		/** @brief Set to true if v-sync will be forced for the swapchain */
+		bool vsync = false;
+	} settings;
+
+	vk::ClearColorValue default_clear_color = std::array<float, 4>({{0.025f, 0.025f, 0.025f, 1.0f}});
+
+	float zoom = 0;
+
+	// Defines a frame rate independent timer value clamped from -1.0...1.0
+	// For use in animations, rotations, etc.
+	float timer = 0.0f;
+	// Multiplier for speeding up (or slowing down) the global timer
+	float timer_speed = 0.0025f;
+
+	bool paused = false;
+
+	// Use to adjust mouse rotation speed
+	float rotation_speed = 1.0f;
+	// Use to adjust mouse zoom speed
+	float zoom_speed = 1.0f;
+
+	vkb::Camera camera;
+
+	glm::vec3 rotation   = glm::vec3();
+	glm::vec3 camera_pos = glm::vec3();
+	glm::vec2 mouse_pos;
+
+	std::string title = "HPP Vulkan API Example";
+	std::string name  = "HPPAPIVulkanExample";
+
+	struct
+	{
+		vk::Image        image;
+		vk::DeviceMemory mem;
+		vk::ImageView    view;
+	} depth_stencil;
+
+	struct
+	{
+		glm::vec2 axis_left  = glm::vec2(0.0f);
+		glm::vec2 axis_right = glm::vec2(0.0f);
+	} game_pad_state;
+
+	struct
+	{
+		bool left   = false;
+		bool right  = false;
+		bool middle = false;
+	} mouse_buttons;
+
+	// true if application has focused, false if moved to background
+	bool focused = false;
+	struct TouchPos
+	{
+		int32_t x;
+		int32_t y;
+	} touch_pos;
+	bool    touch_down    = false;
+	double  touch_timer   = 0.0;
+	int64_t last_tap_time = 0;
 };

--- a/framework/hpp_gltf_loader.h
+++ b/framework/hpp_gltf_loader.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <core/hpp_device.h>
+#include <gltf_loader.h>
+
+namespace vkb
+{
+/**
+ * @brief facade class around vkb::GLTFLoader, providing a vulkan.hpp-based interface
+ *
+ * See vkb::GLTFLoader for documentation
+ */
+class HPPGLTFLoader : protected vkb::GLTFLoader
+{
+  public:
+	HPPGLTFLoader(vkb::core::HPPDevice const &device) :
+	    GLTFLoader(reinterpret_cast<vkb::Device const &>(device))
+	{}
+
+	std::unique_ptr<vkb::scene_graph::components::HPPSubMesh> read_model_from_file(const std::string &file_name, uint32_t index)
+	{
+		return std::unique_ptr<vkb::scene_graph::components::HPPSubMesh>(
+		    reinterpret_cast<vkb::scene_graph::components::HPPSubMesh *>(
+		        vkb::GLTFLoader::read_model_from_file(file_name, index).release()));
+	}
+};
+}        // namespace vkb

--- a/framework/hpp_vulkan_sample.h
+++ b/framework/hpp_vulkan_sample.h
@@ -1,0 +1,67 @@
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <core/hpp_device.h>
+#include <core/hpp_instance.h>
+#include <platform/hpp_platform.h>
+#include <rendering/hpp_render_context.h>
+#include <vulkan_sample.h>
+
+namespace vkb
+{
+/**
+ * @brief facade class around vkb::VulkanSample, providing a vulkan.hpp-based interface
+ *
+ * See vkb::VulkanSample for documentation
+ */
+class HPPVulkanSample : public VulkanSample
+{
+  public:
+	void create_render_context(Platform &platform, std::vector<vk::SurfaceFormatKHR> const &surface_priority_list)
+	{
+		std::vector<VkSurfaceFormatKHR> spl;
+		spl.reserve(surface_priority_list.size());
+		for (auto const &format : surface_priority_list)
+		{
+			spl.push_back(static_cast<VkSurfaceFormatKHR>(format));
+		}
+		render_context = platform.create_render_context(*device, surface, spl);
+	}
+
+	vkb::core::HPPDevice const &get_device() const
+	{
+		return *reinterpret_cast<vkb::core::HPPDevice const *>(&*device);
+	}
+
+	vkb::core::HPPInstance const &get_instance() const
+	{
+		return *reinterpret_cast<vkb::core::HPPInstance const *>(&*instance);
+	}
+
+	vkb::platform::HPPPlatform const &get_platform() const
+	{
+		return *reinterpret_cast<vkb::platform::HPPPlatform const *>(platform);
+	}
+
+	vkb::rendering::HPPRenderContext &get_render_context() const
+	{
+		return *reinterpret_cast<vkb::rendering::HPPRenderContext *>(&*render_context);
+	}
+};
+}        // namespace vkb

--- a/framework/platform/hpp_platform.h
+++ b/framework/platform/hpp_platform.h
@@ -1,0 +1,41 @@
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <platform/platform.h>
+#include <rendering/hpp_render_context.h>
+
+namespace vkb
+{
+namespace platform
+{
+/**
+ * @brief facade class around vkb::Platform, providing a vulkan.hpp-based interface
+ *
+ * See vkb::Platform for documentation
+ */
+class HPPPlatform : protected vkb::Platform
+{
+  public:
+	void on_post_draw(vkb::rendering::HPPRenderContext &context) const
+	{
+		vkb::Platform::on_post_draw(reinterpret_cast<vkb::RenderContext &>(context));
+	}
+};
+}        // namespace platform
+}        // namespace vkb

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -431,7 +431,7 @@ void Platform::resize(uint32_t width, uint32_t height)
 		}                               \
 	}
 
-void Platform::on_post_draw(RenderContext &context)
+void Platform::on_post_draw(RenderContext &context) const
 {
 	HOOK(Hook::PostDraw, on_post_draw(context));
 }

--- a/framework/platform/platform.h
+++ b/framework/platform/platform.h
@@ -140,7 +140,7 @@ class Platform
 
 	void set_window_properties(const Window::OptionalProperties &properties);
 
-	void on_post_draw(RenderContext &context);
+	void on_post_draw(RenderContext &context) const;
 
 	static const uint32_t MIN_WINDOW_WIDTH;
 	static const uint32_t MIN_WINDOW_HEIGHT;

--- a/framework/rendering/hpp_render_context.h
+++ b/framework/rendering/hpp_render_context.h
@@ -1,0 +1,65 @@
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <core/hpp_swapchain.h>
+#include <rendering/render_context.h>
+
+namespace vkb
+{
+namespace rendering
+{
+/**
+ * @brief facade class around vkb::RenderContext, providing a vulkan.hpp-based interface
+ *
+ * See vkb::RenderContext for documentation
+ */
+class HPPRenderContext : protected vkb::RenderContext
+{
+  public:
+	using vkb::RenderContext::get_render_frames;
+	using vkb::RenderContext::handle_surface_changes;
+	using vkb::RenderContext::has_swapchain;
+
+	vk::Format get_format() const
+	{
+		return static_cast<vk::Format>(vkb::RenderContext::get_format());
+	}
+
+	vk::Extent2D const &get_surface_extent() const
+	{
+		return *reinterpret_cast<vk::Extent2D const *>(&vkb::RenderContext::get_surface_extent());
+	}
+
+	vkb::core::HPPSwapchain const &get_swapchain() const
+	{
+		return reinterpret_cast<vkb::core::HPPSwapchain const &>(vkb::RenderContext::get_swapchain());
+	}
+
+	void update_swapchain(const std::set<vk::ImageUsageFlagBits> &image_usage_flags)
+	{
+		std::set<VkImageUsageFlagBits> flags;
+		for (auto flag : image_usage_flags)
+		{
+			flags.insert(static_cast<VkImageUsageFlagBits>(flag));
+		}
+		vkb::RenderContext::update_swapchain(flags);
+	}
+};
+}        // namespace rendering
+}        // namespace vkb

--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -119,7 +119,7 @@ void RenderContext::set_surface_format_priority(const std::vector<VkSurfaceForma
 	surface_format_priority_list = new_surface_format_priority_list;
 }
 
-VkFormat RenderContext::get_format()
+VkFormat RenderContext::get_format() const
 {
 	VkFormat format = DEFAULT_VK_FORMAT;
 
@@ -527,13 +527,13 @@ bool RenderContext::has_swapchain()
 	return swapchain != nullptr;
 }
 
-Swapchain &RenderContext::get_swapchain()
+Swapchain const &RenderContext::get_swapchain() const
 {
 	assert(swapchain && "Swapchain is not valid");
 	return *swapchain;
 }
 
-VkExtent2D RenderContext::get_surface_extent() const
+VkExtent2D const &RenderContext::get_surface_extent() const
 {
 	return surface_extent;
 }

--- a/framework/rendering/render_context.h
+++ b/framework/rendering/render_context.h
@@ -213,11 +213,11 @@ class RenderContext
 	/**
 	 * @brief Returns the format that the RenderTargets are created with within the RenderContext
 	 */
-	VkFormat get_format();
+	VkFormat get_format() const;
 
-	Swapchain &get_swapchain();
+	Swapchain const &get_swapchain() const;
 
-	VkExtent2D get_surface_extent() const;
+	VkExtent2D const &get_surface_extent() const;
 
 	uint32_t get_active_frame_index() const;
 

--- a/framework/rendering/render_target.h
+++ b/framework/rendering/render_target.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -102,7 +102,7 @@ class RenderTarget
 	VkImageLayout get_layout(uint32_t attachment) const;
 
   private:
-	Device &device;
+	Device const &device;
 
 	VkExtent2D extent{};
 

--- a/framework/scene_graph/components/hpp_image.h
+++ b/framework/scene_graph/components/hpp_image.h
@@ -1,0 +1,68 @@
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <scene_graph/components/image.h>
+
+#include <core/hpp_device.h>
+#include <core/hpp_image.h>
+
+namespace vkb
+{
+namespace scene_graph
+{
+namespace components
+{
+/**
+ * @brief facade class around vkb::sg::Image, providing a vulkan.hpp-based interface
+ *
+ * See vkb::sb::Image for documentation
+ */
+class HPPImage : protected vkb::sg::Image
+{
+  public:
+	using vkb::sg::Image::get_data;
+	using vkb::sg::Image::get_layers;
+	using vkb::sg::Image::get_mipmaps;
+	using vkb::sg::Image::get_offsets;
+
+	static std::unique_ptr<HPPImage> load(std::string const &name, std::string const &uri)
+	{
+		return std::unique_ptr<HPPImage>(reinterpret_cast<HPPImage *>(vkb::sg::Image::load(name, uri).release()));
+	}
+
+	void create_vk_image(vkb::core::HPPDevice const &device, vk::ImageViewType image_view_type = vk::ImageViewType::e2D, vk::ImageCreateFlags flags = {})
+	{
+		vkb::sg::Image::create_vk_image(
+		    reinterpret_cast<vkb::Device const &>(device), static_cast<VkImageViewType>(image_view_type), static_cast<VkImageCreateFlags>(flags));
+	}
+
+	vk::Extent3D const &get_extent() const
+	{
+		return reinterpret_cast<vk::Extent3D const &>(vkb::sg::Image::get_extent());
+	}
+
+	vkb::core::HPPImage const &get_vk_image() const
+	{
+		return reinterpret_cast<vkb::core::HPPImage const &>(vkb::sg::Image::get_vk_image());
+	}
+};
+
+}        // namespace components
+}        // namespace scene_graph
+}        // namespace vkb

--- a/framework/scene_graph/components/hpp_sub_mesh.h
+++ b/framework/scene_graph/components/hpp_sub_mesh.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <core/hpp_buffer.h>
+#include <scene_graph/components/sub_mesh.h>
+
+namespace vkb
+{
+namespace scene_graph
+{
+namespace components
+{
+/**
+ * @brief facade class around vkb::sg::SubMesh, providing a vulkan.hpp-based interface
+ *
+ * See vkb::sb::SubMeshfor documentation
+ */
+class HPPSubMesh : protected vkb::sg::SubMesh
+{
+  public:
+	using vkb::sg::SubMesh::vertex_indices;
+
+	vkb::core::HPPBuffer const &get_index_buffer() const
+	{
+		return reinterpret_cast<vkb::core::HPPBuffer const &>(*vkb::sg::SubMesh::index_buffer);
+	}
+
+	vk::IndexType get_index_type() const
+	{
+		return static_cast<vk::IndexType>(vkb::sg::SubMesh::index_type);
+	}
+
+	vkb::core::HPPBuffer const &get_vertex_buffer(std::string const &name) const
+	{
+		return reinterpret_cast<vkb::core::HPPBuffer const &>(vkb::sg::SubMesh::vertex_buffers.at(name));
+	}
+};
+}        // namespace components
+}        // namespace scene_graph
+}        // namespace vkb

--- a/framework/scene_graph/components/image.cpp
+++ b/framework/scene_graph/components/image.cpp
@@ -117,7 +117,7 @@ const std::vector<std::vector<VkDeviceSize>> &Image::get_offsets() const
 	return offsets;
 }
 
-void Image::create_vk_image(Device &device, VkImageViewType image_view_type, VkImageCreateFlags flags)
+void Image::create_vk_image(Device const &device, VkImageViewType image_view_type, VkImageCreateFlags flags)
 {
 	assert(!vk_image && !vk_image_view && "Vulkan image already constructed");
 

--- a/framework/scene_graph/components/image.h
+++ b/framework/scene_graph/components/image.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2019, Arm Limited and Contributors
+/* Copyright (c) 2018-2021, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -80,7 +80,7 @@ class Image : public Component
 
 	void generate_mipmaps();
 
-	void create_vk_image(Device &device, VkImageViewType image_view_type = VK_IMAGE_VIEW_TYPE_2D, VkImageCreateFlags flags = 0);
+	void create_vk_image(Device const &device, VkImageViewType image_view_type = VK_IMAGE_VIEW_TYPE_2D, VkImageCreateFlags flags = 0);
 
 	const core::Image &get_vk_image() const;
 

--- a/samples/api/hpp_dynamic_uniform_buffers/hpp_dynamic_uniform_buffers.cpp
+++ b/samples/api/hpp_dynamic_uniform_buffers/hpp_dynamic_uniform_buffers.cpp
@@ -28,6 +28,8 @@
 
 #include <benchmark_mode/benchmark_mode.h>
 #include <hpp_dynamic_uniform_buffers.h>
+#include <iostream>
+#include <random>
 
 HPPDynamicUniformBuffers::HPPDynamicUniformBuffers()
 {
@@ -36,7 +38,7 @@ HPPDynamicUniformBuffers::HPPDynamicUniformBuffers()
 
 HPPDynamicUniformBuffers ::~HPPDynamicUniformBuffers()
 {
-	if (get_device())
+	if (get_device().get_handle())
 	{
 		if (ubo_data_dynamic.model)
 		{
@@ -45,10 +47,10 @@ HPPDynamicUniformBuffers ::~HPPDynamicUniformBuffers()
 
 		// Clean up used Vulkan resources
 		// Note : Inherited destructor cleans up resources stored in base class
-		get_device().destroyPipeline(pipeline);
+		get_device().get_handle().destroyPipeline(pipeline);
 
-		get_device().destroyPipelineLayout(pipeline_layout);
-		get_device().destroyDescriptorSetLayout(descriptor_set_layout);
+		get_device().get_handle().destroyPipelineLayout(pipeline_layout);
+		get_device().get_handle().destroyDescriptorSetLayout(descriptor_set_layout);
 	}
 }
 
@@ -79,32 +81,30 @@ void HPPDynamicUniformBuffers::aligned_free(void *data)
 void HPPDynamicUniformBuffers::build_command_buffers()
 {
 	vk::CommandBufferBeginInfo command_buffer_begin_info;
-	vk::Viewport               viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
-	vk::Rect2D                 scissor({0, 0}, {width, height});
+	vk::Viewport               viewport(0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f);
+	vk::Rect2D                 scissor({0, 0}, extent);
 	vk::DeviceSize             offset = 0;
 
-	std::array<vk::ClearValue, 2> clear_values = {get_default_clear_color(), vk::ClearDepthStencilValue(0.0f, 0)};
+	std::array<vk::ClearValue, 2> clear_values = {default_clear_color, vk::ClearDepthStencilValue(0.0f, 0)};
 
-	vk::RenderPassBeginInfo render_pass_begin_info(render_pass, {}, {{0, 0}, {width, height}}, clear_values);
+	vk::RenderPassBeginInfo render_pass_begin_info(render_pass, {}, {{0, 0}, extent}, clear_values);
 
-	size_t command_buffers_count = get_command_buffers_count();
-	for (size_t i = 0; i < command_buffers_count; ++i)
+	for (size_t i = 0; i < draw_cmd_buffers.size(); ++i)
 	{
-		render_pass_begin_info.framebuffer = get_framebuffer(i);
-		vk::CommandBuffer command_buffer   = get_command_buffer(i);
+		render_pass_begin_info.framebuffer = framebuffers[i];
 
-		command_buffer.begin(command_buffer_begin_info);
+		draw_cmd_buffers[i].begin(command_buffer_begin_info);
 
-		command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+		draw_cmd_buffers[i].beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
 
-		command_buffer.setViewport(0, viewport);
+		draw_cmd_buffers[i].setViewport(0, viewport);
 
-		command_buffer.setScissor(0, scissor);
+		draw_cmd_buffers[i].setScissor(0, scissor);
 
-		command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline);
+		draw_cmd_buffers[i].bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline);
 
-		command_buffer.bindVertexBuffers(0, static_cast<vk::Buffer>(vertex_buffer->get_handle()), offset);
-		command_buffer.bindIndexBuffer(index_buffer->get_handle(), 0, vk::IndexType::eUint32);
+		draw_cmd_buffers[i].bindVertexBuffers(0, static_cast<vk::Buffer>(vertex_buffer->get_handle()), offset);
+		draw_cmd_buffers[i].bindIndexBuffer(index_buffer->get_handle(), 0, vk::IndexType::eUint32);
 
 		// Render multiple objects using different model matrices by dynamically offsetting into one uniform buffer
 		for (uint32_t j = 0; j < OBJECT_INSTANCES; j++)
@@ -112,17 +112,16 @@ void HPPDynamicUniformBuffers::build_command_buffers()
 			// One dynamic offset per dynamic descriptor to offset into the ubo containing all model matrices
 			uint32_t dynamic_offset = j * static_cast<uint32_t>(dynamic_alignment);
 			// Bind the descriptor set for rendering a mesh using the dynamic offset
-			command_buffer.bindDescriptorSets(
-			    vk::PipelineBindPoint::eGraphics, pipeline_layout, 0, descriptor_set, dynamic_offset);
+			draw_cmd_buffers[i].bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layout, 0, descriptor_set, dynamic_offset);
 
-			command_buffer.drawIndexed(index_count, 1, 0, 0, 0);
+			draw_cmd_buffers[i].drawIndexed(index_count, 1, 0, 0, 0);
 		}
 
-		draw_ui(command_buffer);
+		draw_ui(draw_cmd_buffers[i]);
 
-		command_buffer.endRenderPass();
+		draw_cmd_buffers[i].endRenderPass();
 
-		command_buffer.end();
+		draw_cmd_buffers[i].end();
 	}
 }
 
@@ -131,7 +130,8 @@ void HPPDynamicUniformBuffers::draw()
 	HPPApiVulkanSample::prepare_frame();
 
 	// Submit to queue
-	get_queue().submit(set_submit_info(get_command_buffer(current_buffer)));
+	submit_info.setCommandBuffers(draw_cmd_buffers[current_buffer]);
+	queue.submit(submit_info);
 
 	HPPApiVulkanSample::submit_frame();
 }
@@ -197,25 +197,23 @@ void HPPDynamicUniformBuffers::generate_cube()
 	// Create buffers
 	// For the sake of simplicity we won't stage the vertex data to the gpu memory
 	// Vertex buffer
-	vertex_buffer = std::make_unique<vkb::core::HPPBuffer>(
-	    get_device_wrapper(), vertex_buffer_size, vk::BufferUsageFlagBits::eVertexBuffer, VMA_MEMORY_USAGE_GPU_TO_CPU);
+	vertex_buffer =
+	    std::make_unique<vkb::core::HPPBuffer>(get_device(), vertex_buffer_size, vk::BufferUsageFlagBits::eVertexBuffer, VMA_MEMORY_USAGE_GPU_TO_CPU);
 	vertex_buffer->update(vertices.data(), vertex_buffer_size);
 
-	index_buffer = std::make_unique<vkb::core::HPPBuffer>(
-	    get_device_wrapper(), index_buffer_size, vk::BufferUsageFlagBits::eIndexBuffer, VMA_MEMORY_USAGE_GPU_TO_CPU);
+	index_buffer = std::make_unique<vkb::core::HPPBuffer>(get_device(), index_buffer_size, vk::BufferUsageFlagBits::eIndexBuffer, VMA_MEMORY_USAGE_GPU_TO_CPU);
 	index_buffer->update(indices.data(), index_buffer_size);
 }
 
 void HPPDynamicUniformBuffers::setup_descriptor_pool()
 {
 	// Example uses one ubo and one image sampler
-	std::array<vk::DescriptorPoolSize, 3> pool_sizes = {{{vk::DescriptorType::eUniformBuffer, 1},
-	                                                     {vk::DescriptorType::eUniformBufferDynamic, 1},
-	                                                     {vk::DescriptorType::eCombinedImageSampler, 1}}};
+	std::array<vk::DescriptorPoolSize, 3> pool_sizes = {
+	    {{vk::DescriptorType::eUniformBuffer, 1}, {vk::DescriptorType::eUniformBufferDynamic, 1}, {vk::DescriptorType::eCombinedImageSampler, 1}}};
 
 	vk::DescriptorPoolCreateInfo descriptor_pool_create_info({}, 2, pool_sizes);
 
-	descriptor_pool = get_device().createDescriptorPool(descriptor_pool_create_info);
+	descriptor_pool = get_device().get_handle().createDescriptorPool(descriptor_pool_create_info);
 }
 
 void HPPDynamicUniformBuffers::setup_descriptor_set_layout()
@@ -227,26 +225,22 @@ void HPPDynamicUniformBuffers::setup_descriptor_set_layout()
 
 	vk::DescriptorSetLayoutCreateInfo descriptor_layout({}, set_layout_bindings);
 
-	descriptor_set_layout = get_device().createDescriptorSetLayout(descriptor_layout);
+	descriptor_set_layout = get_device().get_handle().createDescriptorSetLayout(descriptor_layout);
 
 #if defined(ANDROID)
 	vk::PipelineLayoutCreateInfo pipeline_layout_create_info({}, 1, &descriptor_set_layout);
 #else
-	vk::PipelineLayoutCreateInfo  pipeline_layout_create_info({}, descriptor_set_layout);
+	vk::PipelineLayoutCreateInfo pipeline_layout_create_info({}, descriptor_set_layout);
 #endif
 
-	pipeline_layout = get_device().createPipelineLayout(pipeline_layout_create_info);
+	pipeline_layout = get_device().get_handle().createPipelineLayout(pipeline_layout_create_info);
 }
 
 void HPPDynamicUniformBuffers::setup_descriptor_set()
 {
-#if defined(ANDROID)
-	vk::DescriptorSetAllocateInfo alloc_info(get_descriptor_pool(), 1, &descriptor_set_layout);
-#else
-	vk::DescriptorSetAllocateInfo alloc_info(get_descriptor_pool(), descriptor_set_layout);
-#endif
+	vk::DescriptorSetAllocateInfo alloc_info(descriptor_pool, 1, &descriptor_set_layout);
 
-	descriptor_set = get_device().allocateDescriptorSets(alloc_info).front();
+	descriptor_set = get_device().get_handle().allocateDescriptorSets(alloc_info).front();
 
 	vk::DescriptorBufferInfo view_buffer_descriptor(uniform_buffers.view->get_handle(), 0, VK_WHOLE_SIZE);
 	vk::DescriptorBufferInfo dynamic_buffer_descriptor(uniform_buffers.dynamic->get_handle(), 0, dynamic_alignment);
@@ -257,7 +251,7 @@ void HPPDynamicUniformBuffers::setup_descriptor_set()
 	     // Binding 1 : Instance matrix as dynamic uniform buffer
 	     {descriptor_set, 1, {}, vk::DescriptorType::eUniformBufferDynamic, {}, dynamic_buffer_descriptor}}};
 
-	get_device().updateDescriptorSets(write_descriptor_sets, {});
+	get_device().get_handle().updateDescriptorSets(write_descriptor_sets, {});
 }
 
 void HPPDynamicUniformBuffers::prepare_pipelines()
@@ -271,8 +265,8 @@ void HPPDynamicUniformBuffers::prepare_pipelines()
 	rasterization_state.lineWidth   = 1.0f;
 
 	vk::PipelineColorBlendAttachmentState blend_attachment_state;
-	blend_attachment_state.colorWriteMask = vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG |
-	                                        vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+	blend_attachment_state.colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
 
 	vk::PipelineColorBlendStateCreateInfo color_blend_state({}, {}, {}, blend_attachment_state);
 
@@ -288,14 +282,13 @@ void HPPDynamicUniformBuffers::prepare_pipelines()
 
 	vk::PipelineMultisampleStateCreateInfo multisample_state({}, vk::SampleCountFlagBits::e1);
 
-	std::array<vk::DynamicState, 2>    dynamic_state_enables = {{vk::DynamicState::eViewport,
-                                                              vk::DynamicState::eScissor}};
+	std::array<vk::DynamicState, 2>    dynamic_state_enables = {{vk::DynamicState::eViewport, vk::DynamicState::eScissor}};
 	vk::PipelineDynamicStateCreateInfo dynamic_state({}, dynamic_state_enables);
 
 	// Load shaders
-	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages = {
-	    {load_shader("dynamic_uniform_buffers/base.vert", vk::ShaderStageFlagBits::eVertex),
-	     load_shader("dynamic_uniform_buffers/base.frag", vk::ShaderStageFlagBits::eFragment)}};
+	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages = {{load_shader("dynamic_uniform_buffers/base.vert", vk::ShaderStageFlagBits::eVertex),
+	                                                                   load_shader("dynamic_uniform_buffers/base.frag",
+	                                                                               vk::ShaderStageFlagBits::eFragment)}};
 
 	// Vertex bindings and attributes
 	vk::VertexInputBindingDescription                  vertex_input_binding(0, sizeof(Vertex), vk::VertexInputRate::eVertex);
@@ -321,7 +314,7 @@ void HPPDynamicUniformBuffers::prepare_pipelines()
 	                                                    {},
 	                                                    -1);
 
-	pipeline = get_device().createGraphicsPipeline(pipeline_cache, pipeline_create_info).value;
+	pipeline = get_device().get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info).value;
 }
 
 // Prepare and initialize uniform buffer containing shader uniforms
@@ -331,7 +324,7 @@ void HPPDynamicUniformBuffers::prepare_uniform_buffers()
 	// We allocate this manually as the alignment of the offset differs between GPUs
 
 	// Calculate required alignment based on minimum device offset alignment
-	vk::DeviceSize min_ubo_alignment = get_physical_device().getProperties().limits.minUniformBufferOffsetAlignment;
+	vk::DeviceSize min_ubo_alignment = get_device().get_gpu().get_handle().getProperties().limits.minUniformBufferOffsetAlignment;
 	dynamic_alignment                = sizeof(glm::mat4);
 	if (min_ubo_alignment > 0)
 	{
@@ -349,20 +342,18 @@ void HPPDynamicUniformBuffers::prepare_uniform_buffers()
 	// Vertex shader uniform buffer block
 
 	// Static shared uniform buffer object with projection and view matrix
-	uniform_buffers.view = std::make_unique<vkb::core::HPPBuffer>(
-	    get_device_wrapper(), sizeof(ubo_vs), vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	uniform_buffers.view =
+	    std::make_unique<vkb::core::HPPBuffer>(get_device(), sizeof(ubo_vs), vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
 
-	uniform_buffers.dynamic = std::make_unique<vkb::core::HPPBuffer>(
-	    get_device_wrapper(), buffer_size, vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	uniform_buffers.dynamic =
+	    std::make_unique<vkb::core::HPPBuffer>(get_device(), buffer_size, vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
 
 	// Prepare per-object matrices with offsets and random rotations
-	std::default_random_engine rnd_engine(
-	    platform->using_plugin<::plugins::BenchmarkMode>() ? 0 : (unsigned) time(nullptr));
+	std::default_random_engine      rnd_engine(platform->using_plugin<::plugins::BenchmarkMode>() ? 0 : (unsigned) time(nullptr));
 	std::normal_distribution<float> rnd_dist(-1.0f, 1.0f);
 	for (uint32_t i = 0; i < OBJECT_INSTANCES; i++)
 	{
-		rotations[i] =
-		    glm::vec3(rnd_dist(rnd_engine), rnd_dist(rnd_engine), rnd_dist(rnd_engine)) * 2.0f * glm::pi<float>();
+		rotations[i]       = glm::vec3(rnd_dist(rnd_engine), rnd_dist(rnd_engine), rnd_dist(rnd_engine)) * 2.0f * glm::pi<float>();
 		rotation_speeds[i] = glm::vec3(rnd_dist(rnd_engine), rnd_dist(rnd_engine), rnd_dist(rnd_engine));
 	}
 
@@ -442,7 +433,7 @@ bool HPPDynamicUniformBuffers::prepare(vkb::Platform &platform)
 	camera.set_rotation(glm::vec3(0.0f));
 
 	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
-	camera.set_perspective(60.0f, (float) width / (float) height, 256.0f, 0.1f);
+	camera.set_perspective(60.0f, (float) extent.width / (float) extent.height, 256.0f, 0.1f);
 
 	generate_cube();
 	prepare_uniform_buffers();


### PR DESCRIPTION
## Description

Replacing this part of the framework shows how to manage most of the resources using vulkan.hpp.
In order to do so, a couple of new facade classes and functions are introduced in `hpp_gltf_loader.h`, `hpp_vulkan_sample.h`, `common/hpp_vk_common.h`, `rendering/hpp_rendering_context.h`, `scene_graph/components/hpp_image.h`, `scene_graph/components/hpp_sub_mesh.h`, `core/hpp_image.h`, `core/hpp_instance.h`, `core/hpp_physical_device.h`, `core/hpp_queue.h`, `core/hpp_swapchain.h`, and `platform/hpp_platform.h`.
In addition to that, some `const`s needed to be spread over the framework in `core/buffer.[cpp|h]`, `core/device.[cpp|h]`, `core/image.[cpp|h]`, `core/image_view.h`, `core/instance.[cpp|h]`, `core/physical_device.[cpp|h]`, `core/sampler.[cpp|h]`, `core/swapchain.[cpp|h]`, `framework/gltf_loader.[cpp|h]`, `platform/platform.[cpp|h]`, `rendering/render_context.[cpp|h]`, `rendering/render_target.h`, `scene_graph/components/image.[cpp|h]`
The vulkan.hpp-based classes and facades in `core/hpp_buffer.[cpp|h]` and `core/hpp_device.h` needed some adjustments and additions.
And, finally, the vulkan.hpp based sample `api/hpp_dynamic_uniform_buffers` was adjusted accordingly. I have tested it on Window10 on nvidia HW.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
