### PR TITLE
Event Bus

### DIFF
--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -45,6 +45,8 @@ function(vkb__register_tests)
     add_executable(${TARGET_NAME} ${TARGET_SRC})
     target_link_libraries(${TARGET_NAME} PUBLIC Catch2::Catch2WithMain)
 
+    target_compile_definitions(${TARGET_NAME} PUBLIC VKB_BUILD_TESTS)
+
     if (TARGET_LIBS)
         target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LIBS})
     endif()

--- a/components/events/CMakeLists.txt
+++ b/components/events/CMakeLists.txt
@@ -19,6 +19,7 @@ vkb__register_component(
   NAME events
   SRC
     src/input_manager.cpp
+    src/event_bus.cpp
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
@@ -27,6 +28,7 @@ vkb__register_tests(
   NAME "events_tests"
   SRC
     tests/channel.test.cpp
+    tests/event_bus.test.cpp
     tests/input_manager.test.cpp
   LIBS
     vkb__events

--- a/components/events/include/components/events/channel.hpp
+++ b/components/events/include/components/events/channel.hpp
@@ -42,6 +42,7 @@ class ChannelSender;
 template <typename Type>
 using ChannelSenderPtr = std::unique_ptr<ChannelSender<Type>>;
 
+// Acts as a base for storing multiple channels in a container
 class AbstractChannel
 {
   public:

--- a/components/events/include/components/events/event_bus.hpp
+++ b/components/events/include/components/events/event_bus.hpp
@@ -1,0 +1,272 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <components/events/channel.hpp>
+
+namespace components
+{
+namespace events
+{
+class EventBus;
+
+class EventObserver
+{
+  public:
+	EventObserver()          = default;
+	virtual ~EventObserver() = default;
+
+	virtual void update()              = 0;
+	virtual void attach(EventBus &bus) = 0;
+};
+
+/**
+ * @brief EventBus acts as a collection of event channels and observers
+ * 
+ * 		  An observer is added to the event bus through attach(observer). Once attached, an observer can register event listeners (each<EventType>(), last<EventType>()) and request
+ * 		  ChannelSender<EventTypes>. Each step of the EventBus calls update() on its observers. Which in turn allows an observer to submit events to the bus. After this, the bus then processes
+ * 		  all event callbacks with a stream of events.
+ * 
+ * 		  The combination of these actions will allow for inter component communication without any hard links. This allows samples to create and organize components in anyway they deem fit.
+ *
+ * 		  TODO: Allow an observer to detach from the bus. This should also clear all its callbacks. May need to restructure the internal storage of the bus
+ */
+class EventBus
+{
+  public:
+	EventBus()          = default;
+	virtual ~EventBus() = default;
+
+	/**
+	 * @brief Attach a new observer
+	 * 
+	 * @param observer the observer to attach
+	 * @return EventBus& the event bus
+	 */
+	EventBus &attach(std::weak_ptr<EventObserver> &&observer);
+
+	template <typename Type>
+	using EventCallback = std::function<void(const Type &)>;
+
+	/**
+	 * @brief Attach an event callback for each event in a cycle
+	 * 
+	 * @param cb the callback
+	 * @return EventBus& the event bus
+	 */
+	template <typename Type>
+	EventBus &each(EventCallback<Type> cb);
+
+	/**
+	 * @brief Attach an event callback for the last event in a cycle
+	 * 
+	 * @param cb the callback
+	 * @return EventBus& the event bus
+	 */
+	template <typename Type>
+	EventBus &last(EventCallback<Type> cb);
+
+	/**
+	 * @brief Retrieve a ChannelSender for a given type
+	 * 
+	 * @tparam Type the type of the required sender
+	 * @return ChannelSenderPtr<Type> the requested sender
+	 */
+	template <typename Type>
+	ChannelSenderPtr<Type> request_sender();
+
+	/**
+	 * @brief Process a cycle of events
+	 * 
+	 */
+	void process();
+
+  private:
+	class ChannelCallbacks
+	{
+	  public:
+		ChannelCallbacks()          = default;
+		virtual ~ChannelCallbacks() = default;
+
+		virtual void   process_each()         = 0;
+		virtual void   process_last()         = 0;
+		virtual size_t queue_size() const     = 0;
+		virtual size_t callback_count() const = 0;
+	};
+
+	template <typename Type>
+	class TypedChannelCallbacks final : public ChannelCallbacks
+	{
+	  public:
+		TypedChannelCallbacks(ChannelReceiverPtr<Type> &&receiver) :
+		    m_receiver{std::move(receiver)}
+		{}
+
+		virtual ~TypedChannelCallbacks() = default;
+
+		virtual void   process_each() override;
+		virtual void   process_last() override;
+		virtual size_t queue_size() const override;
+		virtual size_t callback_count() const override;
+		void           append(EventCallback<Type> func);
+
+	  private:
+		ChannelReceiverPtr<Type>         m_receiver;
+		std::vector<EventCallback<Type>> m_callbacks;
+	};
+
+	template <typename Type>
+	inline Channel<Type> *find_or_create_channel()
+	{
+		auto it = m_channels.find(typeid(Type));
+
+		if (it == m_channels.end())
+		{
+			auto result = m_channels.emplace(typeid(Type), Channel<Type>::create());
+			assert(result.second);
+			it = result.first;
+		}
+
+		auto *casted_channel = dynamic_cast<Channel<Type> *>(it->second.get());
+		assert(casted_channel != nullptr);
+
+		return casted_channel;
+	}
+
+	template <typename Type>
+	inline TypedChannelCallbacks<Type> *find_or_create_callbacks(std::unordered_map<std::type_index, std::unique_ptr<ChannelCallbacks>> &container)
+	{
+		auto it = container.find(typeid(Type));
+
+		if (it == container.end())
+		{
+			auto *channel = find_or_create_channel<Type>();
+
+			auto result = container.emplace(typeid(Type), std::make_unique<TypedChannelCallbacks<Type>>(channel->receiver()));
+			assert(result.second);
+			it = result.first;
+		}
+
+		auto *callbacks = dynamic_cast<TypedChannelCallbacks<Type> *>(it->second.get());
+		assert(callbacks != nullptr);
+		return callbacks;
+	}
+
+	inline bool same_ptr(const std::weak_ptr<EventObserver> &first, const std::weak_ptr<EventObserver> &second)
+	{
+		return !first.owner_before(second) && !second.owner_before(first);
+	}
+
+  protected:
+	std::vector<std::weak_ptr<EventObserver>> m_observers;
+
+	// TODO: this should be a LockedMap
+	std::unordered_map<std::type_index, std::shared_ptr<AbstractChannel>>  m_channels;
+	std::unordered_map<std::type_index, std::unique_ptr<ChannelCallbacks>> m_each_callbacks;
+	std::unordered_map<std::type_index, std::unique_ptr<ChannelCallbacks>> m_last_callbacks;
+};
+}        // namespace events
+}        // namespace components
+
+/*
+
+Implementations
+
+*/
+namespace components
+{
+namespace events
+{
+template <typename Type>
+EventBus &EventBus::each(EventCallback<Type> cb)
+{
+	auto *callbacks = find_or_create_callbacks<Type>(m_each_callbacks);
+
+	callbacks->append(cb);
+
+	return *this;
+}
+
+template <typename Type>
+EventBus &EventBus::last(EventCallback<Type> cb)
+{
+	auto *callbacks = find_or_create_callbacks<Type>(m_last_callbacks);
+
+	callbacks->append(cb);
+
+	return *this;
+}
+
+template <typename Type>
+ChannelSenderPtr<Type> EventBus::request_sender()
+{
+	auto *channel = find_or_create_channel<Type>();
+	return channel->sender();
+}
+
+template <typename Type>
+void EventBus::TypedChannelCallbacks<Type>::process_each()
+{
+	while (m_receiver->has_next())
+	{
+		Type element = m_receiver->next();
+
+		for (auto func : m_callbacks)
+		{
+			func(element);
+		}
+	}
+}
+
+template <typename Type>
+void EventBus::TypedChannelCallbacks<Type>::process_last()
+{
+	if (m_receiver->has_next())
+	{
+		Type last_element = m_receiver->drain();
+
+		for (auto func : m_callbacks)
+		{
+			func(last_element);
+		}
+	}
+}
+
+template <typename Type>
+size_t EventBus::TypedChannelCallbacks<Type>::queue_size() const
+{
+	return m_receiver->size();
+}
+
+template <typename Type>
+size_t EventBus::TypedChannelCallbacks<Type>::callback_count() const
+{
+	return m_callbacks.size();
+}
+
+template <typename Type>
+void EventBus::TypedChannelCallbacks<Type>::append(EventCallback<Type> func)
+{
+	m_callbacks.push_back(std::move(func));
+}
+}        // namespace events
+}        // namespace components

--- a/components/events/include/components/events/event_bus.hpp
+++ b/components/events/include/components/events/event_bus.hpp
@@ -123,11 +123,15 @@ class EventBus
 
 		virtual ~TypedChannelCallbacks() = default;
 
-		virtual void   process_each() override;
-		virtual void   process_last() override;
+		virtual void process_each() override;
+		virtual void process_last() override;
+
+#ifdef VKB_BUILD_TESTS
 		virtual size_t queue_size() const override;
 		virtual size_t callback_count() const override;
-		void           append(EventCallback<Type> func);
+#endif
+
+		void append(EventCallback<Type> func);
 
 	  private:
 		ChannelReceiverPtr<Type>         m_receiver;
@@ -161,7 +165,7 @@ class EventBus
 		{
 			auto *channel = find_or_create_channel<Type>();
 
-			auto result = container.emplace(typeid(Type), std::make_unique<TypedChannelCallbacks<Type>>(channel->receiver()));
+			auto result = container.emplace(typeid(Type), std::make_unique<TypedChannelCallbacks<Type>>(channel->create_receiver()));
 			assert(result.second);
 			it = result.first;
 		}
@@ -220,19 +224,17 @@ template <typename Type>
 ChannelSenderPtr<Type> EventBus::request_sender()
 {
 	auto *channel = find_or_create_channel<Type>();
-	return channel->sender();
+	return channel->create_sender();
 }
 
 template <typename Type>
 void EventBus::TypedChannelCallbacks<Type>::process_each()
 {
-	while (m_receiver->has_next())
+	while (auto optional_element = m_receiver->next())
 	{
-		Type element = m_receiver->next();
-
 		for (auto func : m_callbacks)
 		{
-			func(element);
+			func(*optional_element);
 		}
 	}
 }
@@ -240,17 +242,20 @@ void EventBus::TypedChannelCallbacks<Type>::process_each()
 template <typename Type>
 void EventBus::TypedChannelCallbacks<Type>::process_last()
 {
-	if (m_receiver->has_next())
-	{
-		Type last_element = m_receiver->drain();
+	auto optional_last_element = m_receiver->drain();
 
-		for (auto func : m_callbacks)
-		{
-			func(last_element);
-		}
+	if (!optional_last_element)
+	{
+		return;
+	}
+
+	for (auto func : m_callbacks)
+	{
+		func(*optional_last_element);
 	}
 }
 
+#ifdef VKB_BUILD_TESTS
 template <typename Type>
 size_t EventBus::TypedChannelCallbacks<Type>::queue_size() const
 {
@@ -262,6 +267,7 @@ size_t EventBus::TypedChannelCallbacks<Type>::callback_count() const
 {
 	return m_callbacks.size();
 }
+#endif
 
 template <typename Type>
 void EventBus::TypedChannelCallbacks<Type>::append(EventCallback<Type> func)

--- a/components/events/src/event_bus.cpp
+++ b/components/events/src/event_bus.cpp
@@ -1,0 +1,73 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "components/events/event_bus.hpp"
+
+#include <cassert>
+
+namespace components
+{
+namespace events
+{
+EventBus &EventBus::attach(std::weak_ptr<EventObserver> &&observer)
+{
+	for (auto it = m_observers.begin(); it != m_observers.end(); it++)
+	{
+		if (same_ptr(*it, observer))
+		{
+			return *this;
+		}
+	}
+
+	if (auto shared_observer = observer.lock())
+	{
+		shared_observer->attach(*this);
+		m_observers.push_back(shared_observer);
+	}
+
+	return *this;
+}
+
+void EventBus::process()
+{
+	for (auto it = m_observers.begin(); it != m_observers.end(); it++)
+	{
+		if ((*it).expired())
+		{
+			m_observers.erase(it);
+			it++;
+			continue;
+		}
+
+		if (auto shared = it->lock())
+		{
+			shared->update();
+		}
+	}
+
+	for (auto &it : m_each_callbacks)
+	{
+		it.second->process_each();
+	}
+
+	for (auto &it : m_last_callbacks)
+	{
+		it.second->process_last();
+	}
+}
+}        // namespace events
+}        // namespace components

--- a/components/events/src/event_bus.cpp
+++ b/components/events/src/event_bus.cpp
@@ -27,10 +27,7 @@ EventBus &EventBus::attach(std::weak_ptr<EventObserver> &&observer)
 {
 	for (auto it = m_observers.begin(); it != m_observers.end(); it++)
 	{
-		if (same_ptr(*it, observer))
-		{
-			return *this;
-		}
+		assert(!same_ptr(*it, observer) && "attempting to attach an existing observer");
 	}
 
 	if (auto shared_observer = observer.lock())
@@ -48,8 +45,7 @@ void EventBus::process()
 	{
 		if ((*it).expired())
 		{
-			m_observers.erase(it);
-			it++;
+			it = m_observers.erase(it);
 			continue;
 		}
 

--- a/components/events/src/event_bus.cpp
+++ b/components/events/src/event_bus.cpp
@@ -27,7 +27,12 @@ EventBus &EventBus::attach(std::weak_ptr<EventObserver> &&observer)
 {
 	for (auto it = m_observers.begin(); it != m_observers.end(); it++)
 	{
-		assert(!same_ptr(*it, observer) && "attempting to attach an existing observer");
+		auto exists = same_ptr(*it, observer);
+		assert(!exists && "attempting to attach an existing observer");
+		if (exists)
+		{
+			return *this;
+		}
 	}
 
 	if (auto shared_observer = observer.lock())

--- a/components/events/src/input_manager.cpp
+++ b/components/events/src/input_manager.cpp
@@ -25,9 +25,9 @@ namespace events
 {
 void InputManager::process(ChannelReceiverPtr<KeyEvent> &events)
 {
-	while (events->has_next())
+	while (auto optional_event = events->next())
 	{
-		KeyEvent event = events->next();
+		KeyEvent event = *optional_event;
 
 		m_key_state[event.code] = event.action;
 	}
@@ -35,7 +35,14 @@ void InputManager::process(ChannelReceiverPtr<KeyEvent> &events)
 
 void InputManager::process(ChannelReceiverPtr<CursorPositionEvent> &events)
 {
-	auto next_known_position = events->drain();
+	auto optional_next_known_position = events->drain();
+
+	if (!optional_next_known_position)
+	{
+		return;
+	}
+
+	auto &next_known_position = *optional_next_known_position;
 
 	if (next_known_position.pos_x != m_last_cursor_position.x || next_known_position.pos_y != m_last_cursor_position.y)
 	{
@@ -48,9 +55,9 @@ void InputManager::process(ChannelReceiverPtr<CursorPositionEvent> &events)
 
 void InputManager::process(ChannelReceiverPtr<TouchEvent> &events)
 {
-	while (events->has_next())
+	while (auto optional_event = events->next())
 	{
-		auto event = events->next();
+		auto &event = *optional_event;
 
 		auto it = m_touch_state.find(event.pointer_id);
 		if (it == m_touch_state.end())

--- a/components/events/tests/channel.test.cpp
+++ b/components/events/tests/channel.test.cpp
@@ -144,3 +144,17 @@ TEST_CASE("drain a channel", "[events]")
 	REQUIRE(last.value == 5);
 	REQUIRE(rec1->has_next() == false);
 }
+
+TEST_CASE("type index", "[events]")
+{
+	struct Event
+	{
+		uint32_t value;
+	};
+
+	std::type_index type_index = std::type_index{typeid(Event)};
+
+	ChannelPtr<Event> channel = Channel<Event>::create();
+
+	REQUIRE(type_index == channel->type_index());
+}

--- a/components/events/tests/channel.test.cpp
+++ b/components/events/tests/channel.test.cpp
@@ -32,19 +32,20 @@ TEST_CASE("send single event", "[events]")
 
 	ChannelPtr<Event> channel = Channel<Event>::create();
 
-	auto send = channel->sender();
+	auto send = channel->create_sender();
 
-	auto rec1 = channel->receiver();
-	auto rec2 = channel->receiver();
+	auto rec1 = channel->create_receiver();
+	auto rec2 = channel->create_receiver();
 
 	send->push(Event{42});
-	REQUIRE((rec1->has_next() && rec2->has_next()));
 
 	auto val1 = rec1->next();
-	REQUIRE(val1.value == 42);
+	REQUIRE(val1.has_value());
+	REQUIRE((*val1).value == 42);
 
 	auto val2 = rec2->next();
-	REQUIRE(val2.value == 42);
+	REQUIRE(val2.has_value());
+	REQUIRE((*val2).value == 42);
 }
 
 TEST_CASE("send multiple events", "[events]")
@@ -56,10 +57,10 @@ TEST_CASE("send multiple events", "[events]")
 
 	ChannelPtr<Event> channel = Channel<Event>::create();
 
-	auto send1 = channel->sender();
-	auto send2 = channel->sender();
+	auto send1 = channel->create_sender();
+	auto send2 = channel->create_sender();
 
-	auto rec1 = channel->receiver();
+	auto rec1 = channel->create_receiver();
 
 	send1->push({1});
 	send2->push({2});
@@ -77,8 +78,9 @@ TEST_CASE("send multiple events", "[events]")
 
 	for (auto val : expected_values)
 	{
-		REQUIRE(rec1->has_next());
-		REQUIRE(rec1->next().value == val);
+		auto received_value = rec1->next();
+		REQUIRE(received_value.has_value());
+		REQUIRE((*received_value).value == val);
 	}
 }
 
@@ -91,15 +93,15 @@ TEST_CASE("create receiver whilst sending events", "[events]")
 
 	ChannelPtr<Event> channel = Channel<Event>::create();
 
-	auto send1 = channel->sender();
+	auto send1 = channel->create_sender();
 
-	auto rec1 = channel->receiver();
+	auto rec1 = channel->create_receiver();
 
 	send1->push({1});
 	send1->push({2});
 	send1->push({3});
 
-	auto rec2 = channel->receiver();
+	auto rec2 = channel->create_receiver();
 
 	send1->push({4});
 	send1->push({5});
@@ -108,16 +110,18 @@ TEST_CASE("create receiver whilst sending events", "[events]")
 
 	for (auto val : expected_values_1)
 	{
-		REQUIRE(rec1->has_next());
-		REQUIRE(rec1->next().value == val);
+		auto received_value = rec1->next();
+		REQUIRE(received_value.has_value());
+		REQUIRE((*received_value).value == val);
 	}
 
 	std::vector<uint32_t> expected_values_2 = {4, 5};
 
 	for (auto val : expected_values_2)
 	{
-		REQUIRE(rec2->has_next());
-		REQUIRE(rec2->next().value == val);
+		auto received_value = rec2->next();
+		REQUIRE(received_value.has_value());
+		REQUIRE((*received_value).value == val);
 	}
 }
 
@@ -130,9 +134,9 @@ TEST_CASE("drain a channel", "[events]")
 
 	ChannelPtr<Event> channel = Channel<Event>::create();
 
-	auto send1 = channel->sender();
+	auto send1 = channel->create_sender();
 
-	auto rec1 = channel->receiver();
+	auto rec1 = channel->create_receiver();
 
 	send1->push({1});
 	send1->push({2});
@@ -141,8 +145,8 @@ TEST_CASE("drain a channel", "[events]")
 	send1->push({5});
 
 	auto last = rec1->drain();
-	REQUIRE(last.value == 5);
-	REQUIRE(rec1->has_next() == false);
+	REQUIRE(last.has_value());
+	REQUIRE((*last).value == 5);
 }
 
 TEST_CASE("type index", "[events]")

--- a/components/events/tests/event_bus.test.cpp
+++ b/components/events/tests/event_bus.test.cpp
@@ -327,23 +327,22 @@ TEST_CASE("expire an observer before process", "[events]")
 
 	TestEventBus bus{};
 
-	std::shared_ptr<EventObserver> observer = std::make_shared<Observer>();
-	bus.attach(observer);
+	std::shared_ptr<EventObserver> observer_1 = std::make_shared<Observer>();
+	std::shared_ptr<EventObserver> observer_2 = std::make_shared<Observer>();
 
-	auto sender = bus.request_sender<EventType>();
-	REQUIRE(sender != nullptr);
+	bus.attach(observer_1).attach(observer_2);
 
-	bus.each<EventType>([&](const EventType &event) {
-		REQUIRE(event.value == 12);
-	});
+	REQUIRE(bus.observer_count() == 2);
 
-	REQUIRE(bus.each_callback_count() == 1);
-
-	sender->push(EventType{12});
-
-	REQUIRE(bus.unobserved_each_event_count() == 1);
+	observer_1.reset();
 
 	bus.process();
 
-	REQUIRE(bus.unobserved_each_event_count() == 0);
+	REQUIRE(bus.observer_count() == 1);
+
+	observer_2.reset();
+
+	bus.process();
+
+	REQUIRE(bus.observer_count() == 0);
 }

--- a/components/events/tests/event_bus.test.cpp
+++ b/components/events/tests/event_bus.test.cpp
@@ -132,22 +132,6 @@ TEST_CASE("register observer", "[events]")
 	REQUIRE(bus.observer_count() == 1);
 }
 
-TEST_CASE("register multiple observers of the same instance", "[events]")
-{
-	TestEventBus bus{};
-
-	std::shared_ptr<EventObserver> observer = std::make_shared<Observer>();
-
-	REQUIRE(bus.observer_count() == 0);
-
-	bus
-	    .attach(observer)
-	    .attach(observer)
-	    .attach(observer);
-
-	REQUIRE(bus.observer_count() == 1);
-}
-
 TEST_CASE("register multiple observers of the different instances", "[events]")
 {
 	TestEventBus bus{};
@@ -332,4 +316,34 @@ TEST_CASE("process observer", "[events]")
 	bus.process();
 
 	REQUIRE(bus.unobserved_last_event_count() == 0);
+}
+
+TEST_CASE("expire an observer before process", "[events]")
+{
+	struct EventType
+	{
+		uint32_t value;
+	};
+
+	TestEventBus bus{};
+
+	std::shared_ptr<EventObserver> observer = std::make_shared<Observer>();
+	bus.attach(observer);
+
+	auto sender = bus.request_sender<EventType>();
+	REQUIRE(sender != nullptr);
+
+	bus.each<EventType>([&](const EventType &event) {
+		REQUIRE(event.value == 12);
+	});
+
+	REQUIRE(bus.each_callback_count() == 1);
+
+	sender->push(EventType{12});
+
+	REQUIRE(bus.unobserved_each_event_count() == 1);
+
+	bus.process();
+
+	REQUIRE(bus.unobserved_each_event_count() == 0);
 }

--- a/components/events/tests/event_bus.test.cpp
+++ b/components/events/tests/event_bus.test.cpp
@@ -1,0 +1,335 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <vector>
+
+#include <components/events/event_bus.hpp>
+
+using namespace components::events;
+
+class TestEventBus final : public EventBus
+{
+  public:
+	TestEventBus() :
+	    EventBus{}
+	{}
+
+	virtual ~TestEventBus() = default;
+
+	inline size_t observer_count() const
+	{
+		return m_observers.size();
+	}
+
+	inline size_t unobserved_each_event_count() const
+	{
+		size_t unprocessed_events{0};
+
+		for (auto &it : m_each_callbacks)
+		{
+			unprocessed_events += it.second->queue_size();
+		}
+
+		return unprocessed_events;
+	}
+
+	inline size_t unobserved_last_event_count() const
+	{
+		size_t unprocessed_events{0};
+
+		for (auto &it : m_last_callbacks)
+		{
+			unprocessed_events += it.second->queue_size();
+		}
+
+		return unprocessed_events;
+	}
+
+	inline size_t each_callback_count() const
+	{
+		size_t callback_count{0};
+
+		for (auto &it : m_each_callbacks)
+		{
+			callback_count += it.second->callback_count();
+		}
+
+		return callback_count;
+	}
+
+	inline size_t last_callback_count() const
+	{
+		size_t callback_count{0};
+
+		for (auto &it : m_last_callbacks)
+		{
+			callback_count += it.second->callback_count();
+		}
+
+		return callback_count;
+	}
+};
+
+class Observer final : public EventObserver
+{
+  public:
+	Observer(std::function<void()> update = nullptr, std::function<void(EventBus &)> attach = nullptr) :
+	    EventObserver{},
+	    m_update{update},
+	    m_attach{attach}
+	{
+	}
+
+	virtual ~Observer() = default;
+
+	virtual void update() override
+	{
+		if (m_update)
+		{
+			m_update();
+		}
+	}
+
+	virtual void attach(EventBus &bus) override
+	{
+		if (m_attach)
+		{
+			m_attach(bus);
+		}
+	}
+
+  private:
+	std::function<void()>           m_update{nullptr};
+	std::function<void(EventBus &)> m_attach{nullptr};
+};
+
+TEST_CASE("register observer", "[events]")
+{
+	TestEventBus bus{};
+
+	std::shared_ptr<EventObserver> observer = std::make_shared<Observer>();
+
+	REQUIRE(bus.observer_count() == 0);
+
+	bus.attach(observer);
+
+	REQUIRE(bus.observer_count() == 1);
+}
+
+TEST_CASE("register multiple observers of the same instance", "[events]")
+{
+	TestEventBus bus{};
+
+	std::shared_ptr<EventObserver> observer = std::make_shared<Observer>();
+
+	REQUIRE(bus.observer_count() == 0);
+
+	bus
+	    .attach(observer)
+	    .attach(observer)
+	    .attach(observer);
+
+	REQUIRE(bus.observer_count() == 1);
+}
+
+TEST_CASE("register multiple observers of the different instances", "[events]")
+{
+	TestEventBus bus{};
+
+	std::shared_ptr<EventObserver> observer_1 = std::make_shared<Observer>();
+	std::shared_ptr<EventObserver> observer_2 = std::make_shared<Observer>();
+	std::shared_ptr<EventObserver> observer_3 = std::make_shared<Observer>();
+
+	REQUIRE(bus.observer_count() == 0);
+
+	bus
+	    .attach(observer_1)
+	    .attach(observer_2)
+	    .attach(observer_3);
+
+	REQUIRE(bus.observer_count() == 3);
+}
+
+TEST_CASE("request sender", "[events]")
+{
+	struct EventType
+	{
+		uint32_t value;
+	};
+
+	TestEventBus bus{};
+
+	auto sender = bus.request_sender<EventType>();
+	REQUIRE(sender != nullptr);
+}
+
+TEST_CASE("event bus for each event", "[events]")
+{
+	struct EventType
+	{
+		uint32_t value;
+	};
+
+	TestEventBus bus{};
+
+	auto sender = bus.request_sender<EventType>();
+	REQUIRE(sender != nullptr);
+
+	bus.each<EventType>([&](const EventType &event) {
+		REQUIRE(event.value == 12);
+	});
+
+	REQUIRE(bus.each_callback_count() == 1);
+
+	sender->push(EventType{12});
+
+	REQUIRE(bus.unobserved_each_event_count() == 1);
+
+	bus.process();
+
+	REQUIRE(bus.unobserved_each_event_count() == 0);
+}
+
+TEST_CASE("event bus for each event with multiple callbacks", "[events]")
+{
+	struct EventType
+	{
+		uint32_t value;
+	};
+
+	TestEventBus bus{};
+
+	auto sender = bus.request_sender<EventType>();
+	REQUIRE(sender != nullptr);
+
+	bool first = true;        // < tick tock between event callbacks, this technique should be avoided in practice
+
+	// ! do not change the order here
+	bus.each<EventType>([&](const EventType &event) {
+		if (!first)        // < will skip first event
+		{
+			REQUIRE(event.value == 15);
+		}
+	});
+
+	bus.each<EventType>([&](const EventType &event) {
+		if (first)        // < will process the first event and skip the second
+		{
+			first = false;
+			REQUIRE(event.value == 12);
+		}
+	});
+
+	REQUIRE(bus.each_callback_count() == 2);
+
+	sender->push(EventType{12});
+	sender->push(EventType{15});
+
+	REQUIRE(bus.unobserved_each_event_count() == 2);
+
+	bus.process();
+
+	REQUIRE(bus.unobserved_each_event_count() == 0);
+}
+
+TEST_CASE("event bus for last event", "[events]")
+{
+	struct EventType
+	{
+		uint32_t value;
+	};
+
+	TestEventBus bus{};
+
+	auto sender = bus.request_sender<EventType>();
+	REQUIRE(sender != nullptr);
+
+	bus.last<EventType>([&](const EventType &event) {
+		REQUIRE(event.value == 4);
+	});
+
+	REQUIRE(bus.last_callback_count() == 1);
+
+	sender->push(EventType{1});
+	sender->push(EventType{2});
+	sender->push(EventType{3});
+	sender->push(EventType{4});
+
+	REQUIRE(bus.unobserved_last_event_count() == 4);
+
+	bus.process();
+
+	REQUIRE(bus.unobserved_last_event_count() == 0);
+}
+
+TEST_CASE("process observer", "[events]")
+{
+	struct EventType
+	{
+		// true if sent from the observer
+		bool     internal;
+		uint32_t value;
+	};
+
+	TestEventBus bus{};
+
+	auto sender = bus.request_sender<EventType>();
+	REQUIRE(sender != nullptr);
+
+	auto observer = std::make_shared<Observer>(
+	    [&]() {        // update()
+		    sender->push(EventType{true, 5});
+	    },
+	    [&](EventBus &eb) {        // attach(bus)
+		    eb.each<EventType>([](const EventType &event) {
+			    if (event.internal)
+			    {
+				    REQUIRE(event.value == 5);
+			    }
+			    else
+			    {
+				    REQUIRE(event.value == 1);
+			    }
+		    });
+
+		    eb.last<EventType>([](const EventType &event) {
+			    // last event is pushed by the observer
+			    REQUIRE(event.internal == true);
+			    REQUIRE(event.value == 5);
+		    });
+	    });
+
+	bus.attach(observer);
+
+	REQUIRE(bus.last_callback_count() == 1);
+	REQUIRE(bus.each_callback_count() == 1);
+
+	// will always be the first events added
+	sender->push(EventType{false, 1});
+	sender->push(EventType{false, 1});
+	sender->push(EventType{false, 1});
+	sender->push(EventType{false, 1});
+
+	REQUIRE(bus.unobserved_last_event_count() == 4);
+
+	// adds events from observer update
+	bus.process();
+
+	REQUIRE(bus.unobserved_last_event_count() == 0);
+}

--- a/components/events/tests/input_manager.test.cpp
+++ b/components/events/tests/input_manager.test.cpp
@@ -26,9 +26,9 @@ using namespace components::events;
 TEST_CASE("key_down", "[events]")
 {
 	auto channel  = Channel<KeyEvent>::create();
-	auto receiver = channel->receiver();
+	auto receiver = channel->create_receiver();
 
-	auto sender = channel->sender();
+	auto sender = channel->create_sender();
 	sender->push(KeyEvent{KeyCode::A, KeyAction::Down});
 
 	InputManager manager;
@@ -48,9 +48,9 @@ TEST_CASE("key_down", "[events]")
 TEST_CASE("key_down multiple events", "[events]")
 {
 	auto channel  = Channel<KeyEvent>::create();
-	auto receiver = channel->receiver();
+	auto receiver = channel->create_receiver();
 
-	auto sender = channel->sender();
+	auto sender = channel->create_sender();
 	sender->push(KeyEvent{KeyCode::A, KeyAction::Down});
 	sender->push(KeyEvent{KeyCode::A, KeyAction::Up});
 	sender->push(KeyEvent{KeyCode::A, KeyAction::Repeat});
@@ -74,9 +74,9 @@ TEST_CASE("key_down multiple events", "[events]")
 TEST_CASE("key_up", "[events]")
 {
 	auto channel  = Channel<KeyEvent>::create();
-	auto receiver = channel->receiver();
+	auto receiver = channel->create_receiver();
 
-	auto sender = channel->sender();
+	auto sender = channel->create_sender();
 	sender->push(KeyEvent{KeyCode::A, KeyAction::Up});
 
 	InputManager manager;
@@ -90,9 +90,9 @@ TEST_CASE("key_up", "[events]")
 TEST_CASE("current_cursor_position", "[events]")
 {
 	auto channel  = Channel<CursorPositionEvent>::create();
-	auto receiver = channel->receiver();
+	auto receiver = channel->create_receiver();
 
-	auto sender = channel->sender();
+	auto sender = channel->create_sender();
 	sender->push(CursorPositionEvent{10, 25});
 
 	InputManager manager;
@@ -114,9 +114,9 @@ TEST_CASE("cursor_position_movement default", "[events]")
 TEST_CASE("cursor_position_movement", "[events]")
 {
 	auto channel  = Channel<CursorPositionEvent>::create();
-	auto receiver = channel->receiver();
+	auto receiver = channel->create_receiver();
 
-	auto sender = channel->sender();
+	auto sender = channel->create_sender();
 	sender->push(CursorPositionEvent{10, 25});
 
 	InputManager manager;
@@ -133,9 +133,9 @@ TEST_CASE("cursor_position_movement", "[events]")
 TEST_CASE("cursor_position_movement after flush", "[events]")
 {
 	auto channel  = Channel<CursorPositionEvent>::create();
-	auto receiver = channel->receiver();
+	auto receiver = channel->create_receiver();
 
-	auto sender = channel->sender();
+	auto sender = channel->create_sender();
 	sender->push(CursorPositionEvent{10, 25});
 
 	InputManager manager;
@@ -153,9 +153,9 @@ TEST_CASE("cursor_position_movement after flush", "[events]")
 TEST_CASE("get touch state", "[events]")
 {
 	auto channel  = Channel<TouchEvent>::create();
-	auto receiver = channel->receiver();
+	auto receiver = channel->create_receiver();
 
-	auto sender = channel->sender();
+	auto sender = channel->create_sender();
 	sender->push(TouchEvent{TouchAction::PointerDown, 0, 10, 10});
 
 	InputManager manager;


### PR DESCRIPTION
## Description

An observer is added to the event bus through attach(observer). Once attached, an observer can register event listeners (each<EventType>(), last<EventType>()) and request ChannelSender<EventTypes>. Each step of the EventBus calls update() on its observers. Which in turn allows an observer to submit events to the bus. After this, the bus then processes all event callbacks with a stream of events.

The combination of these actions will allow for inter component communication without any hard links. This allows samples to create and organize components in anyway they deem fit. We can also create sets of default components used in a sample.

### Example

```c++
void main() {
    auto window = std::make_shared<Window>();
    auto input_manager = std::make_shared<InputManager>();

    EventBus bus;

    bus

        // recieves window events on process by calling window->update();
        .attach(window) 

        // consumes window events on process as input_manager->attach(bus) registered event callbacks
        .attach(input_manager); 
    
   // A custom user defined event callback which closes the app on an escape key press
   // These callbacks can be used to communicate between core components and reduce the manually pluming needed in each sample
    {
        auto sender = bus.request_sender<AppCloseEvent>();

        bus.each<KeyPress>([auto press_sender = std::move(sender)](const KeyPress& event){
            if (event.key == KeyCode::ESC) {
                press_sender->push(AppCloseEvent{
                    .force = true;
                });
            }
        });
    }
    
    bus.process();
}
```

Works towards #458 

We can also use this to synchronize application stages such as `SurfaceReady` , `SceneReady` or `CloseSample`.  Samples can design custom application flows for their own needs using events. We can build on top of this to add pipelines - a sequential set of events which are automatically fired (`Init`, `Update`, `Draw`)