### PR TITLE
Add Warnings As Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ include(global_config)
 include(sample_helper)
 include(check_atomic)
 include(test_helpers)
+include(component_helpers)
 
 # options
 option(VKB_WARNINGS_AS_ERRORS "Enable Warnings as Errors" ON)

--- a/bldsys/cmake/component_helpers.cmake
+++ b/bldsys/cmake/component_helpers.cmake
@@ -1,0 +1,64 @@
+# Copyright (c) 2022, Arm Limited and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_custom_target(vkb_components)
+
+function(vkb__register_component)
+    set(options)
+    set(oneValueArgs NAME)
+    set(multiValueArgs SRC LINK_LIBS INCLUDE_DIRS)
+
+    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(TARGET_NAME STREQUAL "")
+        message(FATAL_ERROR "NAME must be defined in vkb__register_tests")
+    endif()
+
+    if(TARGET_SRC) ## Create static library
+        message("ADDING STATIC: vkb__${TARGET_NAME}")
+
+        add_library("vkb__${TARGET_NAME}" STATIC ${TARGET_SRC})
+
+        if(TARGET_LINK_LIBS)
+            target_link_libraries("vkb__${TARGET_NAME}" PUBLIC ${TARGET_LINK_LIBS})
+        endif()
+
+        if(TARGET_INCLUDE_DIRS)
+            target_include_directories("vkb__${TARGET_NAME}" PUBLIC ${TARGET_INCLUDE_DIRS})
+        endif()
+        
+        if(MSVC)
+            target_compile_options("vkb__${TARGET_NAME}" PRIVATE /W4 /WX)
+        else()
+            target_compile_options("vkb__${TARGET_NAME}" PRIVATE -Wall -Wextra -Wpedantic -Werror)
+        endif()
+    else() ## Create interface library
+        message("ADDING INTERFACE: vkb__${TARGET_NAME}")
+
+        add_library("vkb__${TARGET_NAME}" INTERFACE)
+
+        if(TARGET_LINK_LIBS)
+            target_link_libraries("vkb__${TARGET_NAME}" INTERFACE ${TARGET_LINK_LIBS})
+        endif()
+
+        if(TARGET_INCLUDE_DIRS)
+            target_include_directories("vkb__${TARGET_NAME}" INTERFACE ${TARGET_INCLUDE_DIRS})
+        endif()
+    endif()
+
+
+    add_dependencies(vkb_components "vkb__${TARGET_NAME}")
+endfunction()

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright (c) 2022, Arm Limited and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 add_subdirectory(common)
 add_subdirectory(events)
 add_subdirectory(vfs)

