### PR TITLE
Change vkb::core::HPPPhysicalDevice and vkb::core::HPPInstance from facades over vkb::PhysicalDevice and vkb::Instance, respectively, to self-contained classes using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -278,7 +278,9 @@ set(CORE_FILES
     core/acceleration_structure.cpp
     core/shader_binding_table.cpp
     core/vulkan_resource.cpp
-    core/hpp_device.cpp)
+    core/hpp_device.cpp
+    core/hpp_instance.cpp
+	core/hpp_physical_device.cpp)
 
 set(PLATFORM_FILES
     # Header Files

--- a/framework/core/hpp_device.cpp
+++ b/framework/core/hpp_device.cpp
@@ -169,7 +169,7 @@ HPPDevice::HPPDevice(vkb::core::HPPPhysicalDevice &              gpu,
 	{
 		vk::QueueFamilyProperties const &queue_family_property = queue_family_properties[queue_family_index];
 
-		vk::Bool32 present_supported = gpu.is_present_supported(surface, queue_family_index);
+		vk::Bool32 present_supported = gpu.get_handle().getSurfaceSupportKHR(queue_family_index, surface);
 
 		for (uint32_t queue_index = 0U; queue_index < queue_family_property.queueCount; ++queue_index)
 		{

--- a/framework/core/hpp_instance.cpp
+++ b/framework/core/hpp_instance.cpp
@@ -1,0 +1,458 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core/hpp_instance.h>
+
+#include <common/logging.h>
+#include <core/hpp_physical_device.h>
+#include <volk.h>
+
+namespace vkb
+{
+namespace
+{
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+VKAPI_ATTR VkBool32 VKAPI_CALL debug_utils_messenger_callback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity, VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                              const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
+                                                              void *                                      user_data)
+{
+	// Log debug messge
+	if (message_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+	{
+		LOGW("{} - {}: {}", callback_data->messageIdNumber, callback_data->pMessageIdName, callback_data->pMessage);
+	}
+	else if (message_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+	{
+		LOGE("{} - {}: {}", callback_data->messageIdNumber, callback_data->pMessageIdName, callback_data->pMessage);
+	}
+	return VK_FALSE;
+}
+
+static VKAPI_ATTR VkBool32 VKAPI_CALL debug_callback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT /*type*/,
+                                                     uint64_t /*object*/, size_t /*location*/, int32_t /*message_code*/,
+                                                     const char *layer_prefix, const char *message, void * /*user_data*/)
+{
+	if (flags & VK_DEBUG_REPORT_ERROR_BIT_EXT)
+	{
+		LOGE("{}: {}", layer_prefix, message);
+	}
+	else if (flags & VK_DEBUG_REPORT_WARNING_BIT_EXT)
+	{
+		LOGW("{}: {}", layer_prefix, message);
+	}
+	else if (flags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT)
+	{
+		LOGW("{}: {}", layer_prefix, message);
+	}
+	else
+	{
+		LOGI("{}: {}", layer_prefix, message);
+	}
+	return VK_FALSE;
+}
+#endif
+
+bool validate_layers(const std::vector<const char *> &       required,
+                     const std::vector<vk::LayerProperties> &available)
+{
+	for (auto layer : required)
+	{
+		bool found = false;
+		for (auto &available_layer : available)
+		{
+			if (strcmp(available_layer.layerName, layer) == 0)
+			{
+				found = true;
+				break;
+			}
+		}
+
+		if (!found)
+		{
+			LOGE("Validation Layer {} not found", layer);
+			return false;
+		}
+	}
+
+	return true;
+}
+}        // namespace
+
+namespace core
+{
+std::vector<const char *> get_optimal_validation_layers(const std::vector<vk::LayerProperties> &supported_instance_layers)
+{
+	std::vector<std::vector<const char *>> validation_layer_priority_list =
+	    {
+	        // The preferred validation layer is "VK_LAYER_KHRONOS_validation"
+	        {"VK_LAYER_KHRONOS_validation"},
+
+	        // Otherwise we fallback to using the LunarG meta layer
+	        {"VK_LAYER_LUNARG_standard_validation"},
+
+	        // Otherwise we attempt to enable the individual layers that compose the LunarG meta layer since it doesn't exist
+	        {
+	            "VK_LAYER_GOOGLE_threading",
+	            "VK_LAYER_LUNARG_parameter_validation",
+	            "VK_LAYER_LUNARG_object_tracker",
+	            "VK_LAYER_LUNARG_core_validation",
+	            "VK_LAYER_GOOGLE_unique_objects",
+	        },
+
+	        // Otherwise as a last resort we fallback to attempting to enable the LunarG core layer
+	        {"VK_LAYER_LUNARG_core_validation"}};
+
+	for (auto &validation_layers : validation_layer_priority_list)
+	{
+		if (validate_layers(validation_layers, supported_instance_layers))
+		{
+			return validation_layers;
+		}
+
+		LOGW("Couldn't enable validation layers (see log for error) - falling back");
+	}
+
+	// Else return nothing
+	return {};
+}
+
+namespace
+{
+bool enable_extension(const char *                                required_ext_name,
+                      const std::vector<vk::ExtensionProperties> &available_exts,
+                      std::vector<const char *> &                 enabled_extensions)
+{
+	for (auto &avail_ext_it : available_exts)
+	{
+		if (strcmp(avail_ext_it.extensionName, required_ext_name) == 0)
+		{
+			auto it = std::find_if(enabled_extensions.begin(), enabled_extensions.end(),
+			                       [required_ext_name](const char *enabled_ext_name) {
+				                       return strcmp(enabled_ext_name, required_ext_name) == 0;
+			                       });
+			if (it != enabled_extensions.end())
+			{
+				// Extension is already enabled
+			}
+			else
+			{
+				LOGI("Extension {} found, enabling it", required_ext_name);
+				enabled_extensions.emplace_back(required_ext_name);
+			}
+			return true;
+		}
+	}
+
+	LOGI("Extension {} not found", required_ext_name);
+	return false;
+}
+
+bool enable_all_extensions(const std::vector<const char *>             required_ext_names,
+                           const std::vector<vk::ExtensionProperties> &available_exts,
+                           std::vector<const char *> &                 enabled_extensions)
+{
+	using std::placeholders::_1;
+
+	return std::all_of(required_ext_names.begin(), required_ext_names.end(),
+	                   std::bind(enable_extension, _1, available_exts, enabled_extensions));
+}
+
+}        // namespace
+
+HPPInstance::HPPInstance(const std::string &                           application_name,
+                         const std::unordered_map<const char *, bool> &required_extensions,
+                         const std::vector<const char *> &             required_validation_layers,
+                         bool                                          headless,
+                         uint32_t                                      api_version)
+{
+	std::vector<vk::ExtensionProperties> available_instance_extensions = vk::enumerateInstanceExtensionProperties();
+
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	// Check if VK_EXT_debug_utils is supported, which supersedes VK_EXT_Debug_Report
+	const bool has_debug_utils  = enable_extension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
+                                                  available_instance_extensions, enabled_extensions);
+	bool       has_debug_report = false;
+
+	if (!has_debug_utils)
+	{
+		has_debug_report = enable_extension(VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
+		                                    available_instance_extensions, enabled_extensions);
+		if (!has_debug_report)
+		{
+			LOGW("Neither of {} or {} are available; disabling debug reporting",
+			     VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+		}
+	}
+#endif
+
+#if (defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)) && defined(VKB_VALIDATION_LAYERS_GPU_ASSISTED)
+	bool validation_features = false;
+	{
+		std::vector<vk::ExtensionProperties> available_layer_instance_extensions = vk::enumerateInstanceExtensionProperties(std::string("VK_LAYER_KHRONOS_validation"));
+
+		for (auto &available_extension : available_layer_instance_extensions)
+		{
+			if (strcmp(available_extension.extensionName, VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME) == 0)
+			{
+				validation_features = true;
+				LOGI("{} is available, enabling it", VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+				enabled_extensions.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+			}
+		}
+	}
+#endif
+
+	// Try to enable headless surface extension if it exists
+	if (headless)
+	{
+		const bool has_headless_surface = enable_extension(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME,
+		                                                   available_instance_extensions, enabled_extensions);
+		if (!has_headless_surface)
+		{
+			LOGW("{} is not available, disabling swapchain creation", VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME);
+		}
+	}
+	else
+	{
+		enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+	}
+
+	// VK_KHR_get_physical_device_properties2 is a prerequisite of VK_KHR_performance_query
+	// which will be used for stats gathering where available.
+	enable_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+	                 available_instance_extensions, enabled_extensions);
+
+	auto extension_error = false;
+	for (auto extension : required_extensions)
+	{
+		auto extension_name        = extension.first;
+		auto extension_is_optional = extension.second;
+		if (!enable_extension(extension_name, available_instance_extensions, enabled_extensions))
+		{
+			if (extension_is_optional)
+			{
+				LOGW("Optional instance extension {} not available, some features may be disabled", extension_name);
+			}
+			else
+			{
+				LOGE("Required instance extension {} not available, cannot run", extension_name);
+				extension_error = true;
+			}
+			extension_error = extension_error || !extension_is_optional;
+		}
+	}
+
+	if (extension_error)
+	{
+		throw std::runtime_error("Required instance extensions are missing.");
+	}
+
+	std::vector<vk::LayerProperties> supported_validation_layers = vk::enumerateInstanceLayerProperties();
+
+	std::vector<const char *> requested_validation_layers(required_validation_layers);
+
+#ifdef VKB_VALIDATION_LAYERS
+	// Determine the optimal validation layers to enable that are necessary for useful debugging
+	std::vector<const char *> optimal_validation_layers = get_optimal_validation_layers(supported_validation_layers);
+	requested_validation_layers.insert(requested_validation_layers.end(), optimal_validation_layers.begin(), optimal_validation_layers.end());
+#endif
+
+	if (validate_layers(requested_validation_layers, supported_validation_layers))
+	{
+		LOGI("Enabled Validation Layers:")
+		for (const auto &layer : requested_validation_layers)
+		{
+			LOGI("	\t{}", layer);
+		}
+	}
+	else
+	{
+		throw std::runtime_error("Required validation layers are missing.");
+	}
+
+	vk::ApplicationInfo app_info(application_name.c_str(), 0, "Vulkan Samples", 0, api_version);
+
+	vk::InstanceCreateInfo instance_info({}, &app_info, requested_validation_layers, enabled_extensions);
+
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	vk::DebugUtilsMessengerCreateInfoEXT debug_utils_create_info;
+	vk::DebugReportCallbackCreateInfoEXT debug_report_create_info;
+	if (has_debug_utils)
+	{
+		debug_utils_create_info =
+		    vk::DebugUtilsMessengerCreateInfoEXT({},
+		                                         vk::DebugUtilsMessageSeverityFlagBitsEXT::eError | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning,
+		                                         vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance,
+		                                         debug_utils_messenger_callback);
+
+		instance_info.pNext = &debug_utils_create_info;
+	}
+	else
+	{
+		debug_report_create_info = vk::DebugReportCallbackCreateInfoEXT(
+		    vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning, debug_callback);
+
+		instance_info.pNext = &debug_report_create_info;
+	}
+#endif
+
+#if (defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)) && defined(VKB_VALIDATION_LAYERS_GPU_ASSISTED)
+	vk::ValidationFeaturesEXT validation_features_info;
+	if (validation_features)
+	{
+		static const std::array<vk::ValidationFeatureEnableEXT, 2> enable_features = {{vk::ValidationFeatureEnableEXT::eGpuAssistedReserveBindingSlot,
+		                                                                               vk::ValidationFeatureEnableEXT::eGpuAssisted}};
+		validation_features_info.setEnabledValidationFeatures(enable_features);
+		validation_features_info.pNext = instance_info.pNext;
+		instance_info.pNext            = &validation_features_info;
+	}
+#endif
+
+	// Create the Vulkan instance
+	handle = vk::createInstance(instance_info);
+
+	// initialize the Vulkan-Hpp default dispatcher on the instance
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(handle);
+
+	// Need to load volk for all the not-yet Vulkan-Hpp calls
+	volkLoadInstance(handle);
+
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	if (has_debug_utils)
+	{
+		debug_utils_messenger = handle.createDebugUtilsMessengerEXT(debug_utils_create_info);
+	}
+	else
+	{
+		debug_report_callback = handle.createDebugReportCallbackEXT(debug_report_create_info);
+	}
+#endif
+
+	query_gpus();
+}
+
+HPPInstance::HPPInstance(vk::Instance instance) :
+    handle{instance}
+{
+	if (handle)
+	{
+		query_gpus();
+	}
+	else
+	{
+		throw std::runtime_error("HPPInstance not valid");
+	}
+}
+
+HPPInstance::~HPPInstance()
+{
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	if (debug_utils_messenger)
+	{
+		handle.destroyDebugUtilsMessengerEXT(debug_utils_messenger);
+	}
+	if (debug_report_callback)
+	{
+		handle.destroyDebugReportCallbackEXT(debug_report_callback);
+	}
+#endif
+
+	if (handle)
+	{
+		handle.destroy();
+	}
+}
+
+const std::vector<const char *> &HPPInstance::get_extensions()
+{
+	return enabled_extensions;
+}
+
+vkb::core::HPPPhysicalDevice &HPPInstance::get_first_gpu()
+{
+	assert(!gpus.empty() && "No physical devices were found on the system.");
+
+	// Find a discrete GPU
+	for (auto &gpu : gpus)
+	{
+		if (gpu->get_properties().deviceType == vk::PhysicalDeviceType::eDiscreteGpu)
+		{
+			return *gpu;
+		}
+	}
+
+	// Otherwise just pick the first one
+	LOGW("Couldn't find a discrete physical device, picking default GPU");
+	return *gpus[0];
+}
+
+vk::Instance HPPInstance::get_handle() const
+{
+	return handle;
+}
+
+vkb::core::HPPPhysicalDevice &HPPInstance::get_suitable_gpu(vk::SurfaceKHR surface)
+{
+	assert(!gpus.empty() && "No physical devices were found on the system.");
+
+	// Find a discrete GPU
+	for (auto &gpu : gpus)
+	{
+		if (gpu->get_properties().deviceType == vk::PhysicalDeviceType::eDiscreteGpu)
+		{
+			//See if it work with the surface
+			size_t queue_count = gpu->get_queue_family_properties().size();
+			for (uint32_t queue_idx = 0; static_cast<size_t>(queue_idx) < queue_count; queue_idx++)
+			{
+				if (gpu->get_handle().getSurfaceSupportKHR(queue_idx, surface))
+				{
+					return *gpu;
+				}
+			}
+		}
+	}
+
+	// Otherwise just pick the first one
+	LOGW("Couldn't find a discrete physical device, picking default GPU");
+	return *gpus.at(0);
+}
+
+bool HPPInstance::is_enabled(const char *extension) const
+{
+	return std::find_if(enabled_extensions.begin(),
+	                    enabled_extensions.end(),
+	                    [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) != enabled_extensions.end();
+}
+
+void HPPInstance::query_gpus()
+{
+	// Querying valid physical devices on the machine
+	std::vector<vk::PhysicalDevice> physical_devices = handle.enumeratePhysicalDevices();
+	if (physical_devices.empty())
+	{
+		throw std::runtime_error("Couldn't find a physical device that supports Vulkan.");
+	}
+
+	// Create gpus wrapper objects from the vk::PhysicalDevice's
+	for (auto &physical_device : physical_devices)
+	{
+		gpus.push_back(std::make_unique<vkb::core::HPPPhysicalDevice>(*this, physical_device));
+	}
+}
+
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_instance.h
+++ b/framework/core/hpp_instance.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,8 +17,7 @@
 
 #pragma once
 
-#include <core/hpp_physical_device.h>
-#include <core/instance.h>
+#include <unordered_map>
 #include <vulkan/vulkan.hpp>
 
 namespace vkb
@@ -26,34 +25,109 @@ namespace vkb
 namespace core
 {
 class HPPPhysicalDevice;
+/**
+ * @brief Returns a list of Khronos/LunarG supported validation layers
+ *        Attempting to enable them in order of preference, starting with later Vulkan SDK versions
+ * @param supported_instance_layers A list of validation layers to check against
+ */
+std::vector<const char *> get_optimal_validation_layers(const std::vector<vk::LayerProperties> &supported_instance_layers);
 
 /**
- * @brief facade class around vkb::Instance, providing a vulkan.hpp-based interface
+ * @brief A wrapper class for vk::Instance
  *
- * See vkb::Instance for documentation
+ * This class is responsible for initializing the dispatcher, enumerating over all available extensions and validation layers
+ * enabling them if they exist, setting up debug messaging and querying all the physical devices existing on the machine.
  */
-class HPPInstance : private vkb::Instance
+class HPPInstance
 {
   public:
-	using vkb::Instance::is_enabled;
-
+	/**
+	 * @brief Initializes the connection to Vulkan
+	 * @param application_name The name of the application
+	 * @param required_extensions The extensions requested to be enabled
+	 * @param required_validation_layers The validation layers to be enabled
+	 * @param headless Whether the application is requesting a headless setup or not
+	 * @param api_version The Vulkan API version that the instance will be using
+	 * @throws runtime_error if the required extensions and validation layers are not found
+	 */
 	HPPInstance(const std::string &                           application_name,
 	            const std::unordered_map<const char *, bool> &required_extensions        = {},
 	            const std::vector<const char *> &             required_validation_layers = {},
 	            bool                                          headless                   = false,
-	            uint32_t                                      api_version                = VK_API_VERSION_1_0) :
-	    vkb::Instance(application_name, required_extensions, required_validation_layers, headless, api_version)
-	{}
+	            uint32_t                                      api_version                = VK_API_VERSION_1_0);
 
-	vk::Instance get_handle() const
-	{
-		return vkb::Instance::get_handle();
-	}
+	/**
+	 * @brief Queries the GPUs of a vk::Instance that is already created
+	 * @param instance A valid vk::Instance
+	 */
+	HPPInstance(vk::Instance instance);
 
-	vkb::core::HPPPhysicalDevice &get_suitable_gpu(vk::SurfaceKHR surface)
-	{
-		return reinterpret_cast<vkb::core::HPPPhysicalDevice &>(vkb::Instance::get_suitable_gpu(surface));
-	}
+	HPPInstance(const HPPInstance &) = delete;
+
+	HPPInstance(HPPInstance &&) = delete;
+
+	~HPPInstance();
+
+	HPPInstance &operator=(const HPPInstance &) = delete;
+
+	HPPInstance &operator=(HPPInstance &&) = delete;
+
+	const std::vector<const char *> &get_extensions();
+
+	/**
+	 * @brief Tries to find the first available discrete GPU
+	 * @returns A valid physical device
+	 */
+	HPPPhysicalDevice &get_first_gpu();
+
+	vk::Instance get_handle() const;
+
+	/**
+	 * @brief Tries to find the first available discrete GPU that can render to the given surface
+	 * @param surface to test against
+	 * @returns A valid physical device
+	 */
+	HPPPhysicalDevice &get_suitable_gpu(vk::SurfaceKHR);
+
+	/**
+	 * @brief Checks if the given extension is enabled in the vk::Instance
+	 * @param extension An extension to check
+	 */
+	bool is_enabled(const char *extension) const;
+
+  private:
+	/**
+	 * @brief Queries the instance for the physical devices on the machine
+	 */
+	void query_gpus();
+
+  private:
+	/**
+	 * @brief The Vulkan instance
+	 */
+	vk::Instance handle;
+
+	/**
+	 * @brief The enabled extensions
+	 */
+	std::vector<const char *> enabled_extensions;
+
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	/**
+	 * @brief Debug utils messenger callback for VK_EXT_Debug_Utils
+	 */
+	vk::DebugUtilsMessengerEXT debug_utils_messenger;
+
+	/**
+	 * @brief The debug report callback
+	 */
+	vk::DebugReportCallbackEXT debug_report_callback;
+#endif
+
+	/**
+	 * @brief The physical devices found on the machine
+	 */
+	std::vector<std::unique_ptr<HPPPhysicalDevice>> gpus;
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_physical_device.cpp
+++ b/framework/core/hpp_physical_device.cpp
@@ -1,0 +1,142 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core/hpp_physical_device.h>
+
+#include <common/logging.h>
+
+namespace vkb
+{
+namespace core
+{
+HPPPhysicalDevice::HPPPhysicalDevice(HPPInstance &instance, vk::PhysicalDevice physical_device) :
+    instance{instance},
+    handle{physical_device}
+{
+	features          = physical_device.getFeatures();
+	properties        = physical_device.getProperties();
+	memory_properties = physical_device.getMemoryProperties();
+
+	LOGI("Found GPU: {}", properties.deviceName);
+
+	queue_family_properties = physical_device.getQueueFamilyProperties();
+}
+
+DriverVersion HPPPhysicalDevice::get_driver_version() const
+{
+	DriverVersion version;
+
+	vk::PhysicalDeviceProperties const &properties = get_properties();
+	switch (properties.vendorID)
+	{
+		case 0x10DE:
+			// Nvidia
+			version.major = (properties.driverVersion >> 22) & 0x3ff;
+			version.minor = (properties.driverVersion >> 14) & 0x0ff;
+			version.patch = (properties.driverVersion >> 6) & 0x0ff;
+			// Ignoring optional tertiary info in lower 6 bits
+			break;
+		case 0x8086:
+			version.major = (properties.driverVersion >> 14) & 0x3ffff;
+			version.minor = properties.driverVersion & 0x3ffff;
+			break;
+		default:
+			version.major = VK_VERSION_MAJOR(properties.driverVersion);
+			version.minor = VK_VERSION_MINOR(properties.driverVersion);
+			version.patch = VK_VERSION_PATCH(properties.driverVersion);
+			break;
+	}
+
+	return version;
+}
+
+void *HPPPhysicalDevice::get_extension_feature_chain() const
+{
+	return last_requested_extension_feature;
+}
+
+const vk::PhysicalDeviceFeatures &HPPPhysicalDevice::get_features() const
+{
+	return features;
+}
+
+vk::PhysicalDevice HPPPhysicalDevice::get_handle() const
+{
+	return handle;
+}
+
+vkb::core::HPPInstance &HPPPhysicalDevice::get_instance() const
+{
+	return instance;
+}
+
+const vk::PhysicalDeviceMemoryProperties &HPPPhysicalDevice::get_memory_properties() const
+{
+	return memory_properties;
+}
+
+uint32_t HPPPhysicalDevice::get_memory_type(uint32_t bits, vk::MemoryPropertyFlags properties, vk::Bool32 *memory_type_found) const
+{
+	for (uint32_t i = 0; i < memory_properties.memoryTypeCount; i++)
+	{
+		if ((bits & 1) == 1)
+		{
+			if ((memory_properties.memoryTypes[i].propertyFlags & properties) == properties)
+			{
+				if (memory_type_found)
+				{
+					*memory_type_found = true;
+				}
+				return i;
+			}
+		}
+		bits >>= 1;
+	}
+
+	if (memory_type_found)
+	{
+		*memory_type_found = false;
+		return ~0;
+	}
+	else
+	{
+		throw std::runtime_error("Could not find a matching memory type");
+	}
+}
+
+const vk::PhysicalDeviceProperties &HPPPhysicalDevice::get_properties() const
+{
+	return properties;
+}
+
+const std::vector<vk::QueueFamilyProperties> &HPPPhysicalDevice::get_queue_family_properties() const
+{
+	return queue_family_properties;
+}
+
+const vk::PhysicalDeviceFeatures HPPPhysicalDevice::get_requested_features() const
+{
+	return requested_features;
+}
+
+vk::PhysicalDeviceFeatures &HPPPhysicalDevice::get_mutable_requested_features()
+{
+	return requested_features;
+}
+
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_physical_device.h
+++ b/framework/core/hpp_physical_device.h
@@ -110,7 +110,8 @@ class HPPPhysicalDevice
 		}
 
 		// If the type already exists in the map, return a casted pointer to get the extension feature struct
-		auto extension_features_it = extension_features.find(HPPStructureType::structureType);
+		vk::StructureType structureType         = HPPStructureType::structureType;        // need to instantiate this value to be usable in find()!
+		auto              extension_features_it = extension_features.find(structureType);
 		if (extension_features_it != extension_features.end())
 		{
 			return *static_cast<HPPStructureType *>(extension_features_it->second.get());
@@ -120,10 +121,10 @@ class HPPPhysicalDevice
 		vk::StructureChain<vk::PhysicalDeviceFeatures2KHR, HPPStructureType> featureChain = handle.getFeatures2KHR<vk::PhysicalDeviceFeatures2KHR, HPPStructureType>();
 
 		// Insert the extension feature into the extension feature map so its ownership is held
-		extension_features.insert({HPPStructureType::structureType, std::make_shared<HPPStructureType>(featureChain.template get<HPPStructureType>())});
+		extension_features.insert({structureType, std::make_shared<HPPStructureType>(featureChain.template get<HPPStructureType>())});
 
 		// Pull out the dereferenced void pointer, we can assume its type based on the template
-		auto *extension_ptr = static_cast<HPPStructureType *>(extension_features.find(HPPStructureType::structureType)->second.get());
+		auto *extension_ptr = static_cast<HPPStructureType *>(extension_features.find(structureType)->second.get());
 
 		// If an extension feature has already been requested, we shift the linked list down by one
 		// Making this current extension the new base pointer

--- a/framework/core/hpp_physical_device.h
+++ b/framework/core/hpp_physical_device.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,9 +17,8 @@
 
 #pragma once
 
-#include <core/physical_device.h>
-
 #include <core/hpp_instance.h>
+#include <map>
 #include <vulkan/vulkan.hpp>
 
 namespace vkb
@@ -36,147 +35,156 @@ struct DriverVersion
 };
 
 /**
- * @brief facade class around vkb::PhysicalDevice, providing a vulkan.hpp-based interface
+ * @brief A wrapper class for vk::PhysicalDevice
  *
- * See vkb::PhysicalDevice for documentation
+ * This class is responsible for handling gpu features, properties, and queue families for the device creation.
  */
-class HPPPhysicalDevice : private vkb::PhysicalDevice
+class HPPPhysicalDevice
 {
   public:
-	using vkb::PhysicalDevice::get_extension_feature_chain;
-	using vkb::PhysicalDevice::has_high_priority_graphics_queue;
-	using vkb::PhysicalDevice::set_high_priority_graphics_queue_enable;
+	HPPPhysicalDevice(HPPInstance &instance, vk::PhysicalDevice physical_device);
+
+	HPPPhysicalDevice(const HPPPhysicalDevice &) = delete;
+
+	HPPPhysicalDevice(HPPPhysicalDevice &&) = delete;
+
+	HPPPhysicalDevice &operator=(const HPPPhysicalDevice &) = delete;
+
+	HPPPhysicalDevice &operator=(HPPPhysicalDevice &&) = delete;
 
 	/**
-   * @return The version of the driver
-   */
-	DriverVersion get_driver_version() const
-	{
-		DriverVersion version;
-
-		vk::PhysicalDeviceProperties const &properties = get_properties();
-		switch (properties.vendorID)
-		{
-			case 0x10DE:
-				// Nvidia
-				version.major = (properties.driverVersion >> 22) & 0x3ff;
-				version.minor = (properties.driverVersion >> 14) & 0x0ff;
-				version.patch = (properties.driverVersion >> 6) & 0x0ff;
-				// Ignoring optional tertiary info in lower 6 bits
-				break;
-			case 0x8086:
-				version.major = (properties.driverVersion >> 14) & 0x3ffff;
-				version.minor = properties.driverVersion & 0x3ffff;
-				break;
-			default:
-				version.major = VK_VERSION_MAJOR(properties.driverVersion);
-				version.minor = VK_VERSION_MINOR(properties.driverVersion);
-				version.patch = VK_VERSION_PATCH(properties.driverVersion);
-				break;
-		}
-
-		return version;
-	}
-
-	vk::PhysicalDeviceFeatures const &get_features() const
-	{
-		return *reinterpret_cast<vk::PhysicalDeviceFeatures const *>(&vkb::PhysicalDevice::get_features());
-	}
-
-	vk::PhysicalDevice get_handle() const
-	{
-		return vkb::PhysicalDevice::get_handle();
-	}
-
-	vkb::core::HPPInstance &get_instance() const
-	{
-		return reinterpret_cast<vkb::core::HPPInstance &>(vkb::PhysicalDevice::get_instance());
-	}
-
-	vk::PhysicalDeviceMemoryProperties const &get_memory_properties() const
-	{
-		return reinterpret_cast<vk::PhysicalDeviceMemoryProperties const &>(vkb::PhysicalDevice::get_memory_properties());
-	}
+     * @return The version of the driver
+     */
+	DriverVersion get_driver_version() const;
 
 	/**
-   * @brief Checks that a given memory type is supported by the GPU
-   * @param bits The memory requirement type bits
-   * @param properties The memory property to search for
-   * @param memory_type_found True if found, false if not found
-   * @returns The memory type index of the found memory type
-   */
-	uint32_t get_memory_type(uint32_t bits, vk::MemoryPropertyFlags properties, vk::Bool32 *memory_type_found = nullptr) const
-	{
-		vk::PhysicalDeviceMemoryProperties const &memory_properties = get_memory_properties();
-		for (uint32_t i = 0; i < memory_properties.memoryTypeCount; i++)
-		{
-			if ((bits & 1) == 1)
-			{
-				if ((memory_properties.memoryTypes[i].propertyFlags & properties) == properties)
-				{
-					if (memory_type_found)
-					{
-						*memory_type_found = true;
-					}
-					return i;
-				}
-			}
-			bits >>= 1;
-		}
+	 * @brief Used at logical device creation to pass the extensions feature chain to vkCreateDevice
+	 * @returns A void pointer to the start of the extension linked list
+	 */
+	void *get_extension_feature_chain() const;
 
-		if (memory_type_found)
-		{
-			*memory_type_found = false;
-			return ~0;
-		}
-		else
-		{
-			throw std::runtime_error("Could not find a matching memory type");
-		}
-	}
+	const vk::PhysicalDeviceFeatures &get_features() const;
 
-	vk::PhysicalDeviceFeatures &get_mutable_requested_features()
-	{
-		return reinterpret_cast<vk::PhysicalDeviceFeatures &>(vkb::PhysicalDevice::get_mutable_requested_features());
-	}
+	vk::PhysicalDevice get_handle() const;
 
-	vk::PhysicalDeviceProperties const &get_properties() const
-	{
-		return reinterpret_cast<vk::PhysicalDeviceProperties const &>(vkb::PhysicalDevice::get_properties());
-	}
+	vkb::core::HPPInstance &get_instance() const;
 
-	std::vector<vk::QueueFamilyProperties> const &get_queue_family_properties() const
-	{
-		return reinterpret_cast<std::vector<vk::QueueFamilyProperties> const &>(vkb::PhysicalDevice::get_queue_family_properties());
-	}
+	const vk::PhysicalDeviceMemoryProperties &get_memory_properties() const;
 
 	/**
-   * @return Whether an image format is supported by the GPU
-   */
-	bool is_image_format_supported(vk::Format format) const
-	{
-		try
-		{
-			get_handle().getImageFormatProperties(format, vk::ImageType::e2D, vk::ImageTiling::eOptimal, vk::ImageUsageFlagBits::eSampled);
-		}
-		catch (vk::SystemError &err)
-		{
-			return err.code() != vk::make_error_code(vk::Result::eErrorFormatNotSupported);
-		}
-		return true;
-	}
+     * @brief Checks that a given memory type is supported by the GPU
+     * @param bits The memory requirement type bits
+     * @param properties The memory property to search for
+     * @param memory_type_found True if found, false if not found
+     * @returns The memory type index of the found memory type
+     */
+	uint32_t get_memory_type(uint32_t bits, vk::MemoryPropertyFlags properties, vk::Bool32 *memory_type_found = nullptr) const;
 
-	vk::Bool32 is_present_supported(vk::SurfaceKHR surface, uint32_t queue_family_index) const
-	{
-		return static_cast<vk::Bool32>(vkb::PhysicalDevice::is_present_supported(static_cast<VkSurfaceKHR>(surface), queue_family_index));
-	}
+	const vk::PhysicalDeviceProperties &get_properties() const;
 
+	const std::vector<vk::QueueFamilyProperties> &get_queue_family_properties() const;
+
+	const vk::PhysicalDeviceFeatures get_requested_features() const;
+
+	vk::PhysicalDeviceFeatures &get_mutable_requested_features();
+
+	/**
+	 * @brief Requests a third party extension to be used by the framework
+	 *
+	 *        To have the features enabled, this function must be called before the logical device
+	 *        is created. To do this request sample specific features inside
+	 *        VulkanSample::request_gpu_features(vkb::HPPPhysicalDevice &gpu).
+	 *
+	 *        If the feature extension requires you to ask for certain features to be enabled, you can
+	 *        modify the struct returned by this function, it will propegate the changes to the logical
+	 *        device.
+	 * @returns The extension feature struct
+	 */
 	template <typename HPPStructureType>
 	HPPStructureType &request_extension_features()
 	{
-		return reinterpret_cast<HPPStructureType &>(vkb::PhysicalDevice::request_extension_features<typename HPPStructureType::NativeType>(
-		    static_cast<VkStructureType>(HPPStructureType::structureType)));
+		// We cannot request extension features if the physical device properties 2 instance extension isnt enabled
+		if (!instance.is_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
+		{
+			throw std::runtime_error("Couldn't request feature from device as " + std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) + " isn't enabled!");
+		}
+
+		// If the type already exists in the map, return a casted pointer to get the extension feature struct
+		auto extension_features_it = extension_features.find(HPPStructureType::structureType);
+		if (extension_features_it != extension_features.end())
+		{
+			return *static_cast<HPPStructureType *>(extension_features_it->second.get());
+		}
+
+		// Get the extension feature
+		vk::StructureChain<vk::PhysicalDeviceFeatures2KHR, HPPStructureType> featureChain = handle.getFeatures2KHR<vk::PhysicalDeviceFeatures2KHR, HPPStructureType>();
+
+		// Insert the extension feature into the extension feature map so its ownership is held
+		extension_features.insert({HPPStructureType::structureType, std::make_shared<HPPStructureType>(featureChain.template get<HPPStructureType>())});
+
+		// Pull out the dereferenced void pointer, we can assume its type based on the template
+		auto *extension_ptr = static_cast<HPPStructureType *>(extension_features.find(HPPStructureType::structureType)->second.get());
+
+		// If an extension feature has already been requested, we shift the linked list down by one
+		// Making this current extension the new base pointer
+		if (last_requested_extension_feature)
+		{
+			extension_ptr->pNext = last_requested_extension_feature;
+		}
+		last_requested_extension_feature = extension_ptr;
+
+		return *extension_ptr;
 	}
+
+	/**
+	 * @brief Sets whether or not the first graphics queue should have higher priority than other queues.
+	 * Very specific feature which is used by async compute samples.
+	 * @param enable If true, present queue will have prio 1.0 and other queues have prio 0.5.
+	 * Default state is false, where all queues have 0.5 priority.
+	 */
+	void set_high_priority_graphics_queue_enable(bool enable)
+	{
+		high_priority_graphics_queue = enable;
+	}
+
+	/**
+	 * @brief Returns high priority graphics queue state.
+	 * @return High priority state.
+	 */
+	bool has_high_priority_graphics_queue() const
+	{
+		return high_priority_graphics_queue;
+	}
+
+  private:
+	// Handle to the Vulkan instance
+	HPPInstance &instance;
+
+	// Handle to the Vulkan physical device
+	vk::PhysicalDevice handle{nullptr};
+
+	// The features that this GPU supports
+	vk::PhysicalDeviceFeatures features;
+
+	// The GPU properties
+	vk::PhysicalDeviceProperties properties;
+
+	// The GPU memory properties
+	vk::PhysicalDeviceMemoryProperties memory_properties;
+
+	// The GPU queue family properties
+	std::vector<vk::QueueFamilyProperties> queue_family_properties;
+
+	// The features that will be requested to be enabled in the logical device
+	vk::PhysicalDeviceFeatures requested_features;
+
+	// The extension feature pointer
+	void *last_requested_extension_feature{nullptr};
+
+	// Holds the extension feature structures, we use a map to retain an order of requested structures
+	std::map<vk::StructureType, std::shared_ptr<void>> extension_features;
+
+	bool high_priority_graphics_queue{false};
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/hpp_vulkan_sample.cpp
+++ b/framework/hpp_vulkan_sample.cpp
@@ -101,8 +101,6 @@ bool HPPVulkanSample::prepare(vkb::platform::HPPPlatform &platform)
 
 	instance = std::make_unique<vkb::core::HPPInstance>(get_name(), get_instance_extensions(), get_validation_layers(), headless, api_version);
 
-	VULKAN_HPP_DEFAULT_DISPATCHER.init(get_instance().get_handle());
-
 	// Getting a valid vulkan surface from the platform
 	surface = platform.get_window().create_surface(*instance);
 


### PR DESCRIPTION
## Description

Replacing this part of the framework shows how to manage some more resources using vulkan.hpp.

In order to do so, minor adjustments in vkb::core::HPPDevice and framework/hpp_vulkan_sample.cpp were needed.

I have tested it on Window10 on nvidia HW.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
