### PR TITLE
Event Channels

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(events)

--- a/components/events/CMakeLists.txt
+++ b/components/events/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(components__events INTERFACE)
+target_include_directories(components__events INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+vkb__register_tests(
+  NAME "events_tests"
+  SRC
+    tests/channel.test.cpp
+  LIBS
+    components__events
+)

--- a/components/events/include/components/events/channel.hpp
+++ b/components/events/include/components/events/channel.hpp
@@ -1,0 +1,264 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <set>
+
+namespace components
+{
+namespace events
+{
+
+template <typename Type>
+class Channel;
+template <typename Type>
+using ChannelPtr = std::shared_ptr<Channel<Type>>;
+
+template <typename Type>
+class ChannelReceiver;
+template <typename Type>
+using ChannelReceiverPtr = std::unique_ptr<ChannelReceiver<Type>>;
+
+template <typename Type>
+class ChannelSender;
+template <typename Type>
+using ChannelSenderPtr = std::unique_ptr<ChannelSender<Type>>;
+
+template <typename Type>
+class Channel
+{
+	friend ChannelReceiver<Type>;
+	friend ChannelSender<Type>;
+
+  public:
+	~Channel();
+
+	static ChannelPtr<Type> shared()
+	{
+		return std::shared_ptr<Channel<Type>>(new Channel<Type>());
+	}
+
+	ChannelReceiverPtr<Type> receiver();
+
+	ChannelSenderPtr<Type> sender();
+
+  protected:
+	Channel();
+
+	void put(const Type &type);
+
+	void unsubscribe(ChannelReceiver<Type> &receiver);
+
+	void subscribe(ChannelReceiver<Type> &receiver);
+
+  private:
+	mutable std::mutex                m_mut;
+	std::set<ChannelReceiver<Type> *> m_receivers;
+};        // namespace components
+
+template <typename Type>
+class ChannelReceiver
+{
+	friend Channel<Type>;
+
+  public:
+	~ChannelReceiver();
+
+	bool has_next() const;
+
+	Type next();
+
+	Type last();
+
+  private:
+	ChannelReceiver(Channel<Type> &channel);
+
+	void put(const Type &item);
+
+	mutable std::mutex m_mut;
+	Channel<Type>     &m_channel;
+	std::queue<Type>   m_queue;
+};
+
+template <typename Type>
+class ChannelSender
+{
+	friend Channel<Type>;
+
+  public:
+	~ChannelSender();
+
+	void put(const Type &item);
+
+  private:
+	ChannelSender(Channel<Type> &channel);
+
+	mutable std::mutex m_mut;
+	Channel<Type>     &m_channel;
+};
+}        // namespace events
+}        // namespace components
+
+/*
+ *
+ * Template Implementations
+ *
+ */
+
+namespace components
+{
+namespace events
+{
+template <typename Type>
+Channel<Type>::Channel()
+{}
+
+template <typename Type>
+Channel<Type>::~Channel()
+{}
+
+template <typename Type>
+ChannelReceiverPtr<Type> Channel<Type>::receiver()
+{
+	return std::unique_ptr<ChannelReceiver<Type>>(new ChannelReceiver<Type>(*this));
+}
+
+template <typename Type>
+ChannelSenderPtr<Type> Channel<Type>::sender()
+{
+	return std::unique_ptr<ChannelSender<Type>>(new ChannelSender<Type>(*this));
+}
+
+template <typename Type>
+void Channel<Type>::put(const Type &type)
+{
+	std::lock_guard<std::mutex> lock{m_mut};
+
+	for (auto *receiver : m_receivers)
+	{
+		receiver->put(type);
+	}
+}
+
+template <typename Type>
+void Channel<Type>::unsubscribe(ChannelReceiver<Type> &receiver)
+{
+	std::lock_guard<std::mutex> lock{m_mut};
+
+	const auto it = m_receivers.find(&receiver);
+	if (it == m_receivers.end())
+	{
+		m_receivers.erase(it);
+	}
+}
+
+template <typename Type>
+void Channel<Type>::subscribe(ChannelReceiver<Type> &receiver)
+{
+	std::lock_guard<std::mutex> lock{m_mut};
+
+	m_receivers.emplace(&receiver);
+}
+
+template <typename Type>
+ChannelReceiver<Type>::ChannelReceiver(Channel<Type> &channel) :
+    m_channel{channel}
+{
+	m_channel.subscribe(*this);
+}
+
+template <typename Type>
+ChannelReceiver<Type>::~ChannelReceiver()
+{
+	m_channel.unsubscribe(*this);
+}
+
+template <typename Type>
+bool ChannelReceiver<Type>::has_next() const
+{
+	std::lock_guard<std::mutex> lock{m_mut};
+
+	return !m_queue.empty();
+}
+
+template <typename Type>
+Type ChannelReceiver<Type>::next()
+{
+	std::lock_guard<std::mutex> lock{m_mut};
+
+	if (m_queue.empty())
+	{
+		return {};
+	}
+
+	auto front = m_queue.front();
+	m_queue.pop();
+
+	return front;
+}
+
+template <typename Type>
+Type ChannelReceiver<Type>::last()
+{
+	std::lock_guard<std::mutex> lock{m_mut};
+
+	if (m_queue.empty())
+	{
+		return {};
+	}
+
+	Type front;
+	while (!m_queue.empty())
+	{
+		front = m_queue.front();
+		m_queue.pop();
+	}
+
+	return front;
+}
+
+template <typename Type>
+void ChannelReceiver<Type>::put(const Type &item)
+{
+	std::lock_guard<std::mutex> lock{m_mut};
+
+	m_queue.push(item);
+}
+
+template <typename Type>
+ChannelSender<Type>::ChannelSender(Channel<Type> &channel) :
+    m_channel{channel}
+{
+}
+
+template <typename Type>
+ChannelSender<Type>::~ChannelSender()
+{}
+
+template <typename Type>
+void ChannelSender<Type>::put(const Type &item)
+{
+	std::lock_guard<std::mutex> lock{m_mut};
+
+	m_channel.put(item);
+}
+}        // namespace events
+}        // namespace components

--- a/components/events/tests/channel.test.cpp
+++ b/components/events/tests/channel.test.cpp
@@ -1,0 +1,122 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <vector>
+
+#include <components/events/channel.hpp>
+
+using namespace components::events;
+
+TEST_CASE("send single event", "[events]")
+{
+	struct Event
+	{
+		uint32_t value;
+	};
+
+	ChannelPtr<Event> channel = Channel<Event>::shared();
+
+	auto send = channel->sender();
+
+	auto rec1 = channel->receiver();
+	auto rec2 = channel->receiver();
+
+	send->put(Event{42});
+	REQUIRE((rec1->has_next() && rec2->has_next()));
+
+	auto val1 = rec1->next();
+	REQUIRE(val1.value == 42);
+
+	auto val2 = rec2->next();
+	REQUIRE(val2.value == 42);
+}
+
+TEST_CASE("send multiple events", "[events]")
+{
+	struct Event
+	{
+		uint32_t value;
+	};
+
+	ChannelPtr<Event> channel = Channel<Event>::shared();
+
+	auto send1 = channel->sender();
+	auto send2 = channel->sender();
+
+	auto rec1 = channel->receiver();
+
+	send1->put({1});
+	send2->put({2});
+	send1->put({3});
+	send1->put({4});
+	send2->put({5});
+
+	std::vector<uint32_t> expected_values = {
+	    1,
+	    2,
+	    3,
+	    4,
+	    5,
+	};
+
+	for (auto val : expected_values)
+	{
+		REQUIRE(rec1->has_next());
+		REQUIRE(rec1->next().value == val);
+	}
+}
+
+TEST_CASE("create receiver whilst sending events", "[events]")
+{
+	struct Event
+	{
+		uint32_t value;
+	};
+
+	ChannelPtr<Event> channel = Channel<Event>::shared();
+
+	auto send1 = channel->sender();
+
+	auto rec1 = channel->receiver();
+
+	send1->put({1});
+	send1->put({2});
+	send1->put({3});
+
+	auto rec2 = channel->receiver();
+
+	send1->put({4});
+	send1->put({5});
+
+	std::vector<uint32_t> expected_values_1 = {1, 2, 3, 4, 5};
+
+	for (auto val : expected_values_1)
+	{
+		REQUIRE(rec1->has_next());
+		REQUIRE(rec1->next().value == val);
+	}
+
+	std::vector<uint32_t> expected_values_2 = {4, 5};
+
+	for (auto val : expected_values_2)
+	{
+		REQUIRE(rec2->has_next());
+		REQUIRE(rec2->next().value == val);
+	}
+}


### PR DESCRIPTION
## Description

Small PR to add event channels to Vulkan Samples.

The idea is these can be used in other components to communicate events. Channels if mutex locked can also be used to push tasks to worker threads. A sample could use these to defer computation to another thread and then update the scene graph when data is returned on an output channel.

The first use case for these will be an `EventBus` scenario, window events and input events.

Fixes #468

Includes Unit Tests