### PR TITLE
Headless and GLFW Windows

### DIFF
--- a/bldsys/cmake/component_helpers.cmake
+++ b/bldsys/cmake/component_helpers.cmake
@@ -44,7 +44,7 @@ function(vkb__register_component)
     if(TARGET_SRC) # Create static library
         message("ADDING STATIC: vkb__${TARGET_NAME}")
 
-        add_library("vkb__${TARGET_NAME}" STATIC ${TARGET_SRC} ${TARGET_HEADERS})
+        add_library("vkb__${TARGET_NAME}" STATIC ${TARGET_SRC})
 
         if(TARGET_LINK_LIBS)
             target_link_libraries("vkb__${TARGET_NAME}" PUBLIC ${TARGET_LINK_LIBS})

--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -45,6 +45,8 @@ function(vkb__register_tests)
         message(FATAL_ERROR "One or more source files must be added to vkb__register_tests")
     endif()
 
+    message("TEST: ${TARGET_NAME}")
+
     add_executable(${TARGET_NAME} ${TARGET_SRC})
     target_link_libraries(${TARGET_NAME} PUBLIC Catch2::Catch2WithMain)
 

--- a/components/events/include/components/events/event_types.hpp
+++ b/components/events/include/components/events/event_types.hpp
@@ -152,8 +152,8 @@ struct KeyEvent
 
 struct CursorPositionEvent
 {
-	uint32_t pos_x;
-	uint32_t pos_y;
+	float x;
+	float y;
 };
 
 enum class TouchAction
@@ -169,8 +169,8 @@ struct TouchEvent
 {
 	TouchAction action;
 	uint32_t    pointer_id;
-	uint32_t    pos_x;
-	uint32_t    pos_y;
+	float       x;
+	float       y;
 };
 }        // namespace events
 }        // namespace components

--- a/components/events/include/components/events/input_manager.hpp
+++ b/components/events/include/components/events/input_manager.hpp
@@ -29,8 +29,8 @@ namespace events
 {
 struct CursorPosition
 {
-	uint32_t x;
-	uint32_t y;
+	float x;
+	float y;
 };
 
 struct Touch

--- a/components/events/src/input_manager.cpp
+++ b/components/events/src/input_manager.cpp
@@ -44,13 +44,13 @@ void InputManager::process(ChannelReceiverPtr<CursorPositionEvent> &events)
 
 	auto &next_known_position = *optional_next_known_position;
 
-	if (next_known_position.pos_x != m_last_cursor_position.x || next_known_position.pos_y != m_last_cursor_position.y)
+	if (next_known_position.x != m_last_cursor_position.x || next_known_position.y != m_last_cursor_position.y)
 	{
-		m_cursor_position_delta.x = next_known_position.pos_x - m_last_cursor_position.x;
-		m_cursor_position_delta.y = next_known_position.pos_y - m_last_cursor_position.y;
+		m_cursor_position_delta.x = next_known_position.x - m_last_cursor_position.x;
+		m_cursor_position_delta.y = next_known_position.y - m_last_cursor_position.y;
 	}
 
-	m_last_cursor_position = CursorPosition{next_known_position.pos_x, next_known_position.pos_y};
+	m_last_cursor_position = CursorPosition{next_known_position.x, next_known_position.y};
 }
 
 void InputManager::process(ChannelReceiverPtr<TouchEvent> &events)
@@ -66,18 +66,18 @@ void InputManager::process(ChannelReceiverPtr<TouchEvent> &events)
 			assert(res.second);
 			it = res.first;
 
-			it->second.position = CursorPosition{event.pos_x, event.pos_y};
+			it->second.position = CursorPosition{event.x, event.y};
 		}
 
 		auto &touch = it->second;
 
-		if (event.pos_x != touch.position.x || event.pos_y != touch.position.y)
+		if (event.x != touch.position.x || event.y != touch.position.y)
 		{
-			touch.position.x = event.pos_x - touch.position.x;
-			touch.position.y = event.pos_y - touch.position.y;
+			touch.position.x = event.x - touch.position.x;
+			touch.position.y = event.y - touch.position.y;
 		}
 
-		touch.position = CursorPosition{event.pos_x, event.pos_y};
+		touch.position = CursorPosition{event.x, event.y};
 	}
 }
 

--- a/components/vfs/include/components/vfs/std_filesystem.hpp
+++ b/components/vfs/include/components/vfs/std_filesystem.hpp
@@ -33,17 +33,18 @@ class StdFSFileSystem : public FileSystem
 {
   public:
 	StdFSFileSystem(const std::filesystem::path &base_path = "");
-	virtual ~StdFSFileSystem() = default;
+	~StdFSFileSystem() override = default;
 
-	virtual bool          folder_exists(const std::string &file_path) override;
-	virtual bool          file_exists(const std::string &file_path) override;
-	virtual StackErrorPtr read_chunk(const std::string &file_path, const size_t offset, const size_t count, std::shared_ptr<Blob> *blob) override;
-	virtual size_t        file_size(const std::string &file_path) override;
-	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size) override;
-	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files) override;
-	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) override;
-	virtual void          make_directory(const std::string &path) override;
-	virtual bool          remove(const std::string &path) override;
+	bool                 folder_exists(const std::string &folder_path) const override;
+	bool                 file_exists(const std::string &file_path) const override;
+	std::vector<uint8_t> read_chunk(const std::string &file_path, size_t offset, size_t count) const override;
+	size_t               file_size(const std::string &file_path) const override;
+	void                 write_file(const std::string &file_path, const void *data, size_t size) override;
+	void                 make_directory(const std::string &path) override;
+	bool                 remove(const std::string &path) override;
+
+	std::vector<std::string> enumerate_files(const std::string &folder_path) const override;
+	std::vector<std::string> enumerate_folders(const std::string &folderPath) const override;
 
   protected:
 	std::filesystem::path m_base_path;
@@ -57,7 +58,7 @@ class StdFSTempFileSystem final : public StdFSFileSystem
 {
   public:
 	StdFSTempFileSystem();
-	virtual ~StdFSTempFileSystem() = default;
+	~StdFSTempFileSystem() override = default;
 };
 }        // namespace vfs
 }        // namespace components

--- a/components/vfs/include/components/vfs/std_filesystem.hpp
+++ b/components/vfs/include/components/vfs/std_filesystem.hpp
@@ -35,15 +35,15 @@ class StdFSFileSystem : public FileSystem
 	StdFSFileSystem(const std::filesystem::path &base_path = "");
 	virtual ~StdFSFileSystem() = default;
 
-	virtual bool                     folder_exists(const std::string &folder_path) const override;
-	virtual bool                     file_exists(const std::string &file_path) const override;
-	virtual std::vector<uint8_t>     read_chunk(const std::string &file_path, size_t offset, size_t count) const override;
-	virtual size_t                   file_size(const std::string &file_path) const override;
-	virtual void                     write_file(const std::string &file_path, const void *data, size_t size) override;
-	virtual std::vector<std::string> enumerate_files(const std::string &folder_path) const override;
-	virtual std::vector<std::string> enumerate_folders(const std::string &folderPath) const override;
-	virtual void                     make_directory(const std::string &path) override;
-	virtual bool                     remove(const std::string &path) override;
+	virtual bool          folder_exists(const std::string &file_path) override;
+	virtual bool          file_exists(const std::string &file_path) override;
+	virtual StackErrorPtr read_chunk(const std::string &file_path, const size_t offset, const size_t count, std::shared_ptr<Blob> *blob) override;
+	virtual size_t        file_size(const std::string &file_path) override;
+	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size) override;
+	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files) override;
+	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) override;
+	virtual void          make_directory(const std::string &path) override;
+	virtual bool          remove(const std::string &path) override;
 
   protected:
 	std::filesystem::path m_base_path;

--- a/components/vfs/src/android_aasset_manager.cpp
+++ b/components/vfs/src/android_aasset_manager.cpp
@@ -182,7 +182,6 @@ void AndroidAAssetManager::make_directory(const std::string &path)
 bool AndroidAAssetManager::remove(const std::string &path)
 {
 	throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "remove not implemented");
-	return false;
 }
 
 }        // namespace vfs

--- a/components/vfs/src/root_file_system.cpp
+++ b/components/vfs/src/root_file_system.cpp
@@ -34,6 +34,11 @@ std::vector<uint8_t> FileSystem::read_file(const std::string &file_path) const
 	return read_chunk(file_path, 0, file_size(file_path));
 }
 
