### PR TITLE
Change vkb::core::HPPVulkanResource from a facade over vkb::core::VulkanResource to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -280,7 +280,9 @@ set(CORE_FILES
     core/vulkan_resource.cpp
     core/hpp_device.cpp
     core/hpp_instance.cpp
-	core/hpp_physical_device.cpp)
+	core/hpp_physical_device.cpp
+    core/hpp_vulkan_resource.cpp
+)
 
 set(PLATFORM_FILES
     # Header Files

--- a/framework/core/hpp_vulkan_resource.cpp
+++ b/framework/core/hpp_vulkan_resource.cpp
@@ -1,0 +1,41 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core/hpp_vulkan_resource.h>
+
+#include <core/hpp_device.h>
+
+namespace vkb
+{
+namespace core
+{
+namespace detail
+{
+void set_debug_name(const HPPDevice *device, vk::ObjectType object_type, uint64_t handle, const char *debug_name)
+{
+	if (!debug_name || *debug_name == '\0' || !device)
+	{
+		// Can't set name, or no point in setting an empty name
+		return;
+	}
+
+	device->get_debug_utils().set_debug_name(device->get_handle(), object_type, handle, debug_name);
+}
+
+}        // namespace detail
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <core/vulkan_resource.h>
+#include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
@@ -25,31 +25,91 @@ namespace core
 {
 class HPPDevice;
 
-/**
- * @brief facade class around vkb::VulkanResource, providing a vulkan.hpp-based interface
- *
- * See vkb::VulkanResource for documentation
- */
-template <typename HPPHandle, typename Device = vkb::core::HPPDevice>
-class HPPVulkanResource : private vkb::core::VulkanResource<typename HPPHandle::NativeType, static_cast<VkObjectType>(HPPHandle::objectType), Device>
+namespace detail
+{
+void set_debug_name(const HPPDevice *device, vk::ObjectType object_type, uint64_t handle, const char *debug_name);
+}
+
+/// Inherit this for any Vulkan object with a handle of type `HPPHandle`.
+///
+/// This allows the derived class to store a Vulkan handle, and also a pointer to the parent vkb::core::Device.
+/// It also allow for adding debug data to any Vulkan object.
+template <typename HPPHandle, typename VKBDevice = vkb::core::HPPDevice>
+class HPPVulkanResource
 {
   public:
-	HPPVulkanResource(HPPHandle handle = nullptr, vkb::core::HPPDevice *device = nullptr) :
-	    vkb::core::VulkanResource<typename HPPHandle::NativeType, static_cast<VkObjectType>(HPPHandle::objectType), Device>(handle, device)
-	{}
-
-	HPPHandle const &get_handle() const
+	HPPVulkanResource(HPPHandle handle = nullptr, VKBDevice *device = nullptr) :
+	    handle{handle}, device{device}
 	{
-		return reinterpret_cast<HPPHandle const &>(
-		    vkb::core::VulkanResource<typename HPPHandle::NativeType, static_cast<VkObjectType>(HPPHandle::objectType), Device>::get_handle());
 	}
 
-  protected:
-	void set_handle(HPPHandle hppHandle)
+	HPPVulkanResource(const HPPVulkanResource &) = delete;
+	HPPVulkanResource &operator=(const HPPVulkanResource &) = delete;
+
+	HPPVulkanResource(HPPVulkanResource &&other) :
+	    handle(std::exchange(other.handle, {})), device(std::exchange(other.device, {}))
 	{
-		vkb::core::VulkanResource<typename HPPHandle::NativeType, static_cast<VkObjectType>(HPPHandle::objectType), Device>::handle =
-		    static_cast<typename HPPHandle::NativeType>(hppHandle);
+		set_debug_name(std::exchange(other.debug_name, {}));
 	}
+
+	HPPVulkanResource &operator=(HPPVulkanResource &&other)
+	{
+		handle = std::exchange(other.handle, {});
+		device = std::exchange(other.device, {});
+		set_debug_name(std::exchange(other.debug_name, {}));
+
+		return *this;
+	}
+
+	virtual ~HPPVulkanResource() = default;
+
+	inline vk::ObjectType get_object_type() const
+	{
+		return HPPHandle::NativeType;
+	}
+
+	inline VKBDevice &get_device() const
+	{
+		assert(device && "VKBDevice handle not set");
+		return *device;
+	}
+
+	inline const HPPHandle &get_handle() const
+	{
+		return handle;
+	}
+
+	inline const uint64_t get_handle_u64() const
+	{
+		// See https://github.com/KhronosGroup/Vulkan-Docs/issues/368 .
+		// Dispatchable and non-dispatchable handle types are *not* necessarily binary-compatible!
+		// Non-dispatchable handles _might_ be only 32-bit long. This is because, on 32-bit machines, they might be a typedef to a 32-bit pointer.
+		using UintHandle = typename std::conditional<sizeof(HPPHandle) == sizeof(uint32_t), uint32_t, uint64_t>::type;
+
+		return static_cast<uint64_t>(reinterpret_cast<UintHandle>(handle));
+	}
+
+	inline void set_handle(HPPHandle hdl)
+	{
+		assert(!handle && hdl);
+		handle = hdl;
+	}
+
+	inline const std::string &get_debug_name() const
+	{
+		return debug_name;
+	}
+
+	inline void set_debug_name(const std::string &name)
+	{
+		debug_name = name;
+		detail::set_debug_name(device, HPPHandle::NativeType, get_handle_u64(), debug_name.c_str());
+	}
+
+  private:
+	HPPHandle   handle;
+	VKBDevice * device;
+	std::string debug_name;
 };
 
 }        // namespace core


### PR DESCRIPTION
## Description

Transcoding this part of the framework completes the minimal set of classes to initialize the framework using Vulkan-Hpp.

I have tested it on Window10 on nvidia HW.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
