### PR TITLE
Fix tutorial links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2019-2021, Arm Limited and Contributors
+- Copyright (c) 2019-2022, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/README.md
+++ b/README.md
@@ -158,5 +158,5 @@ Also see [CONTRIBUTING](CONTRIBUTING.md) for contribution guidelines.
 
 ## Related resources
 
-- [Mali GPU Best Practices](https://developer.arm.com/solutions/graphics/developer-guides/advanced-guides/mali-gpu-best-practices): A document with recommendations for efficient API usage
+- [Mali GPU Best Practices](https://developer.arm.com/documentation/101897/latest/): A document with recommendations for efficient API usage
 - [PerfDoc](https://github.com/ARM-software/perfdoc): A Vulkan layer which aims to validate applications against Mali GPU Best Practices

--- a/samples/performance/command_buffer_usage/README.md
+++ b/samples/performance/command_buffer_usage/README.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2019-2021, Arm Limited and Contributors
+- Copyright (c) 2019-2022, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -148,7 +148,7 @@ In this application the differences between individual reset and pool reset are 
 ## Further reading
 
  * [Multi-threaded recording with multiple render passes](../multithreading_render_passes/README.md)
- * [Command Buffer Allocation and Management](https://vulkan.lunarg.com/doc/view/1.0.33.0/linux/vkspec.chunked/ch05s02.html)
+ * [Command Buffer Allocation and Management](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/chap6.html#commandbuffer-allocation)
  * [Command Buffer Lifecycle](https://www.khronos.org/registry/vulkan/specs/1.0-wsi_extensions/html/chap5.html#commandbuffers-lifecycle)
  * _"Writing an efficient Vulkan renderer"_ by Arseny Kapoulkine (from "GPU Zen 2: Advanced Rendering Techniques")
 

--- a/samples/performance/command_buffer_usage/README.md
+++ b/samples/performance/command_buffer_usage/README.md
@@ -147,7 +147,7 @@ In this application the differences between individual reset and pool reset are 
 
 ## Further reading
 
- * [Multi-threaded recording with multiple render passes](../multithreading_render_passes/multithreading_render_passes_tutorial.md)
+ * [Multi-threaded recording with multiple render passes](../multithreading_render_passes/README.md)
  * [Command Buffer Allocation and Management](https://vulkan.lunarg.com/doc/view/1.0.33.0/linux/vkspec.chunked/ch05s02.html)
  * [Command Buffer Lifecycle](https://www.khronos.org/registry/vulkan/specs/1.0-wsi_extensions/html/chap5.html#commandbuffers-lifecycle)
  * _"Writing an efficient Vulkan renderer"_ by Arseny Kapoulkine (from "GPU Zen 2: Advanced Rendering Techniques")

--- a/samples/performance/descriptor_management/README.md
+++ b/samples/performance/descriptor_management/README.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2019-2021, Arm Limited and Contributors
+- Copyright (c) 2019-2022, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/performance/descriptor_management/README.md
+++ b/samples/performance/descriptor_management/README.md
@@ -72,7 +72,7 @@ This system is reasonably easy to implement for a static scene, but it becomes h
 This may correspond to calling [vkFreeDescriptorSets()](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkFreeDescriptorSets.html), but this solution poses another issue: in order to free individual descriptor sets the pool has to be created with the `VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT` flag.
 Mobile implementations may use a simpler allocator if that flag is not set, relying on the fact that pool memory will only be recycled in block.
 
-It is possible to avoid using that flag by updating descriptor sets instead of deleting them. The application can keep track of recycled descriptor sets and re-use one of them when a new one is requested. The [subpasses sample](../subpasses/subpasses_tutorial.md) uses this approach when it re-creates the G-buffer images.
+It is possible to avoid using that flag by updating descriptor sets instead of deleting them. The application can keep track of recycled descriptor sets and re-use one of them when a new one is requested. The [subpasses sample](../subpasses/README.md) uses this approach when it re-creates the G-buffer images.
 
 ## Buffer management
 

--- a/samples/performance/layout_transitions/README.md
+++ b/samples/performance/layout_transitions/README.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2019-2021, Arm Limited and Contributors
+- Copyright (c) 2019-2022, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/performance/layout_transitions/README.md
+++ b/samples/performance/layout_transitions/README.md
@@ -78,7 +78,7 @@ The sample sets up deferred rendering using two render passes, to show the effec
 G-buffer images from `UNDEFINED` rather than their last known layout.
 
 Note that a deferred rendering implementation using subpasses might be more efficient overall;
-see [the subpasses tutorial](../subpasses/subpasses_tutorial.md) for more detail.
+see [the subpasses tutorial](../subpasses/README.md) for more detail.
 
 The base case is with all color images being transitioned from `UNDEFINED`, as shown in the image below.
 

--- a/samples/performance/msaa/README.md
+++ b/samples/performance/msaa/README.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2021, Arm Limited and Contributors
+- Copyright (c) 2021-2022, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/performance/msaa/README.md
+++ b/samples/performance/msaa/README.md
@@ -44,21 +44,21 @@ This results in different shades of primitive color at the edges, which reduces 
 In the figure above the samples within the pixel are positioned in a rotated grid. Sampling coordinates are defined by the [spec](https://www.khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/chap24.html#primsrast-multisampling). Irregular patterns achieve [better results](https://pdfs.semanticscholar.org/ebd9/ddb08c4244fc7df00672cacb420212cdde54.pdf) in horizontal and vertical edges.
 Note that MSAA has no effect for pixels within the primitive, where all samples store the same color value.
 
-MSAA is different from (and more efficient than) super-sampling anti-aliasing (SSAA) where the fragment shader is evaluated for each sample. This would help reduce aliasing within primitives, but usually [mip-maps](../../api/texture_mipmap_generation/texture_mipmap_generation_tutorial.md) mitigate this already.
+MSAA is different from (and more efficient than) super-sampling anti-aliasing (SSAA) where the fragment shader is evaluated for each sample. This would help reduce aliasing within primitives, but usually [mip-maps](../../api/texture_mipmap_generation/README.md) mitigate this already.
 
 To enable MSAA, first query [`vkPhysicalDeviceLimits`](http://khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/chap32.html#VkPhysicalDeviceLimits) to select a supported level of MSAA e.g. [`VK_SAMPLE_COUNT_4_BIT`](http://khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/chap32.html#VkSampleCountFlagBits), and use this when creating the multisampled attachment, as well as when setting the [`rasterizationSamples`](http://khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/chap24.html#VkPipelineMultisampleStateCreateInfo) member of [`pMultisampleState`](http://khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/chap9.html#VkGraphicsPipelineCreateInfo) in the graphics pipeline.
 As stated earlier for MSAA we do _not_ want to set [sample shading](http://khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/chap24.html#primsrast-sampleshading) as this will enable the more expensive SSAA.
 
 ## Color resolve
 
-4x MSAA can be particularly efficient in [tiler architectures](../pipeline_barriers/pipeline_barriers_tutorial.md#tile-based-rendering), where the multi-sampled attachment is resolved in tile memory and can therefore be transient.
-This is typically the case of the [depth buffer](../render_passes/render_passes_tutorial.md#depth-attachment-store-operation) as shown below:
+4x MSAA can be particularly efficient in [tiler architectures](../pipeline_barriers/README.md#tile-based-rendering), where the multi-sampled attachment is resolved in tile memory and can therefore be transient.
+This is typically the case of the [depth buffer](../render_passes/README.md#depth-attachment-store-operation) as shown below:
 
 ![No MSAA diagram](images/no_msaa.png)
 ![No MSAA sample](images/screenshot_no_msaa.jpg)
 
 It is important to avoid writing multisampled attachments back to main memory if they are not going to be needed after rendering the scene.
-This means that the multisampled attachment must use `storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE` and `usage |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT`, and allocate the image with the `LAZILY_ALLOCATED` memory property, as explained in the [Render Passes tutorial](../render_passes/render_passes_tutorial.md#depth-attachment-store-operation).
+This means that the multisampled attachment must use `storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE` and `usage |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT`, and allocate the image with the `LAZILY_ALLOCATED` memory property, as explained in the [Render Passes tutorial](../render_passes/README.md#depth-attachment-store-operation).
 
 ```
 // Multisampled attachment is transient
@@ -126,7 +126,7 @@ These counters can also be recorded with a profiler such as [Streamline](https:/
 ## Depth resolve
 
 In all of the cases shown above the depth buffer has remained transient, regardless of MSAA.
-This is because once the color is calculated and written out to the swapchain for presentation to the display, the depth can be discarded and therefore we recommend to [configure load/store operations to avoid writing it out](../render_passes/render_passes_tutorial.md#depth-attachment-store-operation).
+This is because once the color is calculated and written out to the swapchain for presentation to the display, the depth can be discarded and therefore we recommend to [configure load/store operations to avoid writing it out](../render_passes/README.md#depth-attachment-store-operation).
 
 There are cases where we might need to save the depth attachment. Consider a simple post-processing pass that samples both color and depth (bound as textures) in order to compute a screen-based effect such as [SSAO](https://en.wikipedia.org/wiki/Screen_space_ambient_occlusion):
 

--- a/samples/performance/multithreading_render_passes/README.md
+++ b/samples/performance/multithreading_render_passes/README.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2021, Arm Limited and Contributors
+- Copyright (c) 2021-2022, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/performance/multithreading_render_passes/README.md
+++ b/samples/performance/multithreading_render_passes/README.md
@@ -47,7 +47,7 @@ One way to use multi-threading with multiple render passes is to create a separa
 
 Another approach is to use secondary level command buffers. First, both of the passes are recorded into two separate secondary command buffers using two threads. Then, we can just reference them in the primary command buffer via ``vkCmdExecuteCommands``.
 
-When using both of these methods for multi-threading, general recommendations should still be taken into account (see [Multi-threaded-recording](https://github.com/KhronosGroup/Vulkan-Samples/blob/master/samples/performance/command_buffer_usage/command_buffer_usage_tutorial.md#Multi-threaded-recording)).
+When using both of these methods for multi-threading, general recommendations should still be taken into account (see [Multi-threaded-recording](https://github.com/KhronosGroup/Vulkan-Samples/blob/master/samples/performance/command_buffer_usage/README.md#Multi-threaded-recording)).
 
 This sample shows the difference between recording both render passes into a single command buffer in one thread and using the methods described above.
 
@@ -81,7 +81,7 @@ And indeed, in debug build, which was used for profiling, frame time is decrease
 
 ## Further reading
 
-[Command buffer usage and multi-threaded recording](../command_buffer_usage/command_buffer_usage_tutorial.md)
+[Command buffer usage and multi-threaded recording](../command_buffer_usage/README.md)
 
 ## Best practice summary
 

--- a/samples/performance/pipeline_barriers/README.md
+++ b/samples/performance/pipeline_barriers/README.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2019-2021, Arm Limited and Contributors
+- Copyright (c) 2019-2022, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/performance/pipeline_barriers/README.md
+++ b/samples/performance/pipeline_barriers/README.md
@@ -115,7 +115,7 @@ The app is fragment-bound, which allows the GPU to fully utilize pipelining.
 The sample sets up deferred rendering with two render passes and uses pipeline barriers to
 synchronize them.
 Note that a deferred rendering implementation using subpasses might be more efficient overall;
-see [the subpasses tutorial](../subpasses/subpasses_tutorial.md) for more detail.
+see [the subpasses tutorial](../subpasses/README.md) for more detail.
 
 The base case is with the most conservative barrier (`BOTTOM_OF_PIPE_BIT` → `TOP_OF_PIPE_BIT`).
 As the graphs show, vertex and fragment work are serialized, as they never happen at the same time.

--- a/samples/performance/render_passes/README.md
+++ b/samples/performance/render_passes/README.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2019-2021, Arm Limited and Contributors
+- Copyright (c) 2019-2022, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/performance/render_passes/README.md
+++ b/samples/performance/render_passes/README.md
@@ -61,7 +61,7 @@ Comparing the read bandwidth values (_External Read Bytes_ graph), we observe a 
 ![Using LOAD_OP_CLEAR](images/clear_store.jpg)
 
 We can estimate the bandwidth cost of loading/storing an uncompressed attachment as `width * height * bpp/8 * FPS [MiB/s]`. We calculate an estimate of `2220 * 1080 * (32/8) * ~60 = ~575 MiB/s`.
-The savings will be lower if the images are compressed, see [Enabling AFBC in your Vulkan Application](../afbc/afbc_tutorial.md).
+The savings will be lower if the images are compressed, see [Enabling AFBC in your Vulkan Application](../afbc/README.md).
 
 ## Depth attachment store operation
 

--- a/samples/performance/subpasses/README.md
+++ b/samples/performance/subpasses/README.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2019-2021, Arm Limited and Contributors
+- Copyright (c) 2019-2022, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/performance/subpasses/README.md
+++ b/samples/performance/subpasses/README.md
@@ -32,7 +32,7 @@ The _Subpasses sample_ implements a [deferred renderer](https://en.wikipedia.org
 
 The G-buffer layout used by the sample is below a limit of 128-bit per pixel of *tile buffer color storage* (more about that in the next section):
 
-* Lighting (`RGBA8_SRGB`), as attachment #0 will take advantage of [transaction elimination](https://developer.arm.com/solutions/graphics-and-gaming/resources/demos/transaction-elimination).
+* Lighting (`RGBA8_SRGB`), as attachment #0 will take advantage of [transaction elimination](https://www.arm.com/technologies/graphics-technologies/transaction-elimination).
 * Depth (`D32_SFLOAT`), which does not add up to the 128-bit limit.
 * Albedo (`RGBA8_UNORM`)
 * Normal (`RGB10A2_UNORM`)

--- a/samples/performance/subpasses/README.md
+++ b/samples/performance/subpasses/README.md
@@ -120,7 +120,7 @@ In practice, their [image usage](https://www.khronos.org/registry/vulkan/specs/1
 * Keep your G-buffer budget for color small.
 * Use `DEPTH_STENCIL_READ_ONLY` image layout for depth after the geometry pass is done.
 * Use `LAZILY_ALLOCATED` memory to back images for every attachment except for the light buffer, which is the only texture written out to memory.
-* Follow the basic [render pass best practices](../render_passes/render_passes_tutorial.md), with `LOAD_OP_CLEAR` or `LOAD_OP_DONT_CARE` for attachment loads and `STORE_OP_DONT_CARE` for transient stores.
+* Follow the basic [render pass best practices](../render_passes/README.md), with `LOAD_OP_CLEAR` or `LOAD_OP_DONT_CARE` for attachment loads and `STORE_OP_DONT_CARE` for transient stores.
 
 **Don't**
 


### PR DESCRIPTION
## Description

Fixes a few links, most related to the recent renaming in https://github.com/KhronosGroup/Vulkan-Samples/pull/403.

## General Checklist:

Please ensure the following points are checked:

- [n/a] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [n/a] I have commented any added functions (in line with Doxygen)
- [n/a] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [n/a] I have used existing framework/helper functions where possible
- [n/a] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [n/a] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making