### PR TITLE
Display sample name instead of ID in UI

### DIFF
--- a/app/apps/apps.h
+++ b/app/apps/apps.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Arm Limited and Contributors
+/* Copyright (c) 2020-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -44,11 +44,12 @@ using CreateFunc = std::function<std::unique_ptr<vkb::Application>()>;
 class AppInfo
 {
   public:
-	AppInfo(const std::string &id, const CreateFunc &create) :
-	    id(id), create(create)
+	AppInfo(const std::string &id, const CreateFunc &create, const std::string &name = "") :
+	    id(id), create(create), name(name)
 	{}
 
 	std::string id;
+	std::string name;
 	CreateFunc  create;
 };
 
@@ -60,7 +61,7 @@ class SampleInfo : public AppInfo
 {
   public:
 	SampleInfo(const std::string &id, const CreateFunc &create, const std::string &category, const std::string &author, const std::string &name, const std::string &description, const std::vector<std::string> &tags = {}) :
-	    AppInfo(id, create), category(category), author(author), name(name), description(description), tags(tags)
+	    AppInfo(id, create, name), category(category), author(author), name(name), description(description), tags(tags)
 	{}
 
 	std::string              category;
@@ -77,7 +78,7 @@ class SampleInfo : public AppInfo
 class TestInfo : public AppInfo
 {
   public:
-	TestInfo(const std::string &id, const CreateFunc &create) :
+	TestInfo(const std::string &id, const std::string &name, const CreateFunc &create) :
 	    AppInfo(id, create)
 	{}
 };

--- a/app/apps/apps.h
+++ b/app/apps/apps.h
@@ -78,7 +78,7 @@ class SampleInfo : public AppInfo
 class TestInfo : public AppInfo
 {
   public:
-	TestInfo(const std::string &id, const std::string &name, const CreateFunc &create) :
+	TestInfo(const std::string &id, const CreateFunc &create) :
 	    AppInfo(id, create)
 	{}
 };

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -369,7 +369,7 @@ bool Platform::start_app()
 
 	active_app = requested_app_info->create();
 
-	active_app->set_name(requested_app_info->id);
+	active_app->set_name(requested_app_info->name);
 
 	if (!active_app)
 	{


### PR DESCRIPTION
## Description

Samples currently only display the ID (set in the CMakeLists.txt) in the UI. This may be cryptic, e.g.:

![image](https://user-images.githubusercontent.com/10283127/174430095-839402bb-a69f-44bb-bbe7-d093f3765990.png)

This PR fixes that and displays the actual name instead:

![image](https://user-images.githubusercontent.com/10283127/174430108-78a5687a-22b6-4d6a-b20f-694d2318fcd4.png)

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making