--- a/components/common/CMakeLists.txt
+++ b/components/common/CMakeLists.txt
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(components__common INTERFACE)
-target_include_directories(components__common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-add_library(Components::Common ALIAS components__common)
+vkb__register_component(
+    NAME common
+    INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
 vkb__register_tests(
     NAME "common_tests"
@@ -24,5 +25,5 @@ vkb__register_tests(
         tests/stack_error.test.cpp
         tests/strings.test.cpp
     LIBS
-        components__common
+        vkb__common
 )

--- a/components/common/include/components/common/stack_error.hpp
+++ b/components/common/include/components/common/stack_error.hpp
@@ -55,7 +55,7 @@ class StackError : std::exception
 			combined->push(err);
 		}
 
-		return std::move(combined);
+		return combined;
 	}
 
 	void push(const std::string &reason, const char *file = nullptr, int line = 0)

--- a/components/events/CMakeLists.txt
+++ b/components/events/CMakeLists.txt
@@ -1,9 +1,27 @@
-set(SRC
-  src/input_manager.cpp
-)
+# Copyright (c) 2022, Arm Limited and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-add_library(components__events STATIC ${SRC})
-target_include_directories(components__events PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+vkb__register_component(
+  NAME events
+  SRC
+    src/input_manager.cpp
+  INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
 vkb__register_tests(
   NAME "events_tests"
@@ -11,5 +29,5 @@ vkb__register_tests(
     tests/channel.test.cpp
     tests/input_manager.test.cpp
   LIBS
-    components__events
+    vkb__events
 )

--- a/components/events/include/components/events/channel.hpp
+++ b/components/events/include/components/events/channel.hpp
@@ -279,7 +279,7 @@ Type ChannelReceiver<Type>::drain()
 		return {};
 	}
 
-	Type front;
+	Type front{};
 	while (!m_queue.empty())
 	{
 		front = m_queue.front();

--- a/components/vfs/CMakeLists.txt
+++ b/components/vfs/CMakeLists.txt
@@ -44,19 +44,25 @@ else()
     list(APPEND PROJECT_FILES ${UNIX_FILES})
 endif()
 
-add_library(components__vfs STATIC ${PROJECT_FILES})
-target_include_directories(components__vfs PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(components__vfs PUBLIC re2::re2 components__common)
+
+vkb__register_component(
+  NAME vfs
+  SRC ${PROJECT_FILES}
+  INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+  LINK_LIBS
+    re2
+    vkb__common
+)
 
 if (ANDROID)
-    target_link_libraries(components__vfs PRIVATE log android native_app_glue)
+    target_link_libraries(vkb__vfs PRIVATE log android native_app_glue)
 endif()
 
 if(${VKB_BUNDLE_ASSETS})
-    target_compile_definitions(components__vfs PUBLIC VKB_BUNDLE_ASSETS)
+    target_compile_definitions(vkb__vfs PUBLIC VKB_BUNDLE_ASSETS)
 endif()
 
-add_library(Components::VFS ALIAS components__vfs)
+
 
 ### virtual_file_system_tests - should work on desktop platforms as they require no specific configuration from a context
 
@@ -66,5 +72,5 @@ vkb__register_tests(
         tests/basic.test.cpp
         tests/helpers.test.cpp
     LIBS
-        components__vfs
+        vkb__vfs
 )

--- a/components/vfs/include/components/vfs/android.hpp
+++ b/components/vfs/include/components/vfs/android.hpp
@@ -66,6 +66,7 @@ class AndroidAAssetManager : public FileSystem
 	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size) override;
 	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files) override;
 	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) override;
+	virtual void          make_directory(const std::string &path) override;
 
   private:
 	std::string get_path(const std::string &path);

--- a/components/vfs/include/components/vfs/filesystem.hpp
+++ b/components/vfs/include/components/vfs/filesystem.hpp
@@ -112,7 +112,7 @@ class FileSystem
 	FileSystem()          = default;
 	virtual ~FileSystem() = default;
 
-	void make_folder_recursive(const std::string &path);
+	void make_directory_recursive(const std::string &path);
 
 	virtual bool          folder_exists(const std::string &file_path)                                                                    = 0;
 	virtual bool          file_exists(const std::string &file_path)                                                                      = 0;
@@ -120,7 +120,7 @@ class FileSystem
 	virtual StackErrorPtr read_chunk(const std::string &file_path, const size_t offset, const size_t count, std::shared_ptr<Blob> *blob) = 0;
 	virtual size_t        file_size(const std::string &file_path)                                                                        = 0;
 	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size)                                        = 0;
-	virtual void          make_folder(const std::string &path){};
+	virtual void          make_directory(const std::string &path)                                                                        = 0;
 
 	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files)     = 0;
 	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) = 0;
@@ -146,6 +146,7 @@ class RootFileSystem : public FileSystem
 	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size) override;
 	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files) override;
 	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) override;
+	virtual void          make_directory(const std::string &path) override;
 
 	StackErrorPtr enumerate_files(const std::string &file_path, const std::string &extension, std::vector<std::string> *files);
 	StackErrorPtr enumerate_files_recursive(const std::string &file_path, const std::string &extension, std::vector<std::string> *files);

--- a/components/vfs/include/components/vfs/unix.hpp
+++ b/components/vfs/include/components/vfs/unix.hpp
@@ -41,7 +41,7 @@ class UnixFileSystem : public FileSystem
 	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size) override;
 	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files) override;
 	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) override;
-	virtual void          make_folder(const std::string &path) override;
+	virtual void          make_directory(const std::string &path) override;
 
   private:
 	std::string m_base_path;

--- a/components/vfs/include/components/vfs/windows.hpp
+++ b/components/vfs/include/components/vfs/windows.hpp
@@ -41,6 +41,7 @@ class WindowsFileSystem : public FileSystem
 	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size) override;
 	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files) override;
 	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) override;
+	virtual void          make_directory(const std::string &path) override;
 
   private:
 	std::string m_base_path;

