### PR TITLE
Fix small typo in multi_draw_indirect sample

### DIFF
--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -36,7 +36,7 @@ struct CopyBuffer
 		{
 			return {};
 		}
-		auto &         buffer = iter->second;
+		auto          &buffer = iter->second;
 		std::vector<T> out;
 
 		const size_t sz = buffer.get_size();
@@ -173,7 +173,7 @@ void MultiDrawIndirect::build_command_buffers()
 		vkCmdBindVertexBuffers(draw_cmd_buffers[i], 0, 1, vertex_buffer->get(), offsets);
 		vkCmdBindVertexBuffers(draw_cmd_buffers[i], 1, 1, model_information_buffer->get(), offsets);
 
-		if (m_enable_mci && m_supports_mdi)
+		if (m_enable_mdi && m_supports_mdi)
 		{
 			vkCmdDrawIndexedIndirect(draw_cmd_buffers[i], indirect_call_buffer->get_handle(), 0, cpu_commands.size(), sizeof(cpu_commands[0]));
 		}
@@ -229,7 +229,7 @@ void MultiDrawIndirect::on_update_ui_overlay(vkb::Drawer &drawer)
 		}
 		drawer.text("Instances: %d / %d", instance_count, 256);
 
-		m_requires_rebuild |= drawer.checkbox("Enable multi-draw", &m_enable_mci);
+		m_requires_rebuild |= drawer.checkbox("Enable multi-draw", &m_enable_mdi);
 		drawer.checkbox("Freeze culling", &m_freeze_cull);
 
 		int32_t render_selection = render_mode;
@@ -312,7 +312,7 @@ void MultiDrawIndirect::load_scene()
 	for (auto &&mesh : scene->get_components<vkb::sg::Mesh>())
 	{
 		const size_t texture_index = textures.size();
-		const auto & short_name    = mesh->get_name();
+		const auto  &short_name    = mesh->get_name();
 		auto         image_name    = scene_path + short_name + ".ktx";
 		auto         image         = vkb::sg::Image::load(image_name, image_name);
 
@@ -864,7 +864,7 @@ void MultiDrawIndirect::run_gpu_cull()
 	vkQueueSubmit(compute_queue->get_handle(), 1, &submit, device->request_fence());
 	device->get_fence_pool().wait();
 	device->get_fence_pool().reset();
-	//we're done so dealloc it from the pool.
+	// we're done so dealloc it from the pool.
 	vkFreeCommandBuffers(device->get_handle(), device->get_command_pool().get_handle(), 1, &cmd);
 }
 
@@ -926,7 +926,7 @@ void MultiDrawIndirect::cpu_cull()
 	for (size_t i = 0; i < models.size(); ++i)
 	{
 		// we control visibility by changing the instance count
-		auto &                       model = models[i];
+		auto		                &model = models[i];
 		VkDrawIndexedIndirectCommand cmd{};
 		cmd.firstIndex    = model.index_buffer_offset / (sizeof(model.triangles[0][0]));
 		cmd.indexCount    = static_cast<uint32_t>(model.triangles.size()) * 3;

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -36,7 +36,7 @@ struct CopyBuffer
 		{
 			return {};
 		}
-		auto          &buffer = iter->second;
+		auto &         buffer = iter->second;
 		std::vector<T> out;
 
 		const size_t sz = buffer.get_size();
@@ -312,7 +312,7 @@ void MultiDrawIndirect::load_scene()
 	for (auto &&mesh : scene->get_components<vkb::sg::Mesh>())
 	{
 		const size_t texture_index = textures.size();
-		const auto  &short_name    = mesh->get_name();
+		const auto & short_name    = mesh->get_name();
 		auto         image_name    = scene_path + short_name + ".ktx";
 		auto         image         = vkb::sg::Image::load(image_name, image_name);
 
@@ -926,7 +926,7 @@ void MultiDrawIndirect::cpu_cull()
 	for (size_t i = 0; i < models.size(); ++i)
 	{
 		// we control visibility by changing the instance count
-		auto		                &model = models[i];
+		auto &                       model = models[i];
 		VkDrawIndexedIndirectCommand cmd{};
 		cmd.firstIndex    = model.index_buffer_offset / (sizeof(model.triangles[0][0]));
 		cmd.indexCount    = static_cast<uint32_t>(model.triangles.size()) * 3;

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Holochip Corporation
+/* Copyright (c) 2021-2022, Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.h
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Holochip Corporation
+/* Copyright (c) 2021-2022, Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.h
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.h
@@ -124,7 +124,7 @@ class MultiDrawIndirect : public ApiVulkanSample
 	std::unique_ptr<vkb::core::Buffer> device_address_buffer{nullptr};
 
 	std::vector<vkb::CommandBuffer> compute_command_buffers{};
-	const vkb::Queue               *compute_queue{nullptr};
+	const vkb::Queue *              compute_queue{nullptr};
 	std::vector<uint32_t>           queue_families;
 
 	// CPU Draw Calls

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.h
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.h
@@ -99,7 +99,7 @@ class MultiDrawIndirect : public ApiVulkanSample
 	std::vector<Texture>               textures;
 	std::vector<VkDescriptorImageInfo> image_descriptors;
 	bool                               m_freeze_cull      = false;
-	bool                               m_enable_mci       = true;
+	bool                               m_enable_mdi       = true;
 	bool                               m_requires_rebuild = false;
 
 	VkPipeline            pipeline{VK_NULL_HANDLE};
@@ -124,7 +124,7 @@ class MultiDrawIndirect : public ApiVulkanSample
 	std::unique_ptr<vkb::core::Buffer> device_address_buffer{nullptr};
 
 	std::vector<vkb::CommandBuffer> compute_command_buffers{};
-	const vkb::Queue *              compute_queue{nullptr};
+	const vkb::Queue               *compute_queue{nullptr};
 	std::vector<uint32_t>           queue_families;
 
 	// CPU Draw Calls


### PR DESCRIPTION
## Description
Fixes a typo in the multi_draw_indirect sample.

Closes #449 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
