### PR TITLE
Dynamic Runtime Samples

### DIFF
--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,17 +31,17 @@ function(vkb__register_tests)
     set(oneValueArgs NAME)
     set(multiValueArgs SRC LIBS)
 
-    if(NOT ((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING) OR VKB_BUILD_TESTS))
+    if(NOT((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING) OR VKB_BUILD_TESTS))
         return() # testing not enabled
     endif()
 
     cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if (TARGET_NAME STREQUAL "")
+    if(TARGET_NAME STREQUAL "")
         message(FATAL_ERROR "NAME must be defined in vkb__register_tests")
     endif()
 
-    if (NOT TARGET_SRC)
+    if(NOT TARGET_SRC)
         message(FATAL_ERROR "One or more source files must be added to vkb__register_tests")
     endif()
 
@@ -52,7 +52,14 @@ function(vkb__register_tests)
 
     set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "tests")
 
-    if (TARGET_LIBS)
+    set_target_properties(${TARGET_NAME}
+        PROPERTIES
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/${CMAKE_BUILD_TYPE}"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/${CMAKE_BUILD_TYPE}"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/${CMAKE_BUILD_TYPE}"
+    )
+
+    if(TARGET_LIBS)
         target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LIBS})
     endif()
 
@@ -64,21 +71,21 @@ function(vkb__register_tests)
 endfunction()
 
 function(vkb__register_tests_no_catch2)
-    set(options)  
+    set(options)
     set(oneValueArgs NAME)
     set(multiValueArgs SRC LIBS)
 
-    if(NOT ((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING) OR VKB_BUILD_TESTS))
+    if(NOT((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING) OR VKB_BUILD_TESTS))
         return() # testing not enabled
     endif()
 
-    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}) 
+    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if (TARGET_NAME STREQUAL "")
+    if(TARGET_NAME STREQUAL "")
         message(FATAL_ERROR "NAME must be defined in vkb__register_tests")
     endif()
 
-    if (NOT TARGET_SRC)
+    if(NOT TARGET_SRC)
         message(FATAL_ERROR "One or more source files must be added to vkb__register_tests")
     endif()
 
@@ -88,7 +95,14 @@ function(vkb__register_tests_no_catch2)
         add_executable(${TARGET_NAME} ${TARGET_SRC})
     endif()
 
-    if (TARGET_LIBS)
+    set_target_properties(${TARGET_NAME}
+        PROPERTIES
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/${CMAKE_BUILD_TYPE}"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/${CMAKE_BUILD_TYPE}"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/${CMAKE_BUILD_TYPE}"
+    )
+
+    if(TARGET_LIBS)
         target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LIBS})
     endif()
 

--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -82,7 +82,11 @@ function(vkb__register_tests_no_catch2)
         message(FATAL_ERROR "One or more source files must be added to vkb__register_tests")
     endif()
 
-    add_executable(${TARGET_NAME} ${TARGET_SRC})
+    if(WIN32)
+        add_executable(${TARGET_NAME} WIN32 ${TARGET_SRC})
+    else()
+        add_executable(${TARGET_NAME} ${TARGET_SRC})
+    endif()
 
     if (TARGET_LIBS)
         target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LIBS})

--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -62,3 +62,34 @@ function(vkb__register_tests)
 
     add_dependencies(vkb_tests ${TARGET_NAME})
 endfunction()
+
+function(vkb__register_tests_no_catch2)
+    set(options)  
+    set(oneValueArgs NAME)
+    set(multiValueArgs SRC LIBS)
+
+    if(NOT ((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING) OR VKB_BUILD_TESTS))
+        return() # testing not enabled
+    endif()
+
+    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}) 
+
+    if (TARGET_NAME STREQUAL "")
+        message(FATAL_ERROR "NAME must be defined in vkb__register_tests")
+    endif()
+
+    if (NOT TARGET_SRC)
+        message(FATAL_ERROR "One or more source files must be added to vkb__register_tests")
+    endif()
+
+    add_executable(${TARGET_NAME} ${TARGET_SRC})
+
+    if (TARGET_LIBS)
+        target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LIBS})
+    endif()
+
+    add_test(NAME ${TARGET_NAME}
+             COMMAND ${TARGET_NAME})
+
+    add_dependencies(vkb_tests ${TARGET_NAME})
+endfunction()

--- a/components/common/include/components/common/stack_error.hpp
+++ b/components/common/include/components/common/stack_error.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <string.h>
+#include <cstring>
 
 #include <deque>
 #include <exception>