--- a/components/vfs/src/android_aasset_manager.cpp
+++ b/components/vfs/src/android_aasset_manager.cpp
@@ -205,5 +205,10 @@ StackErrorPtr AndroidAAssetManager::enumerate_folders(const std::string &file_pa
 {
 	return StackError::unique("not implemented", "vfs/android_aasset_manager.cpp", __LINE__);
 }
+
+void AndroidAAssetManager::make_directory(const std::string &path)
+{
+}
+
 }        // namespace vfs
 }        // namespace components

--- a/components/vfs/src/root_file_system.cpp
+++ b/components/vfs/src/root_file_system.cpp
@@ -42,7 +42,7 @@ const void *StdBlob::data() const
 	return static_cast<const void *>(&buffer.at(0));
 }
 
-void FileSystem::make_folder_recursive(const std::string &path)
+void FileSystem::make_directory_recursive(const std::string &path)
 {
 	auto parts = helpers::get_directory_parts(path);
 
@@ -50,7 +50,7 @@ void FileSystem::make_folder_recursive(const std::string &path)
 	{
 		if (!folder_exists(path))
 		{
-			make_folder(path);
+			make_directory(path);
 		}
 	}
 }
@@ -128,7 +128,7 @@ StackErrorPtr RootFileSystem::write_file(const std::string &file_path, const voi
 		return StackError::unique("failed to select appropriate file system for path: " + file_path, "vfs/root_file_system.cpp", __LINE__);
 	}
 
-	fs->make_folder_recursive(adjusted_path);
+	fs->make_directory_recursive(adjusted_path);
 
 	return fs->write_file(adjusted_path, data, size);
 }
