### PR TITLE
framework: do not mix plain and keyword target_link_libraries() signa…

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -450,7 +450,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
     plugins)
 
 if(${NEED_LINK_ATOMIC})
-    target_link_libraries(${PROJECT_NAME} atomic)
+    target_link_libraries(${PROJECT_NAME} PUBLIC atomic)
 endif()
 
 # Link platform specific libraries

--- a/framework/core/hpp_buffer.cpp
+++ b/framework/core/hpp_buffer.cpp
@@ -146,7 +146,7 @@ void HPPBuffer::destroy()
 	{
 		assert(vmaAllocation != VK_NULL_HANDLE);
 		unmap();
-		vmaDestroyBuffer(vmaAllocator, handle, vmaAllocation);
+		vmaDestroyBuffer(vmaAllocator, static_cast<VkBuffer>(handle), vmaAllocation);
 	}
 }
 


### PR DESCRIPTION
…tures

Fixes
| CMake Error at framework/CMakeLists.txt:461 (target_link_libraries):
|   The plain signature for target_link_libraries has already been used with
|   the target "framework".  All uses of target_link_libraries with a target                                            |   must be either all-keyword or all-plain.
|
|   The uses of the plain signature are here:
|                                                                                                                       |    * framework/CMakeLists.txt:453 (target_link_libraries)
|

Signed-off-by: Khem Raj <raj.khem@gmail.com>

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md)

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
