### PR TITLE
Add transcoding of api sample instancing based on vulkan.hpp

### DIFF
--- a/framework/core/hpp_image.h
+++ b/framework/core/hpp_image.h
@@ -31,6 +31,8 @@ namespace core
 class HPPImage : private Image
 {
   public:
+	using Image::get_array_layer_count;
+
 	vk::Image get_handle() const
 	{
 		return Image::get_handle();

--- a/framework/hpp_gui.h
+++ b/framework/hpp_gui.h
@@ -33,6 +33,7 @@ class HPPDrawer : private vkb::Drawer
 	using vkb::Drawer::input_float;
 	using vkb::Drawer::is_dirty;
 	using vkb::Drawer::slider_float;
+	using vkb::Drawer::text;
 };
 
 /**

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -99,7 +99,8 @@ set(ORDER_LIST
     "hpp_hello_triangle"
 	"hpp_dynamic_uniform_buffers"
 	"hpp_texture_loading"
-	"hpp_hdr")
+	"hpp_hdr"
+	"hpp_instancing")
 
 # Orders the sample ids by the order list above
 set(ORDERED_LIST)

--- a/samples/README.md
+++ b/samples/README.md
@@ -125,6 +125,9 @@ A transcoded version of the API sample [High dynamic range](#hdr)that illustrate
 ### [HPP Hello Triangle](./api/hpp_hello_triangle)<br/>
 A transcoded version of the API sample [Hello Triangle](#hello_triangle) that illustrates the usage of the C++ bindings of vulkan provided by vulkan.hpp.
 
+### [HPP Instancing](./api/hpp_instancing)<br/>
+A transcoded version of the API sample [Instancing](#instancing) that illustrates the usage of the C++ bindings of vulkan provided by vulkan.hpp.
+
 ### [HPP Texture Loading](./api/hpp_texture_loading)<br/>
 A transcoded version of the API sample [Texture loading](#texture_loading) that illustrates the usage of the C++ bindings of vulkan provided by vulkan.hpp.
 

--- a/samples/api/hpp_instancing/CMakeLists.txt
+++ b/samples/api/hpp_instancing/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+get_filename_component(FOLDER_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+get_filename_component(PARENT_DIR ${CMAKE_CURRENT_LIST_DIR} PATH)
+get_filename_component(CATEGORY_NAME ${PARENT_DIR} NAME)
+
+add_sample_with_tags(
+    ID ${FOLDER_NAME}
+    CATEGORY ${CATEGORY_NAME}
+    AUTHOR "Sascha Willems"
+    NAME "HPP Instancing"
+    DESCRIPTION "Instanced mesh rendering, uses a separate vertex buffer for instanced data, using vulkan.hpp"
+    SHADER_FILES_GLSL
+        "instancing/instancing.vert"
+        "instancing/instancing.frag"
+        "instancing/planet.vert"
+        "instancing/planet.frag"
+        "instancing/starfield.vert"
+        "instancing/starfield.frag")

--- a/samples/api/hpp_instancing/README.md
+++ b/samples/api/hpp_instancing/README.md
@@ -1,0 +1,20 @@
+<!--
+- Copyright (c) 2022, The Khronos Group
+-
+- SPDX-License-Identifier: Apache-2.0
+-
+- Licensed under the Apache License, Version 2.0 the "License";
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-
+-->
+### HPP Instancing<br/>
+A transcoded version of the API sample [Instancing](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/instancing) that illustrates the usage of the C++ bindings of vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_instancing/hpp_instancing.cpp
+++ b/samples/api/hpp_instancing/hpp_instancing.cpp
@@ -1,0 +1,481 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Instanced mesh rendering, uses a separate vertex buffer for instanced data, using vulkan.hpp
+ */
+
+#include "hpp_instancing.h"
+
+#include <benchmark_mode/benchmark_mode.h>
+#include <random>
+
+HPPInstancing::HPPInstancing()
+{
+	title = "HPP instanced mesh rendering";
+}
+
+HPPInstancing::~HPPInstancing()
+{
+	if (device)
+	{
+		get_device().get_handle().destroyPipeline(pipelines.instanced_rocks);
+		get_device().get_handle().destroyPipeline(pipelines.planet);
+		get_device().get_handle().destroyPipeline(pipelines.starfield);
+		get_device().get_handle().destroyPipelineLayout(pipeline_layout);
+		get_device().get_handle().destroyDescriptorSetLayout(descriptor_set_layout);
+		get_device().get_handle().destroyBuffer(instance_buffer.buffer);
+		get_device().get_handle().freeMemory(instance_buffer.memory);
+		get_device().get_handle().destroySampler(textures.rocks.sampler);
+		get_device().get_handle().destroySampler(textures.planet.sampler);
+	}
+}
+
+void HPPInstancing::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
+{
+	auto &      requested_features = gpu.get_mutable_requested_features();
+	auto const &features           = gpu.get_features();
+
+	// Enable anisotropic filtering if supported
+	if (features.samplerAnisotropy)
+	{
+		requested_features.samplerAnisotropy = true;
+	}
+	// Enable texture compression
+	if (features.textureCompressionBC)
+	{
+		requested_features.textureCompressionBC = true;
+	}
+	else if (features.textureCompressionASTC_LDR)
+	{
+		requested_features.textureCompressionASTC_LDR = true;
+	}
+	else if (features.textureCompressionETC2)
+	{
+		requested_features.textureCompressionETC2 = true;
+	}
+};
+
+void HPPInstancing::build_command_buffers()
+{
+	vk::CommandBufferBeginInfo command_buffer_begin_info;
+
+	std::array<vk::ClearValue, 2> clear_values =
+	    {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.2f, 0.0f}})),
+	      vk::ClearDepthStencilValue(0.0f, 0)}};
+
+	vk::RenderPassBeginInfo render_pass_begin_info(render_pass, {}, {{0, 0}, extent}, clear_values);
+
+	for (int32_t i = 0; i < draw_cmd_buffers.size(); ++i)
+	{
+		// Set target frame buffer
+		render_pass_begin_info.framebuffer = framebuffers[i];
+
+		auto command_buffer = draw_cmd_buffers[i];
+		command_buffer.begin(command_buffer_begin_info);
+
+		command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+
+		vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f);
+		command_buffer.setViewport(0, viewport);
+
+		vk::Rect2D scissor({0, 0}, extent);
+		command_buffer.setScissor(0, scissor);
+
+		vk::DeviceSize offset = 0;
+
+		// Star field
+		command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layout, 0, descriptor_sets.planet, {});
+		command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipelines.starfield);
+		command_buffer.draw(4, 1, 0, 0);
+
+		// Planet
+		command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layout, 0, descriptor_sets.planet, {});
+		command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipelines.planet);
+		command_buffer.bindVertexBuffers(0, models.planet->get_vertex_buffer("vertex_buffer").get_handle(), offset);
+		command_buffer.bindIndexBuffer(models.planet->get_index_buffer().get_handle(), 0, vk::IndexType::eUint32);
+		command_buffer.drawIndexed(models.planet->vertex_indices, 1, 0, 0, 0);
+
+		// Instanced rocks
+		command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layout, 0, descriptor_sets.instanced_rocks, {});
+		command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipelines.instanced_rocks);
+		// Binding point 0 : Mesh vertex buffer
+		command_buffer.bindVertexBuffers(0, models.rock->get_vertex_buffer("vertex_buffer").get_handle(), offset);
+		// Binding point 1 : Instance data buffer
+		command_buffer.bindVertexBuffers(1, instance_buffer.buffer, offset);
+		command_buffer.bindIndexBuffer(models.rock->get_index_buffer().get_handle(), 0, vk::IndexType::eUint32);
+		// Render instances
+		command_buffer.drawIndexed(models.rock->vertex_indices, INSTANCE_COUNT, 0, 0, 0);
+
+		draw_ui(command_buffer);
+
+		command_buffer.endRenderPass();
+
+		command_buffer.end();
+	}
+}
+
+void HPPInstancing::load_assets()
+{
+	models.rock   = load_model("scenes/rock.gltf");
+	models.planet = load_model("scenes/planet.gltf");
+
+	textures.rocks  = load_texture_array("textures/texturearray_rocks_color_rgba.ktx");
+	textures.planet = load_texture("textures/lavaplanet_color_rgba.ktx");
+}
+
+void HPPInstancing::setup_descriptor_pool()
+{
+	// Example uses one ubo
+	std::array<vk::DescriptorPoolSize, 2> pool_sizes = {{{vk::DescriptorType::eUniformBuffer, 2}, {vk::DescriptorType::eCombinedImageSampler, 2}}};
+
+	vk::DescriptorPoolCreateInfo descriptor_pool_create_info({}, 2, pool_sizes);
+	descriptor_pool = get_device().get_handle().createDescriptorPool(descriptor_pool_create_info);
+}
+
+void HPPInstancing::setup_descriptor_set_layout()
+{
+	std::array<vk::DescriptorSetLayoutBinding, 2> set_layout_bindings = {
+	    {{0, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex},                   // Binding 0 : Vertex shader uniform buffer
+	     {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}}};        // Binding 1 : Fragment shader combined sampler
+
+	vk::DescriptorSetLayoutCreateInfo descriptor_layout_create_info({}, set_layout_bindings);
+
+	descriptor_set_layout = get_device().get_handle().createDescriptorSetLayout(descriptor_layout_create_info);
+
+#if defined(ANDROID)
+	vk::PipelineLayoutCreateInfo pipeline_layout_create_info({}, 1, &descriptor_set_layout);
+#else
+	vk::PipelineLayoutCreateInfo  pipeline_layout_create_info({}, descriptor_set_layout);
+#endif
+
+	pipeline_layout = get_device().get_handle().createPipelineLayout(pipeline_layout_create_info);
+}
+
+void HPPInstancing::setup_descriptor_set()
+{
+#if defined(ANDROID)
+	vk::DescriptorSetAllocateInfo descriptor_set_alloc_info(descriptor_pool, 1, &descriptor_set_layout);
+#else
+	vk::DescriptorSetAllocateInfo descriptor_set_alloc_info(descriptor_pool, descriptor_set_layout);
+#endif
+
+	// Instanced rocks
+	descriptor_sets.instanced_rocks = get_device().get_handle().allocateDescriptorSets(descriptor_set_alloc_info).front();
+	vk::DescriptorBufferInfo buffer_descriptor(uniform_buffers.scene->get_handle(), 0, VK_WHOLE_SIZE);
+	vk::DescriptorImageInfo  image_descriptor(
+        textures.rocks.sampler,
+        textures.rocks.image->get_vk_image_view().get_handle(),
+        descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.rocks.image->get_vk_image_view().get_format()));
+	std::array<vk::WriteDescriptorSet, 2> write_descriptor_sets = {
+	    {{descriptor_sets.instanced_rocks, 0, 0, vk::DescriptorType::eUniformBuffer, {}, buffer_descriptor},            // Binding 0 : Vertex shader uniform buffer
+	     {descriptor_sets.instanced_rocks, 1, 0, vk::DescriptorType::eCombinedImageSampler, image_descriptor}}};        // Binding 1 : Color map
+	get_device().get_handle().updateDescriptorSets(write_descriptor_sets, {});
+
+	// Planet
+	descriptor_sets.planet = get_device().get_handle().allocateDescriptorSets(descriptor_set_alloc_info).front();
+	image_descriptor       = {textures.planet.sampler,
+                        textures.planet.image->get_vk_image_view().get_handle(),
+                        descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.planet.image->get_vk_image_view().get_format())};
+	write_descriptor_sets  = {
+        {{descriptor_sets.planet, 0, 0, vk::DescriptorType::eUniformBuffer, {}, buffer_descriptor},            // Binding 0 : Vertex shader uniform buffer
+         {descriptor_sets.planet, 1, 0, vk::DescriptorType::eCombinedImageSampler, image_descriptor}}};        // Binding 1 : Color map
+	get_device().get_handle().updateDescriptorSets(write_descriptor_sets, {});
+}
+
+void HPPInstancing::prepare_pipelines()
+{
+	// Load shaders: Instancing pipeline
+	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
+	    load_shader("instancing/instancing.vert", vk::ShaderStageFlagBits::eVertex),
+	    load_shader("instancing/instancing.frag", vk::ShaderStageFlagBits::eFragment)};
+
+	// This example uses two different input states, one for the instanced part and one for non-instanced rendering
+
+	// Vertex input bindings
+	// The instancing pipeline uses a vertex input state with two bindings
+	std::array<vk::VertexInputBindingDescription, 2> binding_descriptions = {
+	    {{0, sizeof(HPPVertex), vk::VertexInputRate::eVertex},               // Binding point 0: Mesh vertex layout description at per-vertex rate
+	     {1, sizeof(InstanceData), vk::VertexInputRate::eInstance}}};        // Binding point 1: Instanced data at per-instance rate
+
+	// Vertex attribute bindings
+	// Note that the shader declaration for per-vertex and per-instance attributes is the same, the different input rates are only stored in the bindings:
+	// instanced.vert:
+	//	layout (location = 0) in vec3 inPos;		Per-Vertex
+	//	...
+	//	layout (location = 4) in vec3 instancePos;	Per-Instance
+	std::array<vk::VertexInputAttributeDescription, 8> attribute_descriptions = {
+	    {                                                                // Per-vertex attributees
+	                                                                     // These are advanced for each vertex fetched by the vertex shader
+	     {0, 0, vk::Format::eR32G32B32Sfloat, 0},                        // Location 0: Position
+	     {1, 0, vk::Format::eR32G32B32Sfloat, 3 * sizeof(float)},        // Location 1: Normal
+	     {2, 0, vk::Format::eR32G32Sfloat, 6 * sizeof(float)},           // Location 2: Texture coordinates
+	     {3, 0, vk::Format::eR32G32B32Sfloat, 8 * sizeof(float)},        // Location 3: Color
+	                                                                     // Per-Instance attributes
+	                                                                     // These are fetched for each instance rendered
+	     {4, 1, vk::Format::eR32G32B32Sfloat, 0},                        // Location 4: Position
+	     {5, 1, vk::Format::eR32G32B32Sfloat, 3 * sizeof(float)},        // Location 5: Rotation
+	     {6, 1, vk::Format::eR32Sfloat, 6 * sizeof(float)},              // Location 6: Scale
+	     {7, 1, vk::Format::eR32Sint, 7 * sizeof(float)}}};              // Location 7: Texture array layer index
+
+	// Use all input bindings and attribute descriptions
+	vk::PipelineVertexInputStateCreateInfo input_state({}, binding_descriptions, attribute_descriptions);
+
+	vk::PipelineInputAssemblyStateCreateInfo input_assembly_state({}, vk::PrimitiveTopology::eTriangleList, false);
+
+	vk::PipelineViewportStateCreateInfo viewport_state({}, 1, nullptr, 1, nullptr);
+
+	vk::PipelineRasterizationStateCreateInfo rasterization_state;
+	rasterization_state.polygonMode = vk::PolygonMode::eFill;
+	rasterization_state.cullMode    = vk::CullModeFlagBits::eBack;
+	rasterization_state.frontFace   = vk::FrontFace::eClockwise;
+	rasterization_state.lineWidth   = 1.0f;
+
+	vk::PipelineMultisampleStateCreateInfo multisample_state({}, vk::SampleCountFlagBits::e1);
+
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+	depth_stencil_state.depthCompareOp   = vk::CompareOp::eGreater;
+	depth_stencil_state.depthTestEnable  = true;
+	depth_stencil_state.depthWriteEnable = true;
+	depth_stencil_state.back.compareOp   = vk::CompareOp::eAlways;
+	depth_stencil_state.front            = depth_stencil_state.back;
+
+	vk::PipelineColorBlendAttachmentState blend_attachment_state;
+	blend_attachment_state.colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+
+	vk::PipelineColorBlendStateCreateInfo color_blend_state({}, false, {}, blend_attachment_state);
+
+	std::array<vk::DynamicState, 2> dynamic_state_enables = {vk::DynamicState::eViewport, vk::DynamicState::eScissor};
+
+	vk::PipelineDynamicStateCreateInfo dynamic_state({}, dynamic_state_enables);
+
+	vk::GraphicsPipelineCreateInfo pipeline_create_info({},
+	                                                    shader_stages,
+	                                                    &input_state,
+	                                                    &input_assembly_state,
+	                                                    {},
+	                                                    &viewport_state,
+	                                                    &rasterization_state,
+	                                                    &multisample_state,
+	                                                    &depth_stencil_state,
+	                                                    &color_blend_state,
+	                                                    &dynamic_state,
+	                                                    pipeline_layout,
+	                                                    render_pass,
+	                                                    {},
+	                                                    {},
+	                                                    -1);
+
+	vk::Result result;
+	std::tie(result, pipelines.instanced_rocks) = get_device().get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info);
+	assert(result == vk::Result::eSuccess);
+
+	// Planet rendering pipeline
+	shader_stages = {load_shader("instancing/planet.vert", vk::ShaderStageFlagBits::eVertex),
+	                 load_shader("instancing/planet.frag", vk::ShaderStageFlagBits::eFragment)};
+	// Only use the non-instanced input bindings and attribute descriptions
+	input_state.vertexBindingDescriptionCount   = 1;
+	input_state.vertexAttributeDescriptionCount = 4;
+
+	std::tie(result, pipelines.planet) = get_device().get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info);
+	assert(result == vk::Result::eSuccess);
+
+	// Star field pipeline
+	rasterization_state.cullMode         = vk::CullModeFlagBits::eNone;
+	depth_stencil_state.depthWriteEnable = false;
+	depth_stencil_state.depthTestEnable  = false;
+
+	shader_stages = {load_shader("instancing/starfield.vert", vk::ShaderStageFlagBits::eVertex),
+	                 load_shader("instancing/starfield.frag", vk::ShaderStageFlagBits::eFragment)};
+	// Vertices are generated in the vertex shader
+	input_state.vertexBindingDescriptionCount   = 0;
+	input_state.vertexAttributeDescriptionCount = 0;
+
+	std::tie(result, pipelines.starfield) = get_device().get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info);
+	assert(result == vk::Result::eSuccess);
+}
+
+void HPPInstancing::prepare_instance_data()
+{
+	std::vector<InstanceData> instance_data;
+	instance_data.resize(INSTANCE_COUNT);
+
+	std::default_random_engine              rnd_generator(platform->using_plugin<::plugins::BenchmarkMode>() ? 0 : (unsigned) time(nullptr));
+	std::uniform_real_distribution<float>   uniform_dist(0.0, 1.0);
+	std::uniform_int_distribution<uint32_t> rnd_texture_index(0, textures.rocks.image->get_vk_image().get_array_layer_count());
+
+	// Distribute rocks randomly on two different rings
+	for (auto i = 0; i < INSTANCE_COUNT / 2; i++)
+	{
+		glm::vec2 ring0{7.0f, 11.0f};
+		glm::vec2 ring1{14.0f, 18.0f};
+
+		float rho, theta;
+
+		// Inner ring
+		rho                       = sqrt((pow(ring0[1], 2.0f) - pow(ring0[0], 2.0f)) * uniform_dist(rnd_generator) + pow(ring0[0], 2.0f));
+		theta                     = 2.0f * glm::pi<float>() * uniform_dist(rnd_generator);
+		instance_data[i].pos      = glm::vec3(rho * cos(theta), uniform_dist(rnd_generator) * 0.5f - 0.25f, rho * sin(theta));
+		instance_data[i].rot      = glm::vec3(glm::pi<float>() * uniform_dist(rnd_generator), glm::pi<float>() * uniform_dist(rnd_generator), glm::pi<float>() * uniform_dist(rnd_generator));
+		instance_data[i].scale    = 1.5f + uniform_dist(rnd_generator) - uniform_dist(rnd_generator);
+		instance_data[i].texIndex = rnd_texture_index(rnd_generator);
+		instance_data[i].scale *= 0.75f;
+
+		// Outer ring
+		rho                                                                 = sqrt((pow(ring1[1], 2.0f) - pow(ring1[0], 2.0f)) * uniform_dist(rnd_generator) + pow(ring1[0], 2.0f));
+		theta                                                               = 2.0f * glm::pi<float>() * uniform_dist(rnd_generator);
+		instance_data[static_cast<size_t>(i + INSTANCE_COUNT / 2)].pos      = glm::vec3(rho * cos(theta), uniform_dist(rnd_generator) * 0.5f - 0.25f, rho * sin(theta));
+		instance_data[static_cast<size_t>(i + INSTANCE_COUNT / 2)].rot      = glm::vec3(glm::pi<float>() * uniform_dist(rnd_generator), glm::pi<float>() * uniform_dist(rnd_generator), glm::pi<float>() * uniform_dist(rnd_generator));
+		instance_data[static_cast<size_t>(i + INSTANCE_COUNT / 2)].scale    = 1.5f + uniform_dist(rnd_generator) - uniform_dist(rnd_generator);
+		instance_data[static_cast<size_t>(i + INSTANCE_COUNT / 2)].texIndex = rnd_texture_index(rnd_generator);
+		instance_data[static_cast<size_t>(i + INSTANCE_COUNT / 2)].scale *= 0.75f;
+	}
+
+	instance_buffer.size = instance_data.size() * sizeof(InstanceData);
+
+	// Staging
+	// Instanced data is static, copy to device local memory
+	// On devices with separate memory types for host visible and device local memory this will result in better performance
+	// On devices with unified memory types (DEVICE_LOCAL_BIT and HOST_VISIBLE_BIT supported at once) this isn't necessary and you could skip the staging
+
+	struct
+	{
+		vk::DeviceMemory memory;
+		vk::Buffer       buffer;
+	} staging_buffer;
+
+	std::tie(staging_buffer.buffer, staging_buffer.memory) =
+	    get_device().create_buffer(vk::BufferUsageFlagBits::eTransferSrc,
+	                               vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent,
+	                               instance_buffer.size,
+	                               instance_data.data());
+
+	std::tie(instance_buffer.buffer, instance_buffer.memory) =
+	    get_device().create_buffer(vk::BufferUsageFlagBits::eVertexBuffer | vk::BufferUsageFlagBits::eTransferDst,
+	                               vk::MemoryPropertyFlagBits::eDeviceLocal,
+	                               instance_buffer.size);
+
+	// Copy to staging buffer
+	vk::CommandBuffer copy_command = device->create_command_buffer(vk::CommandBufferLevel::ePrimary, true);
+
+	vk::BufferCopy copy_region(0, 0, instance_buffer.size);
+	copy_command.copyBuffer(staging_buffer.buffer, instance_buffer.buffer, copy_region);
+
+	device->flush_command_buffer(copy_command, queue, true);
+
+	instance_buffer.descriptor.range  = instance_buffer.size;
+	instance_buffer.descriptor.buffer = instance_buffer.buffer;
+	instance_buffer.descriptor.offset = 0;
+
+	// Destroy staging resources
+	get_device().get_handle().destroyBuffer(staging_buffer.buffer);
+	get_device().get_handle().freeMemory(staging_buffer.memory);
+}
+
+void HPPInstancing::prepare_uniform_buffers()
+{
+	uniform_buffers.scene =
+	    std::make_unique<vkb::core::HPPBuffer>(get_device(), sizeof(ubo_vs), vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
+
+	update_uniform_buffer(0.0f);
+}
+
+void HPPInstancing::update_uniform_buffer(float delta_time)
+{
+	ubo_vs.projection = camera.matrices.perspective;
+	ubo_vs.view       = camera.matrices.view;
+
+	if (!paused)
+	{
+		ubo_vs.loc_speed += delta_time * 0.35f;
+		ubo_vs.glob_speed += delta_time * 0.01f;
+	}
+
+	uniform_buffers.scene->convert_and_update(ubo_vs);
+}
+
+void HPPInstancing::draw()
+{
+	HPPApiVulkanSample::prepare_frame();
+
+	// Command buffer to be sumitted to the queue
+	submit_info.setCommandBuffers(draw_cmd_buffers[current_buffer]);
+
+	// Submit to queue
+	queue.submit(submit_info);
+
+	HPPApiVulkanSample::submit_frame();
+}
+
+bool HPPInstancing::prepare(vkb::platform::HPPPlatform &platform)
+{
+	if (!HPPApiVulkanSample::prepare(platform))
+	{
+		return false;
+	}
+
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
+	camera.type = vkb::CameraType::LookAt;
+	camera.set_perspective(60.0f, (float) extent.width / (float) extent.height, 256.0f, 0.1f);
+	camera.set_rotation(glm::vec3(-17.2f, -4.7f, 0.0f));
+	camera.set_translation(glm::vec3(5.5f, -1.85f, -18.5f));
+
+	load_assets();
+	prepare_instance_data();
+	prepare_uniform_buffers();
+	setup_descriptor_set_layout();
+	prepare_pipelines();
+	setup_descriptor_pool();
+	setup_descriptor_set();
+	build_command_buffers();
+	prepared = true;
+	return true;
+}
+
+void HPPInstancing::render(float delta_time)
+{
+	if (prepared)
+	{
+		draw();
+		if (!paused || camera.updated)
+		{
+			update_uniform_buffer(delta_time);
+		}
+	}
+}
+
+void HPPInstancing::on_update_ui_overlay(vkb::HPPDrawer &drawer)
+{
+	if (drawer.header("Statistics"))
+	{
+		drawer.text("Instances: %d", INSTANCE_COUNT);
+	}
+}
+
+bool HPPInstancing::resize(const uint32_t width, const uint32_t height)
+{
+	HPPApiVulkanSample::resize(width, height);
+	build_command_buffers();
+	return true;
+}
+
+std::unique_ptr<vkb::Application> create_hpp_instancing()
+{
+	return std::make_unique<HPPInstancing>();
+}

--- a/samples/api/hpp_instancing/hpp_instancing.h
+++ b/samples/api/hpp_instancing/hpp_instancing.h
@@ -1,0 +1,131 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Instanced mesh rendering, uses a separate vertex buffer for instanced data, using vulkan.hpp
+ */
+
+#pragma once
+
+#include <hpp_api_vulkan_sample.h>
+
+#if defined(__ANDROID__)
+#	define INSTANCE_COUNT 4096
+#else
+#	define INSTANCE_COUNT 8192
+#endif
+
+class HPPInstancing : public HPPApiVulkanSample
+{
+  public:
+	HPPInstancing();
+	~HPPInstancing();
+
+  private:
+	// Contains the instanced data
+	struct InstanceBuffer
+	{
+		vk::Buffer               buffer = nullptr;
+		vk::DeviceMemory         memory = nullptr;
+		size_t                   size   = 0;
+		vk::DescriptorBufferInfo descriptor;
+	};
+
+	// Per-instance data block
+	struct InstanceData
+	{
+		glm::vec3 pos;
+		glm::vec3 rot;
+		float     scale;
+		uint32_t  texIndex;
+	};
+
+	struct Models
+	{
+		std::unique_ptr<vkb::scene_graph::components::HPPSubMesh> rock;
+		std::unique_ptr<vkb::scene_graph::components::HPPSubMesh> planet;
+	};
+
+	struct Textures
+	{
+		HPPTexture rocks;
+		HPPTexture planet;
+	};
+
+	struct UBOVS
+	{
+		glm::mat4 projection;
+		glm::mat4 view;
+		glm::vec4 light_pos  = glm::vec4(0.0f, -5.0f, 0.0f, 1.0f);
+		float     loc_speed  = 0.0f;
+		float     glob_speed = 0.0f;
+	};
+
+	struct UniformBuffers
+	{
+		std::unique_ptr<vkb::core::HPPBuffer> scene;
+	};
+
+	struct Pipelines
+	{
+		vk::Pipeline instanced_rocks;
+		vk::Pipeline planet;
+		vk::Pipeline starfield;
+	};
+
+	struct DescriptorSets
+	{
+		vk::DescriptorSet instanced_rocks;
+		vk::DescriptorSet planet;
+	};
+
+  private:
+	// from platform::HPPApplication
+	bool prepare(vkb::platform::HPPPlatform &platform) override;
+	bool resize(const uint32_t width, const uint32_t height) override;
+
+	// from HPPVulkanSample
+	void request_gpu_features(vkb::core::HPPPhysicalDevice &gpu) override;
+
+	// from HPPApiVulkanSample
+	void build_command_buffers() override;
+	void on_update_ui_overlay(vkb::HPPDrawer &drawer) override;
+	void render(float delta_time) override;
+
+	void draw();
+	void load_assets();
+	void prepare_instance_data();
+	void prepare_pipelines();
+	void prepare_uniform_buffers();
+	void setup_descriptor_pool();
+	void setup_descriptor_set();
+	void setup_descriptor_set_layout();
+	void update_uniform_buffer(float delta_time);
+
+  private:
+	vk::DescriptorSetLayout descriptor_set_layout;
+	DescriptorSets          descriptor_sets;
+	InstanceBuffer          instance_buffer;
+	Models                  models;
+	vk::PipelineLayout      pipeline_layout;
+	Pipelines               pipelines;
+	Textures                textures;
+	UBOVS                   ubo_vs;
+	UniformBuffers          uniform_buffers;
+};
+
+std::unique_ptr<vkb::Application> create_hpp_instancing();


### PR DESCRIPTION
## Description

Introduces a new Vulkan-Hpp-based sample, which is a transcoded version of the instancing sample.
Includes some minor adjustments in vbk::core::HPPImage and vkb::HPPGui.
Build tested on Windows.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
