### PR TITLE
Change vkb::core::HPPDevice from a facade over vkb::Device to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -39,8 +39,10 @@ set(FRAMEWORK_FILES
     timer.h
     camera.h
     hpp_api_vulkan_sample.h
+    hpp_fence_pool.h
     hpp_gltf_loader.h
     hpp_gui.h
+    hpp_resource_cache.h
     hpp_vulkan_sample.h
     # Source Files
     gui.cpp
@@ -75,6 +77,7 @@ set(COMMON_FILES
     common/utils.h
     common/strings.h
     common/tags.h
+    common/hpp_error.h
     common/hpp_strings.h
     common/hpp_utils.h
     common/hpp_vk_common.h
@@ -235,6 +238,7 @@ set(CORE_FILES
     core/shader_binding_table.h
     core/hpp_buffer.h
     core/hpp_command_buffer.h
+    core/hpp_command_pool.h
     core/hpp_debug.h
     core/hpp_device.h
     core/hpp_image.h
@@ -243,6 +247,7 @@ set(CORE_FILES
     core/hpp_physical_device.h
     core/hpp_queue.h
     core/hpp_swapchain.h
+    core/hpp_vulkan_resource.h
     core/vulkan_resource.h
     # Source Files
     core/instance.cpp
@@ -272,7 +277,8 @@ set(CORE_FILES
     core/scratch_buffer.cpp
     core/acceleration_structure.cpp
     core/shader_binding_table.cpp
-    core/vulkan_resource.cpp)
+    core/vulkan_resource.cpp
+    core/hpp_device.cpp)
 
 set(PLATFORM_FILES
     # Header Files

--- a/framework/common/hpp_error.h
+++ b/framework/common/hpp_error.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,29 +17,25 @@
 
 #pragma once
 
-#include <core/image_view.h>
+#include <common/error.h>
+
+#include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
-namespace core
+namespace common
 {
 /**
- * @brief facade class around vkb::core::ImageView, providing a vulkan.hpp-based interface
+ * @brief facade class around vkb::VulkanException, providing a vulkan.hpp-based interface
  *
- * See vkb::core::ImageView for documentation
+ * See vkb::VulkanException for documentation
  */
-class HPPImageView : private vkb::core::ImageView
+class HPPVulkanException : private vkb::VulkanException
 {
   public:
-	vk::Format get_format() const
-	{
-		return static_cast<vk::Format>(vkb::core::ImageView::get_format());
-	}
-
-	vk::ImageView get_handle() const
-	{
-		return static_cast<vk::ImageView>(vkb::core::ImageView::get_handle());
-	}
+	HPPVulkanException(vk::Result result, std::string const &msg = "Vulkan error") :
+	    vkb::VulkanException(static_cast<VkResult>(result), msg)
+	{}
 };
-}        // namespace core
+}        // namespace common
 }        // namespace vkb

--- a/framework/core/hpp_buffer.h
+++ b/framework/core/hpp_buffer.h
@@ -25,12 +25,14 @@ namespace vkb
 {
 namespace core
 {
+class HPPDevice;
+
 /**
  * @brief facade class around vkb::core::Buffer, providing a vulkan.hpp-based interface
  *
  * See vkb::core::Buffer for documentation
  */
-class HPPBuffer : protected vkb::core::Buffer
+class HPPBuffer : private vkb::core::Buffer
 {
   public:
 	using vkb::core::Buffer::convert_and_update;

--- a/framework/core/hpp_command_buffer.h
+++ b/framework/core/hpp_command_buffer.h
@@ -31,10 +31,17 @@ namespace core
  *
  * See vkb::CommandBuffer for documentation
  */
-class HPPCommandBuffer : protected vkb::CommandBuffer
+class HPPCommandBuffer : private vkb::CommandBuffer
 {
   public:
 	using vkb::CommandBuffer::end_render_pass;
+
+	enum class ResetMode
+	{
+		ResetPool,
+		ResetIndividually,
+		AlwaysAllocate,
+	};
 
 	vk::CommandBuffer get_handle() const
 	{

--- a/framework/core/hpp_command_pool.h
+++ b/framework/core/hpp_command_pool.h
@@ -1,0 +1,62 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <core/command_pool.h>
+
+namespace vkb
+{
+namespace rendering
+{
+class HPPRenderFrame;
+}
+
+namespace core
+{
+/**
+ * @brief facade class around vkb::CommandPool, providing a vulkan.hpp-based interface
+ *
+ * See vkb::CommandPool for documentation
+ */
+class HPPCommandPool : private vkb::CommandPool
+{
+  public:
+	HPPCommandPool(vkb::core::HPPDevice &                 device,
+	               uint32_t                               queue_family_index,
+	               vkb::rendering::HPPRenderFrame *       render_frame = nullptr,
+	               size_t                                 thread_index = 0,
+	               vkb::core::HPPCommandBuffer::ResetMode reset_mode   = vkb::core::HPPCommandBuffer::ResetMode::ResetPool) :
+	    vkb::CommandPool(reinterpret_cast<vkb::Device &>(device),
+	                     queue_family_index,
+	                     reinterpret_cast<vkb::RenderFrame *>(render_frame),
+	                     thread_index,
+	                     static_cast<vkb::CommandBuffer::ResetMode>(reset_mode))
+	{}
+
+	vk::CommandPool get_handle() const
+	{
+		return static_cast<vk::CommandPool>(vkb::CommandPool::get_handle());
+	}
+
+	vkb::core::HPPCommandBuffer &request_command_buffer(vk::CommandBufferLevel level = vk::CommandBufferLevel::ePrimary)
+	{
+		return reinterpret_cast<vkb::core::HPPCommandBuffer &>(vkb::CommandPool::request_command_buffer(static_cast<VkCommandBufferLevel>(level)));
+	}
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_debug.h
+++ b/framework/core/hpp_debug.h
@@ -29,7 +29,7 @@ namespace core
  *
  * See vkb::DebugUtils for documentation
  */
-class HPPDebugUtils : protected vkb::DebugUtils
+class HPPDebugUtils : private vkb::DebugUtils
 {
   public:
 	void set_debug_name(VkDevice     device,

--- a/framework/core/hpp_device.cpp
+++ b/framework/core/hpp_device.cpp
@@ -1,0 +1,506 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <common/hpp_error.h>
+#include <core/hpp_device.h>
+
+namespace vkb
+{
+namespace core
+{
+HPPDevice::HPPDevice(vkb::core::HPPPhysicalDevice &              gpu,
+                     vk::SurfaceKHR                              surface,
+                     std::unique_ptr<vkb::core::HPPDebugUtils> &&debug_utils,
+                     std::unordered_map<const char *, bool>      requested_extensions) :
+    HPPVulkanResource{nullptr, this},        // Recursive, but valid
+    debug_utils{std::move(debug_utils)},
+    gpu{gpu},
+    resource_cache{*this}
+{
+	LOGI("Selected GPU: {}", gpu.get_properties().deviceName);
+
+	// Prepare the device queues
+	std::vector<vk::QueueFamilyProperties> queue_family_properties = gpu.get_queue_family_properties();
+	std::vector<vk::DeviceQueueCreateInfo> queue_create_infos(queue_family_properties.size());
+	std::vector<std::vector<float>>        queue_priorities(queue_family_properties.size());
+
+	for (uint32_t queue_family_index = 0U; queue_family_index < queue_family_properties.size(); ++queue_family_index)
+	{
+		vk::QueueFamilyProperties const &queue_family_property = queue_family_properties[queue_family_index];
+
+		if (gpu.has_high_priority_graphics_queue())
+		{
+			uint32_t graphics_queue_family = get_queue_family_index(vk::QueueFlagBits::eGraphics);
+			if (graphics_queue_family == queue_family_index)
+			{
+				queue_priorities[queue_family_index].reserve(queue_family_property.queueCount);
+				queue_priorities[queue_family_index].push_back(1.0f);
+				for (uint32_t i = 1; i < queue_family_property.queueCount; i++)
+				{
+					queue_priorities[queue_family_index].push_back(0.5f);
+				}
+			}
+			else
+			{
+				queue_priorities[queue_family_index].resize(queue_family_property.queueCount, 0.5f);
+			}
+		}
+		else
+		{
+			queue_priorities[queue_family_index].resize(queue_family_property.queueCount, 0.5f);
+		}
+
+		vk::DeviceQueueCreateInfo &queue_create_info = queue_create_infos[queue_family_index];
+
+		queue_create_info.queueFamilyIndex = queue_family_index;
+		queue_create_info.queueCount       = queue_family_property.queueCount;
+		queue_create_info.pQueuePriorities = queue_priorities[queue_family_index].data();
+	}
+
+	// Check extensions to enable Vma Dedicated Allocation
+	device_extensions = gpu.get_handle().enumerateDeviceExtensionProperties();
+
+	// Display supported extensions
+	if (device_extensions.size() > 0)
+	{
+		LOGD("HPPDevice supports the following extensions:");
+		for (auto &extension : device_extensions)
+		{
+			LOGD("  \t{}", extension.extensionName);
+		}
+	}
+
+	bool can_get_memory_requirements = is_extension_supported(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+	bool has_dedicated_allocation    = is_extension_supported(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
+
+	if (can_get_memory_requirements && has_dedicated_allocation)
+	{
+		enabled_extensions.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+		enabled_extensions.push_back(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
+
+		LOGI("Dedicated Allocation enabled");
+	}
+
+	// For performance queries, we also use host query reset since queryPool resets cannot
+	// live in the same command buffer as beginQuery
+	if (is_extension_supported(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME) && is_extension_supported(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME))
+	{
+		auto perf_counter_features     = gpu.request_extension_features<vk::PhysicalDevicePerformanceQueryFeaturesKHR>();
+		auto host_query_reset_features = gpu.request_extension_features<vk::PhysicalDeviceHostQueryResetFeatures>();
+
+		if (perf_counter_features.performanceCounterQueryPools && host_query_reset_features.hostQueryReset)
+		{
+			enabled_extensions.push_back(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
+			enabled_extensions.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
+			LOGI("Performance query enabled");
+		}
+	}
+
+	// Check that extensions are supported before trying to create the device
+	std::vector<const char *> unsupported_extensions{};
+	for (auto &extension : requested_extensions)
+	{
+		if (is_extension_supported(extension.first))
+		{
+			enabled_extensions.emplace_back(extension.first);
+		}
+		else
+		{
+			unsupported_extensions.emplace_back(extension.first);
+		}
+	}
+
+	if (enabled_extensions.size() > 0)
+	{
+		LOGI("HPPDevice supports the following requested extensions:");
+		for (auto &extension : enabled_extensions)
+		{
+			LOGI("  \t{}", extension);
+		}
+	}
+
+	if (unsupported_extensions.size() > 0)
+	{
+		auto error = false;
+		for (auto &extension : unsupported_extensions)
+		{
+			auto extension_is_optional = requested_extensions[extension];
+			if (extension_is_optional)
+			{
+				LOGW("Optional device extension {} not available, some features may be disabled", extension);
+			}
+			else
+			{
+				LOGE("Required device extension {} not available, cannot run", extension);
+				error = true;
+			}
+		}
+
+		if (error)
+		{
+			throw vkb::common::HPPVulkanException(vk::Result::eErrorExtensionNotPresent, "Extensions not present");
+		}
+	}
+
+	vk::DeviceCreateInfo create_info({}, queue_create_infos, {}, enabled_extensions, &gpu.get_mutable_requested_features());
+
+	// Latest requested feature will have the pNext's all set up for device creation.
+	create_info.pNext = gpu.get_extension_feature_chain();
+
+	set_handle(gpu.get_handle().createDevice(create_info));
+
+	queues.resize(queue_family_properties.size());
+
+	for (uint32_t queue_family_index = 0U; queue_family_index < queue_family_properties.size(); ++queue_family_index)
+	{
+		vk::QueueFamilyProperties const &queue_family_property = queue_family_properties[queue_family_index];
+
+		vk::Bool32 present_supported = gpu.is_present_supported(surface, queue_family_index);
+
+		for (uint32_t queue_index = 0U; queue_index < queue_family_property.queueCount; ++queue_index)
+		{
+			queues[queue_family_index].emplace_back(*this, queue_family_index, queue_family_property, present_supported, queue_index);
+		}
+	}
+
+	VmaVulkanFunctions vma_vulkan_func{};
+	vma_vulkan_func.vkAllocateMemory                    = reinterpret_cast<PFN_vkAllocateMemory>(get_handle().getProcAddr("vkAllocateMemory"));
+	vma_vulkan_func.vkBindBufferMemory                  = reinterpret_cast<PFN_vkBindBufferMemory>(get_handle().getProcAddr("vkBindBufferMemory"));
+	vma_vulkan_func.vkBindImageMemory                   = reinterpret_cast<PFN_vkBindImageMemory>(get_handle().getProcAddr("vkBindImageMemory"));
+	vma_vulkan_func.vkCreateBuffer                      = reinterpret_cast<PFN_vkCreateBuffer>(get_handle().getProcAddr("vkCreateBuffer"));
+	vma_vulkan_func.vkCreateImage                       = reinterpret_cast<PFN_vkCreateImage>(get_handle().getProcAddr("vkCreateImage"));
+	vma_vulkan_func.vkDestroyBuffer                     = reinterpret_cast<PFN_vkDestroyBuffer>(get_handle().getProcAddr("vkDestroyBuffer"));
+	vma_vulkan_func.vkDestroyImage                      = reinterpret_cast<PFN_vkDestroyImage>(get_handle().getProcAddr("vkDestroyImage"));
+	vma_vulkan_func.vkFlushMappedMemoryRanges           = reinterpret_cast<PFN_vkFlushMappedMemoryRanges>(get_handle().getProcAddr("vkFlushMappedMemoryRanges"));
+	vma_vulkan_func.vkFreeMemory                        = reinterpret_cast<PFN_vkFreeMemory>(get_handle().getProcAddr("vkFreeMemory"));
+	vma_vulkan_func.vkGetBufferMemoryRequirements       = reinterpret_cast<PFN_vkGetBufferMemoryRequirements>(get_handle().getProcAddr("vkGetBufferMemoryRequirements"));
+	vma_vulkan_func.vkGetImageMemoryRequirements        = reinterpret_cast<PFN_vkGetImageMemoryRequirements>(get_handle().getProcAddr("vkGetImageMemoryRequirements"));
+	vma_vulkan_func.vkGetPhysicalDeviceMemoryProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties>(get_handle().getProcAddr("vkGetPhysicalDeviceMemoryProperties"));
+	vma_vulkan_func.vkGetPhysicalDeviceProperties       = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(get_handle().getProcAddr("vkGetPhysicalDeviceProperties"));
+	vma_vulkan_func.vkInvalidateMappedMemoryRanges      = reinterpret_cast<PFN_vkInvalidateMappedMemoryRanges>(get_handle().getProcAddr("vkInvalidateMappedMemoryRanges"));
+	vma_vulkan_func.vkMapMemory                         = reinterpret_cast<PFN_vkMapMemory>(get_handle().getProcAddr("vkMapMemory"));
+	vma_vulkan_func.vkUnmapMemory                       = reinterpret_cast<PFN_vkUnmapMemory>(get_handle().getProcAddr("vkUnmapMemory"));
+	vma_vulkan_func.vkCmdCopyBuffer                     = reinterpret_cast<PFN_vkCmdCopyBuffer>(get_handle().getProcAddr("vkCmdCopyBuffer"));
+
+	VmaAllocatorCreateInfo allocator_info{};
+	allocator_info.physicalDevice = static_cast<VkPhysicalDevice>(gpu.get_handle());
+	allocator_info.device         = static_cast<VkDevice>(get_handle());
+	allocator_info.instance       = static_cast<VkInstance>(gpu.get_instance().get_handle());
+
+	if (can_get_memory_requirements && has_dedicated_allocation)
+	{
+		allocator_info.flags |= VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
+		vma_vulkan_func.vkGetBufferMemoryRequirements2KHR = vkGetBufferMemoryRequirements2KHR;
+		vma_vulkan_func.vkGetImageMemoryRequirements2KHR  = vkGetImageMemoryRequirements2KHR;
+	}
+
+	if (is_extension_supported(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME) && is_enabled(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME))
+	{
+		allocator_info.flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
+	}
+
+	allocator_info.pVulkanFunctions = &vma_vulkan_func;
+
+	VkResult result = vmaCreateAllocator(&allocator_info, &memory_allocator);
+
+	if (result != VK_SUCCESS)
+	{
+		throw VulkanException{result, "Cannot create allocator"};
+	}
+
+	command_pool = std::make_unique<vkb::core::HPPCommandPool>(
+	    *this, get_queue_by_flags(vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute, 0).get_family_index());
+	fence_pool = std::make_unique<vkb::HPPFencePool>(*this);
+}
+
+HPPDevice::~HPPDevice()
+{
+	resource_cache.clear();
+
+	command_pool.reset();
+	fence_pool.reset();
+
+	if (memory_allocator != VK_NULL_HANDLE)
+	{
+		VmaStats stats;
+		vmaCalculateStats(memory_allocator, &stats);
+
+		LOGI("Total device memory leaked: {} bytes.", stats.total.usedBytes);
+
+		vmaDestroyAllocator(memory_allocator);
+	}
+
+	if (get_handle())
+	{
+		get_handle().destroy();
+	}
+}
+
+bool HPPDevice::is_extension_supported(std::string const &requested_extension) const
+{
+	return std::find_if(device_extensions.begin(),
+	                    device_extensions.end(),
+	                    [requested_extension](auto &device_extension) { return std::strcmp(device_extension.extensionName, requested_extension.c_str()) == 0; }) != device_extensions.end();
+}
+
+bool HPPDevice::is_enabled(std::string const &extension) const
+{
+	return std::find_if(enabled_extensions.begin(),
+	                    enabled_extensions.end(),
+	                    [extension](const char *enabled_extension) { return extension == enabled_extension; }) != enabled_extensions.end();
+}
+
+vkb::core::HPPPhysicalDevice const &HPPDevice::get_gpu() const
+{
+	return gpu;
+}
+
+VmaAllocator const &HPPDevice::get_memory_allocator() const
+{
+	return memory_allocator;
+}
+
+vkb::core::HPPDebugUtils const &HPPDevice::get_debug_utils() const
+{
+	return *debug_utils;
+}
+
+vkb::core::HPPQueue const &HPPDevice::get_queue(uint32_t queue_family_index, uint32_t queue_index) const
+{
+	return queues[queue_family_index][queue_index];
+}
+
+vkb::core::HPPQueue const &HPPDevice::get_queue_by_flags(vk::QueueFlags required_queue_flags, uint32_t queue_index) const
+{
+	for (size_t queue_family_index = 0U; queue_family_index < queues.size(); ++queue_family_index)
+	{
+		vkb::core::HPPQueue const &first_queue = queues[queue_family_index][0];
+
+		vk::QueueFlags queue_flags = first_queue.get_properties().queueFlags;
+		uint32_t       queue_count = first_queue.get_properties().queueCount;
+
+		if (((queue_flags & required_queue_flags) == required_queue_flags) && queue_index < queue_count)
+		{
+			return queues[queue_family_index][queue_index];
+		}
+	}
+
+	throw std::runtime_error("Queue not found");
+}
+
+vkb::core::HPPQueue const &HPPDevice::get_queue_by_present(uint32_t queue_index) const
+{
+	for (uint32_t queue_family_index = 0U; queue_family_index < queues.size(); ++queue_family_index)
+	{
+		vkb::core::HPPQueue const &first_queue = queues[queue_family_index][0];
+
+		uint32_t queue_count = first_queue.get_properties().queueCount;
+
+		if (first_queue.support_present() && queue_index < queue_count)
+		{
+			return queues[queue_family_index][queue_index];
+		}
+	}
+
+	throw std::runtime_error("Queue not found");
+}
+
+uint32_t HPPDevice::get_queue_family_index(vk::QueueFlagBits queue_flag) const
+{
+	const auto &queue_family_properties = gpu.get_queue_family_properties();
+
+	// Dedicated queue for compute
+	// Try to find a queue family index that supports compute but not graphics
+	if (queue_flag & vk::QueueFlagBits::eCompute)
+	{
+		for (uint32_t i = 0; i < static_cast<uint32_t>(queue_family_properties.size()); i++)
+		{
+			if ((queue_family_properties[i].queueFlags & queue_flag) && !(queue_family_properties[i].queueFlags & vk::QueueFlagBits::eGraphics))
+			{
+				return i;
+				break;
+			}
+		}
+	}
+
+	// Dedicated queue for transfer
+	// Try to find a queue family index that supports transfer but not graphics and compute
+	if (queue_flag & vk::QueueFlagBits::eTransfer)
+	{
+		for (uint32_t i = 0; i < static_cast<uint32_t>(queue_family_properties.size()); i++)
+		{
+			if ((queue_family_properties[i].queueFlags & queue_flag) && !(queue_family_properties[i].queueFlags & vk::QueueFlagBits::eGraphics) &&
+			    !(queue_family_properties[i].queueFlags & vk::QueueFlagBits::eCompute))
+			{
+				return i;
+				break;
+			}
+		}
+	}
+
+	// For other queue types or if no separate compute queue is present, return the first one to support the requested
+	// flags
+	for (uint32_t i = 0; i < static_cast<uint32_t>(queue_family_properties.size()); i++)
+	{
+		if (queue_family_properties[i].queueFlags & queue_flag)
+		{
+			return i;
+			break;
+		}
+	}
+
+	throw std::runtime_error("Could not find a matching queue family index");
+}
+
+vkb::core::HPPQueue const &HPPDevice::get_suitable_graphics_queue() const
+{
+	for (size_t queue_family_index = 0U; queue_family_index < queues.size(); ++queue_family_index)
+	{
+		vkb::core::HPPQueue const &first_queue = queues[queue_family_index][0];
+
+		uint32_t queue_count = first_queue.get_properties().queueCount;
+
+		if (first_queue.support_present() && 0 < queue_count)
+		{
+			return queues[queue_family_index][0];
+		}
+	}
+
+	return get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);
+}
+
+std::pair<vk::Buffer, vk::DeviceMemory> HPPDevice::create_buffer(vk::BufferUsageFlags usage, vk::MemoryPropertyFlags properties, vk::DeviceSize size, void *data) const
+{
+	// Create the buffer handle
+	vk::BufferCreateInfo buffer_create_info({}, size, usage, vk::SharingMode::eExclusive);
+	vk::Buffer           buffer = get_handle().createBuffer(buffer_create_info);
+
+	// Create the memory backing up the buffer handle
+	vk::MemoryRequirements memory_requirements = get_handle().getBufferMemoryRequirements(buffer);
+	vk::MemoryAllocateInfo memory_allocation(memory_requirements.size, get_gpu().get_memory_type(memory_requirements.memoryTypeBits, properties));
+	vk::DeviceMemory       memory = get_handle().allocateMemory(memory_allocation);
+
+	// If a pointer to the buffer data has been passed, map the buffer and copy over the
+	if (data != nullptr)
+	{
+		void *mapped = get_handle().mapMemory(memory, 0, size);
+		memcpy(mapped, data, static_cast<size_t>(size));
+		// If host coherency hasn't been requested, do a manual flush to make writes visible
+		if (!(properties & vk::MemoryPropertyFlagBits::eHostCoherent))
+		{
+			vk::MappedMemoryRange mapped_range(memory, 0, size);
+			get_handle().flushMappedMemoryRanges(mapped_range);
+		}
+		get_handle().unmapMemory(memory);
+	}
+
+	// Attach the memory to the buffer object
+	get_handle().bindBufferMemory(buffer, memory, 0);
+
+	return std::make_pair(buffer, memory);
+}
+
+void HPPDevice::copy_buffer(vkb::core::HPPBuffer &src, vkb::core::HPPBuffer &dst, vk::Queue queue, vk::BufferCopy *copy_region) const
+{
+	assert(dst.get_size() <= src.get_size());
+	assert(src.get_handle());
+
+	vk::CommandBuffer command_buffer = create_command_buffer(vk::CommandBufferLevel::ePrimary, true);
+
+	vk::BufferCopy buffer_copy{};
+	if (copy_region)
+	{
+		buffer_copy = *copy_region;
+	}
+	else
+	{
+		buffer_copy.size = src.get_size();
+	}
+
+	command_buffer.copyBuffer(src.get_handle(), dst.get_handle(), buffer_copy);
+
+	flush_command_buffer(command_buffer, queue);
+}
+
+vk::CommandBuffer HPPDevice::create_command_buffer(vk::CommandBufferLevel level, bool begin) const
+{
+	assert(command_pool && "No command pool exists in the device");
+
+	vk::CommandBuffer command_buffer = get_handle().allocateCommandBuffers({command_pool->get_handle(), level, 1}).front();
+
+	// If requested, also start recording for the new command buffer
+	if (begin)
+	{
+		command_buffer.begin(vk::CommandBufferBeginInfo());
+	}
+
+	return command_buffer;
+}
+
+void HPPDevice::flush_command_buffer(vk::CommandBuffer command_buffer, vk::Queue queue, bool free, vk::Semaphore signalSemaphore) const
+{
+	if (!command_buffer)
+	{
+		return;
+	}
+
+	command_buffer.end();
+
+	vk::SubmitInfo submit_info({}, {}, command_buffer);
+	if (signalSemaphore)
+	{
+		submit_info.setSignalSemaphores(signalSemaphore);
+	}
+
+	// Create fence to ensure that the command buffer has finished executing
+	vk::Fence fence = get_handle().createFence({});
+
+	// Submit to the queue
+	queue.submit(submit_info, fence);
+
+	// Wait for the fence to signal that command buffer has finished executing
+	vk::Result result = get_handle().waitForFences(fence, true, DEFAULT_FENCE_TIMEOUT);
+	if (result != vk::Result::eSuccess)
+	{
+		LOGE("Detected Vulkan error: {}", vkb::to_string(result));
+		abort();
+	}
+
+	get_handle().destroyFence(fence);
+
+	if (command_pool && free)
+	{
+		get_handle().freeCommandBuffers(command_pool->get_handle(), command_buffer);
+	}
+}
+
+vkb::core::HPPCommandPool const &HPPDevice::get_command_pool() const
+{
+	return *command_pool;
+}
+
+vkb::HPPFencePool const &HPPDevice::get_fence_pool() const
+{
+	return *fence_pool;
+}
+
+vkb::HPPResourceCache const &HPPDevice::get_resource_cache() const
+{
+	return resource_cache;
+}
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_device.h
+++ b/framework/core/hpp_device.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,82 +17,137 @@
 
 #pragma once
 
-#include <core/device.h>
-
+#include <core/hpp_buffer.h>
+#include <core/hpp_command_buffer.h>
+#include <core/hpp_command_pool.h>
 #include <core/hpp_debug.h>
 #include <core/hpp_physical_device.h>
 #include <core/hpp_queue.h>
+#include <core/hpp_vulkan_resource.h>
+#include <hpp_fence_pool.h>
+#include <hpp_resource_cache.h>
 #include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
 namespace core
 {
-/**
- * @brief facade class around vkb::Device, providing a vulkan.hpp-based interface
- *
- * See vkb::Device for documentation
- */
-class HPPDevice : protected vkb::Device
+class HPPDevice : public vkb::core::HPPVulkanResource<vk::Device>
 {
   public:
-	using vkb::Device::get_driver_version;
-	using vkb::Device::get_memory_allocator;
-
+	/**
+   * @brief HPPDevice constructor
+   * @param gpu A valid Vulkan physical device and the requested gpu features
+   * @param surface The surface
+   * @param debug_utils The debug utils to be associated to this device
+   * @param requested_extensions (Optional) List of required device extensions and whether support is optional or not
+   */
 	HPPDevice(vkb::core::HPPPhysicalDevice &              gpu,
 	          vk::SurfaceKHR                              surface,
 	          std::unique_ptr<vkb::core::HPPDebugUtils> &&debug_utils,
-	          std::unordered_map<const char *, bool>      requested_extensions = {}) :
-	    vkb::Device(reinterpret_cast<vkb::PhysicalDevice &>(gpu),
-	                static_cast<VkSurfaceKHR>(surface),
-	                std::unique_ptr<vkb::DebugUtils>(reinterpret_cast<vkb::DebugUtils *>(debug_utils.release())),
-	                std::move(requested_extensions))
-	{}
+	          std::unordered_map<const char *, bool>      requested_extensions = {});
 
-	vk::CommandBuffer create_command_buffer(vk::CommandBufferLevel level, bool begin = false) const
-	{
-		return vkb::Device::create_command_buffer(static_cast<VkCommandBufferLevel>(level), begin);
-	}
+	HPPDevice(const HPPDevice &) = delete;
 
-	void flush_command_buffer(vk::CommandBuffer command_buffer, vk::Queue queue, bool free = true, vk::Semaphore signalSemaphore = nullptr) const
-	{
-		vkb::Device::flush_command_buffer(command_buffer, queue, free, signalSemaphore);
-	}
+	HPPDevice(HPPDevice &&) = delete;
 
-	vk::Device get_handle() const
-	{
-		return vkb::Device::get_handle();
-	}
+	~HPPDevice();
 
-	vkb::core::HPPPhysicalDevice const &get_gpu() const
-	{
-		return reinterpret_cast<vkb::core::HPPPhysicalDevice const &>(vkb::Device::get_gpu());
-	}
+	HPPDevice &operator=(const HPPDevice &) = delete;
 
-	uint32_t get_memory_type(uint32_t bits, vk::MemoryPropertyFlags properties, vk::Bool32 *memory_type_found = nullptr) const
-	{
-		return vkb::Device::get_memory_type(bits, static_cast<VkMemoryPropertyFlags>(properties), memory_type_found);
-	}
+	HPPDevice &operator=(HPPDevice &&) = delete;
 
-	vkb::core::HPPQueue const &get_queue_by_flags(vk::QueueFlags queue_flags, uint32_t queue_index) const
-	{
-		return reinterpret_cast<vkb::core::HPPQueue const &>(vkb::Device::get_queue_by_flags(static_cast<VkQueueFlags>(queue_flags), queue_index));
-	}
+	vkb::core::HPPPhysicalDevice const &get_gpu() const;
 
-	vkb::core::HPPQueue const &get_queue_by_present(uint32_t queue_index) const
-	{
-		return reinterpret_cast<vkb::core::HPPQueue const &>(vkb::Device::get_queue_by_present(queue_index));
-	}
+	VmaAllocator const &get_memory_allocator() const;
 
-	vkb::core::HPPQueue const &get_suitable_graphics_queue() const
-	{
-		return reinterpret_cast<vkb::core::HPPQueue const &>(vkb::Device::get_suitable_graphics_queue());
-	}
+	/**
+   * @brief Returns the debug utils associated with this HPPDevice.
+   */
+	vkb::core::HPPDebugUtils const &get_debug_utils() const;
 
-	vk::Result wait_idle() const
-	{
-		return static_cast<vk::Result>(vkb::Device::wait_idle());
-	}
+	vkb::core::HPPQueue const &get_queue(uint32_t queue_family_index, uint32_t queue_index) const;
+
+	vkb::core::HPPQueue const &get_queue_by_flags(vk::QueueFlags queue_flags, uint32_t queue_index) const;
+
+	vkb::core::HPPQueue const &get_queue_by_present(uint32_t queue_index) const;
+
+	/**
+   * @brief Finds a suitable graphics queue to submit to
+   * @return The first present supported queue, otherwise just any graphics queue
+   */
+	vkb::core::HPPQueue const &get_suitable_graphics_queue() const;
+
+	bool is_extension_supported(std::string const &extension) const;
+
+	bool is_enabled(std::string const &extension) const;
+
+	uint32_t get_queue_family_index(vk::QueueFlagBits queue_flag) const;
+
+	vkb::core::HPPCommandPool const &get_command_pool() const;
+
+	/**
+   * @brief Creates a vulkan buffer
+   * @param usage The buffer usage
+   * @param properties The memory properties
+   * @param size The size of the buffer
+   * @param data The data to place inside the buffer
+   * @returns A valid vk::Buffer and a corresponding vk::DeviceMemory
+   */
+	std::pair<vk::Buffer, vk::DeviceMemory> create_buffer(vk::BufferUsageFlags usage, vk::MemoryPropertyFlags properties, vk::DeviceSize size, void *data = nullptr) const;
+
+	/**
+   * @brief Copies a buffer from one to another
+   * @param src The buffer to copy from
+   * @param dst The buffer to copy to
+   * @param queue The queue to submit the copy command to
+   * @param copy_region The amount to copy, if null copies the entire buffer
+   */
+	void copy_buffer(vkb::core::HPPBuffer &src, vkb::core::HPPBuffer &dst, vk::Queue queue, vk::BufferCopy *copy_region = nullptr) const;
+
+	/**
+   * @brief Requests a command buffer from the device's command pool
+   * @param level The command buffer level
+   * @param begin Whether the command buffer should be implictly started before it's returned
+   * @returns A valid vk::CommandBuffer
+   */
+	vk::CommandBuffer create_command_buffer(vk::CommandBufferLevel level, bool begin = false) const;
+
+	/**
+   * @brief Submits and frees up a given command buffer
+   * @param command_buffer The command buffer
+   * @param queue The queue to submit the work to
+   * @param free Whether the command buffer should be implictly freed up
+   * @param signalSemaphore An optional semaphore to signal when the commands have been executed
+   */
+	void flush_command_buffer(vk::CommandBuffer command_buffer, vk::Queue queue, bool free = true, vk::Semaphore signalSemaphore = VK_NULL_HANDLE) const;
+
+	vkb::HPPFencePool const &get_fence_pool() const;
+
+	vkb::HPPResourceCache const &get_resource_cache() const;
+
+  private:
+	vkb::core::HPPPhysicalDevice const &gpu;
+
+	vk::SurfaceKHR surface{nullptr};
+
+	std::unique_ptr<vkb::core::HPPDebugUtils> debug_utils;
+
+	std::vector<vk::ExtensionProperties> device_extensions;
+
+	std::vector<const char *> enabled_extensions{};
+
+	VmaAllocator memory_allocator{VK_NULL_HANDLE};
+
+	std::vector<std::vector<vkb::core::HPPQueue>> queues;
+
+	/// A command pool associated to the primary queue
+	std::unique_ptr<vkb::core::HPPCommandPool> command_pool;
+
+	/// A fence pool associated to the primary queue
+	std::unique_ptr<vkb::HPPFencePool> fence_pool;
+
+	vkb::HPPResourceCache resource_cache;
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_image.h
+++ b/framework/core/hpp_image.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -28,7 +28,7 @@ namespace core
  *
  * See vkb::core::Image for documentation
  */
-class HPPImage : protected Image
+class HPPImage : private Image
 {
   public:
 	vk::Image get_handle() const

--- a/framework/core/hpp_instance.h
+++ b/framework/core/hpp_instance.h
@@ -25,12 +25,14 @@ namespace vkb
 {
 namespace core
 {
+class HPPPhysicalDevice;
+
 /**
  * @brief facade class around vkb::Instance, providing a vulkan.hpp-based interface
  *
  * See vkb::Instance for documentation
  */
-class HPPInstance : protected vkb::Instance
+class HPPInstance : private vkb::Instance
 {
   public:
 	using vkb::Instance::is_enabled;

--- a/framework/core/hpp_physical_device.h
+++ b/framework/core/hpp_physical_device.h
@@ -18,21 +18,65 @@
 #pragma once
 
 #include <core/physical_device.h>
+
+#include <core/hpp_instance.h>
 #include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
 namespace core
 {
+class HPPInstance;
+
+struct DriverVersion
+{
+	uint16_t major;
+	uint16_t minor;
+	uint16_t patch;
+};
+
 /**
  * @brief facade class around vkb::PhysicalDevice, providing a vulkan.hpp-based interface
  *
  * See vkb::PhysicalDevice for documentation
  */
-class HPPPhysicalDevice : protected vkb::PhysicalDevice
+class HPPPhysicalDevice : private vkb::PhysicalDevice
 {
   public:
+	using vkb::PhysicalDevice::get_extension_feature_chain;
+	using vkb::PhysicalDevice::has_high_priority_graphics_queue;
 	using vkb::PhysicalDevice::set_high_priority_graphics_queue_enable;
+
+	/**
+   * @return The version of the driver
+   */
+	DriverVersion get_driver_version() const
+	{
+		DriverVersion version;
+
+		vk::PhysicalDeviceProperties const &properties = get_properties();
+		switch (properties.vendorID)
+		{
+			case 0x10DE:
+				// Nvidia
+				version.major = (properties.driverVersion >> 22) & 0x3ff;
+				version.minor = (properties.driverVersion >> 14) & 0x0ff;
+				version.patch = (properties.driverVersion >> 6) & 0x0ff;
+				// Ignoring optional tertiary info in lower 6 bits
+				break;
+			case 0x8086:
+				version.major = (properties.driverVersion >> 14) & 0x3ffff;
+				version.minor = properties.driverVersion & 0x3ffff;
+				break;
+			default:
+				version.major = VK_VERSION_MAJOR(properties.driverVersion);
+				version.minor = VK_VERSION_MINOR(properties.driverVersion);
+				version.patch = VK_VERSION_PATCH(properties.driverVersion);
+				break;
+		}
+
+		return version;
+	}
 
 	vk::PhysicalDeviceFeatures const &get_features() const
 	{
@@ -44,14 +88,94 @@ class HPPPhysicalDevice : protected vkb::PhysicalDevice
 		return vkb::PhysicalDevice::get_handle();
 	}
 
+	vkb::core::HPPInstance &get_instance() const
+	{
+		return reinterpret_cast<vkb::core::HPPInstance &>(vkb::PhysicalDevice::get_instance());
+	}
+
+	vk::PhysicalDeviceMemoryProperties const &get_memory_properties() const
+	{
+		return reinterpret_cast<vk::PhysicalDeviceMemoryProperties const &>(vkb::PhysicalDevice::get_memory_properties());
+	}
+
+	/**
+   * @brief Checks that a given memory type is supported by the GPU
+   * @param bits The memory requirement type bits
+   * @param properties The memory property to search for
+   * @param memory_type_found True if found, false if not found
+   * @returns The memory type index of the found memory type
+   */
+	uint32_t get_memory_type(uint32_t bits, vk::MemoryPropertyFlags properties, vk::Bool32 *memory_type_found = nullptr) const
+	{
+		vk::PhysicalDeviceMemoryProperties const &memory_properties = get_memory_properties();
+		for (uint32_t i = 0; i < memory_properties.memoryTypeCount; i++)
+		{
+			if ((bits & 1) == 1)
+			{
+				if ((memory_properties.memoryTypes[i].propertyFlags & properties) == properties)
+				{
+					if (memory_type_found)
+					{
+						*memory_type_found = true;
+					}
+					return i;
+				}
+			}
+			bits >>= 1;
+		}
+
+		if (memory_type_found)
+		{
+			*memory_type_found = false;
+			return ~0;
+		}
+		else
+		{
+			throw std::runtime_error("Could not find a matching memory type");
+		}
+	}
+
 	vk::PhysicalDeviceFeatures &get_mutable_requested_features()
 	{
-		return *reinterpret_cast<vk::PhysicalDeviceFeatures *>(&vkb::PhysicalDevice::get_mutable_requested_features());
+		return reinterpret_cast<vk::PhysicalDeviceFeatures &>(vkb::PhysicalDevice::get_mutable_requested_features());
 	}
 
 	vk::PhysicalDeviceProperties const &get_properties() const
 	{
-		return *reinterpret_cast<vk::PhysicalDeviceProperties const *>(&vkb::PhysicalDevice::get_properties());
+		return reinterpret_cast<vk::PhysicalDeviceProperties const &>(vkb::PhysicalDevice::get_properties());
+	}
+
+	std::vector<vk::QueueFamilyProperties> const &get_queue_family_properties() const
+	{
+		return reinterpret_cast<std::vector<vk::QueueFamilyProperties> const &>(vkb::PhysicalDevice::get_queue_family_properties());
+	}
+
+	/**
+   * @return Whether an image format is supported by the GPU
+   */
+	bool is_image_format_supported(vk::Format format) const
+	{
+		try
+		{
+			get_handle().getImageFormatProperties(format, vk::ImageType::e2D, vk::ImageTiling::eOptimal, vk::ImageUsageFlagBits::eSampled);
+		}
+		catch (vk::SystemError &err)
+		{
+			return err.code() != vk::make_error_code(vk::Result::eErrorFormatNotSupported);
+		}
+		return true;
+	}
+
+	vk::Bool32 is_present_supported(vk::SurfaceKHR surface, uint32_t queue_family_index) const
+	{
+		return static_cast<vk::Bool32>(vkb::PhysicalDevice::is_present_supported(static_cast<VkSurfaceKHR>(surface), queue_family_index));
+	}
+
+	template <typename HPPStructureType>
+	HPPStructureType &request_extension_features()
+	{
+		return reinterpret_cast<HPPStructureType &>(vkb::PhysicalDevice::request_extension_features<typename HPPStructureType::NativeType>(
+		    static_cast<VkStructureType>(HPPStructureType::structureType)));
 	}
 };
 }        // namespace core

--- a/framework/core/hpp_queue.h
+++ b/framework/core/hpp_queue.h
@@ -28,19 +28,37 @@ namespace core
  *
  * See vkb::Queue for documentation
  */
-class HPPQueue : protected vkb::Queue
+class HPPQueue : private vkb::Queue
 {
   public:
 	using vkb::Queue::get_family_index;
+
+	HPPQueue(vkb::core::HPPDevice &device, uint32_t family_index, vk::QueueFamilyProperties properties, vk::Bool32 can_present, uint32_t index) :
+	    vkb::Queue(reinterpret_cast<vkb::Device &>(device),
+	               family_index,
+	               static_cast<VkQueueFamilyProperties>(properties),
+	               static_cast<VkBool32>(can_present),
+	               index)
+	{}
 
 	vk::Queue get_handle() const
 	{
 		return vkb::Queue::get_handle();
 	}
 
+	vk::QueueFamilyProperties const &get_properties() const
+	{
+		return reinterpret_cast<vk::QueueFamilyProperties const &>(vkb::Queue::get_properties());
+	}
+
 	vk::Result present(const vk::PresentInfoKHR &present_infos) const
 	{
 		return static_cast<vk::Result>(vkb::Queue::present(reinterpret_cast<VkPresentInfoKHR const &>(present_infos)));
+	}
+
+	vk::Bool32 support_present() const
+	{
+		return static_cast<vk::Bool32>(vkb::Queue::support_present());
 	}
 
 	vk::Result wait_idle() const

--- a/framework/core/hpp_swapchain.h
+++ b/framework/core/hpp_swapchain.h
@@ -28,7 +28,7 @@ namespace core
  *
  * See vkb::Swapchain for documentation
  */
-class HPPSwapchain : protected vkb::Swapchain
+class HPPSwapchain : private vkb::Swapchain
 {
   public:
 	vk::Result acquire_next_image(uint32_t &image_index, vk::Semaphore image_acquired_semaphore, vk::Fence fence = nullptr) const

--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <core/vulkan_resource.h>
+
+namespace vkb
+{
+namespace core
+{
+class HPPDevice;
+
+/**
+ * @brief facade class around vkb::VulkanResource, providing a vulkan.hpp-based interface
+ *
+ * See vkb::VulkanResource for documentation
+ */
+template <typename HPPHandle, typename Device = vkb::core::HPPDevice>
+class HPPVulkanResource : private vkb::core::VulkanResource<typename HPPHandle::NativeType, static_cast<VkObjectType>(HPPHandle::objectType), Device>
+{
+  public:
+	HPPVulkanResource(HPPHandle handle = nullptr, vkb::core::HPPDevice *device = nullptr) :
+	    vkb::core::VulkanResource<typename HPPHandle::NativeType, static_cast<VkObjectType>(HPPHandle::objectType), Device>(handle, device)
+	{}
+
+	HPPHandle const &get_handle() const
+	{
+		return reinterpret_cast<HPPHandle const &>(
+		    vkb::core::VulkanResource<typename HPPHandle::NativeType, static_cast<VkObjectType>(HPPHandle::objectType), Device>::get_handle());
+	}
+
+  protected:
+	void set_handle(HPPHandle hppHandle)
+	{
+		vkb::core::VulkanResource<typename HPPHandle::NativeType, static_cast<VkObjectType>(HPPHandle::objectType), Device>::handle =
+		    static_cast<typename HPPHandle::NativeType>(hppHandle);
+	}
+};
+
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/physical_device.cpp
+++ b/framework/core/physical_device.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Arm Limited and Contributors
+/* Copyright (c) 2020-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -76,7 +76,7 @@ const VkPhysicalDeviceProperties &PhysicalDevice::get_properties() const
 	return properties;
 }
 
-const VkPhysicalDeviceMemoryProperties PhysicalDevice::get_memory_properties() const
+const VkPhysicalDeviceMemoryProperties &PhysicalDevice::get_memory_properties() const
 {
 	return memory_properties;
 }

--- a/framework/core/physical_device.h
+++ b/framework/core/physical_device.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Arm Limited and Contributors
+/* Copyright (c) 2020-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -53,7 +53,7 @@ class PhysicalDevice
 
 	const VkPhysicalDeviceProperties &get_properties() const;
 
-	const VkPhysicalDeviceMemoryProperties get_memory_properties() const;
+	const VkPhysicalDeviceMemoryProperties &get_memory_properties() const;
 
 	const std::vector<VkQueueFamilyProperties> &get_queue_family_properties() const;
 

--- a/framework/core/queue.cpp
+++ b/framework/core/queue.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -67,7 +67,7 @@ uint32_t Queue::get_index() const
 	return index;
 }
 
-VkQueueFamilyProperties Queue::get_properties() const
+const VkQueueFamilyProperties &Queue::get_properties() const
 {
 	return properties;
 }

--- a/framework/core/queue.h
+++ b/framework/core/queue.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -47,7 +47,7 @@ class Queue
 
 	uint32_t get_index() const;
 
-	VkQueueFamilyProperties get_properties() const;
+	const VkQueueFamilyProperties &get_properties() const;
 
 	VkBool32 support_present() const;
 

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -115,7 +115,7 @@ bool HPPApiVulkanSample::resize(const uint32_t, const uint32_t)
 	prepared = false;
 
 	// Ensure all operations on the device have been finished before destroying resources
-	get_device().wait_idle();
+	get_device().get_handle().waitIdle();
 
 	create_swapchain_buffers();
 
@@ -142,7 +142,7 @@ bool HPPApiVulkanSample::resize(const uint32_t, const uint32_t)
 	create_command_buffers();
 	build_command_buffers();
 
-	get_device().wait_idle();
+	get_device().get_handle().waitIdle();
 
 	if (extent.width && extent.height)
 	{
@@ -517,7 +517,7 @@ HPPApiVulkanSample::~HPPApiVulkanSample()
 {
 	if (get_device().get_handle())
 	{
-		get_device().wait_idle();
+		get_device().get_handle().waitIdle();
 
 		// Clean up Vulkan resources
 		get_device().get_handle().destroyDescriptorPool(descriptor_pool);
@@ -595,7 +595,7 @@ void HPPApiVulkanSample::setup_depth_stencil()
 	depth_stencil.image            = get_device().get_handle().createImage(image_create_info);
 	vk::MemoryRequirements memReqs = get_device().get_handle().getImageMemoryRequirements(depth_stencil.image);
 
-	vk::MemoryAllocateInfo memory_allocation(memReqs.size, get_device().get_memory_type(memReqs.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
+	vk::MemoryAllocateInfo memory_allocation(memReqs.size, get_device().get_gpu().get_memory_type(memReqs.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
 	depth_stencil.mem = get_device().get_handle().allocateMemory(memory_allocation);
 	get_device().get_handle().bindImageMemory(depth_stencil.image, depth_stencil.mem, 0);
 

--- a/framework/hpp_fence_pool.h
+++ b/framework/hpp_fence_pool.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,29 +17,32 @@
 
 #pragma once
 
-#include <core/image_view.h>
+#include <fence_pool.h>
+#include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
 namespace core
 {
+class HPPDevice;
+}
+
 /**
- * @brief facade class around vkb::core::ImageView, providing a vulkan.hpp-based interface
+ * @brief facade class around vkb::FencePool, providing a vulkan.hpp-based interface
  *
- * See vkb::core::ImageView for documentation
+ * See vkb::FencePool for documentation
  */
-class HPPImageView : private vkb::core::ImageView
+class HPPFencePool : private vkb::FencePool
 {
   public:
-	vk::Format get_format() const
-	{
-		return static_cast<vk::Format>(vkb::core::ImageView::get_format());
-	}
+	HPPFencePool(vkb::core::HPPDevice &device) :
+	    vkb::FencePool(reinterpret_cast<vkb::Device &>(device))
+	{}
 
-	vk::ImageView get_handle() const
+	vk::Fence request_fence()
 	{
-		return static_cast<vk::ImageView>(vkb::core::ImageView::get_handle());
+		return static_cast<vk::Fence>(vkb::FencePool::request_fence());
 	}
 };
-}        // namespace core
+
 }        // namespace vkb

--- a/framework/hpp_gltf_loader.h
+++ b/framework/hpp_gltf_loader.h
@@ -29,7 +29,7 @@ namespace vkb
  *
  * See vkb::GLTFLoader for documentation
  */
-class HPPGLTFLoader : protected vkb::GLTFLoader
+class HPPGLTFLoader : private vkb::GLTFLoader
 {
   public:
 	using vkb::GLTFLoader::read_scene_from_file;

--- a/framework/hpp_gui.h
+++ b/framework/hpp_gui.h
@@ -23,7 +23,7 @@
 
 namespace vkb
 {
-class HPPDrawer : protected vkb::Drawer
+class HPPDrawer : private vkb::Drawer
 {
   public:
 	using vkb::Drawer::checkbox;
@@ -40,7 +40,7 @@ class HPPDrawer : protected vkb::Drawer
  *
  * See vkb::Gui for documentation
  */
-class HPPGui : protected vkb::Gui
+class HPPGui : private vkb::Gui
 {
   public:
 	using vkb::Gui::get_drawer;

--- a/framework/hpp_resource_cache.h
+++ b/framework/hpp_resource_cache.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,29 +17,28 @@
 
 #pragma once
 
-#include <core/image_view.h>
+#include <resource_cache.h>
 
 namespace vkb
 {
 namespace core
 {
+class HPPDevice;
+}
+
 /**
- * @brief facade class around vkb::core::ImageView, providing a vulkan.hpp-based interface
+ * @brief facade class around vkb::ResourceCache, providing a vulkan.hpp-based interface
  *
- * See vkb::core::ImageView for documentation
+ * See vkb::ResourceCache for documentation
  */
-class HPPImageView : private vkb::core::ImageView
+class HPPResourceCache : private vkb::ResourceCache
 {
   public:
-	vk::Format get_format() const
-	{
-		return static_cast<vk::Format>(vkb::core::ImageView::get_format());
-	}
+	using vkb::ResourceCache::clear;
 
-	vk::ImageView get_handle() const
-	{
-		return static_cast<vk::ImageView>(vkb::core::ImageView::get_handle());
-	}
+	HPPResourceCache(vkb::core::HPPDevice &device) :
+	    vkb::ResourceCache(reinterpret_cast<vkb::Device &>(device))
+	{}
 };
-}        // namespace core
+
 }        // namespace vkb

--- a/framework/hpp_vulkan_sample.cpp
+++ b/framework/hpp_vulkan_sample.cpp
@@ -29,7 +29,7 @@ HPPVulkanSample::~HPPVulkanSample()
 {
 	if (device)
 	{
-		device->wait_idle();
+		device->get_handle().waitIdle();
 	}
 
 	scene.reset();
@@ -420,7 +420,7 @@ void HPPVulkanSample::finish()
 
 	if (device)
 	{
-		device->wait_idle();
+		device->get_handle().waitIdle();
 	}
 }
 
@@ -445,7 +445,7 @@ void HPPVulkanSample::draw_gui() const
 
 void HPPVulkanSample::update_debug_window()
 {
-	auto        driver_version     = device->get_driver_version();
+	auto        driver_version     = device->get_gpu().get_driver_version();
 	std::string driver_version_str = fmt::format("major: {} minor: {} patch: {}", driver_version.major, driver_version.minor, driver_version.patch);
 
 	get_debug_info().insert<field::Static, std::string>("driver_version", driver_version_str);

--- a/framework/platform/hpp_platform.h
+++ b/framework/platform/hpp_platform.h
@@ -32,7 +32,7 @@ namespace platform
  *
  * See vkb::Platform for documentation
  */
-class HPPPlatform : protected vkb::Platform
+class HPPPlatform : private vkb::Platform
 {
   public:
 	using vkb::Platform::get_surface_extension;

--- a/framework/platform/hpp_window.h
+++ b/framework/platform/hpp_window.h
@@ -30,7 +30,7 @@ namespace platform
  *
  * See vkb::Window for documentation
  */
-class HPPWindow : protected vkb::Window
+class HPPWindow : private vkb::Window
 {
   public:
 	using vkb::Window::create_surface;

--- a/framework/rendering/hpp_render_context.h
+++ b/framework/rendering/hpp_render_context.h
@@ -32,7 +32,7 @@ namespace rendering
  *
  * See vkb::RenderContext for documentation
  */
-class HPPRenderContext : protected vkb::RenderContext
+class HPPRenderContext : private vkb::RenderContext
 {
   public:
 	using vkb::RenderContext::get_render_frames;

--- a/framework/rendering/hpp_render_frame.h
+++ b/framework/rendering/hpp_render_frame.h
@@ -30,7 +30,7 @@ namespace rendering
  *
  * See vkb::RenderFrame for documentation
  */
-class HPPRenderFrame : protected vkb::RenderFrame
+class HPPRenderFrame : private vkb::RenderFrame
 {
   public:
 	vkb::rendering::HPPRenderTarget &get_render_target()

--- a/framework/rendering/hpp_render_pipeline.h
+++ b/framework/rendering/hpp_render_pipeline.h
@@ -28,7 +28,7 @@ namespace rendering
  *
  * See vkb::RenderPipeline for documentation
  */
-class HPPRenderPipeline : protected vkb::RenderPipeline
+class HPPRenderPipeline : private vkb::RenderPipeline
 {
   public:
 	void draw(vkb::core::HPPCommandBuffer &    command_buffer,

--- a/framework/rendering/hpp_render_target.h
+++ b/framework/rendering/hpp_render_target.h
@@ -28,7 +28,7 @@ namespace rendering
  *
  * See vkb::RenderTarget for documentation
  */
-class HPPRenderTarget : protected vkb::RenderTarget
+class HPPRenderTarget : private vkb::RenderTarget
 {
   public:
 	const vk::Extent2D &get_extent() const

--- a/framework/scene_graph/components/hpp_image.h
+++ b/framework/scene_graph/components/hpp_image.h
@@ -33,7 +33,7 @@ namespace components
  *
  * See vkb::sb::Image for documentation
  */
-class HPPImage : protected vkb::sg::Image
+class HPPImage : private vkb::sg::Image
 {
   public:
 	using vkb::sg::Image::get_data;

--- a/framework/scene_graph/components/hpp_sub_mesh.h
+++ b/framework/scene_graph/components/hpp_sub_mesh.h
@@ -31,7 +31,7 @@ namespace components
  *
  * See vkb::sb::SubMeshfor for documentation
  */
-class HPPSubMesh : protected vkb::sg::SubMesh
+class HPPSubMesh : private vkb::sg::SubMesh
 {
   public:
 	using vkb::sg::SubMesh::vertex_indices;

--- a/framework/stats/hpp_stats.h
+++ b/framework/stats/hpp_stats.h
@@ -28,7 +28,7 @@ namespace stats
  *
  * See vkb::Stats for documentation
  */
-class HPPStats : protected vkb::Stats
+class HPPStats : private vkb::Stats
 {
   public:
 	using vkb::Stats::resize;

--- a/samples/api/hpp_hdr/hpp_hdr.cpp
+++ b/samples/api/hpp_hdr/hpp_hdr.cpp
@@ -226,7 +226,7 @@ HPPHDR::FrameBufferAttachment HPPHDR::create_attachment(vk::Format format, vk::I
 
 	vk::MemoryRequirements memory_requirements = get_device().get_handle().getImageMemoryRequirements(image);
 	vk::MemoryAllocateInfo memory_allocate_info(memory_requirements.size,
-	                                            get_device().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
+	                                            get_device().get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
 	vk::DeviceMemory       mem = get_device().get_handle().allocateMemory(memory_allocate_info);
 	get_device().get_handle().bindImageMemory(image, mem, 0);
 

--- a/samples/api/hpp_texture_loading/hpp_texture_loading.cpp
+++ b/samples/api/hpp_texture_loading/hpp_texture_loading.cpp
@@ -122,7 +122,7 @@ void HPPTextureLoading::load_texture()
 		vk::MemoryAllocateInfo memory_allocate_info(
 		    memory_requirements.size,
 		    // Get memory type index for a host visible buffer
-		    get_device().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent));
+		    get_device().get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent));
 		vk::DeviceMemory staging_memory = get_device().get_handle().allocateMemory(memory_allocate_info);
 		get_device().get_handle().bindBufferMemory(staging_buffer, staging_memory, 0);
 
@@ -166,7 +166,7 @@ void HPPTextureLoading::load_texture()
 
 		memory_requirements   = get_device().get_handle().getImageMemoryRequirements(texture.image);
 		memory_allocate_info  = {memory_requirements.size,
-                                get_device().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal)};
+                                get_device().get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal)};
 		texture.device_memory = get_device().get_handle().allocateMemory(memory_allocate_info);
 		VK_CHECK(vkBindImageMemory(get_device().get_handle(), texture.image, texture.device_memory, 0));
 
@@ -248,7 +248,7 @@ void HPPTextureLoading::load_texture()
 		vk::MemoryAllocateInfo memory_allocate_info(
 		    memory_requirements.size,
 		    // Get memory type that can be mapped to host memory
-		    get_device().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent));
+		    get_device().get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent));
 		vk::DeviceMemory mappable_memory = get_device().get_handle().allocateMemory(memory_allocate_info);
 		get_device().get_handle().bindImageMemory(mappable_image, mappable_memory, 0);
 


### PR DESCRIPTION
## Description

Replacing this part of the framework shows how to manage some more resources using vulkan.hpp.

In order to do so, a couple of new facade classes and functions are introduced in `common/hpp_error.h`, `core/hpp_command_pool.h`, `core/hpp_vulkan_resource.h`, `hpp_fence_pool.h`, and `hpp_resource_cache.h`.

The Vulkan-Hpp-based facade classes in `core/hpp_command_buffer.h`, `core/hpp_physical_device.h`, `core/hpp_queue.h`, `hpp_api_vulkan_sample.cpp`, `hpp_vulkan_sample.cpp`, `samples/api/hpp_hdr/hpp_hdr.cpp`, and `samples/api/hpp_texture_loading/hpp_texture_loading.cpp` needed some adjustments and additions.

To further enforce encapsulation, all facade classes are changed to derive privately, instead of protected, from their respective base class.

`vkb::PhysicalDevice::get_memory_properties()` is changed to return a const reference to the memory properties, instead of a copy.
`vkb::Queue::get_properties()` is changed to return a const reference to the properties, instead of a copy.

I have tested it on Window10 on nvidia HW.
## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
