### PR TITLE
Platform Context and CUSTOM_MAIN

### DIFF
--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -74,7 +74,11 @@ function(vkb__register_tests_no_catch2)
         message(FATAL_ERROR "One or more source files must be added to vkb__register_tests")
     endif()
 
-    add_executable(${TARGET_NAME} ${TARGET_SRC})
+    if(WIN32)
+        add_executable(${TARGET_NAME} WIN32 ${TARGET_SRC})
+    else()
+        add_executable(${TARGET_NAME} ${TARGET_SRC})
+    endif()
 
     if (TARGET_LIBS)
         target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LIBS})

--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -54,3 +54,34 @@ function(vkb__register_tests)
 
     add_dependencies(vkb_tests ${TARGET_NAME})
 endfunction()
+
+function(vkb__register_tests_no_catch2)
+    set(options)  
+    set(oneValueArgs NAME)
+    set(multiValueArgs SRC LIBS)
+
+    if(NOT ((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING) OR VKB_BUILD_TESTS))
+        return() # testing not enabled
+    endif()
+
+    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}) 
+
+    if (TARGET_NAME STREQUAL "")
+        message(FATAL_ERROR "NAME must be defined in vkb__register_tests")
+    endif()
+
+    if (NOT TARGET_SRC)
+        message(FATAL_ERROR "One or more source files must be added to vkb__register_tests")
+    endif()
+
+    add_executable(${TARGET_NAME} ${TARGET_SRC})
+
+    if (TARGET_LIBS)
+        target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LIBS})
+    endif()
+
+    add_test(NAME ${TARGET_NAME}
+             COMMAND ${TARGET_NAME})
+
+    add_dependencies(vkb_tests ${TARGET_NAME})
+endfunction()

--- a/components/platform/CMakeLists.txt
+++ b/components/platform/CMakeLists.txt
@@ -15,8 +15,16 @@
 # limitations under the License.
 #
 
-# order matters
-add_subdirectory(common)
-add_subdirectory(platform)
-add_subdirectory(events)
-add_subdirectory(vfs)
+vkb__register_component(
+  NAME platform
+  INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+vkb__register_tests_no_catch2(
+  NAME "platform_tests"
+  SRC
+    tests/platform.test.cpp
+  LIBS
+    vkb__platform
+)

--- a/components/platform/include/components/platform/platform.hpp
+++ b/components/platform/include/components/platform/platform.hpp
@@ -1,0 +1,163 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#define EXPORT
+#define IMPORT
+
+#if defined(_WIN32)
+#	undef EXPORT
+#	undef IMPORT
+#	define EXPORT __declspec(dllexport)
+#	define IMPORT __declspec(dllimport)
+#endif
+
+#define EXPORT_CLIB extern "C" EXPORT
+#define IMPORT_CLIB extern "C" IMPORT
+
+namespace components
+{
+/**
+ * @brief A base context used for platform detection. Components or functions that consume this context can use it to create platform specific functionality.
+ */
+struct PlatformContext
+{
+};
+}        // namespace components
+
+/**
+ * @brief Forward declare platform_main so that it can be defined elsewhere. CUSTOM_MAIN must only be used once in an executable
+ * 
+ *  Example Usage:
+ * 
+ *  CUSTOM_MAIN(context) {
+ *      auto* windows = dynamic_cast<WindowsContext>(context);
+ *      if (windows) {
+ *           ... windows stuff
+ *      }
+ *
+ *      ... other code
+ *
+ *      return EXIT_SUCCESS;
+ *  }
+ * 
+ * @return int status code
+ */
+int platform_main(components::PlatformContext *);
+
+#if defined(_WIN32)
+
+namespace components
+{
+#	include <Windows.h>
+struct WindowsContext : PlatformContext
+{
+	HINSTANCE                hInstance;
+	HINSTANCE                hPrevInstance;
+	PSTR                     lpCmdLine;
+	INT                      nCmdShow;
+	std::vector<std::string> arguments;
+};
+}        // namespace components
+
+// TODO: get arguments from handles
+#	define CUSTOM_MAIN(context_name)                                                                    \
+		int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow) \
+		{                                                                                                \
+			components::WindowsContext context{};                                                        \
+			context.hInstance     = hInstance;                                                           \
+			context.hPrevInstance = hPrevInstance;                                                       \
+			context.lpCmdLine     = lpCmdLine;                                                           \
+			context.nCmdShow      = nCmdShow;                                                            \
+                                                                                                         \
+			return platform_main(&context);                                                              \
+		}                                                                                                \
+                                                                                                         \
+		int platform_main(components::PlatformContext *context_name)
+
+#elif defined(__ANDROID__)
+
+#	include <android_native_app_glue.h>
+
+namespace components
+{
+struct AndroidContext : PlatformContext
+{
+	android_app *            android_app;
+	std::vector<std::string> arguments;
+};
+}        // namespace components
+
+// TODO: get arguments from bundle
+#	define CUSTOM_MAIN(context_name)               \
+		void android_main(android_app *android_app) \
+		{                                           \
+			components::AndroidContext context{};   \
+			context.android_app = android_app;      \
+                                                    \
+			platform_main(&context);                \
+		}                                           \
+                                                    \
+		int platform_main(components::PlatformContext *context_name)
+
+#elif defined(__APPLE__) || defined(__MACH__)
+
+namespace components
+{
+struct MacOSXContext
+{
+	std::vector<std::string> arguments;
+};
+}        // namespace components
+
+#	define CUSTOM_MAIN(context_name)                                            \
+		int main(int argc, char *argv[])                                         \
+		{                                                                        \
+			components::MacOSXContext context{};                                 \
+			context.arguments = std::vector<std::string>{argv + 1, argv + argc}; \
+                                                                                 \
+			return platform_main(&context);                                      \
+		}                                                                        \
+                                                                                 \
+		int platform_main(components::PlatformContext *context_name)
+
+#elif defined(__linux__)
+
+namespace components
+{
+struct UnixContext : PlatformContext
+{
+	std::vector<std::string> arguments;
+};
+}        // namespace components
+
+#	define CUSTOM_MAIN(context_name)                                            \
+		int main(int argc, char *argv[])                                         \
+		{                                                                        \
+			components::UnixContext context{};                                   \
+			context.arguments = std::vector<std::string>{argv + 1, argv + argc}; \
+                                                                                 \
+			return platform_main(&context);                                      \
+		}                                                                        \
+                                                                                 \
+		int platform_main(components::PlatformContext *context_name)
+
+#endif

