### PR TITLE
Visual Studio Folders

### DIFF
--- a/bldsys/cmake/component_helpers.cmake
+++ b/bldsys/cmake/component_helpers.cmake
@@ -16,10 +16,22 @@
 
 add_custom_target(vkb_components)
 
+function(vkb__register_headers)
+    set(options)
+    set(oneValueArgs FOLDER OUTPUT)
+    set(multiValueArgs HEADERS)
+
+    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(TEMP ${TARGET_HEADERS})
+    list(TRANSFORM TEMP PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/include/components/${TARGET_FOLDER}/")
+    set(${TARGET_OUTPUT} ${TEMP} PARENT_SCOPE)
+endfunction()
+
 function(vkb__register_component)
     set(options)
     set(oneValueArgs NAME)
-    set(multiValueArgs SRC LINK_LIBS INCLUDE_DIRS)
+    set(multiValueArgs SRC HEADERS LINK_LIBS INCLUDE_DIRS)
 
     cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -27,10 +39,10 @@ function(vkb__register_component)
         message(FATAL_ERROR "NAME must be defined in vkb__register_tests")
     endif()
 
-    if(TARGET_SRC) ## Create static library
+    if(TARGET_SRC) # Create static library
         message("ADDING STATIC: vkb__${TARGET_NAME}")
 
-        add_library("vkb__${TARGET_NAME}" STATIC ${TARGET_SRC})
+        add_library("vkb__${TARGET_NAME}" STATIC ${TARGET_SRC} ${TARGET_HEADERS})
 
         if(TARGET_LINK_LIBS)
             target_link_libraries("vkb__${TARGET_NAME}" PUBLIC ${TARGET_LINK_LIBS})
@@ -39,13 +51,15 @@ function(vkb__register_component)
         if(TARGET_INCLUDE_DIRS)
             target_include_directories("vkb__${TARGET_NAME}" PUBLIC ${TARGET_INCLUDE_DIRS})
         endif()
-        
+
         if(MSVC)
             target_compile_options("vkb__${TARGET_NAME}" PRIVATE /W4 /WX)
         else()
             target_compile_options("vkb__${TARGET_NAME}" PRIVATE -Wall -Wextra -Wpedantic -Werror)
         endif()
-    else() ## Create interface library
+
+        set_property(TARGET vkb__${TARGET_NAME} PROPERTY FOLDER "components/${TARGET_NAME}")
+    else() # Create interface library
         message("ADDING INTERFACE: vkb__${TARGET_NAME}")
 
         add_library("vkb__${TARGET_NAME}" INTERFACE)
@@ -58,7 +72,6 @@ function(vkb__register_component)
             target_include_directories("vkb__${TARGET_NAME}" INTERFACE ${TARGET_INCLUDE_DIRS})
         endif()
     endif()
-
 
     add_dependencies(vkb_components "vkb__${TARGET_NAME}")
 endfunction()

--- a/bldsys/cmake/component_helpers.cmake
+++ b/bldsys/cmake/component_helpers.cmake
@@ -16,6 +16,8 @@
 
 add_custom_target(vkb_components)
 
+set_property(TARGET vkb_components PROPERTY FOLDER "components")
+
 function(vkb__register_headers)
     set(options)
     set(oneValueArgs FOLDER OUTPUT)
@@ -57,12 +59,10 @@ function(vkb__register_component)
         else()
             target_compile_options("vkb__${TARGET_NAME}" PRIVATE -Wall -Wextra -Wpedantic -Werror)
         endif()
-
-        set_property(TARGET vkb__${TARGET_NAME} PROPERTY FOLDER "components/${TARGET_NAME}")
     else() # Create interface library
         message("ADDING INTERFACE: vkb__${TARGET_NAME}")
 
-        add_library("vkb__${TARGET_NAME}" INTERFACE)
+        add_library("vkb__${TARGET_NAME}" INTERFACE ${TARGET_HEADERS})
 
         if(TARGET_LINK_LIBS)
             target_link_libraries("vkb__${TARGET_NAME}" INTERFACE ${TARGET_LINK_LIBS})
@@ -72,6 +72,8 @@ function(vkb__register_component)
             target_include_directories("vkb__${TARGET_NAME}" INTERFACE ${TARGET_INCLUDE_DIRS})
         endif()
     endif()
+
+    set_property(TARGET vkb__${TARGET_NAME} PROPERTY FOLDER "components/${TARGET_NAME}")
 
     add_dependencies(vkb_components "vkb__${TARGET_NAME}")
 endfunction()

--- a/bldsys/cmake/component_helpers.cmake
+++ b/bldsys/cmake/component_helpers.cmake
@@ -73,7 +73,7 @@ function(vkb__register_component)
         endif()
     endif()
 
-    set_property(TARGET vkb__${TARGET_NAME} PROPERTY FOLDER "components/${TARGET_NAME}")
+    set_property(TARGET vkb__${TARGET_NAME} PROPERTY FOLDER "components")
 
     add_dependencies(vkb_components "vkb__${TARGET_NAME}")
 endfunction()

--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -46,6 +46,8 @@ function(vkb__register_tests)
     target_link_libraries(${TARGET_NAME} PUBLIC Catch2::Catch2WithMain)
 
     target_compile_definitions(${TARGET_NAME} PUBLIC VKB_BUILD_TESTS)
+    
+    set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "tests")
 
     if (TARGET_LIBS)
         target_link_libraries(${TARGET_NAME} PUBLIC ${TARGET_LIBS})

