### PR TITLE
WIP: Fix crash on android when trying to log into file

### DIFF
--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -26,9 +26,9 @@
 #include <spdlog/details/thread_pool.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #ifdef __ANDROID__
-#include <spdlog/sinks/android_sink.h>
+#	include <spdlog/sinks/android_sink.h>
 #else
-#include <spdlog/sinks/stdout_color_sinks.h>
+#	include <spdlog/sinks/stdout_color_sinks.h>
 #endif
 #include <spdlog/spdlog.h>
 

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -25,7 +25,11 @@
 #include <spdlog/async_logger.h>
 #include <spdlog/details/thread_pool.h>
 #include <spdlog/sinks/basic_file_sink.h>
+#ifdef __ANDROID__
+#include <spdlog/sinks/android_sink.h>
+#else
 #include <spdlog/sinks/stdout_color_sinks.h>
+#endif
 #include <spdlog/spdlog.h>
 
 #include "common/logging.h"
@@ -337,7 +341,11 @@ void Platform::set_temp_directory(const std::string &dir)
 std::vector<spdlog::sink_ptr> Platform::get_platform_sinks()
 {
 	std::vector<spdlog::sink_ptr> sinks;
+#ifdef __ANDROID__
+	sinks.push_back(std::make_shared<spdlog::sinks::android_sink_mt>());
+#else
 	sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+#endif
 	return sinks;
 }
 


### PR DESCRIPTION
## Description

Using `android_sink_mt` for android sinks.
If `stdout_color_sink_mt` is used, spdlog will try to write to `storage/emulated/0/com.khronos.vulkan_samples/output/[date].txt` . Spdlog fail to open the file and `throw spdlog_ex("Failed opening file " + os::filename_to_str(_filename) + " for writing", errno);`.

Apparently, spdlog_ex is not handled and leads to a crash.

Crashed on `Samsumg S10` with Android 11(OneUI) installed.


## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
