### PR TITLE
framework/core/hpp_vulkan_resource.h: add header include that defines  std::exchange

### DIFF
--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <utility>
 #include <vulkan/vulkan.hpp>
 
 namespace vkb


### PR DESCRIPTION
This avoids:
```
| In file included from /srv/work/alex/poky/build-64-alt/tmp/work/core2-64-poky-linux/vulkan-samples/git-r0/git/framework/core/hpp_vulkan_resource.cpp:18:
| /srv/work/alex/poky/build-64-alt/tmp/work/core2-64-poky-linux/vulkan-samples/git-r0/git/framework/core/hpp_vulkan_resource.h: In constructor 'vkb::core::HPPVulkanResource<HPPHandle, VKBDevice>::HPPVulkanResource(vkb::core::HPPVulkanResource<HPPHandle, VKBDevice>&&)':
| /srv/work/alex/poky/build-64-alt/tmp/work/core2-64-poky-linux/vulkan-samples/git-r0/git/framework/core/hpp_vulkan_resource.h:50:25: error: 'exchange' is not a member of 'std'
|    50 |             handle(std::exchange(other.handle, {})), device(std::exchange(other.device, {}))
|       |                         ^~~~~~~~
```