### PR TITLE
Explicitily set window focus

### DIFF
--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -413,8 +413,6 @@ class ApiVulkanSample : public vkb::VulkanSample
 		bool middle = false;
 	} mouse_buttons;
 
-	// true if application has focused, false if moved to background
-	bool focused = false;
 	struct TouchPos
 	{
 		int32_t x;

--- a/framework/platform/platform.h
+++ b/framework/platform/platform.h
@@ -175,7 +175,7 @@ class Platform
 	bool               fixed_simulation_fps{false};    /* Delta time should be fixed with a fabricated value */
 	float              simulation_frame_time = 0.016f; /* A fabricated delta time */
 	bool               process_input_events{true};     /* App should continue processing input events */
-	bool               focused;                        /* App is currently in focus at an operating system level */
+	bool               focused{true};                  /* App is currently in focus at an operating system level */
 	bool               close_requested{false};         /* Close requested */
 
   private:


### PR DESCRIPTION
## Description

Explicitly set window focus to true so that the application begins rendering on start.

Currently the first frame renders but rendering is then halted until the window is perceived as focused again. For GLFW this takes multiple resizes or min/maximizing the window. Setting focus to true to begin with resolves this issue for me

Fixes #399 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
