### PR TITLE
WIP: Vulkan Instance Builder

### DIFF
--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -26,7 +26,7 @@ add_custom_target(vkb_tests)
 function(vkb__register_tests)
     set(options)  
     set(oneValueArgs NAME)
-    set(multiValueArgs SRC LIBS)
+    set(multiValueArgs SRC LINK_LIBS INCLUDE_DIRS)
 
     if(NOT ((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING) OR VKB_BUILD_TESTS))
         return() # testing not enabled
@@ -45,8 +45,12 @@ function(vkb__register_tests)
     add_executable(${TARGET_NAME} ${TARGET_SRC})
     target_link_libraries(${TARGET_NAME} PUBLIC Catch2::Catch2WithMain)
 
-    if (TARGET_LIBS)
-        target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LIBS})
+    if (TARGET_LINK_LIBS)
+        target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LINK_LIBS})
+    endif()
+
+    if (TARGET_INCLUDE_DIRS)
+        target_include_directories(${TARGET_NAME} PUBLIC ${TARGET_INCLUDE_DIRS})
     endif()
 
     add_test(NAME ${TARGET_NAME}

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(vulkan)

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,1 +1,3 @@
+add_subdirectory(common)
+
 add_subdirectory(vulkan)

--- a/components/common/CMakeLists.txt
+++ b/components/common/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) 2022, Arm Limited and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(components__common INTERFACE)
+target_include_directories(components__common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_library(Components::Common ALIAS components__common)
+
+vkb__register_tests(
+    NAME "common_tests"
+    SRC
+        tests/stack_error.test.cpp
+    LIBS
+        components__common
+)

--- a/components/common/CMakeLists.txt
+++ b/components/common/CMakeLists.txt
@@ -22,6 +22,6 @@ vkb__register_tests(
     NAME "common_tests"
     SRC
         tests/stack_error.test.cpp
-    LIBS
+    LINK_LIBS
         components__common
 )

--- a/components/common/include/components/common/stack_error.hpp
+++ b/components/common/include/components/common/stack_error.hpp
@@ -1,0 +1,131 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string.h>
+
+#include <deque>
+#include <exception>
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace components
+{
+class StackError;
+using StackErrorPtr = std::unique_ptr<StackError>;
+
+class StackError : std::exception
+{
+  public:
+	StackError()  = default;
+	~StackError() = default;
+
+	StackError(const std::string &reason, const char *file = nullptr, int line = 0)
+	{
+		push(reason, file, line);
+	}
+
+	static StackErrorPtr combine(StackErrorPtr &&first, StackErrorPtr &&second)
+	{
+		auto combined = std::make_unique<StackError>();
+
+		for (auto &err : first->m_stack)
+		{
+			combined->push(err);
+		}
+
+		for (auto &err : second->m_stack)
+		{
+			combined->push(err);
+		}
+
+		return std::move(combined);
+	}
+
+	void push(const std::string &reason, const char *file = nullptr, int line = 0)
+	{
+		std::stringstream stream;
+
+		if (file && strlen(file) > 0)
+		{
+			stream << "[" << file << ":" << line << "] ";
+		}
+
+		stream << reason.c_str();
+
+		m_stack.push_back(stream.str());
+	}
+
+	inline size_t size() const
+	{
+		return m_stack.size();
+	}
+
+	/**
+	 * @brief Returns the Vulkan error code as string
+	 * @return String message of exception
+	 */
+	const char *what() const noexcept override
+	{
+		if (m_stack.empty())
+		{
+			return nullptr;
+		}
+
+		std::deque<std::string> queue{m_stack};
+
+		m_final = "";
+
+		while (!queue.empty())
+		{
+			auto first = queue.front();
+
+			m_final += first;
+			m_final += "\n";
+
+			queue.pop_front();
+		}
+
+		return m_final.c_str();
+	}
+
+	static std::unique_ptr<StackError> unique(const std::string &reason, const char *file = nullptr, int line = 0)
+	{
+		return std::make_unique<StackError>(reason, file, line);
+	}
+
+  private:
+	StackError &operator+=(const StackError &b)
+	{
+		std::deque<std::string> queue{b.m_stack};
+
+		while (!queue.empty())
+		{
+			m_stack.push_front(queue.back());
+			queue.pop_back();
+		}
+
+		return *this;
+	}
+
+	std::deque<std::string> m_stack;
+	mutable std::string     m_final;
+};
+
+}        // namespace components

--- a/components/common/tests/stack_error.test.cpp
+++ b/components/common/tests/stack_error.test.cpp
@@ -1,0 +1,101 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <vector>
+
+#include <components/common/stack_error.hpp>
+
+using namespace components;
+
+TEST_CASE("what() exists and is as expected", "[common]")
+{
+	struct Test
+	{
+		std::string message;
+		std::string file;
+		uint32_t    line;
+		std::string expected;
+	};
+
+	std::vector<Test> tests{
+	    {
+	        "this is an error",
+	        "some/file.cpp",
+	        24,
+	        "[some/file.cpp:24] this is an error\n",
+	    },
+	    {
+	        "this is another error",
+	        "some/file.cpp",
+	        0,
+	        "[some/file.cpp:0] this is another error\n",
+	    },
+	    {
+	        "this is another error",
+	        "",
+	        0,
+	        "this is another error\n",
+	    },
+	};
+
+	for (auto &test : tests)
+	{
+		auto error = StackError::unique(test.message, test.file.c_str(), test.line);
+		REQUIRE(error->what() != nullptr);
+		REQUIRE(std::string{error->what()} == test.expected);
+	}
+}
+
+TEST_CASE("multiple stack errors", "[common]")
+{
+	auto error = StackError::unique("this is a test message", "file.cpp", 1);
+	error->push("this is a another test message", "file.cpp", 2);
+	error->push("this is a final test message");
+	REQUIRE(error->size() == 3);
+	REQUIRE(std::string{error->what()} == "[file.cpp:1] this is a test message\n[file.cpp:2] this is a another test message\nthis is a final test message\n");
+}
+
+TEST_CASE("combine stack errors", "[common]")
+{
+	auto error1 = StackError::unique("this is a test message", "file.cpp", 1);
+	auto error2 = StackError::unique("this is a test message", "another_file.cpp", 2);
+	auto error  = StackError::combine(std::move(error1), std::move(error2));
+	REQUIRE(error->size() == 2);
+	REQUIRE(std::string{error->what()} == "[file.cpp:1] this is a test message\n[another_file.cpp:2] this is a test message\n");
+}
+
+TEST_CASE("combine larger stack errors", "[common]")
+{
+	auto error1 = StackError::unique("this is a test message", "file.cpp", 1);
+	error1->push("this is a test message", "file.cpp", 1);
+	error1->push("this is a test message", "file.cpp", 1);
+	error1->push("this is a test message", "file.cpp", 1);
+	REQUIRE(error1->size() == 4);
+
+	auto error2 = StackError::unique("this is a test message", "another_file.cpp", 2);
+	error2->push("this is a test message", "another_file.cpp", 2);
+	error2->push("this is a test message", "another_file.cpp", 2);
+	REQUIRE(error2->size() == 3);
+
+	auto error = StackError::combine(std::move(error1), std::move(error2));
+	REQUIRE(error->size() == 7);
+
+	REQUIRE(std::string{error->what()} == "[file.cpp:1] this is a test message\n[file.cpp:1] this is a test message\n[file.cpp:1] this is a test message\n[file.cpp:1] this is a test message\n[another_file.cpp:2] this is a test message\n[another_file.cpp:2] this is a test message\n[another_file.cpp:2] this is a test message\n");
+}

--- a/components/vulkan/CMakeLists.txt
+++ b/components/vulkan/CMakeLists.txt
@@ -1,17 +1,31 @@
+# volk
+set(VOLK_DIR "${CMAKE_SOURCE_DIR}/third_party/volk")
+set(VOLK_SRC ${VOLK_DIR}/volk.c)
+
 set(SRC
+    ${VOLK_SRC}
     src/instance.cpp
 )
 
 add_library(components__vulkan STATIC ${SRC})
-target_include_directories(components__vulkan PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(components__vulkan PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${VOLK_DIR})
 target_link_libraries(components__vulkan PUBLIC
-    components__common
-    volk)
+    vulkan
+    ${CMAKE_DL_LIBS}
+    components__common)
+
+if (VKB_WSI_SELECTION STREQUAL XCB)
+    target_include_directories(components__vulkan PUBLIC ${XCB_INCLUDE_DIRS})
+elseif (VKB_WSI_SELECTION STREQUAL XLIB)
+    target_include_directories(components__vulkan PUBLIC ${X11_INCLUDE_DIRS})
+elseif (VKB_WSI_SELECTION STREQUAL WAYLAND)
+    target_include_directories(components__vulkan PUBLIC ${WAYLAND_INCLUDE_DIRS})
+endif()
 
 
 add_library(components__vulkan_test_framework STATIC tests/vulkan_test_functions.cpp)
 target_include_directories(components__vulkan_test_framework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-target_link_libraries(components__vulkan_test_framework PUBLIC volk Catch2::Catch2)
+target_link_libraries(components__vulkan_test_framework PUBLIC components__vulkan Catch2::Catch2)
 
 # force CXX linkage
 set_target_properties(components__vulkan_test_framework PROPERTIES LINKER_LANGUAGE CXX)
@@ -21,6 +35,5 @@ vkb__register_tests(
     SRC
         tests/instance.test.cpp
     LIBS
-        components__vulkan
         components__vulkan_test_framework
 )

--- a/components/vulkan/CMakeLists.txt
+++ b/components/vulkan/CMakeLists.txt
@@ -4,7 +4,14 @@ set(SRC
 
 add_library(components__vulkan STATIC ${SRC})
 target_include_directories(components__vulkan PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(components__vulkan PUBLIC volk)
+target_link_libraries(components__vulkan PUBLIC
+    components__common
+    volk)
+
+
+add_library(components__vulkan_test_framework STATIC tests/vulkan_test_functions.cpp)
+target_include_directories(components__vulkan_test_framework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+target_link_libraries(components__vulkan_test_framework PUBLIC volk Catch2::Catch2)
 
 vkb__register_tests(
     NAME "vulkan_tests"
@@ -12,4 +19,5 @@ vkb__register_tests(
         tests/instance.test.cpp
     LIBS
         components__vulkan
+        components__vulkan_test_framework
 )

--- a/components/vulkan/CMakeLists.txt
+++ b/components/vulkan/CMakeLists.txt
@@ -13,6 +13,9 @@ add_library(components__vulkan_test_framework STATIC tests/vulkan_test_functions
 target_include_directories(components__vulkan_test_framework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 target_link_libraries(components__vulkan_test_framework PUBLIC volk Catch2::Catch2)
 
+# force CXX linkage
+set_target_properties(components__vulkan_test_framework PROPERTIES LINKER_LANGUAGE CXX)
+
 vkb__register_tests(
     NAME "vulkan_tests"
     SRC

--- a/components/vulkan/CMakeLists.txt
+++ b/components/vulkan/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(SRC
+    src/instance.cpp
+)
+
+add_library(components__vulkan STATIC ${SRC})
+target_include_directories(components__vulkan PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(components__vulkan PUBLIC volk)
+
+vkb__register_tests(
+    NAME "vulkan_tests"
+    SRC
+        tests/instance.test.cpp
+    LIBS
+        components__vulkan
+)

--- a/components/vulkan/CMakeLists.txt
+++ b/components/vulkan/CMakeLists.txt
@@ -22,18 +22,18 @@ elseif (VKB_WSI_SELECTION STREQUAL WAYLAND)
     target_include_directories(components__vulkan PUBLIC ${WAYLAND_INCLUDE_DIRS})
 endif()
 
-
-add_library(components__vulkan_test_framework STATIC tests/vulkan_test_functions.cpp)
-target_include_directories(components__vulkan_test_framework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-target_link_libraries(components__vulkan_test_framework PUBLIC components__vulkan Catch2::Catch2)
-
-# force CXX linkage
-set_target_properties(components__vulkan_test_framework PROPERTIES LINKER_LANGUAGE CXX)
-
 vkb__register_tests(
     NAME "vulkan_tests"
     SRC
+        ${SRC}
+        tests/vulkan_test_functions.cpp
         tests/instance.test.cpp
-    LIBS
-        components__vulkan_test_framework
+    LINK_LIBS
+        vulkan
+        ${CMAKE_DL_LIBS}
+        components__common
+    INCLUDE_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests
+        ${VOLK_DIR}
 )

--- a/components/vulkan/CMakeLists.txt
+++ b/components/vulkan/CMakeLists.txt
@@ -22,6 +22,14 @@ elseif (VKB_WSI_SELECTION STREQUAL WAYLAND)
     target_include_directories(components__vulkan PUBLIC ${WAYLAND_INCLUDE_DIRS})
 endif()
 
+
+
+## Vulkan unit tests overrite the Volk vulkan function definitions with custom written ones
+## In the custom vulkan function implementations we can add test logic to verify that our code is using Vulkan as expected
+## This does not remove the need to out of box test on specific platforms as drivers can contain bugs
+
+## This library must contain all source, libraries and include dirs as components__vulkan. It must be a single compile target to avoid linker errors when compiling on Mac
+
 vkb__register_tests(
     NAME "vulkan_tests"
     SRC

--- a/components/vulkan/include/components/vulkan/instance.hpp
+++ b/components/vulkan/include/components/vulkan/instance.hpp
@@ -19,6 +19,7 @@
 
 #include <cassert>
 #include <memory>
+#include <optional>
 #include <set>
 #include <unordered_map>
 #include <vector>

--- a/components/vulkan/include/components/vulkan/instance.hpp
+++ b/components/vulkan/include/components/vulkan/instance.hpp
@@ -1,0 +1,61 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <volk.h>
+
+namespace components
+{
+namespace vulkan
+{
+struct Instance
+{
+	VkInstance instance_handle;
+};
+
+class InstanceBuilder
+{
+  public:
+	InstanceBuilder()  = default;
+	~InstanceBuilder() = default;
+
+	inline InstanceBuilder &set_vulkan_api_version(uint32_t major, uint32_t minor, uint32_t patch = 0, uint32_t variant = 0)
+	{
+		return set_vulkan_api_version(VK_MAKE_API_VERSION(variant, major, minor, patch));
+	}
+
+	InstanceBuilder &set_vulkan_api_version(uint32_t encoded_version);
+	InstanceBuilder &enable_layer(const char *layer_name);
+	InstanceBuilder &enable_extension(const char *layer_name);
+
+	template <typename Func>
+	InstanceBuilder &apply(Func &&func)
+	{
+		func(*this);
+	}
+
+	StackError build(Instance *o_instance);
+
+  private:
+	VkApplicationInfo    m_application_info{VK_STRUCTURE_TYPE_APPLICATION_INFO};
+	VkInstanceCreateInfo m_instance_create_info{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+};
+}        // namespace vulkan
+}        // namespace components

--- a/components/vulkan/include/components/vulkan/instance.hpp
+++ b/components/vulkan/include/components/vulkan/instance.hpp
@@ -17,18 +17,163 @@
 
 #pragma once
 
+#include <cassert>
 #include <memory>
+#include <set>
+#include <unordered_map>
+#include <vector>
 
 #include <volk.h>
+
+#include <components/common/stack_error.hpp>
 
 namespace components
 {
 namespace vulkan
 {
+// Unified message severity for DebugUtils and DebugReporter
+enum class DebugMessageSeverity
+{
+	VERBOSE,
+	INFO,
+	WARNING,
+	ERROR
+};
+
+// Unified message types for DebugUtils and DebugReporter
+enum class DebugMessageType
+{
+	GENERAL,
+	VALIDATION,
+	PERFORMANCE,
+};
+
+namespace
+{
+inline DebugMessageSeverity message_severity(VkDebugUtilsMessageSeverityFlagBitsEXT severity)
+{
+	if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+	{
+		return DebugMessageSeverity::ERROR;
+	}
+	else if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+	{
+		return DebugMessageSeverity::WARNING;
+	}
+	else if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)
+	{
+		return DebugMessageSeverity::INFO;
+	}
+
+	return DebugMessageSeverity::VERBOSE;
+}
+
+inline DebugMessageType message_type(VkDebugUtilsMessageTypeFlagsEXT type)
+{
+	if (type & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
+	{
+		return DebugMessageType::PERFORMANCE;
+	}
+	else if (type & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)
+	{
+		return DebugMessageType::VALIDATION;
+	}
+
+	return DebugMessageType::GENERAL;
+}
+
+template <typename Func>
+PFN_vkDebugUtilsMessengerCallbackEXT wrap_debug_utils(Func &&func)
+{
+	return [func](VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
+	              VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
+	              const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData,
+	              void *                                      pUserData) -> VkBool32 {
+		if (pCallbackData)
+		{
+			func(message_severity(messageSeverity), message_type(messageTypes), pCallbackData->pMessage, pUserData);
+		}
+
+		return VK_FALSE;
+	};
+}
+
+template <typename Func>
+PFN_vkDebugReportCallbackEXT wrap_debug_report(Func &&func)
+{
+	return [func](
+	           VkDebugReportFlagsEXT      flags,
+	           VkDebugReportObjectTypeEXT objectType,
+	           uint64_t                   object,
+	           size_t                     location,
+	           int32_t                    messageCode,
+	           const char *               pLayerPrefix,
+	           const char *               pMessage,
+	           void *                     pUserData) -> VkBool32 {
+		DebugMessageSeverity severity{DebugMessageSeverity::VERBOSE};
+		DebugMessageType     type{DebugMessageType::GENERAL};
+
+		if (flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
+		{
+			severity = DebugMessageSeverity::INFO;
+		}
+		if (flags & VK_DEBUG_REPORT_WARNING_BIT_EXT)
+		{
+			severity = DebugMessageSeverity::WARNING;
+		}
+		if (flags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT)
+		{
+			severity = DebugMessageSeverity::WARNING;
+			type     = DebugMessageType::PERFORMANCE;
+		}
+		if (flags & VK_DEBUG_REPORT_ERROR_BIT_EXT)
+		{
+			severity = DebugMessageSeverity::ERROR;
+		}
+		if (flags & VK_DEBUG_REPORT_DEBUG_BIT_EXT)
+		{
+			severity = DebugMessageSeverity::INFO;
+		}
+
+		func(severity, type, pMessage, pUserData);
+
+		return VK_FALSE;
+	};
+}
+}        // namespace
+
 struct Instance
 {
-	VkInstance instance_handle;
+	VkInstance instance_handle{VK_NULL_HANDLE};
+
+	// Debug Callbacks
+	VkDebugReportCallbackEXT debug_report_callback{VK_NULL_HANDLE};
+	VkDebugUtilsMessengerEXT debug_messenger_handle{VK_NULL_HANDLE};
+
+	~Instance()
+	{
+		if (debug_report_callback != VK_NULL_HANDLE)
+		{
+			assert(instance_handle != VK_NULL_HANDLE);
+			vkDestroyDebugReportCallbackEXT(instance_handle, debug_report_callback, nullptr);
+		}
+
+		if (debug_messenger_handle != VK_NULL_HANDLE)
+		{
+			assert(instance_handle != VK_NULL_HANDLE);
+			vkDestroyDebugUtilsMessengerEXT(instance_handle, debug_messenger_handle, nullptr);
+		}
+
+		if (instance_handle != VK_NULL_HANDLE)
+		{
+			vkDestroyInstance(instance_handle, nullptr);
+		}
+	}
 };
+
+class InstanceBuilder;
+
+void default_instance_func(InstanceBuilder &builder);
 
 class InstanceBuilder
 {
@@ -42,20 +187,76 @@ class InstanceBuilder
 	}
 
 	InstanceBuilder &set_vulkan_api_version(uint32_t encoded_version);
-	InstanceBuilder &enable_layer(const char *layer_name);
-	InstanceBuilder &enable_extension(const char *layer_name);
+
+	InstanceBuilder &enable_required_layer(const char *layer_name);
+	InstanceBuilder &enable_optional_layer(const char *layer_name);
+
+	InstanceBuilder &enable_required_extension(const char *extension_name);
+	InstanceBuilder &enable_optional_extension(const char *extension_name);
+
+	InstanceBuilder &enable_validation_layers();
+
+	template <typename Func>
+	InstanceBuilder &enable_debugger(Func &&func, void *user_data = nullptr)
+	{
+		m_debug_utils = {
+		    wrap_debug_func(func),
+		    user_data,
+		};
+
+		return *this;
+	}
 
 	template <typename Func>
 	InstanceBuilder &apply(Func &&func)
 	{
 		func(*this);
+		return *this;
 	}
 
-	StackError build(Instance *o_instance);
+	StackErrorPtr build(Instance *o_instance) const;
 
   private:
 	VkApplicationInfo    m_application_info{VK_STRUCTURE_TYPE_APPLICATION_INFO};
 	VkInstanceCreateInfo m_instance_create_info{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+
+	std::set<std::string> m_required_layer_names;
+	std::set<std::string> m_optional_layer_names;
+
+	// header for all extension structs
+	struct ChainedExtension
+	{
+		VkStructureType sType;
+		void *          pNext;
+	};
+
+	std::unordered_map<std::string, std::unique_ptr<ChainedExtension>> m_required_extensions;
+	std::unordered_map<std::string, std::unique_ptr<ChainedExtension>> m_optional_extensions;
+
+	struct DebugReport
+	{
+		PFN_vkDebugReportCallbackEXT callback;
+	};
+
+	struct DebugUtils
+	{
+		PFN_vkDebugUtilsMessengerCallbackEXT callback;
+		void *                               user_data;
+
+		inline VkDebugUtilsMessengerCreateInfoEXT create_info() const
+		{
+			VkDebugUtilsMessengerCreateInfoEXT create_info{VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT};
+			create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+			create_info.messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+			create_info.pfnUserCallback = callback;
+			return create_info;
+		}
+	};
+	std::optional<DebugUtils> m_debug_utils;
+
+	bool m_enable_validation{false};
+
+	static std::vector<std::vector<const char *>> validation_layer_priority_list;
 };
 }        // namespace vulkan
 }        // namespace components

--- a/components/vulkan/src/instance.cpp
+++ b/components/vulkan/src/instance.cpp
@@ -1,0 +1,54 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "components/vulkan/instance.hpp"
+
+namespace components
+{
+namespace vulkan
+{
+InstanceBuilder &InstanceBuilder::set_vulkan_api_version(uint32_t encoded_version)
+{
+	return *this;
+}
+
+InstanceBuilder &InstanceBuilder::enable_layer(const char *layer_name)
+{
+	return *this;
+}
+
+InstanceBuilder &InstanceBuilder::enable_extension(const char *layer_name)
+{
+	return *this;
+}
+
+StackError InstanceBuilder::build(Instance *o_instance)
+{
+	m_instance_create_info.pApplicationInfo = &m_application_info;
+
+	Instance instance;
+
+	auto result = vkCreateInstance(&m_instance_create_info, nullptr, &instance.instance_handle);
+	if (result != VK_SUCCESS)
+	{
+		return StackError::create("failed to create instance", "vulkan/instance.cpp", __LINE__);
+	}
+
+	return nullptr;
+}
+}        // namespace vulkan
+}        // namespace components

--- a/components/vulkan/src/instance.cpp
+++ b/components/vulkan/src/instance.cpp
@@ -17,38 +17,178 @@
 
 #include "components/vulkan/instance.hpp"
 
+#include <vector>
+
 namespace components
 {
 namespace vulkan
 {
+void default_instance_func(InstanceBuilder &builder)
+{
+	builder
+	    .enable_validation_layers();
+}
+
+std::vector<std::vector<const char *>> InstanceBuilder::validation_layer_priority_list =
+    {
+        // The preferred validation layer is "VK_LAYER_KHRONOS_validation"
+        {"VK_LAYER_KHRONOS_validation"},
+
+        // Otherwise we fallback to using the LunarG meta layer
+        {"VK_LAYER_LUNARG_standard_validation"},
+
+        // Otherwise we attempt to enable the individual layers that compose the LunarG meta layer since it doesn't exist
+        {
+            "VK_LAYER_GOOGLE_threading",
+            "VK_LAYER_LUNARG_parameter_validation",
+            "VK_LAYER_LUNARG_object_tracker",
+            "VK_LAYER_LUNARG_core_validation",
+            "VK_LAYER_GOOGLE_unique_objects",
+        },
+
+        // Otherwise as a last resort we fallback to attempting to enable the LunarG core layer
+        {"VK_LAYER_LUNARG_core_validation"},
+};
+
 InstanceBuilder &InstanceBuilder::set_vulkan_api_version(uint32_t encoded_version)
 {
+	m_application_info.apiVersion = encoded_version;
 	return *this;
 }
 
-InstanceBuilder &InstanceBuilder::enable_layer(const char *layer_name)
+InstanceBuilder &InstanceBuilder::enable_required_layer(const char *layer_name)
 {
+	m_required_layer_names.emplace(layer_name);
 	return *this;
 }
 
-InstanceBuilder &InstanceBuilder::enable_extension(const char *layer_name)
+InstanceBuilder &InstanceBuilder::enable_optional_layer(const char *layer_name)
 {
+	m_optional_layer_names.emplace(layer_name);
 	return *this;
 }
 
-StackError InstanceBuilder::build(Instance *o_instance)
+InstanceBuilder &InstanceBuilder::enable_required_extension(const char *extension_name)
 {
-	m_instance_create_info.pApplicationInfo = &m_application_info;
+	m_required_extensions[std::string{extension_name}] = nullptr;
+	return *this;
+}
 
+InstanceBuilder &InstanceBuilder::enable_optional_extension(const char *extension_name)
+{
+	m_optional_extensions[std::string{extension_name}] = nullptr;
+	return *this;
+}
+
+InstanceBuilder &InstanceBuilder::enable_validation_layers()
+{
+	m_enable_validation = true;
+	return *this;
+}
+
+#define APPEND_ERROR(msg, file, line)                  \
+	{                                                  \
+		if (err == nullptr)                            \
+		{                                              \
+			err = StackError::unique(msg, file, line); \
+		}                                              \
+		else                                           \
+		{                                              \
+			err->push(msg, file, line);                \
+		}                                              \
+	}
+
+StackErrorPtr InstanceBuilder::build(Instance *o_instance) const
+{
+	StackErrorPtr err{nullptr};
+
+	// populate application info
+	VkApplicationInfo application_info = m_application_info;
+	application_info.engineVersion     = VK_MAKE_API_VERSION(0, 1, 0, 0);
+	application_info.pEngineName       = "vulkan_samples";
+	application_info.pApplicationName  = "vulkan_application";
+
+	// enumerate instance layers
+	uint32_t available_layer_count;
+	vkEnumerateInstanceLayerProperties(&available_layer_count, nullptr);
+
+	std::vector<VkLayerProperties> available_layers;
+	available_layers.resize(available_layer_count);
+	vkEnumerateInstanceLayerProperties(&available_layer_count, available_layers.data());
+
+	std::set<std::string> enabled_layers;
+
+	// enable required layers
+	for (auto &layer_name : m_required_layer_names)
+	{
+		bool found = false;
+
+		for (auto &layer_properties : available_layers)
+		{
+			if (layer_name == layer_properties.layerName)
+			{
+				// layer available
+				enabled_layers.emplace(layer_name);
+				found = true;
+				break;
+			}
+		}
+
+		if (found)
+		{
+			continue;
+		}
+
+		// layer not found
+		APPEND_ERROR("required layer not supported", "vulkan/instance.cpp", __LINE__);
+	}
+
+	// enable optional layers
+	for (auto &layer_name : m_optional_layer_names)
+	{
+		for (auto &layer_properties : available_layers)
+		{
+			if (layer_name == layer_properties.layerName)
+			{
+				// layer available
+				enabled_layers.emplace(layer_name);
+				break;
+			}
+		}
+	}
+
+	// populate instance create info
+	std::vector<const char *> enable_layers_c_str;
+	enable_layers_c_str.reserve(enabled_layers.size());
+
+	for (auto &layer_name : enabled_layers)
+	{
+		enable_layers_c_str.push_back(layer_name.c_str());
+	}
+
+	VkInstanceCreateInfo instance_create_info = m_instance_create_info;
+	instance_create_info.pApplicationInfo     = &application_info;
+	instance_create_info.enabledLayerCount    = enable_layers_c_str.size();
+	instance_create_info.ppEnabledLayerNames  = enable_layers_c_str.data();
+
+	// return if a config error ocurred
+	if (err)
+	{
+		return std::move(err);
+	}
+
+	// create a new instance
 	Instance instance;
-
-	auto result = vkCreateInstance(&m_instance_create_info, nullptr, &instance.instance_handle);
+	auto     result = vkCreateInstance(&instance_create_info, nullptr, &instance.instance_handle);
 	if (result != VK_SUCCESS)
 	{
-		return StackError::create("failed to create instance", "vulkan/instance.cpp", __LINE__);
+		return StackError::unique("failed to create instance", "vulkan/instance.cpp", __LINE__);
 	}
+
+	*o_instance = instance;
 
 	return nullptr;
 }
+
 }        // namespace vulkan
 }        // namespace components

--- a/components/vulkan/tests/instance.test.cpp
+++ b/components/vulkan/tests/instance.test.cpp
@@ -18,36 +18,129 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "components/vulkan/instance.hpp"
+#include "vulkan_test_functions.hpp"
 
 namespace components
 {
 namespace vulkan
 {
-void default_config(InstanceBuilder &builder)
+struct TestCase
 {
-	builder.set_vulkan_api_version(1, 2);
+	PFN_vkEnumerateInstanceLayerProperties EnumerateInstanceLayerProperties{test::vkEnumerateInstanceLayerProperties};
+	PFN_vkCreateInstance                   CreateInstance{test::vkCreateInstance};
+	PFN_vkDestroyDebugReportCallbackEXT    DestroyDebugReportCallbackEXT{test::vkDestroyDebugReportCallbackEXT};
+	PFN_vkDestroyDebugUtilsMessengerEXT    DestroyDebugUtilsMessengerEXT{test::vkDestroyDebugUtilsMessengerEXT};
+	PFN_vkDestroyInstance                  DestroyInstance{test::vkDestroyInstance};
+
+	inline void setup() const
+	{
+		// Overrides global vkFunction ptrs - classes vulkan usage gets passed to these functions instead
+		vkEnumerateInstanceLayerProperties = EnumerateInstanceLayerProperties;
+		vkCreateInstance                   = CreateInstance;
+		vkDestroyDebugReportCallbackEXT    = DestroyDebugReportCallbackEXT;
+		vkDestroyDebugUtilsMessengerEXT    = DestroyDebugUtilsMessengerEXT;
+		vkDestroyInstance                  = DestroyInstance;
+	}
+
+	bool expect_build_error{false};
+};
+
+void execute_test(const TestCase &test, InstanceBuilder &builder)
+{
+	test.setup();
+
+	Instance instance;
+	instance.instance_handle = VK_NULL_HANDLE;
+
+	if (test.expect_build_error)
+	{
+		REQUIRE(builder.build(&instance) != nullptr);
+	}
+	else
+	{
+		REQUIRE(builder.build(&instance) == nullptr);
+		REQUIRE(instance.instance_handle != VK_NULL_HANDLE);
+	}
 }
 
-VkResult instance_minimum_config_override(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance)
+TEST_CASE("instance apply vulkan api version", "[vulkan]")
 {
-	REQUIRE(pCreateInfo != nullptr);
-	REQUIRE(pAllocator == nullptr);
-	REQUIRE(pInstance != nullptr);
+	TestCase test;
 
-	return VK_SUCCESS;
-}
+	test.CreateInstance = test::wrapper<PFN_vkCreateInstance>([](const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) -> VkResult {
+		test::vkCreateInstance(pCreateInfo, pAllocator, pInstance);
 
-TEST_CASE("instance minimum config", "[vulkan]")
-{
-	// Override vkCreateInstance call
-	vkCreateInstance = (PFN_vkCreateInstance) instance_minimum_config_override;
+		// correct API version in use
+		REQUIRE(pCreateInfo->pApplicationInfo->apiVersion == VK_MAKE_API_VERSION(0, 1, 2, 0));
+		return VK_SUCCESS;
+	});
 
 	InstanceBuilder builder;
 
 	builder
-	    .apply(default_config);        // apply default minimum config
+	    .set_vulkan_api_version(1, 2);
 
-	REQUIRE(builder.build() != nullptr);
+	execute_test(test, builder);
+}
+
+TEST_CASE("instance add optional layer", "[vulkan]")
+{
+	TestCase test;
+	test.CreateInstance = test::wrapper<PFN_vkCreateInstance>([](const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) -> VkResult {
+		test::vkCreateInstance(pCreateInfo, pAllocator, pInstance);
+
+		// only one requested layer exists in the test harness
+		REQUIRE(pCreateInfo->enabledLayerCount == 1);
+		REQUIRE(std::string{pCreateInfo->ppEnabledLayerNames[0]} == "VK_some_vulkan_layer");
+		REQUIRE(pCreateInfo->pApplicationInfo->apiVersion == VK_MAKE_API_VERSION(0, 1, 2, 0));
+
+		return VK_SUCCESS;
+	});
+
+	InstanceBuilder builder;
+
+	builder
+	    .set_vulkan_api_version(1, 2, 0, 0)
+	    .enable_optional_layer("VK_some_vulkan_layer")
+	    .enable_optional_layer("non_existent_layer");
+
+	execute_test(test, builder);
+}
+
+TEST_CASE("instance add required layer", "[vulkan]")
+{
+	TestCase test;
+	test.CreateInstance = test::wrapper<PFN_vkCreateInstance>([](const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) -> VkResult {
+		test::vkCreateInstance(pCreateInfo, pAllocator, pInstance);
+
+		REQUIRE(pCreateInfo->enabledLayerCount == 1);
+		REQUIRE(std::string{pCreateInfo->ppEnabledLayerNames[0]} == "VK_some_vulkan_layer");
+		REQUIRE(pCreateInfo->pApplicationInfo->apiVersion == VK_MAKE_API_VERSION(0, 1, 2, 0));
+
+		return VK_SUCCESS;
+	});
+
+	InstanceBuilder builder;
+
+	builder
+	    .set_vulkan_api_version(1, 2, 0, 0)
+	    .enable_required_layer("VK_some_vulkan_layer");
+
+	execute_test(test, builder);
+}
+
+TEST_CASE("instance add required layer that doesn't exist", "[vulkan]")
+{
+	TestCase test;
+	test.expect_build_error = true;
+
+	InstanceBuilder builder;
+
+	builder
+	    .set_vulkan_api_version(1, 2, 0, 0)
+	    .enable_required_layer("non_existant_layer");
+
+	execute_test(test, builder);
 }
 }        // namespace vulkan
 }        // namespace components

--- a/components/vulkan/tests/instance.test.cpp
+++ b/components/vulkan/tests/instance.test.cpp
@@ -1,0 +1,53 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "components/vulkan/instance.hpp"
+
+namespace components
+{
+namespace vulkan
+{
+void default_config(InstanceBuilder &builder)
+{
+	builder.set_vulkan_api_version(1, 2);
+}
+
+VkResult instance_minimum_config_override(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance)
+{
+	REQUIRE(pCreateInfo != nullptr);
+	REQUIRE(pAllocator == nullptr);
+	REQUIRE(pInstance != nullptr);
+
+	return VK_SUCCESS;
+}
+
+TEST_CASE("instance minimum config", "[vulkan]")
+{
+	// Override vkCreateInstance call
+	vkCreateInstance = (PFN_vkCreateInstance) instance_minimum_config_override;
+
+	InstanceBuilder builder;
+
+	builder
+	    .apply(default_config);        // apply default minimum config
+
+	REQUIRE(builder.build() != nullptr);
+}
+}        // namespace vulkan
+}        // namespace components

--- a/components/vulkan/tests/vulkan_test_functions.cpp
+++ b/components/vulkan/tests/vulkan_test_functions.cpp
@@ -1,0 +1,90 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vulkan_test_functions.hpp"
+
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace components
+{
+namespace vulkan
+{
+namespace test
+{
+PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties = wrapper<PFN_vkEnumerateInstanceLayerProperties>([](uint32_t *pPropertyCount, VkLayerProperties *pProperties) -> VkResult {
+	static std::vector<VkLayerProperties> default_layers = {
+	    VkLayerProperties{
+	        "VK_some_vulkan_layer",
+	        VK_MAKE_API_VERSION(0, 1, 0, 0),
+	        VK_MAKE_API_VERSION(0, 1, 0, 0),
+	        "Just your average vulkan layer",
+	    },
+	    VkLayerProperties{
+	        "VK_another_layer",
+	        VK_MAKE_API_VERSION(0, 1, 0, 0),
+	        VK_MAKE_API_VERSION(0, 1, 0, 0),
+	        "Just your average vulkan layer",
+	    },
+	};
+
+	if (pPropertyCount)
+	{
+		*pPropertyCount = static_cast<uint32_t>(default_layers.size());
+	}
+
+	if (pProperties)
+	{
+		memcpy(pProperties, default_layers.data(), default_layers.size() * sizeof(default_layers[0]));
+	}
+
+	return VK_SUCCESS;
+});
+
+PFN_vkCreateInstance vkCreateInstance = wrapper<PFN_vkCreateInstance>([](const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) -> VkResult {
+	REQUIRE(pCreateInfo != nullptr);
+	REQUIRE(pAllocator == nullptr);
+	REQUIRE(pInstance != nullptr);
+	REQUIRE(pCreateInfo->pApplicationInfo != nullptr);
+
+	// spoof instance creation
+	*pInstance = reinterpret_cast<VkInstance>(0x1);
+
+	return VK_SUCCESS;
+});
+
+PFN_vkDestroyDebugReportCallbackEXT vkDestroyDebugReportCallbackEXT = wrapper<PFN_vkDestroyDebugReportCallbackEXT>([](VkInstance instance, VkDebugReportCallbackEXT callback, const VkAllocationCallbacks *pAllocator) {
+	REQUIRE(instance != VK_NULL_HANDLE);
+	REQUIRE(callback != VK_NULL_HANDLE);
+	REQUIRE(pAllocator == nullptr);
+});
+
+PFN_vkDestroyDebugUtilsMessengerEXT vkDestroyDebugUtilsMessengerEXT = wrapper<PFN_vkDestroyDebugUtilsMessengerEXT>([](VkInstance instance, VkDebugUtilsMessengerEXT messenger, const VkAllocationCallbacks *pAllocator) {
+	REQUIRE(instance != VK_NULL_HANDLE);
+	REQUIRE(messenger != VK_NULL_HANDLE);
+	REQUIRE(pAllocator == nullptr);
+});
+
+PFN_vkDestroyInstance vkDestroyInstance = wrapper<PFN_vkDestroyInstance>([](VkInstance instance, const VkAllocationCallbacks *pAllocator) {
+	REQUIRE(instance != VK_NULL_HANDLE);
+	REQUIRE(pAllocator == nullptr);
+});
+
+}        // namespace test
+}        // namespace vulkan
+}        // namespace components

--- a/components/vulkan/tests/vulkan_test_functions.hpp
+++ b/components/vulkan/tests/vulkan_test_functions.hpp
@@ -1,0 +1,49 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <volk.h>
+
+namespace components
+{
+namespace vulkan
+{
+namespace test
+{
+/**
+ * @brief utility used to wrap a vulkan function pointer
+ * 
+ * @tparam Override PFN_vkFunctionX
+ * @tparam Func A function used to override the original
+ * @param func See Func
+ * @return Override A new PFN_vkFunctionX function
+ */
+template <typename Override, typename Func>
+Override wrapper(Func &&func)
+{
+	return (Override) func;
+}
+
+// not a complete list of vulkan functions.
+// add default implementations here when they are used in testing
+extern PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties;
+extern PFN_vkCreateInstance                   vkCreateInstance;
+extern PFN_vkDestroyDebugReportCallbackEXT    vkDestroyDebugReportCallbackEXT;
+extern PFN_vkDestroyDebugUtilsMessengerEXT    vkDestroyDebugUtilsMessengerEXT;
+extern PFN_vkDestroyInstance                  vkDestroyInstance;
+}        // namespace test
+}        // namespace vulkan
+}        // namespace components

--- a/components/vulkan/tests/vulkan_test_functions.hpp
+++ b/components/vulkan/tests/vulkan_test_functions.hpp
@@ -39,11 +39,11 @@ Override wrapper(Func &&func)
 
 // not a complete list of vulkan functions.
 // add default implementations here when they are used in testing
-extern "C" PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties;
-extern "C" PFN_vkCreateInstance                   vkCreateInstance;
-extern "C" PFN_vkDestroyDebugReportCallbackEXT    vkDestroyDebugReportCallbackEXT;
-extern "C" PFN_vkDestroyDebugUtilsMessengerEXT    vkDestroyDebugUtilsMessengerEXT;
-extern "C" PFN_vkDestroyInstance                  vkDestroyInstance;
+extern PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties;
+extern PFN_vkCreateInstance                   vkCreateInstance;
+extern PFN_vkDestroyDebugReportCallbackEXT    vkDestroyDebugReportCallbackEXT;
+extern PFN_vkDestroyDebugUtilsMessengerEXT    vkDestroyDebugUtilsMessengerEXT;
+extern PFN_vkDestroyInstance                  vkDestroyInstance;
 }        // namespace test
 }        // namespace vulkan
 }        // namespace components

--- a/components/vulkan/tests/vulkan_test_functions.hpp
+++ b/components/vulkan/tests/vulkan_test_functions.hpp
@@ -39,11 +39,11 @@ Override wrapper(Func &&func)
 
 // not a complete list of vulkan functions.
 // add default implementations here when they are used in testing
-extern PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties;
-extern PFN_vkCreateInstance                   vkCreateInstance;
-extern PFN_vkDestroyDebugReportCallbackEXT    vkDestroyDebugReportCallbackEXT;
-extern PFN_vkDestroyDebugUtilsMessengerEXT    vkDestroyDebugUtilsMessengerEXT;
-extern PFN_vkDestroyInstance                  vkDestroyInstance;
+extern "C" PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties;
+extern "C" PFN_vkCreateInstance                   vkCreateInstance;
+extern "C" PFN_vkDestroyDebugReportCallbackEXT    vkDestroyDebugReportCallbackEXT;
+extern "C" PFN_vkDestroyDebugUtilsMessengerEXT    vkDestroyDebugUtilsMessengerEXT;
+extern "C" PFN_vkDestroyInstance                  vkDestroyInstance;
 }        // namespace test
 }        // namespace vulkan
 }        // namespace components

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -179,27 +179,6 @@ target_link_libraries(ktx PUBLIC vulkan)
 
 set_property(TARGET ktx PROPERTY FOLDER "ThirdParty")
 
-# volk
-set(VOLK_DIR "${CMAKE_CURRENT_SOURCE_DIR}/volk")
-set(VOLK_FILES
-    "${VOLK_DIR}/volk.c"
-    "${VOLK_DIR}/volk.h")
-
-add_library(volk STATIC ${VOLK_FILES})
-
-target_link_libraries(volk PUBLIC vulkan ${CMAKE_DL_LIBS})
-
-target_include_directories(volk PUBLIC ${VOLK_DIR})
-if (VKB_WSI_SELECTION STREQUAL XCB)
-    target_include_directories(volk PUBLIC ${XCB_INCLUDE_DIRS})
-elseif (VKB_WSI_SELECTION STREQUAL XLIB)
-    target_include_directories(volk PUBLIC ${X11_INCLUDE_DIRS})
-elseif (VKB_WSI_SELECTION STREQUAL WAYLAND)
-    target_include_directories(volk PUBLIC ${WAYLAND_INCLUDE_DIRS})
-endif()
-
-set_property(TARGET volk PROPERTY FOLDER "ThirdParty")
-
 # imgui
 set(IMGUI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/imgui")
 set(IMGUI_FILES

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -187,7 +187,7 @@ set(VOLK_FILES
 
 add_library(volk STATIC ${VOLK_FILES})
 
-target_link_libraries(volk PUBLIC dl vulkan)
+target_link_libraries(volk PUBLIC vulkan ${CMAKE_DL_LIBS})
 
 target_include_directories(volk PUBLIC ${VOLK_DIR})
 if (VKB_WSI_SELECTION STREQUAL XCB)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -187,7 +187,7 @@ set(VOLK_FILES
 
 add_library(volk STATIC ${VOLK_FILES})
 
-target_link_libraries(volk PUBLIC vulkan)
+target_link_libraries(volk PUBLIC dl vulkan)
 
 target_include_directories(volk PUBLIC ${VOLK_DIR})
 if (VKB_WSI_SELECTION STREQUAL XCB)


### PR DESCRIPTION
## Description

Adds an instance builder to allow a sample to completely customize how a vulkan instance is constructed.

Also adds a vulkan test framework so that we can intercept vulkan calls and make sure that our API usage is as expected. I've never been able to do Vulkan TDD before but I think this solution makes it viable. It works by overriding global volk `PFN_vkFunction` declarations so that we can intercept vulkan calls and validate our actual vulkan usage.

This method of testing will never replace OOB testing against an actual driver. But at least with good test coverage we can confidently say that a specific Vulkan component should work as expected against the Vulkan specification.

fixes #466