### PR TITLE
Fix for multithreading_render_passes drawing garbage at times

### DIFF
--- a/framework/rendering/subpasses/geometry_subpass.cpp
+++ b/framework/rendering/subpasses/geometry_subpass.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -98,7 +98,7 @@ void GeometrySubpass::draw(CommandBuffer &command_buffer)
 
 		for (auto node_it = opaque_nodes.begin(); node_it != opaque_nodes.end(); node_it++)
 		{
-			update_uniform(command_buffer, *node_it->second.first);
+			update_uniform(command_buffer, *node_it->second.first, thread_index);
 
 			// Invert the front face if the mesh was flipped
 			const auto &scale      = node_it->second.first->get_transform().get_scale();
@@ -132,7 +132,7 @@ void GeometrySubpass::draw(CommandBuffer &command_buffer)
 
 		for (auto node_it = transparent_nodes.rbegin(); node_it != transparent_nodes.rend(); node_it++)
 		{
-			update_uniform(command_buffer, *node_it->second.first);
+			update_uniform(command_buffer, *node_it->second.first, thread_index);
 
 			draw_submesh(command_buffer, *node_it->second.second);
 		}

--- a/framework/rendering/subpasses/geometry_subpass.h
+++ b/framework/rendering/subpasses/geometry_subpass.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -91,7 +91,7 @@ class GeometrySubpass : public Subpass
 	void set_thread_index(uint32_t index);
 
   protected:
-	virtual void update_uniform(CommandBuffer &command_buffer, sg::Node &node, size_t thread_index = 0);
+	virtual void update_uniform(CommandBuffer &command_buffer, sg::Node &node, size_t thread_index);
 
 	void draw_submesh(CommandBuffer &command_buffer, sg::SubMesh &sub_mesh, VkFrontFace front_face = VK_FRONT_FACE_COUNTER_CLOCKWISE);
 

--- a/samples/performance/constant_data/constant_data.h
+++ b/samples/performance/constant_data/constant_data.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: MIT
  *
@@ -129,7 +129,7 @@ class ConstantData : public vkb::VulkanSample
 		/**
 		 * @brief Updates the MVP uniform member variable to then be pushed into the shader
 		 */
-		virtual void update_uniform(vkb::CommandBuffer &command_buffer, vkb::sg::Node &node, size_t thread_index = 0) override;
+		virtual void update_uniform(vkb::CommandBuffer &command_buffer, vkb::sg::Node &node, size_t thread_index) override;
 
 		/**
 		 * @brief Overridden to intentionally disable any dynamic shader module updates
@@ -161,7 +161,7 @@ class ConstantData : public vkb::VulkanSample
 		/**
 		 * @brief Creates a buffer filled with the mvp data and binds it
 		 */
-		virtual void update_uniform(vkb::CommandBuffer &command_buffer, vkb::sg::Node &node, size_t thread_index = 0) override;
+		virtual void update_uniform(vkb::CommandBuffer &command_buffer, vkb::sg::Node &node, size_t thread_index) override;
 
 		/**
 		 * @brief Dynamically retrieves the correct pipeline layout depending on the method of UBO
@@ -195,7 +195,7 @@ class ConstantData : public vkb::VulkanSample
 		/**
 		 * @brief No-op, uniform data is sent upfront before the draw call
 		 */
-		virtual void update_uniform(vkb::CommandBuffer &command_buffer, vkb::sg::Node &node, size_t thread_index = 0) override;
+		virtual void update_uniform(vkb::CommandBuffer &command_buffer, vkb::sg::Node &node, size_t thread_index) override;
 
 		/**
 		 * @brief Returns a default pipeline layout


### PR DESCRIPTION
## Description

PR #406 inadvertently removed the thread_index parameter to a couple of update_uniform() calls.

I've re-added those parameters and removed the default parameter value so that callers of those functions will need to consider what to pass in future.

Fixes #420
