### PR TITLE
Resolve missing casts of structs from/to vk-namespace.

### DIFF
--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -93,7 +93,7 @@ void set_image_layout(vk::CommandBuffer         command_buffer,
 	                      image,
 	                      static_cast<VkImageLayout>(old_layout),
 	                      static_cast<VkImageLayout>(new_layout),
-	                      subresource_range,
+	                      static_cast<VkImageSubresourceRange>(subresource_range),
 	                      static_cast<VkPipelineStageFlags>(src_mask),
 	                      static_cast<VkPipelineStageFlags>(dst_mask));
 }

--- a/framework/core/hpp_queue.h
+++ b/framework/core/hpp_queue.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -40,7 +40,7 @@ class HPPQueue : protected vkb::Queue
 
 	vk::Result present(const vk::PresentInfoKHR &present_infos) const
 	{
-		return static_cast<vk::Result>(vkb::Queue::present(present_infos));
+		return static_cast<vk::Result>(vkb::Queue::present(reinterpret_cast<VkPresentInfoKHR const &>(present_infos)));
 	}
 
 	vk::Result wait_idle() const

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -75,8 +75,8 @@ bool HPPApiVulkanSample::prepare(vkb::platform::HPPPlatform &platform)
 	gui = std::make_unique<vkb::Gui>(*this, platform.get_window(), /*stats=*/nullptr, 15.0f, true);
 	gui->prepare(pipeline_cache,
 	             render_pass,
-	             {load_shader("uioverlay/uioverlay.vert", vk::ShaderStageFlagBits::eVertex),
-	              load_shader("uioverlay/uioverlay.frag", vk::ShaderStageFlagBits::eFragment)});
+	             {static_cast<VkPipelineShaderStageCreateInfo>(load_shader("uioverlay/uioverlay.vert", vk::ShaderStageFlagBits::eVertex)),
+	              static_cast<VkPipelineShaderStageCreateInfo>(load_shader("uioverlay/uioverlay.frag", vk::ShaderStageFlagBits::eFragment))});
 
 	return true;
 }

--- a/samples/api/hpp_texture_loading/hpp_texture_loading.cpp
+++ b/samples/api/hpp_texture_loading/hpp_texture_loading.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -243,7 +243,7 @@ void HPPTextureLoading::load_texture()
 		vk::Image mappable_image        = get_device().get_handle().createImage(image_create_info);
 
 		// Get memory requirements for this image like size and alignment
-		VkMemoryRequirements memory_requirements = get_device().get_handle().getImageMemoryRequirements(mappable_image);
+		vk::MemoryRequirements memory_requirements = get_device().get_handle().getImageMemoryRequirements(mappable_image);
 		// Set memory allocation size to required memory size
 		vk::MemoryAllocateInfo memory_allocate_info(
 		    memory_requirements.size,


### PR DESCRIPTION
## Description

Some casts from/to vk-namespace structs were missing. With Vulkan header version 202, those casts were made explicit to catch them.
Build tested on Windows.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
