### PR TITLE
Change vkb::core::HPPQueue from a facade over vkb::Queue to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -280,7 +280,8 @@ set(CORE_FILES
     core/vulkan_resource.cpp
     core/hpp_device.cpp
     core/hpp_instance.cpp
-	core/hpp_physical_device.cpp
+    core/hpp_physical_device.cpp
+    core/hpp_queue.cpp
     core/hpp_vulkan_resource.cpp
 )
 

--- a/framework/core/hpp_queue.cpp
+++ b/framework/core/hpp_queue.cpp
@@ -1,0 +1,93 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core/hpp_queue.h>
+
+#include <core/hpp_command_buffer.h>
+#include <core/hpp_device.h>
+
+namespace vkb
+{
+namespace core
+{
+HPPQueue::HPPQueue(vkb::core::HPPDevice &device, uint32_t family_index, vk::QueueFamilyProperties properties, vk::Bool32 can_present, uint32_t index) :
+    device{device},
+    family_index{family_index},
+    index{index},
+    can_present{can_present},
+    properties{properties}
+{
+	handle = device.get_handle().getQueue(family_index, index);
+}
+
+HPPQueue::HPPQueue(HPPQueue &&other) :
+    device(other.device),
+    handle(std::exchange(other.handle, {})),
+    family_index(std::exchange(other.family_index, {})),
+    index(std::exchange(other.index, 0)),
+    can_present(std::exchange(other.can_present, false)),
+    properties(std::exchange(other.properties, {}))
+{}
+
+const HPPDevice &HPPQueue::get_device() const
+{
+	return device;
+}
+
+vk::Queue HPPQueue::get_handle() const
+{
+	return handle;
+}
+
+uint32_t HPPQueue::get_family_index() const
+{
+	return family_index;
+}
+
+uint32_t HPPQueue::get_index() const
+{
+	return index;
+}
+
+const vk::QueueFamilyProperties &HPPQueue::get_properties() const
+{
+	return properties;
+}
+
+vk::Bool32 HPPQueue::support_present() const
+{
+	return can_present;
+}
+
+void HPPQueue::submit(const HPPCommandBuffer &command_buffer, vk::Fence fence) const
+{
+	vk::CommandBuffer commandBuffer = command_buffer.get_handle();
+	vk::SubmitInfo    submit_info({}, {}, commandBuffer);
+	handle.submit(submit_info, fence);
+}
+
+vk::Result HPPQueue::present(const vk::PresentInfoKHR &present_info) const
+{
+	if (!can_present)
+	{
+		return vk::Result::eErrorIncompatibleDisplayKHR;
+	}
+
+	return handle.presentKHR(present_info);
+}
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_queue.h
+++ b/framework/core/hpp_queue.h
@@ -17,54 +17,60 @@
 
 #pragma once
 
-#include <core/queue.h>
+#include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
 namespace core
 {
+class HPPCommandBuffer;
+class HPPDevice;
+
 /**
- * @brief facade class around vkb::Queue, providing a vulkan.hpp-based interface
+ * @brief A wrapper class for vk::Queue
  *
- * See vkb::Queue for documentation
  */
-class HPPQueue : private vkb::Queue
+class HPPQueue
 {
   public:
-	using vkb::Queue::get_family_index;
+	HPPQueue(HPPDevice &device, uint32_t family_index, vk::QueueFamilyProperties properties, vk::Bool32 can_present, uint32_t index);
 
-	HPPQueue(vkb::core::HPPDevice &device, uint32_t family_index, vk::QueueFamilyProperties properties, vk::Bool32 can_present, uint32_t index) :
-	    vkb::Queue(reinterpret_cast<vkb::Device &>(device),
-	               family_index,
-	               static_cast<VkQueueFamilyProperties>(properties),
-	               static_cast<VkBool32>(can_present),
-	               index)
-	{}
+	HPPQueue(const HPPQueue &) = default;
 
-	vk::Queue get_handle() const
-	{
-		return vkb::Queue::get_handle();
-	}
+	HPPQueue(HPPQueue &&other);
 
-	vk::QueueFamilyProperties const &get_properties() const
-	{
-		return reinterpret_cast<vk::QueueFamilyProperties const &>(vkb::Queue::get_properties());
-	}
+	HPPQueue &operator=(const HPPQueue &) = delete;
 
-	vk::Result present(const vk::PresentInfoKHR &present_infos) const
-	{
-		return static_cast<vk::Result>(vkb::Queue::present(reinterpret_cast<VkPresentInfoKHR const &>(present_infos)));
-	}
+	HPPQueue &operator=(HPPQueue &&) = delete;
 
-	vk::Bool32 support_present() const
-	{
-		return static_cast<vk::Bool32>(vkb::Queue::support_present());
-	}
+	const HPPDevice &get_device() const;
 
-	vk::Result wait_idle() const
-	{
-		return static_cast<vk::Result>(vkb::Queue::wait_idle());
-	}
+	vk::Queue get_handle() const;
+
+	uint32_t get_family_index() const;
+
+	uint32_t get_index() const;
+
+	const vk::QueueFamilyProperties &get_properties() const;
+
+	vk::Bool32 support_present() const;
+
+	void submit(const HPPCommandBuffer &command_buffer, vk::Fence fence) const;
+
+	vk::Result present(const vk::PresentInfoKHR &present_infos) const;
+
+  private:
+	HPPDevice &device;
+
+	vk::Queue handle;
+
+	uint32_t family_index{0};
+
+	uint32_t index{0};
+
+	vk::Bool32 can_present = false;
+
+	vk::QueueFamilyProperties properties{};
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -21,9 +21,14 @@
 
 namespace vkb
 {
+class HPPDevice;
+
 namespace core
 {
-class HPPDevice;
+namespace detail
+{
+void set_debug_name(const HPPDevice *device, vk::ObjectType object_type, uint64_t handle, const char *debug_name);
+}
 
 namespace detail
 {

--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -21,14 +21,9 @@
 
 namespace vkb
 {
-class HPPDevice;
-
 namespace core
 {
-namespace detail
-{
-void set_debug_name(const HPPDevice *device, vk::ObjectType object_type, uint64_t handle, const char *debug_name);
-}
+class HPPDevice;
 
 namespace detail
 {

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -510,7 +510,7 @@ void HPPApiVulkanSample::submit_frame()
 	// DO NOT USE
 	// vkDeviceWaitIdle and vkQueueWaitIdle are extremely expensive functions, and are used here purely for demonstrating the vulkan API
 	// without having to concern ourselves with proper syncronization. These functions should NEVER be used inside the render loop like this (every frame).
-	get_device()->get_queue_by_present(0).wait_idle();
+	get_device()->get_queue_by_present(0).get_handle().waitIdle();
 }
 
 HPPApiVulkanSample::~HPPApiVulkanSample()


### PR DESCRIPTION
## Description

Transcoding this part of the framework using Vulkan-Hpp.

I have tested it on Window10 on nvidia HW.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