--- a/components/platform/CMakeLists.txt
+++ b/components/platform/CMakeLists.txt
@@ -26,8 +26,6 @@ vkb__register_component(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-
-
 vkb__register_tests_no_catch2(
   NAME "platform_test"
   SRC
@@ -43,13 +41,6 @@ vkb__register_tests_no_catch2(
 add_library(vkb__platform__dummy_sample SHARED tests/dummy_sample.cpp)
 target_link_libraries(vkb__platform__dummy_sample PUBLIC vkb__platform)
 add_dependencies(vkb_tests vkb__platform__dummy_sample)
-
-set_target_properties(vkb__platform__dummy_sample
-  PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
-  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
-)
 
 vkb__register_tests_no_catch2(
   NAME "sample_test"

--- a/components/platform/CMakeLists.txt
+++ b/components/platform/CMakeLists.txt
@@ -17,14 +17,47 @@
 
 vkb__register_component(
   NAME platform
+  SRC
+    src/dl.cpp
+    src/sample.cpp
+  LINK_LIBS
+    ${CMAKE_DL_LIBS}
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+
+
 vkb__register_tests_no_catch2(
-  NAME "platform_tests"
+  NAME "platform_test"
   SRC
     tests/platform.test.cpp
   LIBS
     vkb__platform
+    vkb__platform__dummy_sample
 )
+
+
+# Dummy Sample
+
+add_library(vkb__platform__dummy_sample SHARED tests/dummy_sample.cpp)
+target_link_libraries(vkb__platform__dummy_sample PUBLIC vkb__platform)
+add_dependencies(vkb_tests vkb__platform__dummy_sample)
+
+set_target_properties(vkb__platform__dummy_sample
+  PROPERTIES
+  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+)
+
+vkb__register_tests_no_catch2(
+  NAME "sample_test"
+  SRC
+    tests/sample.test.cpp
+  LIBS
+    vkb__platform
+    vkb__platform__dummy_sample
+    vkb__vfs
+)
+

--- a/components/platform/CMakeLists.txt
+++ b/components/platform/CMakeLists.txt
@@ -15,8 +15,16 @@
 # limitations under the License.
 #
 
-# order matters
-add_subdirectory(common)
-add_subdirectory(platform)
-add_subdirectory(events)
-add_subdirectory(vfs)
+vkb__register_component(
+  NAME platform
+  INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+vkb__register_tests_no_catch2(
+  NAME "platform_tests"
+  SRC
+    tests/platform.test.cpp
+  LIBS
+    vkb__platform
+)

--- a/components/platform/include/components/platform/dl.hpp
+++ b/components/platform/include/components/platform/dl.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <string>
+#include <string_view>
 
 #define EXPORT
 #define IMPORT
@@ -42,7 +42,7 @@ namespace dl
  * @param name library name
  * @return std::string OS library name
  */
-std::string os_library_name(const std::string &name);
+std::string os_library_name(const std::string_view &name);
 
 /**
  * @brief Open a dynamic library
@@ -50,7 +50,7 @@ std::string os_library_name(const std::string &name);
  * @param library_path library path
  * @return void* library handle
  */
-void *open_library(const char *library_path);
+void *open_library(const std::string_view &library_path);
 
 /**
  * @brief Load a function ptr from a library
@@ -59,7 +59,7 @@ void *open_library(const char *library_path);
  * @param function_name function name
  * @return void* function ptr
  */
-void *load_function(void *library, const char *function_name);
+void *load_function(void *library, const std::string_view &function_name);
 
 /**
  * @brief Load a function ptr from a library and cast to a specific type
@@ -70,7 +70,7 @@ void *load_function(void *library, const char *function_name);
  * @return PFN function pointer
  */
 template <typename PFN>
-PFN load_function(void *library, const char *function_name)
+PFN load_function(void *library, const std::string_view &function_name)
 {
 	return reinterpret_cast<PFN>(load_function(library, function_name));
 }

--- a/components/platform/include/components/platform/dl.hpp
+++ b/components/platform/include/components/platform/dl.hpp
@@ -36,12 +36,39 @@ namespace components
 {
 namespace dl
 {
+/**
+ * @brief Convert a library name to an OS specific library name
+ * 
+ * @param name library name
+ * @return std::string OS library name
+ */
 std::string os_library_name(const std::string &name);
 
+/**
+ * @brief Open a dynamic library
+ * 
+ * @param library_path library path
+ * @return void* library handle
+ */
 void *open_library(const char *library_path);
 
+/**
+ * @brief Load a function ptr from a library
+ * 
+ * @param library library handle
+ * @param function_name function name
+ * @return void* function ptr
+ */
 void *load_function(void *library, const char *function_name);
 
+/**
+ * @brief Load a function ptr from a library and cast to a specific type
+ * 
+ * @tparam PFN type to cast too
+ * @param library library handle
+ * @param function_name function name
+ * @return PFN function pointer
+ */
 template <typename PFN>
 PFN load_function(void *library, const char *function_name)
 {

--- a/components/platform/include/components/platform/dl.hpp
+++ b/components/platform/include/components/platform/dl.hpp
@@ -15,31 +15,37 @@
  * limitations under the License.
  */
 
-#include <components/platform/platform.hpp>
+#pragma once
 
-#include <stdexcept>
+#include <string>
 
-using namespace components;
-
-CUSTOM_MAIN(context)
-{
-	if (context == nullptr)
-	{
-		throw std::runtime_error{"context should not be null"};
-	}
+#define EXPORT
+#define IMPORT
 
 #if defined(_WIN32)
-	if (dynamic_cast<WindowsContext *>(context) == nullptr)
-#elif defined(__ANDROID__)
-	if (dynamic_cast<AndroidContext *>(context) == nullptr)
-#elif defined(__APPLE__) || defined(__MACH__)
-	if (dynamic_cast<MacOSXContext *>(context) == nullptr)
-#elif defined(__linux__)
-	if (dynamic_cast<UnixContext *>(context) == nullptr)
+#	undef EXPORT
+#	undef IMPORT
+#	define EXPORT __declspec(dllexport)
+#	define IMPORT __declspec(dllimport)
 #endif
-	{
-		throw std::runtime_error{"incorrect context provided for this platform"};
-	}
 
-	return EXIT_SUCCESS;
+#define EXPORT_CLIB extern "C" EXPORT
+#define IMPORT_CLIB extern "C" IMPORT
+
+namespace components
+{
+namespace dl
+{
+std::string os_library_name(const std::string &name);
+
+void *open_library(const char *library_path);
+
+void *load_function(void *library, const char *function_name);
+
+template <typename PFN>
+PFN load_function(void *library, const char *function_name)
+{
+	return reinterpret_cast<PFN>(load_function(library, function_name));
 }
+}        // namespace dl
+}        // namespace components

--- a/components/platform/include/components/platform/platform.hpp
+++ b/components/platform/include/components/platform/platform.hpp
@@ -1,0 +1,163 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#define EXPORT
+#define IMPORT
+
+#if defined(_WIN32)
+#	undef EXPORT
+#	undef IMPORT
+#	define EXPORT __declspec(dllexport)
+#	define IMPORT __declspec(dllimport)
+#endif
+
+#define EXPORT_CLIB extern "C" EXPORT
+#define IMPORT_CLIB extern "C" IMPORT
+
+namespace components
+{
+/**
+ * @brief A base context used for platform detection. Components or functions that consume this context can use it to create platform specific functionality.
+ */
+struct PlatformContext
+{
+};
+}        // namespace components
+
+/**
+ * @brief Forward declare platform_main so that it can be defined elsewhere. CUSTOM_MAIN must only be used once in an executable
+ * 
+ *  Example Usage:
+ * 
+ *  CUSTOM_MAIN(context) {
+ *      auto* windows = dynamic_cast<WindowsContext>(context);
+ *      if (windows) {
+ *           ... windows stuff
+ *      }
+ *
+ *      ... other code
+ *
+ *      return EXIT_SUCCESS;
+ *  }
+ * 
+ * @return int status code
+ */
+int platform_main(components::PlatformContext *);
+
+#if defined(_WIN32)
+
+namespace components
+{
+#	include <Windows.h>
+struct WindowsContext : PlatformContext
+{
+	HINSTANCE                hInstance;
+	HINSTANCE                hPrevInstance;
+	PSTR                     lpCmdLine;
+	INT                      nCmdShow;
+	std::vector<std::string> arguments;
+};
+}        // namespace components
+
+// TODO: get arguments from handles
+#	define CUSTOM_MAIN(context_name)                                                                    \
+		int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow) \
+		{                                                                                                \
+			components::WindowsContext context{};                                                        \
+			context.hInstance     = hInstance;                                                           \
+			context.hPrevInstance = hPrevInstance;                                                       \
+			context.lpCmdLine     = lpCmdLine;                                                           \
+			context.nCmdShow      = nCmdShow;                                                            \
+                                                                                                         \
+			return platform_main(&context);                                                              \
+		}                                                                                                \
+                                                                                                         \
+		int platform_main(components::PlatformContext *context_name)
+
+#elif defined(__ANDROID__)
+
+#	include <android_native_app_glue.h>
+
+namespace components
+{
+struct AndroidContext : PlatformContext
+{
+	android_app *            android_app;
+	std::vector<std::string> arguments;
+};
+}        // namespace components
+
+// TODO: get arguments from bundle
+#	define CUSTOM_MAIN(context_name)               \
+		void android_main(android_app *android_app) \
+		{                                           \
+			components::AndroidContext context{};   \
+			context.android_app = android_app;      \
+                                                    \
+			platform_main(&context);                \
+		}                                           \
+                                                    \
+		int platform_main(components::PlatformContext *context_name)
+
+#elif defined(__APPLE__) || defined(__MACH__)
+
+namespace components
+{
+struct MacOSXContext
+{
+	std::vector<std::string> arguments;
+};
+}        // namespace components
+
+#	define CUSTOM_MAIN(context_name)                                            \
+		int main(int argc, char *argv[])                                         \
+		{                                                                        \
+			components::MacOSXContext context{};                                 \
+			context.arguments = std::vector<std::string>{argv + 1, argv + argc}; \
+                                                                                 \
+			return platform_main(&context);                                      \
+		}                                                                        \
+                                                                                 \
+		int platform_main(components::PlatformContext *context_name)
+
+#elif defined(__linux__)
+
+namespace components
+{
+struct UnixContext : PlatformContext
+{
+	std::vector<std::string> arguments;
+};
+}        // namespace components
+
+#	define CUSTOM_MAIN(context_name)                                            \
+		int main(int argc, char *argv[])                                         \
+		{                                                                        \
+			components::UnixContext context{};                                   \
+			context.arguments = std::vector<std::string>{argv + 1, argv + argc}; \
+                                                                                 \
+			return platform_main(&context);                                      \
+		}                                                                        \
+                                                                                 \
+		int platform_main(components::PlatformContext *context_name)
+
+#endif

--- a/components/platform/include/components/platform/platform.hpp
+++ b/components/platform/include/components/platform/platform.hpp
@@ -18,22 +18,40 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 
-extern "C"
+namespace components
 {
-	namespace components
-	{
-	/**
+class WindowsContext;
+class AndroidContext;
+class MacOSXContext;
+class UnixContext;
+
+/**
  * @brief A base context used for platform detection. Components or functions that consume this context can use it to create platform specific functionality.
  */
-	struct PlatformContext
-	{
-		virtual void _(){};        // < requires a function to be polymorphic (dynamic_cast)
-	};
-	}        // namespace components
+class PlatformContext
+{
+  public:
+	PlatformContext()          = default;
+	virtual ~PlatformContext() = default;
 
-	/**
+	virtual std::vector<std::string_view> arguments() const = 0;
+
+#if defined(_WIN32)
+	inline const WindowsContext *cast() const;
+#elif defined(__ANDROID__)
+	inline const AndroidContext *cast() const;
+#elif defined(__APPLE__) || defined(__MACH__)
+	inline const MacOSXContext *cast() const;
+#elif defined(__linux__)
+	inline const UnixContext *cast() const;
+#endif
+};
+}        // namespace components
+
+/**
  * @brief Forward declare platform_main so that it can be defined elsewhere. CUSTOM_MAIN must only be used once in an executable
  * 
  *  Example Usage:
@@ -51,104 +69,39 @@ extern "C"
  * 
  * @return int status code
  */
-	int platform_main(components::PlatformContext *);
+int platform_main(const components::PlatformContext *);
 
 #if defined(_WIN32)
-
-	namespace components
-	{
-#	include <Windows.h>
-	struct WindowsContext : virtual PlatformContext
-	{
-		HINSTANCE                hInstance;
-		HINSTANCE                hPrevInstance;
-		PSTR                     lpCmdLine;
-		INT                      nCmdShow;
-		std::vector<std::string> arguments;
-	};
-	}        // namespace components
-
-// TODO: get arguments from handles
-#	define CUSTOM_MAIN(context_name)                                                                    \
-		int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow) \
-		{                                                                                                \
-			components::WindowsContext context{};                                                        \
-			context.hInstance     = hInstance;                                                           \
-			context.hPrevInstance = hPrevInstance;                                                       \
-			context.lpCmdLine     = lpCmdLine;                                                           \
-			context.nCmdShow      = nCmdShow;                                                            \
-                                                                                                         \
-			return platform_main(&context);                                                              \
-		}                                                                                                \
-                                                                                                         \
-		int platform_main(components::PlatformContext *context_name)
-
+#	include <components/platform/platforms/windows.hpp>
 #elif defined(__ANDROID__)
-
-#	include <android_native_app_glue.h>
-
-	namespace components
-	{
-	struct AndroidContext : virtual PlatformContext
-	{
-		android_app *            android_app;
-		std::vector<std::string> arguments;
-	};
-	}        // namespace components
-
-// TODO: get arguments from bundle
-#	define CUSTOM_MAIN(context_name)               \
-		void android_main(android_app *android_app) \
-		{                                           \
-			components::AndroidContext context{};   \
-			context.android_app = android_app;      \
-                                                    \
-			platform_main(&context);                \
-		}                                           \
-                                                    \
-		int platform_main(components::PlatformContext *context_name)
-
+#	include <components/platform/platforms/android.hpp>
 #elif defined(__APPLE__) || defined(__MACH__)
-
-	namespace components
-	{
-	struct MacOSXContext : virtual PlatformContext
-	{
-		std::vector<std::string> arguments;
-	};
-	}        // namespace components
-
-#	define CUSTOM_MAIN(context_name)                                            \
-		int main(int argc, char *argv[])                                         \
-		{                                                                        \
-			components::MacOSXContext context{};                                 \
-			context.arguments = std::vector<std::string>{argv + 1, argv + argc}; \
-                                                                                 \
-			return platform_main(&context);                                      \
-		}                                                                        \
-                                                                                 \
-		int platform_main(components::PlatformContext *context_name)
-
+#	include <components/platform/platforms/macos.hpp>
 #elif defined(__linux__)
-
-	namespace components
-	{
-	struct UnixContext : virtual PlatformContext
-	{
-		std::vector<std::string> arguments;
-	};
-	}        // namespace components
-
-#	define CUSTOM_MAIN(context_name)                                            \
-		int main(int argc, char *argv[])                                         \
-		{                                                                        \
-			components::UnixContext context{};                                   \
-			context.arguments = std::vector<std::string>{argv + 1, argv + argc}; \
-                                                                                 \
-			return platform_main(&context);                                      \
-		}                                                                        \
-                                                                                 \
-		int platform_main(components::PlatformContext *context_name)
-
+#	include <components/platform/platforms/unix.hpp>
 #endif
+
+namespace components
+{
+#if defined(_WIN32)
+inline const WindowsContext *PlatformContext::cast() const
+{
+	return dynamic_cast<const WindowsContext *>(this);
 }
+#elif defined(__ANDROID__)
+inline const AndroidContext *PlatformContext::cast() const
+{
+	return dynamic_cast<const AndroidContext *>(this);
+}
+#elif defined(__APPLE__) || defined(__MACH__)
+inline const MacOSXContext *PlatformContext::cast() const
+{
+	return dynamic_cast<const MacOSXContext *>(this);
+}
+#elif defined(__linux__)
+inline const UnixContext *PlatformContext::cast() const
+{
+	return dynamic_cast<const UnixContext *>(this);
+}
+#endif
+}        // namespace components

--- a/components/platform/include/components/platform/platform.hpp
+++ b/components/platform/include/components/platform/platform.hpp
@@ -40,6 +40,7 @@ namespace components
  */
 struct PlatformContext
 {
+	virtual void _(){};        // < requires a function to be polymorphic (dynamic_cast)
 };
 }        // namespace components
 
@@ -68,7 +69,7 @@ int platform_main(components::PlatformContext *);
 namespace components
 {
 #	include <Windows.h>
-struct WindowsContext : PlatformContext
+struct WindowsContext : virtual PlatformContext
 {
 	HINSTANCE                hInstance;
 	HINSTANCE                hPrevInstance;
@@ -99,7 +100,7 @@ struct WindowsContext : PlatformContext
 
 namespace components
 {
-struct AndroidContext : PlatformContext
+struct AndroidContext : virtual PlatformContext
 {
 	android_app *            android_app;
 	std::vector<std::string> arguments;
@@ -122,7 +123,7 @@ struct AndroidContext : PlatformContext
 
 namespace components
 {
-struct MacOSXContext
+struct MacOSXContext : virtual PlatformContext
 {
 	std::vector<std::string> arguments;
 };
@@ -143,7 +144,7 @@ struct MacOSXContext
 
 namespace components
 {
-struct UnixContext : PlatformContext
+struct UnixContext : virtual PlatformContext
 {
 	std::vector<std::string> arguments;
 };

--- a/components/platform/include/components/platform/platform.hpp
+++ b/components/platform/include/components/platform/platform.hpp
@@ -20,31 +20,20 @@
 #include <string>
 #include <vector>
 
-#define EXPORT
-#define IMPORT
-
-#if defined(_WIN32)
-#	undef EXPORT
-#	undef IMPORT
-#	define EXPORT __declspec(dllexport)
-#	define IMPORT __declspec(dllimport)
-#endif
-
-#define EXPORT_CLIB extern "C" EXPORT
-#define IMPORT_CLIB extern "C" IMPORT
-
-namespace components
+extern "C"
 {
-/**
+	namespace components
+	{
+	/**
  * @brief A base context used for platform detection. Components or functions that consume this context can use it to create platform specific functionality.
  */
-struct PlatformContext
-{
-	virtual void _(){};        // < requires a function to be polymorphic (dynamic_cast)
-};
-}        // namespace components
+	struct PlatformContext
+	{
+		virtual void _(){};        // < requires a function to be polymorphic (dynamic_cast)
+	};
+	}        // namespace components
 
-/**
+	/**
  * @brief Forward declare platform_main so that it can be defined elsewhere. CUSTOM_MAIN must only be used once in an executable
  * 
  *  Example Usage:
@@ -62,22 +51,22 @@ struct PlatformContext
  * 
  * @return int status code
  */
-int platform_main(components::PlatformContext *);
+	int platform_main(components::PlatformContext *);
 
 #if defined(_WIN32)
 
-namespace components
-{
+	namespace components
+	{
 #	include <Windows.h>
-struct WindowsContext : virtual PlatformContext
-{
-	HINSTANCE                hInstance;
-	HINSTANCE                hPrevInstance;
-	PSTR                     lpCmdLine;
-	INT                      nCmdShow;
-	std::vector<std::string> arguments;
-};
-}        // namespace components
+	struct WindowsContext : virtual PlatformContext
+	{
+		HINSTANCE                hInstance;
+		HINSTANCE                hPrevInstance;
+		PSTR                     lpCmdLine;
+		INT                      nCmdShow;
+		std::vector<std::string> arguments;
+	};
+	}        // namespace components
 
 // TODO: get arguments from handles
 #	define CUSTOM_MAIN(context_name)                                                                    \
@@ -98,14 +87,14 @@ struct WindowsContext : virtual PlatformContext
 
 #	include <android_native_app_glue.h>
 
-namespace components
-{
-struct AndroidContext : virtual PlatformContext
-{
-	android_app *            android_app;
-	std::vector<std::string> arguments;
-};
-}        // namespace components
+	namespace components
+	{
+	struct AndroidContext : virtual PlatformContext
+	{
+		android_app *            android_app;
+		std::vector<std::string> arguments;
+	};
+	}        // namespace components
 
 // TODO: get arguments from bundle
 #	define CUSTOM_MAIN(context_name)               \
@@ -121,13 +110,13 @@ struct AndroidContext : virtual PlatformContext
 
 #elif defined(__APPLE__) || defined(__MACH__)
 
-namespace components
-{
-struct MacOSXContext : virtual PlatformContext
-{
-	std::vector<std::string> arguments;
-};
-}        // namespace components
+	namespace components
+	{
+	struct MacOSXContext : virtual PlatformContext
+	{
+		std::vector<std::string> arguments;
+	};
+	}        // namespace components
 
 #	define CUSTOM_MAIN(context_name)                                            \
 		int main(int argc, char *argv[])                                         \
@@ -142,13 +131,13 @@ struct MacOSXContext : virtual PlatformContext
 
 #elif defined(__linux__)
 
-namespace components
-{
-struct UnixContext : virtual PlatformContext
-{
-	std::vector<std::string> arguments;
-};
-}        // namespace components
+	namespace components
+	{
+	struct UnixContext : virtual PlatformContext
+	{
+		std::vector<std::string> arguments;
+	};
+	}        // namespace components
 
 #	define CUSTOM_MAIN(context_name)                                            \
 		int main(int argc, char *argv[])                                         \
@@ -162,3 +151,4 @@ struct UnixContext : virtual PlatformContext
 		int platform_main(components::PlatformContext *context_name)
 
 #endif
+}

--- a/components/platform/include/components/platform/platforms/android.hpp
+++ b/components/platform/include/components/platform/platforms/android.hpp
@@ -1,0 +1,57 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <android_native_app_glue.h>
+
+#include "components/platform/platform.hpp"
+
+namespace components
+{
+class AndroidContext final : public PlatformContext
+{
+  public:
+	AndroidContext(android_app *app, const std::vector<std::string> &arguments) :
+	    android_app{app},
+	    m_arguments{arguments}
+	{}
+
+	virtual ~AndroidContext() = default;
+
+	virtual std::vector<std::string_view> arguments() const override
+	{
+		return {m_arguments.begin(), m_arguments.end()};
+	}
+
+	android_app *android_app;
+
+  private:
+	std::vector<std::string> m_arguments;
+};
+}        // namespace components
+
+// TODO: get arguments from bundle
+#define CUSTOM_MAIN(context_name)                            \
+	void android_main(android_app *android_app)              \
+	{                                                        \
+		components::AndroidContext context{android_app, {}}; \
+                                                             \
+		platform_main(&context);                             \
+	}                                                        \
+                                                             \
+	int platform_main(const components::PlatformContext *context_name)

--- a/components/platform/include/components/platform/platforms/macos.hpp
+++ b/components/platform/include/components/platform/platforms/macos.hpp
@@ -1,0 +1,51 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "components/platform/platform.hpp"
+
+namespace components
+{
+class MacOSXContext final : public PlatformContext
+{
+  public:
+	MacOSXContext(const std::vector<std::string> &arguments) :
+	    m_arguments{arguments}
+	{}
+
+	virtual ~MacOSXContext() = default;
+
+	virtual std::vector<std::string_view> arguments() const override
+	{
+		return {m_arguments.begin(), m_arguments.end()};
+	}
+
+  private:
+	std::vector<std::string> m_arguments;
+};
+}        // namespace components
+
+#define CUSTOM_MAIN(context_name)                                                           \
+	int main(int argc, char *argv[])                                                        \
+	{                                                                                       \
+		components::MacOSXContext context{std::vector<std::string>{argv + 1, argv + argc}}; \
+                                                                                            \
+		return platform_main(&context);                                                     \
+	}                                                                                       \
+                                                                                            \
+	int platform_main(const components::PlatformContext *context_name)

--- a/components/platform/include/components/platform/platforms/unix.hpp
+++ b/components/platform/include/components/platform/platforms/unix.hpp
@@ -1,0 +1,51 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "components/platform/platform.hpp"
+
+namespace components
+{
+class UnixContext final : public PlatformContext
+{
+  public:
+	UnixContext(const std::vector<std::string> &arguments) :
+	    m_arguments{arguments}
+	{}
+
+	virtual ~UnixContext() = default;
+
+	virtual std::vector<std::string_view> arguments() const override
+	{
+		return {m_arguments.begin(), m_arguments.end()};
+	}
+
+  private:
+	std::vector<std::string> m_arguments;
+};
+}        // namespace components
+
+#define CUSTOM_MAIN(context_name)                                                         \
+	int main(int argc, char *argv[])                                                      \
+	{                                                                                     \
+		components::UnixContext context{std::vector<std::string>{argv + 1, argv + argc}}; \
+                                                                                          \
+		return platform_main(&context);                                                   \
+	}                                                                                     \
+                                                                                          \
+	int platform_main(const components::PlatformContext *context_name)

--- a/components/platform/include/components/platform/platforms/windows.hpp
+++ b/components/platform/include/components/platform/platforms/windows.hpp
@@ -1,0 +1,60 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <Windows.h>
+
+#include "components/platform/platform.hpp"
+
+namespace components
+{
+class WindowsContext final : public PlatformContext
+{
+  public:
+	WindowsContext()          = default;
+	virtual ~WindowsContext() = default;
+
+	virtual std::vector<std::string_view> arguments() const override
+	{
+		return {m_arguments.begin(), m_arguments.end()};
+	}
+
+	HINSTANCE hInstance;
+	HINSTANCE hPrevInstance;
+	PSTR      lpCmdLine;
+	INT       nCmdShow;
+
+  private:
+	std::vector<std::string> m_arguments;
+};
+}        // namespace components
+
+// TODO: get arguments from handles
+#define CUSTOM_MAIN(context_name)                                                                    \
+	int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow) \
+	{                                                                                                \
+		components::WindowsContext context{};                                                        \
+		context.hInstance     = hInstance;                                                           \
+		context.hPrevInstance = hPrevInstance;                                                       \
+		context.lpCmdLine     = lpCmdLine;                                                           \
+		context.nCmdShow      = nCmdShow;                                                            \
+                                                                                                     \
+		return platform_main(&context);                                                              \
+	}                                                                                                \
+                                                                                                     \
+	int platform_main(const components::PlatformContext *context_name)

--- a/components/platform/include/components/platform/sample.hpp
+++ b/components/platform/include/components/platform/sample.hpp
@@ -22,7 +22,7 @@
 extern "C"
 {
 	// Sample Main
-	typedef int (*PFN_SampleMain)(components::PlatformContext *context);
+	typedef int (*PFN_SampleMain)(const components::PlatformContext *context);
 }
 
 struct Sample

--- a/components/platform/include/components/platform/sample.hpp
+++ b/components/platform/include/components/platform/sample.hpp
@@ -1,0 +1,41 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "components/platform/platform.hpp"
+
+extern "C"
+{
+	// Sample Main
+	typedef int (*PFN_SampleMain)(components::PlatformContext *context);
+}
+
+struct Sample
+{
+	PFN_SampleMain sample_main{nullptr};
+};
+
+/**
+ * @brief load 
+ * 
+ * @param library_name 
+ * @param o_sample 
+ * @return true 
+ * @return false 
+ */
+bool load_sample(const std::string &library_name, Sample *o_sample);

--- a/components/platform/include/components/platform/sample_main.hpp
+++ b/components/platform/include/components/platform/sample_main.hpp
@@ -20,4 +20,10 @@
 #include "components/platform/dl.hpp"
 #include "components/platform/platform.hpp"
 
+/**
+ * @brief Sample Main, can be called to run a Dynamic Sample
+ * 
+ * @param context a platform context
+ * @return status code
+ */
 EXPORT_CLIB int sample_main(components::PlatformContext *context);

--- a/components/platform/include/components/platform/sample_main.hpp
+++ b/components/platform/include/components/platform/sample_main.hpp
@@ -1,0 +1,23 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "components/platform/dl.hpp"
+#include "components/platform/platform.hpp"
+
+EXPORT_CLIB int sample_main(components::PlatformContext *context);

--- a/components/platform/include/components/platform/sample_main.hpp
+++ b/components/platform/include/components/platform/sample_main.hpp
@@ -26,4 +26,4 @@
  * @param context a platform context
  * @return status code
  */
-EXPORT_CLIB int sample_main(components::PlatformContext *context);
+EXPORT_CLIB int sample_main(const components::PlatformContext *context);

--- a/components/platform/src/dl.cpp
+++ b/components/platform/src/dl.cpp
@@ -21,7 +21,7 @@
 #include <sstream>
 
 #ifdef _WIN32
-#	include <libloaderapi.h>
+#	include <windows.h>
 #else
 #	include <dlfcn.h>
 #endif

--- a/components/platform/src/dl.cpp
+++ b/components/platform/src/dl.cpp
@@ -1,0 +1,78 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "components/platform/dl.hpp"
+
+#include <cassert>
+#include <sstream>
+
+#ifdef _WIN32
+#	include <libloaderapi.h>
+#else
+#	include <dlfcn.h>
+#endif
+
+namespace components
+{
+namespace dl
+{
+std::string os_library_name(const std::string &name)
+{
+	std::stringstream lib_name;
+#ifdef _WIN32
+	lib_name << name << ".dll";
+#elif defined(__APPLE__)
+	lib_name << name << ".dylib";
+#else
+	lib_name << "lib" << name << ".so";
+#endif
+
+	return lib_name.str();
+}
+
+void *open_library(const char *library_name)
+{
+#if defined(_WIN32)
+	HMODULE module = LoadLibraryA(library_name);
+	if (!module)
+	{
+		return nullptr;
+	}
+
+	return reinterpret_cast<void *>(HMODULE);
+#elif defined(__APPLE__)
+	return dlopen(library_name, RTLD_NOW | RTLD_LOCAL);
+#else
+	return dlopen(library_name, RTLD_NOW | RTLD_LOCAL);
+#endif
+}
+
+void *load_function(void *library, const char *function_name)
+{
+	assert(library && "library must be a pointer to a dl handle. see open_library()");
+
+#if defined(_WIN32)
+	HMODULE module = static_cast<HMODULE>(library);
+	return reinterpret_cast<void *>(GetProcAddress(module, function_name));
+#elif defined(__APPLE__)
+	return dlsym(library, function_name);
+#else
+	return dlsym(library, function_name);
+#endif
+}
+}        // namespace dl
+}        // namespace components

--- a/components/platform/src/dl.cpp
+++ b/components/platform/src/dl.cpp
@@ -30,7 +30,7 @@ namespace components
 {
 namespace dl
 {
-std::string os_library_name(const std::string &name)
+std::string os_library_name(const std::string_view &name)
 {
 	std::stringstream lib_name;
 #ifdef _WIN32
@@ -44,10 +44,10 @@ std::string os_library_name(const std::string &name)
 	return lib_name.str();
 }
 
-void *open_library(const char *library_name)
+void *open_library(const std::string_view &library_name)
 {
 #if defined(_WIN32)
-	HMODULE module = LoadLibraryA(library_name);
+	HMODULE module = LoadLibraryA(library_name.data());
 	if (!module)
 	{
 		return nullptr;
@@ -55,23 +55,23 @@ void *open_library(const char *library_name)
 
 	return reinterpret_cast<void *>(module);
 #elif defined(__APPLE__)
-	return dlopen(library_name, RTLD_NOW | RTLD_LOCAL);
+	return dlopen(library_name.data(), RTLD_NOW | RTLD_LOCAL);
 #else
-	return dlopen(library_name, RTLD_NOW | RTLD_LOCAL);
+	return dlopen(library_name.data(), RTLD_NOW | RTLD_LOCAL);
 #endif
 }
 
-void *load_function(void *library, const char *function_name)
+void *load_function(void *library, const std::string_view &function_name)
 {
 	assert(library && "library must be a pointer to a dl handle. see open_library()");
 
 #if defined(_WIN32)
 	HMODULE module = static_cast<HMODULE>(library);
-	return reinterpret_cast<void *>(GetProcAddress(module, function_name));
+	return reinterpret_cast<void *>(GetProcAddress(module, function_name.data()));
 #elif defined(__APPLE__)
-	return dlsym(library, function_name);
+	return dlsym(library, function_name.data());
 #else
-	return dlsym(library, function_name);
+	return dlsym(library, function_name.data());
 #endif
 }
 }        // namespace dl

--- a/components/platform/src/dl.cpp
+++ b/components/platform/src/dl.cpp
@@ -36,7 +36,7 @@ std::string os_library_name(const std::string &name)
 #ifdef _WIN32
 	lib_name << name << ".dll";
 #elif defined(__APPLE__)
-	lib_name << name << ".dylib";
+	lib_name << "lib" << name << ".dylib";
 #else
 	lib_name << "lib" << name << ".so";
 #endif

--- a/components/platform/src/dl.cpp
+++ b/components/platform/src/dl.cpp
@@ -53,7 +53,7 @@ void *open_library(const char *library_name)
 		return nullptr;
 	}
 
-	return reinterpret_cast<void *>(HMODULE);
+	return reinterpret_cast<void *>(module);
 #elif defined(__APPLE__)
 	return dlopen(library_name, RTLD_NOW | RTLD_LOCAL);
 #else

--- a/components/platform/tests/dummy_sample.cpp
+++ b/components/platform/tests/dummy_sample.cpp
@@ -17,18 +17,14 @@
 
 #include "components/platform/sample_main.hpp"
 
-int sample_main(components::PlatformContext *context)
+#include <iostream>
+
+int sample_main(const components::PlatformContext *context)
 {
-#if defined(_WIN32)
-	if (dynamic_cast<components::WindowsContext *>(context) == nullptr)
-#elif defined(__ANDROID__)
-	if (dynamic_cast<components::AndroidContext *>(context) == nullptr)
-#elif defined(__APPLE__) || defined(__MACH__)
-	if (dynamic_cast<components::MacOSXContext *>(context) == nullptr)
-#elif defined(__linux__)
-	if (dynamic_cast<components::UnixContext *>(context) == nullptr)
-#endif
+	auto *platform_specific_context = context->cast();
+	if (platform_specific_context == nullptr)
 	{
+		std::cout << "incorrect context provided for this platform\n";
 		return false;
 	}
 

--- a/components/platform/tests/dummy_sample.cpp
+++ b/components/platform/tests/dummy_sample.cpp
@@ -15,31 +15,23 @@
  * limitations under the License.
  */
 
-#include <components/platform/platform.hpp>
+#include "components/platform/sample_main.hpp"
 
-#include <stdexcept>
-
-using namespace components;
-
-CUSTOM_MAIN(context)
+int sample_main(components::PlatformContext *context)
 {
-	if (context == nullptr)
-	{
-		throw std::runtime_error{"context should not be null"};
-	}
-
 #if defined(_WIN32)
-	if (dynamic_cast<WindowsContext *>(context) == nullptr)
+	if (dynamic_cast<components::WindowsContext *>(context) == nullptr)
 #elif defined(__ANDROID__)
-	if (dynamic_cast<AndroidContext *>(context) == nullptr)
+	if (dynamic_cast<components::AndroidContext *>(context) == nullptr)
 #elif defined(__APPLE__) || defined(__MACH__)
-	if (dynamic_cast<MacOSXContext *>(context) == nullptr)
+	if (dynamic_cast<components::MacOSXContext *>(context) == nullptr)
 #elif defined(__linux__)
-	if (dynamic_cast<UnixContext *>(context) == nullptr)
+	if (dynamic_cast<components::UnixContext *>(context) == nullptr)
 #endif
 	{
-		throw std::runtime_error{"incorrect context provided for this platform"};
+		return false;
 	}
 
-	return EXIT_SUCCESS;
+	// sample was loaded correctly with the correct context
+	return true;
 }

--- a/components/platform/tests/platform.test.cpp
+++ b/components/platform/tests/platform.test.cpp
@@ -17,7 +17,7 @@
 
 #include <components/platform/platform.hpp>
 
-#include <stdexcept>
+#include <iostream>
 
 using namespace components;
 
@@ -25,20 +25,15 @@ CUSTOM_MAIN(context)
 {
 	if (context == nullptr)
 	{
-		throw std::runtime_error{"context should not be null"};
+		std::cout << "context should not be null\n";
+		return EXIT_FAILURE;
 	}
 
-#if defined(_WIN32)
-	if (dynamic_cast<WindowsContext *>(context) == nullptr)
-#elif defined(__ANDROID__)
-	if (dynamic_cast<AndroidContext *>(context) == nullptr)
-#elif defined(__APPLE__) || defined(__MACH__)
-	if (dynamic_cast<MacOSXContext *>(context) == nullptr)
-#elif defined(__linux__)
-	if (dynamic_cast<UnixContext *>(context) == nullptr)
-#endif
+	auto *platform_specific_context = context->cast();
+	if (platform_specific_context == nullptr)
 	{
-		throw std::runtime_error{"incorrect context provided for this platform"};
+		std::cout << "incorrect context provided for this platform\n";
+		return EXIT_FAILURE;
 	}
 
 	return EXIT_SUCCESS;

--- a/components/platform/tests/platform.test.cpp
+++ b/components/platform/tests/platform.test.cpp
@@ -1,0 +1,29 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <components/platform/platform.hpp>
+
+using namespace components;
+
+CUSTOM_MAIN(context)
+{
+	if (context == nullptr)
+	{
+		throw "context should not be null";
+	}
+	return EXIT_SUCCESS;
+}

--- a/components/platform/tests/platform.test.cpp
+++ b/components/platform/tests/platform.test.cpp
@@ -25,5 +25,19 @@ CUSTOM_MAIN(context)
 	{
 		throw "context should not be null";
 	}
+
+#if defined(_WIN32)
+	if (dynamic_cast<WindowsContext *>(context) == nullptr)
+#elif defined(__ANDROID__)
+	if (dynamic_cast<AndroidContext *>(context) == nullptr)
+#elif defined(__APPLE__) || defined(__MACH__)
+	if (dynamic_cast<MacOSXContext *>(context) == nullptr)
+#elif defined(__linux__)
+	if (dynamic_cast<UnixContext *>(context) == nullptr)
+#endif
+	{
+		throw "incorrect context provided for this platform";
+	}
+
 	return EXIT_SUCCESS;
 }

--- a/components/platform/tests/sample.test.cpp
+++ b/components/platform/tests/sample.test.cpp
@@ -1,0 +1,53 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdexcept>
+
+
+#include <components/platform/dl.hpp>
+#include <components/platform/platform.hpp>
+#include <components/platform/sample.hpp>
+#include <components/vfs/filesystem.hpp>
+
+using namespace components;
+
+CUSTOM_MAIN(context)
+{
+	// resolving dynamic library paths should improve over time - for now, we need to make sure we can atleast load the dummy library
+
+	auto &fs = vfs::_default(context);
+
+	auto files = fs.enumerate_files_recursive("/build", dl::os_library_name("vkb__platform__dummy_sample"));
+	if (files.size() != 1) {
+		throw std::runtime_error{"filed to find dummy dynamic library"};
+	}
+
+	Sample sample;
+
+	// this is a "hack" to make the sample library resolve relatively to the test directory
+	if (!load_sample("./" + files[0], &sample))
+	{
+		throw std::runtime_error{"failed to load sample"};
+	}
+
+	if (!(*sample.sample_main)(context))
+	{
+		throw std::runtime_error{"failed to call sample_main()"};
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/components/platform/tests/sample.test.cpp
+++ b/components/platform/tests/sample.test.cpp
@@ -31,7 +31,7 @@ CUSTOM_MAIN(context)
 
 	auto &fs = vfs::_default(context);
 
-	auto files = fs.enumerate_files_recursive("/build", dl::os_library_name("vkb__platform__dummy_sample"));
+	auto files = fs.enumerate_files_recursive("/", dl::os_library_name("vkb__platform__dummy_sample"));
 	if (files.size() != 1) {
 		throw std::runtime_error{"filed to find dummy dynamic library"};
 	}

--- a/components/vfs/CMakeLists.txt
+++ b/components/vfs/CMakeLists.txt
@@ -53,6 +53,7 @@ vkb__register_component(
   LINK_LIBS
     re2
     vkb__common
+    vkb__platform
 )
 
 if(ANDROID)

--- a/components/vfs/include/components/vfs/filesystem.hpp
+++ b/components/vfs/include/components/vfs/filesystem.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include <components/common/stack_error.hpp>
+#include <components/platform/platform.hpp>
 
 namespace components
 {
@@ -96,6 +96,6 @@ class RootFileSystem : public FileSystem
  * @param context An OS specific context ptr
  * @return RootFileSystem& A root file system reference
  */
-extern RootFileSystem &_default(void *context = nullptr);
+extern RootFileSystem &_default(const PlatformContext *context = nullptr);
 }        // namespace vfs
 }        // namespace components

--- a/components/vfs/src/default.cpp
+++ b/components/vfs/src/default.cpp
@@ -22,7 +22,7 @@ namespace components
 {
 namespace vfs
 {
-RootFileSystem &_default(void *context)
+RootFileSystem &_default(const PlatformContext *context)
 {
 	static vfs::RootFileSystem fs;
 
@@ -63,7 +63,7 @@ namespace components
 {
 namespace vfs
 {
-RootFileSystem &_default(void * /* context */)
+RootFileSystem &_default(const PlatformContext * /* context */)
 {
 	static vfs::RootFileSystem fs;
 

--- a/components/vfs/src/root_file_system.cpp
+++ b/components/vfs/src/root_file_system.cpp
@@ -64,6 +64,10 @@ std::vector<std::string> FileSystem::enumerate_files(const std::string &folder_p
 		{
 			files_with_extension.push_back(file);
 		}
+		else if (file.size() >= extension.size() && file.substr(file.size() - extension.size()) == extension)
+		{
+			files_with_extension.push_back(file);
+		}
 	}
 
 	return files_with_extension;
@@ -274,12 +278,7 @@ std::shared_ptr<FileSystem> RootFileSystem::find_file_system(const std::string &
 		return nullptr;
 	}
 
-	auto trimmed = file_path.substr(best_score, file_path.size() - best_score);
-
-	if (trimmed[0] != '/')
-	{
-		trimmed = "/" + trimmed;
-	}
+	auto trimmed = helpers::sanitize(file_path.substr(best_score, file_path.size() - best_score));
 
 	*trimmed_path = trimmed;
 

--- a/components/vfs/src/root_file_system.cpp
+++ b/components/vfs/src/root_file_system.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <deque>
 #include <set>
+#include <stdexcept>
 
 #include "components/vfs/helpers.hpp"
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -259,16 +259,16 @@ set_property(TARGET GenericCodeGen PROPERTY FOLDER "third_party")
 set_property(TARGET MachineIndependent PROPERTY FOLDER "third_party")
 
 # spirv-cross
-add_subdirectory(spirv-cross)
+# add_subdirectory(spirv-cross)
 
-set_property(TARGET spirv-cross PROPERTY FOLDER "third_party")
-set_property(TARGET spirv-cross-core PROPERTY FOLDER "third_party")
-set_property(TARGET spirv-cross-glsl PROPERTY FOLDER "third_party")
-set_property(TARGET spirv-cross-cpp PROPERTY FOLDER "third_party")
-set_property(TARGET spirv-cross-hlsl PROPERTY FOLDER "third_party")
-set_property(TARGET spirv-cross-msl PROPERTY FOLDER "third_party")
-set_property(TARGET spirv-cross-reflect PROPERTY FOLDER "third_party")
-set_property(TARGET spirv-cross-util PROPERTY FOLDER "third_party")
+# set_property(TARGET spirv-cross PROPERTY FOLDER "third_party")
+# set_property(TARGET spirv-cross-core PROPERTY FOLDER "third_party")
+# set_property(TARGET spirv-cross-glsl PROPERTY FOLDER "third_party")
+# set_property(TARGET spirv-cross-cpp PROPERTY FOLDER "third_party")
+# set_property(TARGET spirv-cross-hlsl PROPERTY FOLDER "third_party")
+# set_property(TARGET spirv-cross-msl PROPERTY FOLDER "third_party")
+# set_property(TARGET spirv-cross-reflect PROPERTY FOLDER "third_party")
+# set_property(TARGET spirv-cross-util PROPERTY FOLDER "third_party")
 
 # hwcpipe
 add_subdirectory(hwcpipe)


### PR DESCRIPTION
## Description

There is a high chance that we want to reuse cross platform components in many executables. `CUSTOM_MAIN` aims to reduce duplication of a cross platform main.

```
CUSTOM_MAIN(context)
{
	// _default is a temporary pattern, this is likely to be replaced in the future

	auto window = windows::_default(context, "A Window");        // < window platform default
	auto fs     = vfs::_default(context);                        // < virtual fs platform default
	auto camera = cameras::_default(context);                    // < get a devices camera AR?
}
```

Adds `sample_main(context)`. Works similar to a normal `main` function except it hides the cross platform support.

The minimum code needed for a sample is

```
#include "components/platform/sample_main.hpp"

#include <iostream>

int sample_main(const components::PlatformContext *context)
{
	return true;
}
```

Later a Sample Launcher will read library paths and sample info from a JSON file. Allow the user to select a sample to run and then run the sample by loading the dynamic library and calling  `sample_main`. We can extend this to allow for CLI configuration and more.