@@ -209,7 +209,7 @@ StackErrorPtr RootFileSystem::enumerate_files_recursive(const std::string &file_
 	auto                     res = enumerate_folders_recursive(file_path, &folders);
 	if (res != nullptr)
 	{
-		return std::move(res);
+		return res;
 	}
 
 	std::vector<std::string> all_files;
@@ -220,7 +220,7 @@ StackErrorPtr RootFileSystem::enumerate_files_recursive(const std::string &file_
 		auto                     res = enumerate_files(folder, extension, &folder_files);
 		if (res != nullptr)
 		{
-			return std::move(res);
+			return res;
 		}
 
 		all_files.reserve(folder_files.size());
@@ -253,7 +253,7 @@ StackErrorPtr RootFileSystem::enumerate_folders_recursive(const std::string &fil
 		auto res = enumerate_folders(front, &dirs);
 		if (res != nullptr)
 		{
-			return std::move(res);
+			return res;
 		}
 
 		for (std::string &dir : dirs)
@@ -271,6 +271,18 @@ StackErrorPtr RootFileSystem::enumerate_folders_recursive(const std::string &fil
 	*folders = std::vector<std::string>{all_dirs.begin(), all_dirs.end()};
 
 	return nullptr;
+}
+
+void RootFileSystem::make_directory(const std::string &file_path)
+{
+	std::string adjusted_path;
+	auto        fs = find_file_system(file_path, &adjusted_path);
+	if (!fs)
+	{
+		return;
+	}
+
+	fs->make_directory(file_path);
 }
 
 void RootFileSystem::mount(const std::string &file_path, std::shared_ptr<FileSystem> file_system)

--- a/components/vfs/src/root_file_system.cpp
+++ b/components/vfs/src/root_file_system.cpp
@@ -46,11 +46,11 @@ void FileSystem::make_directory_recursive(const std::string &path)
 {
 	auto parts = helpers::get_directory_parts(path);
 
-	for (auto &path : parts)
+	for (auto &sub_path : parts)
 	{
-		if (!folder_exists(path))
+		if (!folder_exists(sub_path))
 		{
-			make_directory(path);
+			make_directory(sub_path);
 		}
 	}
 }
@@ -217,7 +217,7 @@ StackErrorPtr RootFileSystem::enumerate_files_recursive(const std::string &file_
 	for (auto &folder : folders)
 	{
 		std::vector<std::string> folder_files;
-		auto                     res = enumerate_files(folder, extension, &folder_files);
+		res = enumerate_files(folder, extension, &folder_files);
 		if (res != nullptr)
 		{
 			return res;

--- a/components/vfs/src/unix.cpp
+++ b/components/vfs/src/unix.cpp
@@ -30,7 +30,7 @@ namespace vfs
 {
 // Android reuses the Unix filesystem. This stops a redefinition of the instance function
 #ifndef ANDROID
-RootFileSystem &_default(void *context)
+RootFileSystem &_default(void * /* context */)
 {
 	static vfs::RootFileSystem fs;
 
@@ -155,7 +155,7 @@ StackErrorPtr UnixFileSystem::read_chunk(const std::string &file_path, const siz
 	std::streamsize size = stream.gcount();
 	stream.clear();
 
-	if (offset + count > size)
+	if (offset + count > static_cast<size_t>(size))
 	{
 		return StackError::unique("file chunk out of bounds", "vfs/unix.cpp", __LINE__);
 	}
@@ -313,7 +313,7 @@ StackErrorPtr UnixFileSystem::enumerate_folders(const std::string &file_path, st
 	return nullptr;
 }
 
-void UnixFileSystem::make_folder(const std::string &path)
+void UnixFileSystem::make_directory(const std::string &path)
 {
 	auto full_path = m_base_path + path;
 

--- a/components/vfs/src/unix.cpp
+++ b/components/vfs/src/unix.cpp
@@ -37,10 +37,14 @@ RootFileSystem &_default(void * /* context */)
 	static bool first_time = true;
 	if (first_time)
 	{
-		char buf[256];
-		getcwd(buf, 256);
+		char *c_cwd = getcwd(nullptr, 0);
 
-		std::string cwd{buf};
+		if (!c_cwd)
+		{
+			throw std::runtime_error{"failed to determine working directory"};
+		}
+
+		std::string cwd{c_cwd};
 		fs.mount("/", std::make_shared<vfs::UnixFileSystem>(cwd));
 		fs.mount("/scenes/", std::make_shared<vfs::UnixFileSystem>(cwd + "/assets/scenes"));
 		fs.mount("/textures/", std::make_shared<vfs::UnixFileSystem>(cwd + "/assets/textures"));

--- a/components/vfs/src/windows.cpp
+++ b/components/vfs/src/windows.cpp
@@ -21,6 +21,7 @@
 #include <Windows.h>
 #include <direct.h>
 
+#include <cassert>
 #include <fstream>
 #include <iostream>
 #include <limits>

--- a/components/vfs/src/windows.cpp
+++ b/components/vfs/src/windows.cpp
@@ -32,7 +32,7 @@ namespace components
 {
 namespace vfs
 {
-RootFileSystem &_default(void *context)
+RootFileSystem &_default(void * /* context */)
 {
 	static vfs::RootFileSystem fs;
 
@@ -224,14 +224,19 @@ StackErrorPtr WindowsFileSystem::write_file(const std::string &file_path, const 
 	return nullptr;
 }
 
-StackErrorPtr WindowsFileSystem::enumerate_files(const std::string &file_path, std::vector<std::string> *files)
+StackErrorPtr WindowsFileSystem::enumerate_files(const std::string & /*file_path*/, std::vector<std::string> * /*files*/)
 {
 	return StackError::unique("not implemented", "vfs/windows.cpp", __LINE__);
 }
 
-StackErrorPtr WindowsFileSystem::enumerate_folders(const std::string &file_path, std::vector<std::string> *folders)
+StackErrorPtr WindowsFileSystem::enumerate_folders(const std::string & /*file_path*/, std::vector<std::string> * /*folders*/)
 {
 	return StackError::unique("not implemented", "vfs/windows.cpp", __LINE__);
+}
+
+void WindowsFileSystem::make_directory(const std::string &path)
+{
+	assert(false && "not implemented");
 }
 
 }        // namespace vfs

--- a/components/vfs/src/windows.cpp
+++ b/components/vfs/src/windows.cpp
@@ -235,7 +235,7 @@ StackErrorPtr WindowsFileSystem::enumerate_folders(const std::string & /*file_pa
 	return StackError::unique("not implemented", "vfs/windows.cpp", __LINE__);
 }
 
-void WindowsFileSystem::make_directory(const std::string &path)
+void WindowsFileSystem::make_directory(const std::string & /* path */)
 {
 	assert(false && "not implemented");
 }


### PR DESCRIPTION
## Description

Adds warnings as errors.

Adds `vkb__register_component` to guarantee consistent library creation. Warnings are set at a target level which should make sure third party warnings are ignored. If this is not the case then we will need to create warning wrappers similar to the master branch.

Fixes #478