--- a/components/platform/include/components/platform/platform.hpp
+++ b/components/platform/include/components/platform/platform.hpp
@@ -40,6 +40,7 @@ namespace components
  */
 struct PlatformContext
 {
+	virtual void _(){};        // < requires a function to be polymorphic (dynamic_cast)
 };
 }        // namespace components
 
@@ -68,7 +69,7 @@ int platform_main(components::PlatformContext *);
 namespace components
 {
 #	include <Windows.h>
-struct WindowsContext : PlatformContext
+struct WindowsContext : virtual PlatformContext
 {
 	HINSTANCE                hInstance;
 	HINSTANCE                hPrevInstance;
@@ -99,7 +100,7 @@ struct WindowsContext : PlatformContext
 
 namespace components
 {
-struct AndroidContext : PlatformContext
+struct AndroidContext : virtual PlatformContext
 {
 	android_app *            android_app;
 	std::vector<std::string> arguments;
@@ -122,7 +123,7 @@ struct AndroidContext : PlatformContext
 
 namespace components
 {
-struct MacOSXContext
+struct MacOSXContext : virtual PlatformContext
 {
 	std::vector<std::string> arguments;
 };
@@ -143,7 +144,7 @@ struct MacOSXContext
 
 namespace components
 {
-struct UnixContext : PlatformContext
+struct UnixContext : virtual PlatformContext
 {
 	std::vector<std::string> arguments;
 };

--- a/components/platform/tests/platform.test.cpp
+++ b/components/platform/tests/platform.test.cpp
@@ -1,0 +1,29 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <components/platform/platform.hpp>
+
+using namespace components;
+
+CUSTOM_MAIN(context)
+{
+	if (context == nullptr)
+	{
+		throw "context should not be null";
+	}
+	return EXIT_SUCCESS;
+}

--- a/components/platform/tests/platform.test.cpp
+++ b/components/platform/tests/platform.test.cpp
@@ -25,5 +25,19 @@ CUSTOM_MAIN(context)
 	{
 		throw "context should not be null";
 	}
+
+#if defined(_WIN32)
+	if (dynamic_cast<WindowsContext *>(context) == nullptr)
+#elif defined(__ANDROID__)
+	if (dynamic_cast<AndroidContext *>(context) == nullptr)
+#elif defined(__APPLE__) || defined(__MACH__)
+	if (dynamic_cast<MacOSXContext *>(context) == nullptr)
+#elif defined(__linux__)
+	if (dynamic_cast<UnixContext *>(context) == nullptr)
+#endif
+	{
+		throw "incorrect context provided for this platform";
+	}
+
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Description

In VFS there is mention of a  `void* context`. This context should contain all information available for a given platform so that components can have specialized implementations for each primary OS. This PR introduces very basic contexts for each OS.

There is a likely hood that we want to reuse cross platform components in many executables. `CUSTOM_MAIN` aims to reduce duplication of a cross platform main.

### Example

```
CUSTOM_MAIN(context)
{
	// _default is a temporary pattern, this is likely to be replaced in the future

	auto window = windows::_default(context, "A Window");        // < window platform default
	auto fs     = vfs::_default(context);                        // < virtual fs platform default
	auto camera = cameras::_default(context);                    // < get a devices camera AR?
}
```