--- a/bldsys/cmake/test_helpers.cmake
+++ b/bldsys/cmake/test_helpers.cmake
@@ -23,6 +23,9 @@ endmacro()
 
 add_custom_target(vkb_tests)
 
+set_property(TARGET vkb_tests PROPERTY FOLDER "tests")
+
+
 function(vkb__register_tests)
     set(options)  
     set(oneValueArgs NAME)
@@ -46,7 +49,7 @@ function(vkb__register_tests)
     target_link_libraries(${TARGET_NAME} PUBLIC Catch2::Catch2WithMain)
 
     target_compile_definitions(${TARGET_NAME} PUBLIC VKB_BUILD_TESTS)
-    
+
     set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "tests")
 
     if (TARGET_LIBS)

--- a/components/common/CMakeLists.txt
+++ b/components/common/CMakeLists.txt
@@ -14,8 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+vkb__register_headers(
+    FOLDER
+        common
+    HEADERS
+        stack_error.hpp
+        strings.hpp
+    OUTPUT
+      COMMON_HEADERS
+)
+
 vkb__register_component(
     NAME common
+    HEADERS ${COMMON_HEADERS}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 

--- a/components/events/CMakeLists.txt
+++ b/components/events/CMakeLists.txt
@@ -15,11 +15,25 @@
 # limitations under the License.
 #
 
+vkb__register_headers(
+    FOLDER
+        events
+    HEADERS
+        channel.hpp
+        event_types.hpp
+        input_manager.hpp
+        event_bus.hpp
+    OUTPUT
+      EVENTS_HEADERS
+)
+
 vkb__register_component(
   NAME events
   SRC
     src/input_manager.cpp
     src/event_bus.cpp
+  HEADERS
+    ${EVENTS_HEADERS}
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/components/vfs/CMakeLists.txt
+++ b/components/vfs/CMakeLists.txt
@@ -44,10 +44,23 @@ else()
     list(APPEND PROJECT_FILES ${UNIX_FILES})
 endif()
 
+vkb__register_headers(
+    FOLDER
+        vfs
+    HEADERS
+        android.hpp
+        filesystem.hpp
+        helpers.hpp
+        unix.hpp
+        windows.hpp
+    OUTPUT
+      VFS_HEADERS
+)
 
 vkb__register_component(
   NAME vfs
   SRC ${PROJECT_FILES}
+  HEADERS ${VFS_HEADERS}
   INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
   LINK_LIBS
     re2

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -346,6 +346,8 @@ endif()
 # spdlog
 add_subdirectory(spdlog)
 
+set_property(TARGET spdlog PROPERTY FOLDER "ThirdParty")
+
 # ctpl
 add_library(ctpl INTERFACE)
 set(CTPL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/CTPL)
@@ -374,5 +376,11 @@ target_include_directories(opencl INTERFACE ${OPENCL_INCLUDE_DIR})
 # Catch2
 add_subdirectory(catch2)
 
+set_property(TARGET Catch2 PROPERTY FOLDER "ThirdParty")
+set_property(TARGET Catch2WithMain PROPERTY FOLDER "ThirdParty")
+
 # RE2
+set(RE2_BUILD_TESTING OFF)
 add_subdirectory(re)
+
+set_property(TARGET re2 PROPERTY FOLDER "ThirdParty")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -177,7 +177,7 @@ target_include_directories(ktx PUBLIC ${KTX_INCLUDE_DIRS})
 
 target_link_libraries(ktx PUBLIC vulkan)
 
-set_property(TARGET ktx PROPERTY FOLDER "ThirdParty")
+set_property(TARGET ktx PROPERTY FOLDER "third_party")
 
 # volk
 set(VOLK_DIR "${CMAKE_CURRENT_SOURCE_DIR}/volk")
@@ -198,7 +198,7 @@ elseif (VKB_WSI_SELECTION STREQUAL WAYLAND)
     target_include_directories(volk PUBLIC ${WAYLAND_INCLUDE_DIRS})
 endif()
 
-set_property(TARGET volk PROPERTY FOLDER "ThirdParty")
+set_property(TARGET volk PROPERTY FOLDER "third_party")
 
 # imgui
 set(IMGUI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/imgui")
@@ -218,7 +218,7 @@ add_library(imgui STATIC ${IMGUI_FILES})
 
 target_include_directories(imgui PUBLIC ${IMGUI_DIR})
 
-set_property(TARGET imgui PROPERTY FOLDER "ThirdParty")
+set_property(TARGET imgui PROPERTY FOLDER "third_party")
 
 # glslang
 option(ENABLE_SPVREMAPPER OFF)
@@ -234,7 +234,7 @@ if (NOT TARGET glslang-default-resource-limits)
     add_library(glslang-default-resource-limits
                 glslang/StandAlone/ResourceLimits.cpp)
 
-    set_property(TARGET glslang-default-resource-limits PROPERTY FOLDER "ThirdParty")
+    set_property(TARGET glslang-default-resource-limits PROPERTY FOLDER "third_party")
     
     target_include_directories(glslang-default-resource-limits
                                 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/glslang/StandAlone)
@@ -250,27 +250,30 @@ if(NOT MSVC)
         "-Wno-unused-parameter")
 endif()
 
-set_property(TARGET glslang PROPERTY FOLDER "ThirdParty")
-set_property(TARGET OGLCompiler PROPERTY FOLDER "ThirdParty")
-set_property(TARGET OSDependent PROPERTY FOLDER "ThirdParty")
-set_property(TARGET SPIRV PROPERTY FOLDER "ThirdParty")
+set_property(TARGET glslang PROPERTY FOLDER "third_party")
+set_property(TARGET OGLCompiler PROPERTY FOLDER "third_party")
+set_property(TARGET OSDependent PROPERTY FOLDER "third_party")
+set_property(TARGET SPIRV PROPERTY FOLDER "third_party")
+set_property(TARGET HLSL PROPERTY FOLDER "third_party")
+set_property(TARGET GenericCodeGen PROPERTY FOLDER "third_party")
+set_property(TARGET MachineIndependent PROPERTY FOLDER "third_party")
 
 # spirv-cross
 add_subdirectory(spirv-cross)
 
-set_property(TARGET spirv-cross PROPERTY FOLDER "ThirdParty")
-set_property(TARGET spirv-cross-core PROPERTY FOLDER "ThirdParty")
-set_property(TARGET spirv-cross-glsl PROPERTY FOLDER "ThirdParty")
-set_property(TARGET spirv-cross-cpp PROPERTY FOLDER "ThirdParty")
-set_property(TARGET spirv-cross-hlsl PROPERTY FOLDER "ThirdParty")
-set_property(TARGET spirv-cross-msl PROPERTY FOLDER "ThirdParty")
-set_property(TARGET spirv-cross-reflect PROPERTY FOLDER "ThirdParty")
-set_property(TARGET spirv-cross-util PROPERTY FOLDER "ThirdParty")
+set_property(TARGET spirv-cross PROPERTY FOLDER "third_party")
+set_property(TARGET spirv-cross-core PROPERTY FOLDER "third_party")
+set_property(TARGET spirv-cross-glsl PROPERTY FOLDER "third_party")
+set_property(TARGET spirv-cross-cpp PROPERTY FOLDER "third_party")
+set_property(TARGET spirv-cross-hlsl PROPERTY FOLDER "third_party")
+set_property(TARGET spirv-cross-msl PROPERTY FOLDER "third_party")
+set_property(TARGET spirv-cross-reflect PROPERTY FOLDER "third_party")
+set_property(TARGET spirv-cross-util PROPERTY FOLDER "third_party")
 
 # hwcpipe
 add_subdirectory(hwcpipe)
 
-set_property(TARGET hwcpipe PROPERTY FOLDER "ThirdParty")
+set_property(TARGET hwcpipe PROPERTY FOLDER "third_party")
 
 # stb
 add_library(stb INTERFACE)
@@ -312,7 +315,7 @@ set(ASTC_SOURCES
 add_library(astc ${ASTC_SOURCES})
 target_include_directories(astc PUBLIC ${ASTC_INCLUDE_DIR})
 target_compile_definitions(astc PRIVATE -DNO_STB_IMAGE_IMPLEMENTATION)
-set_property(TARGET astc PROPERTY FOLDER "ThirdParty")
+set_property(TARGET astc PROPERTY FOLDER "third_party")
 
 if(ANDROID)
     # native_app_glue
@@ -324,7 +327,7 @@ if(ANDROID)
         
     target_include_directories(native_app_glue PUBLIC ${NATIVE_APP_GLUE_DIR})
     
-    set_property(TARGET native_app_glue PROPERTY FOLDER "ThirdParty")
+    set_property(TARGET native_app_glue PROPERTY FOLDER "third_party")
 else()
     if (NOT DIRECT_TO_DISPLAY)
         # GLFW
@@ -339,14 +342,14 @@ else()
 
         add_subdirectory(glfw)
 
-        set_property(TARGET glfw PROPERTY FOLDER "ThirdParty")
+        set_property(TARGET glfw PROPERTY FOLDER "third_party")
     endif()
 endif()
 
 # spdlog
 add_subdirectory(spdlog)
 
-set_property(TARGET spdlog PROPERTY FOLDER "ThirdParty")
+set_property(TARGET spdlog PROPERTY FOLDER "third_party")
 
 # ctpl
 add_library(ctpl INTERFACE)
@@ -376,11 +379,11 @@ target_include_directories(opencl INTERFACE ${OPENCL_INCLUDE_DIR})
 # Catch2
 add_subdirectory(catch2)
 
-set_property(TARGET Catch2 PROPERTY FOLDER "ThirdParty")
-set_property(TARGET Catch2WithMain PROPERTY FOLDER "ThirdParty")
+set_property(TARGET Catch2 PROPERTY FOLDER "third_party")
+set_property(TARGET Catch2WithMain PROPERTY FOLDER "third_party")
 
 # RE2
 set(RE2_BUILD_TESTING OFF)
 add_subdirectory(re)
 
-set_property(TARGET re2 PROPERTY FOLDER "ThirdParty")
+set_property(TARGET re2 PROPERTY FOLDER "third_party")


### PR DESCRIPTION
## Description

An attempt at fixing the visual studio folder structure. When using the VS CMake View I get:

![image](https://user-images.githubusercontent.com/48598630/178249325-7774f9d4-dfc3-4c45-a8e5-2e5ec14854e5.png)

When using the folder view instead of the CMake target view I get:

![image](https://user-images.githubusercontent.com/48598630/178249784-8c48fa63-0c65-4d77-8874-6e3824107f00.png)

There are two issues here. One, we have to manually add header files - not a deal breaker as we do this in the main branch. Secondly, interface libraries are not shown in the solution view. This is a deal breaker as common is a header only interface library.

I'm open to suggestions on how to improve this but as I am not a Visual Studio user I am not sure what to expect from their solution explorer? @SaschaWillems @asuessenbach any suggestions?