+StackErrorPtr FileSystem::read_file(const std::string &file_path, std::shared_ptr<Blob> *blob)
+{
+	return read_chunk(file_path, 0, file_size(file_path), blob);
+}
+
 void FileSystem::make_directory_recursive(const std::string &path)
 {
 	auto parts = helpers::get_directory_parts(path);
@@ -118,6 +123,8 @@ RootFileSystem::RootFileSystem(const std::string &base_path) :
 
 bool RootFileSystem::folder_exists(const std::string &folder_path) const
 {
+	assert(blob);
+
 	std::string adjusted_path;
 	auto        fs = find_file_system(folder_path, &adjusted_path);
 	if (!fs)
@@ -141,6 +148,8 @@ bool RootFileSystem::file_exists(const std::string &file_path) const
 
 std::vector<uint8_t> RootFileSystem::read_chunk(const std::string &file_path, size_t offset, size_t count) const
 {
+	assert(data);
+
 	std::string adjusted_path;
 	auto        fs = find_file_system(file_path, &adjusted_path);
 	if (!fs)
@@ -153,6 +162,8 @@ std::vector<uint8_t> RootFileSystem::read_chunk(const std::string &file_path, si
 
 size_t RootFileSystem::file_size(const std::string &file_path) const
 {
+	assert(files);
+
 	std::string adjusted_path;
 	auto        fs = find_file_system(file_path, &adjusted_path);
 	if (!fs)
@@ -165,7 +176,10 @@ size_t RootFileSystem::file_size(const std::string &file_path) const
 
 void RootFileSystem::write_file(const std::string &file_path, const void *data, size_t size)
 {
-	assert(data);
+	if (!data)
+	{
+		return;
+	}
 
 	std::string adjusted_path;
 	auto        fs = find_file_system(file_path, &adjusted_path);
@@ -213,6 +227,18 @@ void RootFileSystem::make_directory(const std::string &file_path)
 	}
 
 	fs->make_directory(file_path);
+}
+
+bool RootFileSystem::remove(const std::string &path)
+{
+	std::string adjusted_path;
+	auto        fs = find_file_system(path, &adjusted_path);
+	if (!fs)
+	{
+		return false;
+	}
+
+	return fs->remove(adjusted_path);
 }
 
 bool RootFileSystem::remove(const std::string &path)

--- a/components/vfs/src/root_file_system.cpp
+++ b/components/vfs/src/root_file_system.cpp
@@ -34,10 +34,6 @@ std::vector<uint8_t> FileSystem::read_file(const std::string &file_path) const
 	return read_chunk(file_path, 0, file_size(file_path));
 }
 
-StackErrorPtr FileSystem::read_file(const std::string &file_path, std::shared_ptr<Blob> *blob)
-{
-	return read_chunk(file_path, 0, file_size(file_path), blob);
-}
 
 void FileSystem::make_directory_recursive(const std::string &path)
 {
@@ -123,8 +119,6 @@ RootFileSystem::RootFileSystem(const std::string &base_path) :
 
 bool RootFileSystem::folder_exists(const std::string &folder_path) const
 {
-	assert(blob);
-
 	std::string adjusted_path;
 	auto        fs = find_file_system(folder_path, &adjusted_path);
 	if (!fs)
@@ -148,8 +142,6 @@ bool RootFileSystem::file_exists(const std::string &file_path) const
 
 std::vector<uint8_t> RootFileSystem::read_chunk(const std::string &file_path, size_t offset, size_t count) const
 {
-	assert(data);
-
 	std::string adjusted_path;
 	auto        fs = find_file_system(file_path, &adjusted_path);
 	if (!fs)
@@ -162,8 +154,6 @@ std::vector<uint8_t> RootFileSystem::read_chunk(const std::string &file_path, si
 
 size_t RootFileSystem::file_size(const std::string &file_path) const
 {
-	assert(files);
-
 	std::string adjusted_path;
 	auto        fs = find_file_system(file_path, &adjusted_path);
 	if (!fs)
@@ -227,18 +217,6 @@ void RootFileSystem::make_directory(const std::string &file_path)
 	}
 
 	fs->make_directory(file_path);
-}
-
-bool RootFileSystem::remove(const std::string &path)
-{
-	std::string adjusted_path;
-	auto        fs = find_file_system(path, &adjusted_path);
-	if (!fs)
-	{
-		return false;
-	}
-
-	return fs->remove(adjusted_path);
 }
 
 bool RootFileSystem::remove(const std::string &path)

--- a/components/vfs/tests/basic.test.cpp
+++ b/components/vfs/tests/basic.test.cpp
@@ -9,13 +9,6 @@
 
 using namespace components;
 
-#define CHECK_ERROR(err)         \
-	if (err != nullptr)          \
-	{                            \
-		INFO(err->what());       \
-		REQUIRE(err == nullptr); \
-	}
-
 #define CATCH_ERROR()            \
 	catch (std::exception & err) \
 	{                            \

--- a/components/windows/CMakeLists.txt
+++ b/components/windows/CMakeLists.txt
@@ -41,7 +41,8 @@ vkb__register_tests(
     vkb__headless_window
 )
 
-# glfw window
+## glfw window
+
 vkb__register_component(
   NAME glfw_window
   SRC

--- a/components/windows/CMakeLists.txt
+++ b/components/windows/CMakeLists.txt
@@ -40,3 +40,14 @@ vkb__register_tests(
   LIBS
     vkb__headless_window
 )
+
+## glfw window
+
+vkb__register_component(
+  NAME glfw_window
+  SRC
+    src/glfw.cpp
+  LINK_LIBS
+    vkb__window_headers
+    glfw
+)

--- a/components/windows/CMakeLists.txt
+++ b/components/windows/CMakeLists.txt
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,36 +18,37 @@
 vkb__register_component(
   NAME window_headers
   LINK_LIBS
-  vkb__events
+    vkb__events
+    volk
   INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# # headless window
+# headless window
 vkb__register_component(
   NAME headless_window
   SRC
-  src/headless.cpp
+    src/headless.cpp
   LINK_LIBS
-  vkb__window_headers
+    vkb__window_headers
 )
 
 vkb__register_tests(
   NAME headless_window_tests
   SRC
-  tests/headless.test.cpp
+    tests/headless.test.cpp
   LIBS
-  vkb__headless_window
+    vkb__headless_window
 )
 
-# # glfw window
+# glfw window
 vkb__register_component(
   NAME glfw_window
   SRC
-  src/glfw.cpp
+    src/glfw.cpp
   LINK_LIBS
-  vkb__window_headers
-  glfw
+    vkb__window_headers
+    glfw
 )
 
 option(VKB_TEST_GLFW "Enable GLFW Tests" OFF)

--- a/components/windows/CMakeLists.txt
+++ b/components/windows/CMakeLists.txt
@@ -15,9 +15,28 @@
 # limitations under the License.
 #
 
-# order matters
-add_subdirectory(common)
-add_subdirectory(platform)
-add_subdirectory(events)
-add_subdirectory(windows)
-add_subdirectory(vfs)
+vkb__register_component(
+  NAME window_headers
+  LINK_LIBS
+    vkb__events
+  INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+## headless window
+
+vkb__register_component(
+  NAME headless_window
+  SRC
+    src/headless.cpp
+  LINK_LIBS
+    vkb__window_headers
+)
+
+vkb__register_tests(
+  NAME headless_window_tests
+  SRC
+    tests/headless.test.cpp
+  LIBS
+    vkb__headless_window
+)

--- a/components/windows/CMakeLists.txt
+++ b/components/windows/CMakeLists.txt
@@ -21,32 +21,31 @@ vkb__register_component(
     vkb__events
     volk
   INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 # headless window
 vkb__register_component(
   NAME headless_window
   SRC
-    src/headless.cpp
+  src/headless.cpp
   LINK_LIBS
-    vkb__window_headers
+  vkb__window_headers
 )
 
 vkb__register_tests(
   NAME headless_window_tests
   SRC
-    tests/headless.test.cpp
+  tests/headless.test.cpp
   LIBS
-    vkb__headless_window
+  vkb__headless_window
 )
 
-## glfw window
-
+# # glfw window
 vkb__register_component(
   NAME glfw_window
   SRC
-    src/glfw.cpp
+  src/glfw.cpp
   LINK_LIBS
     vkb__window_headers
     glfw

--- a/components/windows/CMakeLists.txt
+++ b/components/windows/CMakeLists.txt
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,36 +18,46 @@
 vkb__register_component(
   NAME window_headers
   LINK_LIBS
-    vkb__events
+  vkb__events
   INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-## headless window
-
+# # headless window
 vkb__register_component(
   NAME headless_window
   SRC
-    src/headless.cpp
+  src/headless.cpp
   LINK_LIBS
-    vkb__window_headers
+  vkb__window_headers
 )
 
 vkb__register_tests(
   NAME headless_window_tests
   SRC
-    tests/headless.test.cpp
+  tests/headless.test.cpp
   LIBS
-    vkb__headless_window
+  vkb__headless_window
 )
 
-## glfw window
-
+# # glfw window
 vkb__register_component(
   NAME glfw_window
   SRC
-    src/glfw.cpp
+  src/glfw.cpp
   LINK_LIBS
-    vkb__window_headers
-    glfw
+  vkb__window_headers
+  glfw
 )
+
+option(VKB_TEST_GLFW "Enable GLFW Tests" OFF)
+
+if(VKB_TEST_GLFW)
+  vkb__register_tests(
+    NAME glfw_window_test
+    SRC
+    tests/glfw.test.cpp
+    LIBS
+    vkb__glfw_window
+  )
+endif()

--- a/components/windows/CMakeLists.txt
+++ b/components/windows/CMakeLists.txt
@@ -41,7 +41,12 @@ vkb__register_tests(
   vkb__headless_window
 )
 
-# # glfw window
+if(DIRECT_TO_DISPLAY)
+  # Direct to display can only use specific windows. windows past this point are not compatible
+  return()
+endif()
+
+# glfw window
 vkb__register_component(
   NAME glfw_window
   SRC

--- a/components/windows/include/components/windows/glfw.hpp
+++ b/components/windows/include/components/windows/glfw.hpp
@@ -1,0 +1,59 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "components/events/event_types.hpp"
+#include <components/windows/window.hpp>
+
+struct GLFWwindow;
+
+namespace components
+{
+namespace windows
+{
+class GLFWCallbackHelper;
+
+class GLFWWindow : public Window
+{
+	friend class GLFWCallbackHelper;
+
+  public:
+	GLFWWindow(const std::string &title = "New Window", const Extent &initial_extent = {600, 600});
+	virtual ~GLFWWindow();
+	virtual void     set_extent(const Extent &extent) override;
+	virtual Extent   extent() const override;
+	virtual void     set_position(const Position &position) override;
+	virtual Position position() const override;
+	virtual float    dpi_factor() const override;
+	virtual void     update() override;
+	virtual void     attach(events::EventBus &bus) override;
+
+  protected:
+	GLFWwindow *                                      m_handle{nullptr};
+	std::unique_ptr<GLFWCallbackHelper>               m_callback_helper{nullptr};
+	events::ChannelSenderPtr<PositionChangedEvent>    m_position_sender{nullptr};
+	events::ChannelSenderPtr<ContentRectChangedEvent> m_content_rect_sender{nullptr};
+	events::ChannelSenderPtr<FocusChangedEvent>       m_focus_sender{nullptr};
+	events::ChannelSenderPtr<ShouldCloseEvent>        m_should_close_sender{nullptr};
+
+	events::ChannelSenderPtr<events::KeyEvent>            m_key_sender{nullptr};
+	events::ChannelSenderPtr<events::CursorPositionEvent> m_cursor_position_sender{nullptr};
+	events::ChannelSenderPtr<events::TouchEvent>          m_touch_sender{nullptr};
+};
+}        // namespace windows
+}        // namespace components

--- a/components/windows/include/components/windows/glfw.hpp
+++ b/components/windows/include/components/windows/glfw.hpp
@@ -47,6 +47,8 @@ class GLFWWindow : public Window
 
   protected:
 	std::string m_title;
+	Extent      m_extent;
+	Position    m_position;
 
 	GLFWwindow *                                      m_handle{nullptr};
 	std::unique_ptr<GLFWCallbackHelper>               m_callback_helper{nullptr};

--- a/components/windows/include/components/windows/glfw.hpp
+++ b/components/windows/include/components/windows/glfw.hpp
@@ -45,12 +45,43 @@ class GLFWWindow : public Window
 	virtual void             update() override;
 	virtual void             attach(events::EventBus &bus) override;
 
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+	virtual VkResult populate_surface_create_info(VkAndroidSurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_WIN32_KHR)
+	virtual VkResult populate_surface_create_info(VkWin32SurfaceCreateInfoKHR * /* info */) const override;
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
+	virtual VkResult populate_surface_create_info(VkMetalSurfaceCreateInfoEXT * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_XLIB_KHR)
+	virtual VkResult populate_surface_create_info(VkXlibSurfaceCreateInfoKHR * /* info */) const override;
+#elif defined(VK_USE_PLATFORM_XCB_KHR)
+	virtual VkResult populate_surface_create_info(VkXcbSurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
+	virtual VkResult populate_surface_create_info(VkWaylandSurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_DISPLAY_KHR)
+	virtual VkResult populate_surface_create_info(VkDisplaySurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#endif
+
   protected:
 	std::string m_title;
 	Extent      m_extent;
 	Position    m_position;
 
-	GLFWwindow *                                      m_handle{nullptr};
+	GLFWwindow	                                   *m_handle{nullptr};
 	std::unique_ptr<GLFWCallbackHelper>               m_callback_helper{nullptr};
 	events::ChannelSenderPtr<PositionChangedEvent>    m_position_sender{nullptr};
 	events::ChannelSenderPtr<ContentRectChangedEvent> m_content_rect_sender{nullptr};

--- a/components/windows/include/components/windows/glfw.hpp
+++ b/components/windows/include/components/windows/glfw.hpp
@@ -35,15 +35,19 @@ class GLFWWindow : public Window
   public:
 	GLFWWindow(const std::string &title = "New Window", const Extent &initial_extent = {600, 600});
 	virtual ~GLFWWindow();
-	virtual void     set_extent(const Extent &extent) override;
-	virtual Extent   extent() const override;
-	virtual void     set_position(const Position &position) override;
-	virtual Position position() const override;
-	virtual float    dpi_factor() const override;
-	virtual void     update() override;
-	virtual void     attach(events::EventBus &bus) override;
+	virtual void             set_extent(const Extent &extent) override;
+	virtual Extent           extent() const override;
+	virtual void             set_position(const Position &position) override;
+	virtual Position         position() const override;
+	virtual float            dpi_factor() const override;
+	virtual void             set_title(const std::string &title) override;
+	virtual std::string_view title() const override;
+	virtual void             update() override;
+	virtual void             attach(events::EventBus &bus) override;
 
   protected:
+	std::string m_title;
+
 	GLFWwindow *                                      m_handle{nullptr};
 	std::unique_ptr<GLFWCallbackHelper>               m_callback_helper{nullptr};
 	events::ChannelSenderPtr<PositionChangedEvent>    m_position_sender{nullptr};

--- a/components/windows/include/components/windows/glfw.hpp
+++ b/components/windows/include/components/windows/glfw.hpp
@@ -34,47 +34,18 @@ class GLFWWindow : public Window
 
   public:
 	GLFWWindow(const std::string &title = "New Window", const Extent &initial_extent = {600, 600});
-	virtual ~GLFWWindow();
-	virtual void             set_extent(const Extent &extent) override;
-	virtual Extent           extent() const override;
-	virtual void             set_position(const Position &position) override;
-	virtual Position         position() const override;
-	virtual float            dpi_factor() const override;
-	virtual void             set_title(const std::string &title) override;
-	virtual std::string_view title() const override;
-	virtual void             update() override;
-	virtual void             attach(events::EventBus &bus) override;
+	~GLFWWindow();
+	void             set_extent(const Extent &extent) override;
+	Extent           extent() const override;
+	void             set_position(const Position &position) override;
+	Position         position() const override;
+	float            dpi_factor() const override;
+	void             set_title(const std::string &title) override;
+	std::string_view title() const override;
+	void             update() override;
+	void             attach(events::EventBus &bus) override;
 
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	virtual VkResult populate_surface_create_info(VkAndroidSurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_WIN32_KHR)
-	virtual VkResult populate_surface_create_info(VkWin32SurfaceCreateInfoKHR * /* info */) const override;
-#elif defined(VK_USE_PLATFORM_METAL_EXT)
-	virtual VkResult populate_surface_create_info(VkMetalSurfaceCreateInfoEXT * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_XLIB_KHR)
-	virtual VkResult populate_surface_create_info(VkXlibSurfaceCreateInfoKHR * /* info */) const override;
-#elif defined(VK_USE_PLATFORM_XCB_KHR)
-	virtual VkResult populate_surface_create_info(VkXcbSurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	virtual VkResult populate_surface_create_info(VkWaylandSurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_DISPLAY_KHR)
-	virtual VkResult populate_surface_create_info(VkDisplaySurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#endif
+	VkResult create_surface(VkInstance instance, VkSurfaceKHR* surface) override;
 
   protected:
 	std::string m_title;

--- a/components/windows/include/components/windows/headless.hpp
+++ b/components/windows/include/components/windows/headless.hpp
@@ -1,0 +1,52 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <components/windows/window.hpp>
+
+namespace components
+{
+namespace windows
+{
+class HeadlessWindow : public Window
+{
+  public:
+	HeadlessWindow(const std::string &title = "New Window", const Extent &initial_extent = {600, 600});
+	virtual ~HeadlessWindow() = default;
+	virtual void     set_extent(const Extent &extent) override;
+	virtual Extent   extent() const override;
+	virtual void     set_position(const Position &position) override;
+	virtual Position position() const override;
+	virtual float    dpi_factor() const override;
+	virtual void     update() override;
+	virtual void     attach(events::EventBus &bus) override;
+
+  private:
+	bool   m_extent_changed{false};
+	Extent m_extent{};
+
+	bool     m_position_changed{false};
+	Position m_position{0, 0};
+
+	float m_dpi_factor{1.0f};
+
+	events::ChannelSenderPtr<PositionChangedEvent>    m_position_sender{nullptr};
+	events::ChannelSenderPtr<ContentRectChangedEvent> m_content_rect_sender{nullptr};
+};
+}        // namespace windows
+}        // namespace components

--- a/components/windows/include/components/windows/headless.hpp
+++ b/components/windows/include/components/windows/headless.hpp
@@ -27,53 +27,18 @@ class HeadlessWindow : public Window
 {
   public:
 	HeadlessWindow(const std::string &title = "New Window", const Extent &initial_extent = {600, 600});
-	virtual ~HeadlessWindow() = default;
-	virtual void             set_extent(const Extent &extent) override;
-	virtual Extent           extent() const override;
-	virtual void             set_position(const Position &position) override;
-	virtual Position         position() const override;
-	virtual float            dpi_factor() const override;
-	virtual void             set_title(const std::string &title) override;
-	virtual std::string_view title() const override;
-	virtual void             update() override;
-	virtual void             attach(events::EventBus &bus) override;
+	~HeadlessWindow() = default;
+	void             set_extent(const Extent &extent) override;
+	Extent           extent() const override;
+	void             set_position(const Position &position) override;
+	Position         position() const override;
+	float            dpi_factor() const override;
+	void             set_title(const std::string &title) override;
+	std::string_view title() const override;
+	void             update() override;
+	void             attach(events::EventBus &bus) override;
 
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	virtual VkResult populate_surface_create_info(VkAndroidSurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_WIN32_KHR)
-	virtual VkResult populate_surface_create_info(VkWin32SurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_METAL_EXT)
-	virtual VkResult populate_surface_create_info(VkMetalSurfaceCreateInfoEXT * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_XLIB_KHR)
-	virtual VkResult populate_surface_create_info(VkXlibSurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_XCB_KHR)
-	virtual VkResult populate_surface_create_info(VkXcbSurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	virtual VkResult populate_surface_create_info(VkWaylandSurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#elif defined(VK_USE_PLATFORM_DISPLAY_KHR)
-	virtual VkResult populate_surface_create_info(VkDisplaySurfaceCreateInfoKHR * /* info */) const override
-	{
-		return VK_INCOMPLETE;
-	}
-#endif
+	VkResult create_surface(VkInstance instance, VkSurfaceKHR* surface) override;
 
   private:
 	std::string m_title;

--- a/components/windows/include/components/windows/headless.hpp
+++ b/components/windows/include/components/windows/headless.hpp
@@ -28,15 +28,19 @@ class HeadlessWindow : public Window
   public:
 	HeadlessWindow(const std::string &title = "New Window", const Extent &initial_extent = {600, 600});
 	virtual ~HeadlessWindow() = default;
-	virtual void     set_extent(const Extent &extent) override;
-	virtual Extent   extent() const override;
-	virtual void     set_position(const Position &position) override;
-	virtual Position position() const override;
-	virtual float    dpi_factor() const override;
-	virtual void     update() override;
-	virtual void     attach(events::EventBus &bus) override;
+	virtual void             set_extent(const Extent &extent) override;
+	virtual Extent           extent() const override;
+	virtual void             set_position(const Position &position) override;
+	virtual Position         position() const override;
+	virtual float            dpi_factor() const override;
+	virtual void             set_title(const std::string &title) override;
+	virtual std::string_view title() const override;
+	virtual void             update() override;
+	virtual void             attach(events::EventBus &bus) override;
 
   private:
+	std::string m_title;
+
 	bool   m_extent_changed{false};
 	Extent m_extent{};
 

--- a/components/windows/include/components/windows/headless.hpp
+++ b/components/windows/include/components/windows/headless.hpp
@@ -38,6 +38,43 @@ class HeadlessWindow : public Window
 	virtual void             update() override;
 	virtual void             attach(events::EventBus &bus) override;
 
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+	virtual VkResult populate_surface_create_info(VkAndroidSurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_WIN32_KHR)
+	virtual VkResult populate_surface_create_info(VkWin32SurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
+	virtual VkResult populate_surface_create_info(VkMetalSurfaceCreateInfoEXT * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_XLIB_KHR)
+	virtual VkResult populate_surface_create_info(VkXlibSurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_XCB_KHR)
+	virtual VkResult populate_surface_create_info(VkXcbSurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
+	virtual VkResult populate_surface_create_info(VkWaylandSurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#elif defined(VK_USE_PLATFORM_DISPLAY_KHR)
+	virtual VkResult populate_surface_create_info(VkDisplaySurfaceCreateInfoKHR * /* info */) const override
+	{
+		return VK_INCOMPLETE;
+	}
+#endif
+
   private:
 	std::string m_title;
 

--- a/components/windows/include/components/windows/window.hpp
+++ b/components/windows/include/components/windows/window.hpp
@@ -23,6 +23,8 @@
 
 #include <components/events/event_bus.hpp>
 
+#include <volk.h>
+
 namespace components
 {
 namespace windows
@@ -73,6 +75,25 @@ class Window : public events::EventObserver
 
 	virtual void             set_title(const std::string &title) = 0;
 	virtual std::string_view title() const                       = 0;
+
+	// supported vulkan surface create infos
+	// compile errors indicate that a platform supports a surface but we do not have an implementation for it
+
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+	virtual VkResult populate_surface_create_info(VkAndroidSurfaceCreateInfoKHR * /* info */) const = 0;
+#elif defined(VK_USE_PLATFORM_WIN32_KHR)
+	virtual VkResult populate_surface_create_info(VkWin32SurfaceCreateInfoKHR * /* info */) const = 0;
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
+	virtual VkResult populate_surface_create_info(VkMetalSurfaceCreateInfoEXT * /* info */) const = 0;
+#elif defined(VK_USE_PLATFORM_XLIB_KHR)
+	virtual VkResult populate_surface_create_info(VkXlibSurfaceCreateInfoKHR * /* info */) const = 0;
+#elif defined(VK_USE_PLATFORM_XCB_KHR)
+	virtual VkResult populate_surface_create_info(VkXcbSurfaceCreateInfoKHR * /* info */) const = 0;
+#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
+	virtual VkResult populate_surface_create_info(VkWaylandSurfaceCreateInfoKHR * /* info */) const = 0;
+#elif defined(VK_USE_PLATFORM_DISPLAY_KHR)
+	virtual VkResult populate_surface_create_info(VkDisplaySurfaceCreateInfoKHR * /* info */) const = 0;
+#endif
 };
 }        // namespace windows
 }        // namespace components

--- a/components/windows/include/components/windows/window.hpp
+++ b/components/windows/include/components/windows/window.hpp
@@ -19,6 +19,8 @@
 
 #include <stdint.h>
 
+#include <string_view>
+
 #include <components/events/event_bus.hpp>
 
 namespace components
@@ -58,10 +60,7 @@ struct FocusChangedEvent
 class Window : public events::EventObserver
 {
   public:
-	Window(const std::string &title) :
-	    m_title{title}
-	{}
-
+	Window()          = default;
 	virtual ~Window() = default;
 
 	virtual void   set_extent(const Extent &extent) = 0;
@@ -72,18 +71,8 @@ class Window : public events::EventObserver
 
 	virtual float dpi_factor() const = 0;
 
-	inline void set_title(const std::string &title)
-	{
-		m_title = title;
-	}
-
-	inline const std::string &title() const
-	{
-		return m_title;
-	}
-
-  private:
-	std::string m_title;
+	virtual void             set_title(const std::string &title) = 0;
+	virtual std::string_view title() const                       = 0;
 };
 }        // namespace windows
 }        // namespace components

--- a/components/windows/include/components/windows/window.hpp
+++ b/components/windows/include/components/windows/window.hpp
@@ -76,24 +76,7 @@ class Window : public events::EventObserver
 	virtual void             set_title(const std::string &title) = 0;
 	virtual std::string_view title() const                       = 0;
 
-	// supported vulkan surface create infos
-	// compile errors indicate that a platform supports a surface but we do not have an implementation for it
-
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	virtual VkResult populate_surface_create_info(VkAndroidSurfaceCreateInfoKHR * /* info */) const = 0;
-#elif defined(VK_USE_PLATFORM_WIN32_KHR)
-	virtual VkResult populate_surface_create_info(VkWin32SurfaceCreateInfoKHR * /* info */) const = 0;
-#elif defined(VK_USE_PLATFORM_METAL_EXT)
-	virtual VkResult populate_surface_create_info(VkMetalSurfaceCreateInfoEXT * /* info */) const = 0;
-#elif defined(VK_USE_PLATFORM_XLIB_KHR)
-	virtual VkResult populate_surface_create_info(VkXlibSurfaceCreateInfoKHR * /* info */) const = 0;
-#elif defined(VK_USE_PLATFORM_XCB_KHR)
-	virtual VkResult populate_surface_create_info(VkXcbSurfaceCreateInfoKHR * /* info */) const = 0;
-#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	virtual VkResult populate_surface_create_info(VkWaylandSurfaceCreateInfoKHR * /* info */) const = 0;
-#elif defined(VK_USE_PLATFORM_DISPLAY_KHR)
-	virtual VkResult populate_surface_create_info(VkDisplaySurfaceCreateInfoKHR * /* info */) const = 0;
-#endif
+	virtual VkResult create_surface(VkInstance instance, VkSurfaceKHR* surface) = 0;
 };
 }        // namespace windows
 }        // namespace components

--- a/components/windows/include/components/windows/window.hpp
+++ b/components/windows/include/components/windows/window.hpp
@@ -37,14 +37,22 @@ struct Position
 	uint32_t y;
 };
 
+struct ShouldCloseEvent
+{};
+
 struct ContentRectChangedEvent
 {
-	Extent extent;
+	Extent extent{0, 0};
 };
 
 struct PositionChangedEvent
 {
-	Position position;
+	Position position{0, 0};
+};
+
+struct FocusChangedEvent
+{
+	bool is_focused{false};
 };
 
 class Window : public events::EventObserver

--- a/components/windows/include/components/windows/window.hpp
+++ b/components/windows/include/components/windows/window.hpp
@@ -1,0 +1,81 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include <components/events/event_bus.hpp>
+
+namespace components
+{
+namespace windows
+{
+struct Extent
+{
+	uint32_t width;
+	uint32_t height;
+};
+
+struct Position
+{
+	uint32_t x;
+	uint32_t y;
+};
+
+struct ContentRectChangedEvent
+{
+	Extent extent;
+};
+
+struct PositionChangedEvent
+{
+	Position position;
+};
+
+class Window : public events::EventObserver
+{
+  public:
+	Window(const std::string &title) :
+	    m_title{title}
+	{}
+
+	virtual ~Window() = default;
+
+	virtual void   set_extent(const Extent &extent) = 0;
+	virtual Extent extent() const                   = 0;
+
+	virtual void     set_position(const Position &position) = 0;
+	virtual Position position() const                       = 0;
+
+	virtual float dpi_factor() const = 0;
+
+	inline void set_title(const std::string &title)
+	{
+		m_title = title;
+	}
+
+	inline const std::string &title() const
+	{
+		return m_title;
+	}
+
+  private:
+	std::string m_title;
+};
+}        // namespace windows
+}        // namespace components

--- a/components/windows/src/glfw.cpp
+++ b/components/windows/src/glfw.cpp
@@ -327,6 +327,7 @@ void mouse_button_callback(GLFWwindow *window, int button, int action, int /*mod
 GLFWWindow::GLFWWindow(const std::string &title, const Extent &initial_extent) :
     Window{},
     m_title{title},
+    m_extent{initial_extent},
     m_callback_helper{std::make_unique<GLFWCallbackHelper>(*this)}
 {
 	// TODO: GLFW_X11_XCB_VULKAN_SURFACE
@@ -357,6 +358,10 @@ GLFWWindow::GLFWWindow(const std::string &title, const Extent &initial_extent) :
 
 	glfwSetInputMode(m_handle, GLFW_STICKY_KEYS, 1);
 	glfwSetInputMode(m_handle, GLFW_STICKY_MOUSE_BUTTONS, 1);
+
+	int x, y;
+	glfwGetWindowPos(m_handle, &x, &y);
+	m_position = Position{static_cast<uint32_t>(x), static_cast<uint32_t>(y)};
 }
 
 GLFWWindow::~GLFWWindow()
@@ -366,7 +371,8 @@ GLFWWindow::~GLFWWindow()
 
 void GLFWWindow::set_extent(const Extent &extent)
 {
-	glfwSetWindowSize(m_handle, static_cast<int>(extent.width), static_cast<int>(extent.height));
+	glfwSetWindowSize(m_handle, (int) extent.width, (int) extent.height);
+	m_extent = extent;
 	if (m_content_rect_sender)
 	{
 		m_content_rect_sender->push(ContentRectChangedEvent{extent});
@@ -375,15 +381,13 @@ void GLFWWindow::set_extent(const Extent &extent)
 
 Extent GLFWWindow::extent() const
 {
-	int width;
-	int height;
-	glfwGetWindowSize(m_handle, &width, &height);
-	return Extent{static_cast<uint32_t>(width), static_cast<uint32_t>(height)};
+	return m_extent;
 }
 
 void GLFWWindow::set_position(const Position &position)
 {
-	glfwSetWindowPos(m_handle, static_cast<int>(position.x), static_cast<int>(position.y));
+	glfwSetWindowPos(m_handle, (int) position.x, (int) position.y);
+	m_position = position;
 	if (m_position_sender)
 	{
 		m_position_sender->push(PositionChangedEvent{position});
@@ -392,10 +396,7 @@ void GLFWWindow::set_position(const Position &position)
 
 Position GLFWWindow::position() const
 {
-	int x;
-	int y;
-	glfwGetWindowPos(m_handle, &x, &y);
-	return Position{static_cast<uint32_t>(x), static_cast<uint32_t>(y)};
+	return m_position;
 }
 
 float GLFWWindow::dpi_factor() const

--- a/components/windows/src/glfw.cpp
+++ b/components/windows/src/glfw.cpp
@@ -1,0 +1,444 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <components/windows/glfw.hpp>
+
+#include <GLFW/glfw3.h>
+
+namespace components
+{
+namespace windows
+{
+class GLFWCallbackHelper
+{
+  public:
+	GLFWCallbackHelper(GLFWWindow &window) :
+	    m_window{window}
+	{
+	}
+
+	events::ChannelSenderPtr<PositionChangedEvent> &position_sender() const
+	{
+		return m_window.m_position_sender;
+	}
+
+	events::ChannelSenderPtr<ContentRectChangedEvent> &content_rect_sender() const
+	{
+		return m_window.m_content_rect_sender;
+	}
+
+	events::ChannelSenderPtr<FocusChangedEvent> &focus_sender() const
+	{
+		return m_window.m_focus_sender;
+	}
+
+	events::ChannelSenderPtr<ShouldCloseEvent> &should_close_sender() const
+	{
+		return m_window.m_should_close_sender;
+	}
+
+	events::ChannelSenderPtr<events::KeyEvent> &key_sender() const
+	{
+		return m_window.m_key_sender;
+	}
+
+	events::ChannelSenderPtr<events::CursorPositionEvent> &cursor_position_sender() const
+	{
+		return m_window.m_cursor_position_sender;
+	}
+
+	events::ChannelSenderPtr<events::TouchEvent> &touch_sender() const
+	{
+		return m_window.m_touch_sender;
+	}
+
+  private:
+	GLFWWindow &m_window;
+};
+
+void error_callback(int /* error */, const char * /* description */)
+{
+	// TODO: logging
+	// LOGE("GLFW Error (code {}): {}", error, description);
+}
+
+void window_close_callback(GLFWwindow *handle)
+{
+	glfwSetWindowShouldClose(handle, GLFW_TRUE);
+
+	if (auto *helper = reinterpret_cast<GLFWCallbackHelper *>(glfwGetWindowUserPointer(handle)))
+	{
+		auto &sender = helper->should_close_sender();
+		assert(sender);
+		if (sender)
+		{
+			sender->push(ShouldCloseEvent{});
+		}
+	}
+}
+
+void window_size_callback(GLFWwindow *handle, int width, int height)
+{
+	if (auto *helper = reinterpret_cast<GLFWCallbackHelper *>(glfwGetWindowUserPointer(handle)))
+	{
+		auto &sender = helper->content_rect_sender();
+		assert(sender);
+		if (sender)
+		{
+			sender->push(ContentRectChangedEvent{static_cast<uint32_t>(width), static_cast<uint32_t>(height)});
+		}
+	}
+}
+
+void window_focus_callback(GLFWwindow *handle, int focused)
+{
+	if (auto *helper = reinterpret_cast<GLFWCallbackHelper *>(glfwGetWindowUserPointer(handle)))
+	{
+		auto &sender = helper->focus_sender();
+		assert(sender);
+		if (sender)
+		{
+			sender->push(FocusChangedEvent{focused == GLFW_FOCUSED});
+		}
+	}
+}
+
+inline events::KeyCode translate_key_code(int key)
+{
+	static const std::unordered_map<int, events::KeyCode> key_lookup =
+	    {
+	        {GLFW_KEY_SPACE, events::KeyCode::Space},
+	        {GLFW_KEY_APOSTROPHE, events::KeyCode::Apostrophe},
+	        {GLFW_KEY_COMMA, events::KeyCode::Comma},
+	        {GLFW_KEY_MINUS, events::KeyCode::Minus},
+	        {GLFW_KEY_PERIOD, events::KeyCode::Period},
+	        {GLFW_KEY_SLASH, events::KeyCode::Slash},
+	        {GLFW_KEY_0, events::KeyCode::_0},
+	        {GLFW_KEY_1, events::KeyCode::_1},
+	        {GLFW_KEY_2, events::KeyCode::_2},
+	        {GLFW_KEY_3, events::KeyCode::_3},
+	        {GLFW_KEY_4, events::KeyCode::_4},
+	        {GLFW_KEY_5, events::KeyCode::_5},
+	        {GLFW_KEY_6, events::KeyCode::_6},
+	        {GLFW_KEY_7, events::KeyCode::_7},
+	        {GLFW_KEY_8, events::KeyCode::_8},
+	        {GLFW_KEY_9, events::KeyCode::_9},
+	        {GLFW_KEY_SEMICOLON, events::KeyCode::Semicolon},
+	        {GLFW_KEY_EQUAL, events::KeyCode::Equal},
+	        {GLFW_KEY_A, events::KeyCode::A},
+	        {GLFW_KEY_B, events::KeyCode::B},
+	        {GLFW_KEY_C, events::KeyCode::C},
+	        {GLFW_KEY_D, events::KeyCode::D},
+	        {GLFW_KEY_E, events::KeyCode::E},
+	        {GLFW_KEY_F, events::KeyCode::F},
+	        {GLFW_KEY_G, events::KeyCode::G},
+	        {GLFW_KEY_H, events::KeyCode::H},
+	        {GLFW_KEY_I, events::KeyCode::I},
+	        {GLFW_KEY_J, events::KeyCode::J},
+	        {GLFW_KEY_K, events::KeyCode::K},
+	        {GLFW_KEY_L, events::KeyCode::L},
+	        {GLFW_KEY_M, events::KeyCode::M},
+	        {GLFW_KEY_N, events::KeyCode::N},
+	        {GLFW_KEY_O, events::KeyCode::O},
+	        {GLFW_KEY_P, events::KeyCode::P},
+	        {GLFW_KEY_Q, events::KeyCode::Q},
+	        {GLFW_KEY_R, events::KeyCode::R},
+	        {GLFW_KEY_S, events::KeyCode::S},
+	        {GLFW_KEY_T, events::KeyCode::T},
+	        {GLFW_KEY_U, events::KeyCode::U},
+	        {GLFW_KEY_V, events::KeyCode::V},
+	        {GLFW_KEY_W, events::KeyCode::W},
+	        {GLFW_KEY_X, events::KeyCode::X},
+	        {GLFW_KEY_Y, events::KeyCode::Y},
+	        {GLFW_KEY_Z, events::KeyCode::Z},
+	        {GLFW_KEY_LEFT_BRACKET, events::KeyCode::LeftBracket},
+	        {GLFW_KEY_BACKSLASH, events::KeyCode::Backslash},
+	        {GLFW_KEY_RIGHT_BRACKET, events::KeyCode::RightBracket},
+	        {GLFW_KEY_GRAVE_ACCENT, events::KeyCode::GraveAccent},
+	        {GLFW_KEY_ESCAPE, events::KeyCode::Escape},
+	        {GLFW_KEY_ENTER, events::KeyCode::Enter},
+	        {GLFW_KEY_TAB, events::KeyCode::Tab},
+	        {GLFW_KEY_BACKSPACE, events::KeyCode::Backspace},
+	        {GLFW_KEY_INSERT, events::KeyCode::Insert},
+	        {GLFW_KEY_DELETE, events::KeyCode::DelKey},
+	        {GLFW_KEY_RIGHT, events::KeyCode::Right},
+	        {GLFW_KEY_LEFT, events::KeyCode::Left},
+	        {GLFW_KEY_DOWN, events::KeyCode::Down},
+	        {GLFW_KEY_UP, events::KeyCode::Up},
+	        {GLFW_KEY_PAGE_UP, events::KeyCode::PageUp},
+	        {GLFW_KEY_PAGE_DOWN, events::KeyCode::PageDown},
+	        {GLFW_KEY_HOME, events::KeyCode::Home},
+	        {GLFW_KEY_END, events::KeyCode::End},
+	        {GLFW_KEY_CAPS_LOCK, events::KeyCode::CapsLock},
+	        {GLFW_KEY_SCROLL_LOCK, events::KeyCode::ScrollLock},
+	        {GLFW_KEY_NUM_LOCK, events::KeyCode::NumLock},
+	        {GLFW_KEY_PRINT_SCREEN, events::KeyCode::PrintScreen},
+	        {GLFW_KEY_PAUSE, events::KeyCode::Pause},
+	        {GLFW_KEY_F1, events::KeyCode::F1},
+	        {GLFW_KEY_F2, events::KeyCode::F2},
+	        {GLFW_KEY_F3, events::KeyCode::F3},
+	        {GLFW_KEY_F4, events::KeyCode::F4},
+	        {GLFW_KEY_F5, events::KeyCode::F5},
+	        {GLFW_KEY_F6, events::KeyCode::F6},
+	        {GLFW_KEY_F7, events::KeyCode::F7},
+	        {GLFW_KEY_F8, events::KeyCode::F8},
+	        {GLFW_KEY_F9, events::KeyCode::F9},
+	        {GLFW_KEY_F10, events::KeyCode::F10},
+	        {GLFW_KEY_F11, events::KeyCode::F11},
+	        {GLFW_KEY_F12, events::KeyCode::F12},
+	        {GLFW_KEY_KP_0, events::KeyCode::KP_0},
+	        {GLFW_KEY_KP_1, events::KeyCode::KP_1},
+	        {GLFW_KEY_KP_2, events::KeyCode::KP_2},
+	        {GLFW_KEY_KP_3, events::KeyCode::KP_3},
+	        {GLFW_KEY_KP_4, events::KeyCode::KP_4},
+	        {GLFW_KEY_KP_5, events::KeyCode::KP_5},
+	        {GLFW_KEY_KP_6, events::KeyCode::KP_6},
+	        {GLFW_KEY_KP_7, events::KeyCode::KP_7},
+	        {GLFW_KEY_KP_8, events::KeyCode::KP_8},
+	        {GLFW_KEY_KP_9, events::KeyCode::KP_9},
+	        {GLFW_KEY_KP_DECIMAL, events::KeyCode::KP_Decimal},
+	        {GLFW_KEY_KP_DIVIDE, events::KeyCode::KP_Divide},
+	        {GLFW_KEY_KP_MULTIPLY, events::KeyCode::KP_Multiply},
+	        {GLFW_KEY_KP_SUBTRACT, events::KeyCode::KP_Subtract},
+	        {GLFW_KEY_KP_ADD, events::KeyCode::KP_Add},
+	        {GLFW_KEY_KP_ENTER, events::KeyCode::KP_Enter},
+	        {GLFW_KEY_KP_EQUAL, events::KeyCode::KP_Equal},
+	        {GLFW_KEY_LEFT_SHIFT, events::KeyCode::LeftShift},
+	        {GLFW_KEY_LEFT_CONTROL, events::KeyCode::LeftControl},
+	        {GLFW_KEY_LEFT_ALT, events::KeyCode::LeftAlt},
+	        {GLFW_KEY_RIGHT_SHIFT, events::KeyCode::RightShift},
+	        {GLFW_KEY_RIGHT_CONTROL, events::KeyCode::RightControl},
+	        {GLFW_KEY_RIGHT_ALT, events::KeyCode::RightAlt},
+	    };
+
+	auto key_it = key_lookup.find(key);
+
+	if (key_it == key_lookup.end())
+	{
+		return events::KeyCode::Unknown;
+	}
+
+	return key_it->second;
+}
+
+inline events::KeyAction translate_key_action(int action)
+{
+	if (action == GLFW_PRESS)
+	{
+		return events::KeyAction::Down;
+	}
+	else if (action == GLFW_RELEASE)
+	{
+		return events::KeyAction::Up;
+	}
+	else if (action == GLFW_REPEAT)
+	{
+		return events::KeyAction::Repeat;
+	}
+
+	return events::KeyAction::Unknown;
+}
+
+void key_callback(GLFWwindow *window, int key, int /*scancode*/, int action, int /*mods*/)
+{
+	events::KeyCode   key_code   = translate_key_code(key);
+	events::KeyAction key_action = translate_key_action(action);
+
+	if (auto *helper = reinterpret_cast<GLFWCallbackHelper *>(glfwGetWindowUserPointer(window)))
+	{
+		auto &sender = helper->key_sender();
+		assert(sender);
+		if (sender)
+		{
+			sender->push(events::KeyEvent{key_code, key_action});
+		}
+	}
+}
+
+inline events::KeyCode translate_mouse_key(int code)
+{
+	if (code == GLFW_MOUSE_BUTTON_LEFT)
+	{
+		return events::KeyCode::Mouse_Left;
+	}
+	if (code == GLFW_MOUSE_BUTTON_RIGHT)
+	{
+		return events::KeyCode::Mouse_Right;
+	}
+	if (code == GLFW_MOUSE_BUTTON_MIDDLE)
+	{
+		return events::KeyCode::Mouse_Middle;
+	}
+
+	return events::KeyCode::Unknown;
+}
+
+inline events::KeyAction translate_mouse_action(int action)
+{
+	if (action == GLFW_PRESS)
+	{
+		return events::KeyAction::Down;
+	}
+	else if (action == GLFW_RELEASE)
+	{
+		return events::KeyAction::Up;
+	}
+
+	return events::KeyAction::Unknown;
+}
+
+void cursor_position_callback(GLFWwindow *window, double xpos, double ypos)
+{
+	if (auto *helper = reinterpret_cast<GLFWCallbackHelper *>(glfwGetWindowUserPointer(window)))
+	{
+		auto &sender = helper->cursor_position_sender();
+		assert(sender);
+		if (sender)
+		{
+			sender->push(events::CursorPositionEvent{static_cast<float>(xpos), static_cast<float>(ypos)});
+		}
+	}
+}
+
+void mouse_button_callback(GLFWwindow *window, int button, int action, int /*mods*/)
+{
+	auto key_code     = translate_key_code(button);
+	auto mouse_action = translate_mouse_action(action);
+
+	if (auto *helper = reinterpret_cast<GLFWCallbackHelper *>(glfwGetWindowUserPointer(window)))
+	{
+		auto &sender = helper->key_sender();
+		assert(sender);
+		if (sender)
+		{
+			sender->push(events::KeyEvent{key_code, mouse_action});
+		}
+	}
+}
+
+GLFWWindow::GLFWWindow(const std::string &title, const Extent &initial_extent) :
+    Window{title},
+    m_callback_helper{std::make_unique<GLFWCallbackHelper>(*this)}
+{
+	// TODO: GLFW_X11_XCB_VULKAN_SURFACE
+
+	if (!glfwInit())
+	{
+		throw std::runtime_error("GLFW couldn't be initialized.");
+	}
+
+	glfwSetErrorCallback(error_callback);
+	glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+
+	// TODO: do we want to support fullscreen and fullscreen borderless still?
+
+	m_handle = glfwCreateWindow(initial_extent.width, initial_extent.height, title.c_str(), NULL, NULL);
+	if (!m_handle)
+	{
+		throw std::runtime_error("Couldn't create glfw window.");
+	}
+
+	glfwSetWindowUserPointer(m_handle, m_callback_helper.get());
+	glfwSetWindowCloseCallback(m_handle, window_close_callback);
+	glfwSetWindowSizeCallback(m_handle, window_size_callback);
+	glfwSetWindowFocusCallback(m_handle, window_focus_callback);
+	glfwSetKeyCallback(m_handle, key_callback);
+	glfwSetCursorPosCallback(m_handle, cursor_position_callback);
+	glfwSetMouseButtonCallback(m_handle, mouse_button_callback);
+
+	glfwSetInputMode(m_handle, GLFW_STICKY_KEYS, 1);
+	glfwSetInputMode(m_handle, GLFW_STICKY_MOUSE_BUTTONS, 1);
+}
+
+GLFWWindow::~GLFWWindow()
+{
+	glfwDestroyWindow(m_handle);
+}
+
+void GLFWWindow::set_extent(const Extent &extent)
+{
+	glfwSetWindowSize(m_handle, static_cast<int>(extent.width), static_cast<int>(extent.height));
+	m_content_rect_sender->push(ContentRectChangedEvent{extent});
+}
+
+Extent GLFWWindow::extent() const
+{
+	int width;
+	int height;
+	glfwGetWindowSize(m_handle, &width, &height);
+	return Extent{static_cast<uint32_t>(width), static_cast<uint32_t>(height)};
+}
+
+void GLFWWindow::set_position(const Position &position)
+{
+	glfwSetWindowPos(m_handle, static_cast<int>(position.x), static_cast<int>(position.y));
+	m_position_sender->push(PositionChangedEvent{position});
+}
+
+Position GLFWWindow::position() const
+{
+	int x;
+	int y;
+	glfwGetWindowPos(m_handle, &x, &y);
+	return Position{static_cast<uint32_t>(x), static_cast<uint32_t>(y)};
+}
+
+float GLFWWindow::dpi_factor() const
+{
+	auto primary_monitor = glfwGetPrimaryMonitor();
+	auto vidmode         = glfwGetVideoMode(primary_monitor);
+
+	int width_mm, height_mm;
+	glfwGetMonitorPhysicalSize(primary_monitor, &width_mm, &height_mm);
+
+	// As suggested by the GLFW monitor guide
+	static const float inch_to_mm       = 25.0f;
+	static const float win_base_density = 96.0f;
+
+	auto dpi        = static_cast<uint32_t>(vidmode->width / (width_mm / inch_to_mm));
+	auto dpi_factor = dpi / win_base_density;
+	return dpi_factor;
+}
+
+void GLFWWindow::update()
+{
+	glfwPollEvents();
+}
+
+void GLFWWindow::attach(events::EventBus &bus)
+{
+	m_content_rect_sender = bus.request_sender<ContentRectChangedEvent>();
+
+	{
+		int width;
+		int height;
+		glfwGetWindowSize(m_handle, &width, &height);
+		m_content_rect_sender->push(ContentRectChangedEvent{Extent{static_cast<uint32_t>(width), static_cast<uint32_t>(height)}});
+	}
+
+	m_position_sender = bus.request_sender<PositionChangedEvent>();
+
+	{
+		int x;
+		int y;
+		glfwGetWindowPos(m_handle, &x, &y);
+		m_position_sender->push(PositionChangedEvent{Position{static_cast<uint32_t>(x), static_cast<uint32_t>(y)}});
+	}
+}
+
+}        // namespace windows
+}        // namespace components

--- a/components/windows/src/glfw.cpp
+++ b/components/windows/src/glfw.cpp
@@ -17,6 +17,8 @@
 
 #include <components/windows/glfw.hpp>
 
+#include <vulkan/vulkan.h>
+
 #include <GLFW/glfw3.h>
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
@@ -469,36 +471,9 @@ void GLFWWindow::attach(events::EventBus &bus)
 	m_touch_sender           = bus.request_sender<events::TouchEvent>();
 }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-VkResult GLFWWindow::populate_surface_create_info(VkWin32SurfaceCreateInfoKHR *o_info) const
+VkResult GLFWWindow::create_surface(VkInstance instance, VkSurfaceKHR *surface)
 {
-	assert(o_info);
-
-	VkWin32SurfaceCreateInfoKHR info{};
-	info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	info.hwnd  = glfwGetWin32Window(m_handle);
-
-	*o_info = info;
-
-	return VK_SUCCESS;
+	return glfwCreateWindowSurface(instance, m_handle, nullptr, surface);
 }
-#endif
-
-#ifdef VK_USE_PLATFORM_XLIB_KHR
-VkResult GLFWWindow::populate_surface_create_info(VkXlibSurfaceCreateInfoKHR *o_info) const
-{
-	assert(o_info);
-
-	VkXlibSurfaceCreateInfoKHR info{};
-	info.sType  = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
-	info.window = glfwGetX11Window(m_handle);
-	info.dpy    = glfwGetX11Display();
-
-	*o_info = info;
-
-	return VK_SUCCESS;
-}
-#endif
-
 }        // namespace windows
 }        // namespace components

--- a/components/windows/src/headless.cpp
+++ b/components/windows/src/headless.cpp
@@ -17,6 +17,8 @@
 
 #include <components/windows/headless.hpp>
 
+#include <vulkan/vulkan.h>
+
 namespace components
 {
 namespace windows
@@ -84,6 +86,11 @@ void HeadlessWindow::attach(events::EventBus &bus)
 {
 	m_content_rect_sender = bus.request_sender<ContentRectChangedEvent>();
 	m_position_sender     = bus.request_sender<PositionChangedEvent>();
+}
+
+VkResult HeadlessWindow::create_surface(VkInstance /* instance */, VkSurfaceKHR * /* surface */)
+{
+	return VK_ERROR_INCOMPATIBLE_DISPLAY_KHR;
 }
 
 }        // namespace windows

--- a/components/windows/src/headless.cpp
+++ b/components/windows/src/headless.cpp
@@ -22,7 +22,8 @@ namespace components
 namespace windows
 {
 HeadlessWindow::HeadlessWindow(const std::string &title, const Extent &initial_extent) :
-    Window{title},
+    Window{},
+    m_title{title},
     m_extent{initial_extent}
 {
 }
@@ -52,6 +53,16 @@ Position HeadlessWindow::position() const
 float HeadlessWindow::dpi_factor() const
 {
 	return m_dpi_factor;
+}
+
+void HeadlessWindow::set_title(const std::string &title)
+{
+	m_title = title;
+}
+
+std::string_view HeadlessWindow::title() const
+{
+	return m_title;
 }
 
 void HeadlessWindow::update()

--- a/components/windows/src/headless.cpp
+++ b/components/windows/src/headless.cpp
@@ -1,0 +1,79 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <components/windows/headless.hpp>
+
+namespace components
+{
+namespace windows
+{
+HeadlessWindow::HeadlessWindow(const std::string &title, const Extent &initial_extent) :
+    Window{title},
+    m_extent{initial_extent}
+{
+}
+
+void HeadlessWindow::set_extent(const Extent &extent)
+{
+	m_extent         = extent;
+	m_extent_changed = true;
+}
+
+Extent HeadlessWindow::extent() const
+{
+	return m_extent;
+}
+
+void HeadlessWindow::set_position(const Position &position)
+{
+	m_position         = position;
+	m_position_changed = true;
+}
+
+Position HeadlessWindow::position() const
+{
+	return m_position;
+}
+
+float HeadlessWindow::dpi_factor() const
+{
+	return m_dpi_factor;
+}
+
+void HeadlessWindow::update()
+{
+	if (m_extent_changed)
+	{
+		m_content_rect_sender->push(ContentRectChangedEvent{m_extent});
+		m_extent_changed = false;
+	}
+
+	if (m_position_changed)
+	{
+		m_position_sender->push(PositionChangedEvent{m_position});
+		m_position_changed = false;
+	}
+}
+
+void HeadlessWindow::attach(events::EventBus &bus)
+{
+	m_content_rect_sender = bus.request_sender<ContentRectChangedEvent>();
+	m_position_sender     = bus.request_sender<PositionChangedEvent>();
+}
+
+}        // namespace windows
+}        // namespace components

--- a/components/windows/tests/glfw.test.cpp
+++ b/components/windows/tests/glfw.test.cpp
@@ -1,0 +1,89 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <components/windows/glfw.hpp>
+
+using namespace components::windows;
+using namespace components::events;
+
+TEST_CASE("glfw window title correct", "[windows]")
+{
+	GLFWWindow window{"This Is A Headless Window"};
+	REQUIRE(window.title() == "This Is A Headless Window");
+}
+
+TEST_CASE("glfw window extent correct", "[windows]")
+{
+	const Extent expected_initial_extent{270, 130};
+	GLFWWindow   window{"", expected_initial_extent};
+	REQUIRE(window.title() == "");
+
+	auto window_extent = window.extent();
+	REQUIRE(window_extent.width == expected_initial_extent.width);
+	REQUIRE(window_extent.height == expected_initial_extent.height);
+
+	const Extent expected_extent{100, 120};
+	window.set_extent(expected_extent);
+	window_extent = window.extent();
+	REQUIRE(window_extent.width == expected_extent.width);
+	REQUIRE(window_extent.height == expected_extent.height);
+}
+
+TEST_CASE("glfw window position correct", "[windows]")
+{
+	const Position expected_position{270, 130};
+	GLFWWindow     window{};
+
+	auto window_position = window.position();
+
+	REQUIRE(window_position.x == 0);
+	REQUIRE(window_position.y == 0);
+
+	window.set_position(expected_position);
+	window_position = window.position();
+
+	REQUIRE(window_position.x == expected_position.x);
+	REQUIRE(window_position.y == expected_position.y);
+}
+
+TEST_CASE("glfw event bus", "[windows]")
+{
+	std::shared_ptr<GLFWWindow> window = std::make_shared<GLFWWindow>();
+
+	const Extent   expected_extent{270, 130};
+	const Position expected_position{270, 130};
+
+	EventBus bus;
+
+	bus
+	    .attach(window)
+	    .each<ContentRectChangedEvent>([&](const ContentRectChangedEvent &event) {
+		    REQUIRE(event.extent.width == expected_extent.width);
+		    REQUIRE(event.extent.height == expected_extent.height);
+	    })
+	    .each<PositionChangedEvent>([&](const PositionChangedEvent &event) {
+		    REQUIRE(event.position.x == expected_position.x);
+		    REQUIRE(event.position.y == expected_position.y);
+	    });
+
+	window->set_extent(expected_extent);
+	window->set_position(expected_position);
+
+	bus.process();
+}

--- a/components/windows/tests/glfw.test.cpp
+++ b/components/windows/tests/glfw.test.cpp
@@ -34,15 +34,19 @@ TEST_CASE("glfw window extent correct", "[windows]")
 	GLFWWindow   window{"", expected_initial_extent};
 	REQUIRE(window.title() == "");
 
-	auto window_extent = window.extent();
-	REQUIRE(window_extent.width == expected_initial_extent.width);
-	REQUIRE(window_extent.height == expected_initial_extent.height);
+	{
+		auto window_extent = window.extent();
+		REQUIRE(window_extent.width == expected_initial_extent.width);
+		REQUIRE(window_extent.height == expected_initial_extent.height);
+	}
 
-	const Extent expected_extent{100, 120};
-	window.set_extent(expected_extent);
-	window_extent = window.extent();
-	REQUIRE(window_extent.width == expected_extent.width);
-	REQUIRE(window_extent.height == expected_extent.height);
+	{
+		const Extent expected_extent{100, 120};
+		window.set_extent(expected_extent);
+		auto window_extent = window.extent();
+		REQUIRE(window_extent.width == expected_extent.width);
+		REQUIRE(window_extent.height == expected_extent.height);
+	}
 }
 
 TEST_CASE("glfw window position correct", "[windows]")
@@ -50,13 +54,8 @@ TEST_CASE("glfw window position correct", "[windows]")
 	const Position expected_position{270, 130};
 	GLFWWindow     window{};
 
-	auto window_position = window.position();
-
-	REQUIRE(window_position.x == 0);
-	REQUIRE(window_position.y == 0);
-
 	window.set_position(expected_position);
-	window_position = window.position();
+	auto window_position = window.position();
 
 	REQUIRE(window_position.x == expected_position.x);
 	REQUIRE(window_position.y == expected_position.y);

--- a/components/windows/tests/headless.test.cpp
+++ b/components/windows/tests/headless.test.cpp
@@ -1,0 +1,89 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <components/windows/headless.hpp>
+
+using namespace components::windows;
+using namespace components::events;
+
+TEST_CASE("headless window title correct", "[windows]")
+{
+	HeadlessWindow window{"This Is A Headless Window"};
+	REQUIRE(window.title() == "This Is A Headless Window");
+}
+
+TEST_CASE("headless window extent correct", "[windows]")
+{
+	const Extent   expected_initial_extent{270, 130};
+	HeadlessWindow window{"", expected_initial_extent};
+	REQUIRE(window.title() == "");
+
+	auto window_extent = window.extent();
+	REQUIRE(window_extent.width == expected_initial_extent.width);
+	REQUIRE(window_extent.height == expected_initial_extent.height);
+
+	const Extent expected_extent{100, 120};
+	window.set_extent(expected_extent);
+	window_extent = window.extent();
+	REQUIRE(window_extent.width == expected_extent.width);
+	REQUIRE(window_extent.height == expected_extent.height);
+}
+
+TEST_CASE("headless window position correct", "[windows]")
+{
+	const Position expected_position{270, 130};
+	HeadlessWindow window{};
+
+	auto window_position = window.position();
+
+	REQUIRE(window_position.x == 0);
+	REQUIRE(window_position.y == 0);
+
+	window.set_position(expected_position);
+	window_position = window.position();
+
+	REQUIRE(window_position.x == expected_position.x);
+	REQUIRE(window_position.y == expected_position.y);
+}
+
+TEST_CASE("headless event bus", "[windows]")
+{
+	std::shared_ptr<HeadlessWindow> window = std::make_shared<HeadlessWindow>();
+
+	const Extent   expected_extent{270, 130};
+	const Position expected_position{270, 130};
+
+	EventBus bus;
+
+	bus
+	    .attach(window)
+	    .each<ContentRectChangedEvent>([&](const ContentRectChangedEvent &event) {
+		    REQUIRE(event.extent.width == expected_extent.width);
+		    REQUIRE(event.extent.height == expected_extent.height);
+	    })
+	    .each<PositionChangedEvent>([&](const PositionChangedEvent &event) {
+		    REQUIRE(event.position.x == expected_position.x);
+		    REQUIRE(event.position.y == expected_position.y);
+	    });
+
+	window->set_extent(expected_extent);
+	window->set_position(expected_position);
+
+	bus.process();
+}


### PR DESCRIPTION
## Description

Adds Headless and GLFW windows back to the project. Events are forwarded though the Event Bus interface.

No need to pass Platform anymore as the Event Bus acts as the communication mechanism.

Headless and GLFW tests included. GLFW tests will not work in the CI so these require `VKB_TEST_GLFW` locally. All GLFW tests pass locally. We could add a small compile time executable to automatically trigger GLFW tests if a GPU is available.