### PR TITLE
Re-encode KTX2s to have mipmaps, fix mipmap loading order

### DIFF
--- a/framework/scene_graph/components/image/ktx.cpp
+++ b/framework/scene_graph/components/image/ktx.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2019-2022, Arm Limited and Contributors
- * Copyright (c) 2019-2021, Sascha Willems
+ * Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
## Description

This branch re-encodes all KTX2s used in the Bonza scene so that they have mipmaps, plus a higher level of quality for ASTC compression. It also fixes the loading order for mipmap levels, which is flipped in KTX2 vs. KTX1 (in KTX1, smaller mipmaps come last; in KTX2, they come first).

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [-] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
