### PR TITLE
Replace StackErrorPtr in filesystem by exceptions

### DIFF
--- a/components/vfs/include/components/vfs/android.hpp
+++ b/components/vfs/include/components/vfs/android.hpp
@@ -58,15 +58,15 @@ class AndroidAAssetManager : public FileSystem
 	AndroidAAssetManager(android_app *app, const std::string &sub_path = "");
 	virtual ~AndroidAAssetManager() = default;
 
-	virtual bool          folder_exists(const std::string &file_path) override;
-	virtual bool          file_exists(const std::string &file_path) override;
-	virtual StackErrorPtr read_chunk(const std::string &file_path, const size_t offset, const size_t count, std::shared_ptr<Blob> *blob) override;
-	virtual size_t        file_size(const std::string &file_path) override;
-	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size) override;
-	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files) override;
-	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) override;
-	virtual void          make_directory(const std::string &path) override;
-	virtual bool          remove(const std::string &path) override;
+	virtual bool                     folder_exists(const std::string &folder_path) const override;
+	virtual bool                     file_exists(const std::string &file_path) const override;
+	virtual std::vector<uint8_t>     read_chunk(const std::string &file_path, size_t offset, size_t count) const override;
+	virtual size_t                   file_size(const std::string &file_path) const override;
+	virtual void                     write_file(const std::string &file_path, const void *data, size_t size) override;
+	virtual std::vector<std::string> enumerate_files(const std::string &folder_path) const override;
+	virtual std::vector<std::string> enumerate_folders(const std::string &folderPath) const override;
+	virtual void                     make_directory(const std::string &path) override;
+	virtual bool                     remove(const std::string &path) override;
 
   private:
 	std::string get_path(const std::string &path);

--- a/components/vfs/include/components/vfs/filesystem.hpp
+++ b/components/vfs/include/components/vfs/filesystem.hpp
@@ -28,81 +28,6 @@ namespace components
 namespace vfs
 {
 /**
- * @brief Binary Blob container
- */
-class Blob
-{
-  public:
-	Blob()          = default;
-	virtual ~Blob() = default;
-
-	/**
-	 * @brief Query size of blob
-	 *
-	 * @return size_t size of blob in bytes
-	 */
-	virtual size_t size() const = 0;
-
-	/**
-	 * @brief Ptr to blob data
-	 *
-	 * @return const void* ptr to the start of the blob data
-	 */
-	virtual const void *data() const = 0;
-
-	/**
-	 * @brief Check if the blob contains data or not
-	 */
-	inline bool empty() const
-	{
-		return size() == 0 || data() == nullptr;
-	}
-
-	/**
-	 * @brief Convert blob to std vector of uint8_t
-	 *
-	 * @return std::vector<uint8_t> std vector of data
-	 */
-	inline std::vector<uint8_t> binary() const
-	{
-		if (empty())
-		{
-			return {};
-		}
-
-		const uint8_t *bin_ptr = static_cast<const uint8_t *>(data());
-		return {bin_ptr, bin_ptr + size()};
-	}
-
-	/**
-	 * @brief Convert blob to ascii string
-	 *
-	 * @return std::string ascii string
-	 */
-	inline std::string ascii() const
-	{
-		auto bin = binary();
-		return std::string{bin.begin(), bin.end()};
-	}
-};
-
-/**
- * @brief Blob implementation using std::vector<uint8_t>
- *
- */
-class StdBlob final : public Blob
-{
-  public:
-	StdBlob()          = default;
-	virtual ~StdBlob() = default;
-
-	virtual size_t      size() const override;
-	virtual const void *data() const override;
-
-	std::vector<uint8_t> buffer;
-};
-
-/**
  * @brief FileSystem interface
  *
  */
@@ -112,20 +37,23 @@ class FileSystem
 	FileSystem()          = default;
 	virtual ~FileSystem() = default;
 
-	void make_directory_recursive(const std::string &path);
+	void                 make_directory_recursive(const std::string &path);
+	std::vector<uint8_t> read_file(const std::string &file_path) const;
 
-	virtual bool          folder_exists(const std::string &file_path)                                                                    = 0;
-	virtual bool          file_exists(const std::string &file_path)                                                                      = 0;
-	virtual StackErrorPtr read_chunk(const std::string &file_path, const size_t offset, const size_t count, std::shared_ptr<Blob> *blob) = 0;
-	virtual size_t        file_size(const std::string &file_path)                                                                        = 0;
-	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size)                                        = 0;
-	virtual void          make_directory(const std::string &path)                                                                        = 0;
-	virtual bool          remove(const std::string &path)                                                                                = 0;
+	virtual bool                 folder_exists(const std::string &folder_path) const                         = 0;
+	virtual bool                 file_exists(const std::string &file_path) const                             = 0;
+	virtual std::vector<uint8_t> read_chunk(const std::string &file_path, size_t offset, size_t count) const = 0;
+	virtual size_t               file_size(const std::string &file_path) const                               = 0;
+	virtual void                 write_file(const std::string &file_path, const void *data, size_t size)     = 0;
+	virtual void                 make_directory(const std::string &path)                                     = 0;
+	virtual bool                 remove(const std::string &path)                                             = 0;
 
-	virtual StackErrorPtr read_file(const std::string &file_path, std::shared_ptr<Blob> *blob);
+	virtual std::vector<std::string> enumerate_files(const std::string &folder_path) const  = 0;
+	virtual std::vector<std::string> enumerate_folders(const std::string &folderPath) const = 0;
 
-	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files)     = 0;
-	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) = 0;
+	std::vector<std::string> enumerate_files(const std::string &folder_path, const std::string &extension) const;
+	std::vector<std::string> enumerate_files_recursive(const std::string &folder_path, const std::string &extension) const;
+	std::vector<std::string> enumerate_folders_recursive(const std::string &folder_path) const;
 };
 
 /**
@@ -140,27 +68,21 @@ class RootFileSystem : public FileSystem
 	RootFileSystem(const std::string &base_path = "");
 	virtual ~RootFileSystem() = default;
 
-	virtual bool          folder_exists(const std::string &file_path) override;
-	virtual bool          file_exists(const std::string &file_path) override;
-	virtual StackErrorPtr read_chunk(const std::string &file_path, const size_t offset, const size_t count, std::shared_ptr<Blob> *blob) override;
-	virtual size_t        file_size(const std::string &file_path) override;
-	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size) override;
-	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files) override;
-	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) override;
-	virtual void          make_directory(const std::string &path) override;
-	virtual bool          remove(const std::string &path) override;
-
-	virtual StackErrorPtr read_file(const std::string &file_path, std::shared_ptr<Blob> *blob) override;
-
-	StackErrorPtr enumerate_files(const std::string &file_path, const std::string &extension, std::vector<std::string> *files);
-	StackErrorPtr enumerate_files_recursive(const std::string &file_path, const std::string &extension, std::vector<std::string> *files);
-	StackErrorPtr enumerate_folders_recursive(const std::string &folder_path, std::vector<std::string> *folders);
+	virtual bool                     folder_exists(const std::string &folder_path) const override;
+	virtual bool                     file_exists(const std::string &file_path) const override;
+	virtual std::vector<uint8_t>     read_chunk(const std::string &file_path, size_t offset, size_t count) const override;
+	virtual size_t                   file_size(const std::string &file_path) const override;
+	virtual void                     write_file(const std::string &file_path, const void *data, size_t size) override;
+	virtual std::vector<std::string> enumerate_files(const std::string &folder_path) const override;
+	virtual std::vector<std::string> enumerate_folders(const std::string &folderPath) const override;
+	virtual void                     make_directory(const std::string &path) override;
+	virtual bool                     remove(const std::string &path) override;
 
 	void mount(const std::string &file_path, std::shared_ptr<FileSystem> file_system);
 	void unmount(const std::string &file_path);
 
   private:
-	std::shared_ptr<FileSystem> find_file_system(const std::string &file_path, std::string *mount_adjusted_path);
+	std::shared_ptr<FileSystem> find_file_system(const std::string &file_path, std::string *mount_adjusted_path) const;
 
 	std::string                                                      m_root_path;
 	std::vector<std::pair<std::string, std::shared_ptr<FileSystem>>> m_mounts;

--- a/components/vfs/include/components/vfs/std_filesystem.hpp
+++ b/components/vfs/include/components/vfs/std_filesystem.hpp
@@ -35,15 +35,15 @@ class StdFSFileSystem : public FileSystem
 	StdFSFileSystem(const std::filesystem::path &base_path = "");
 	virtual ~StdFSFileSystem() = default;
 
-	virtual bool          folder_exists(const std::string &file_path) override;
-	virtual bool          file_exists(const std::string &file_path) override;
-	virtual StackErrorPtr read_chunk(const std::string &file_path, const size_t offset, const size_t count, std::shared_ptr<Blob> *blob) override;
-	virtual size_t        file_size(const std::string &file_path) override;
-	virtual StackErrorPtr write_file(const std::string &file_path, const void *data, size_t size) override;
-	virtual StackErrorPtr enumerate_files(const std::string &file_path, std::vector<std::string> *files) override;
-	virtual StackErrorPtr enumerate_folders(const std::string &file_path, std::vector<std::string> *folders) override;
-	virtual void          make_directory(const std::string &path) override;
-	virtual bool          remove(const std::string &path) override;
+	virtual bool                     folder_exists(const std::string &folder_path) const override;
+	virtual bool                     file_exists(const std::string &file_path) const override;
+	virtual std::vector<uint8_t>     read_chunk(const std::string &file_path, size_t offset, size_t count) const override;
+	virtual size_t                   file_size(const std::string &file_path) const override;
+	virtual void                     write_file(const std::string &file_path, const void *data, size_t size) override;
+	virtual std::vector<std::string> enumerate_files(const std::string &folder_path) const override;
+	virtual std::vector<std::string> enumerate_folders(const std::string &folderPath) const override;
+	virtual void                     make_directory(const std::string &path) override;
+	virtual bool                     remove(const std::string &path) override;
 
   protected:
 	std::filesystem::path m_base_path;

--- a/components/vfs/src/android_aasset_manager.cpp
+++ b/components/vfs/src/android_aasset_manager.cpp
@@ -61,14 +61,14 @@ std::string AndroidAAssetManager::get_path(const std::string &path)
 	return real_path;
 }
 
-bool AndroidAAssetManager::folder_exists(const std::string &file_path)
+bool AndroidAAssetManager::folder_exists(const std::string &folder_path) const
 {
 	if (!asset_manager)
 	{
-		return false;
+		throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "AAsset Manager not initialized");
 	}
 
-	std::string real_path = get_path(file_path);
+	std::string real_path = get_path(folder_path);
 
 	AAssetDir *dir = AAssetManager_openDir(asset_manager, real_path.c_str());
 
@@ -82,11 +82,11 @@ bool AndroidAAssetManager::folder_exists(const std::string &file_path)
 	return true;
 }
 
-bool AndroidAAssetManager::file_exists(const std::string &file_path)
+bool AndroidAAssetManager::file_exists(const std::string &file_path) const
 {
 	if (!asset_manager)
 	{
-		return false;
+		throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "AAsset Manager not initialized");
 	}
 
 	std::string real_path = get_path(file_path);
@@ -103,11 +103,11 @@ bool AndroidAAssetManager::file_exists(const std::string &file_path)
 	return true;
 }
 
-StackErrorPtr AndroidAAssetManager::read_chunk(const std::string &file_path, const size_t offset, const size_t count, std::shared_ptr<Blob> *blob)
+std::vector<uint8_t> AndroidAAssetManager::read_chunk(const std::string &file_path, size_t offset, size_t count) const
 {
 	if (!asset_manager)
 	{
-		return StackError::unique("AAsset Manager not initialized", "vfs/android_aasset_manager.cpp", __LINE__);
+		throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "AAsset Manager not initialized");
 	}
 
 	std::string real_path = get_path(file_path);
@@ -116,34 +116,31 @@ StackErrorPtr AndroidAAssetManager::read_chunk(const std::string &file_path, con
 
 	if (!asset)
 	{
-		return StackError::unique("failed to find file: " + file_path, "vfs/android_aasset_manager.cpp", __LINE__);
+		throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "failed to find file: " + file_path);
 	}
 
 	size_t size = AAsset_getLength(asset);
 
 	if (offset + count > size)
 	{
-		return StackError::unique("requested chunk out of range", "vfs/android_aasset_manager.cpp", __LINE__);
+		throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "requested chunk out of range");
 	}
 
-	auto a_blob = std::make_shared<StdBlob>();
-	a_blob->buffer.resize(size, 0);
+	std::vector<uint8_t> blob(size, 0);
 
 	AAsset_seek(asset, offset, 0);
-	AAsset_read(asset, const_cast<void *>(reinterpret_cast<const void *>(a_blob->buffer.data())), size);
+	AAsset_read(asset, const_cast<void *>(reinterpret_cast<const void *>(blob.data())), size);
 
 	AAsset_close(asset);
 
-	*blob = a_blob;
-
-	return nullptr;
+	return blob;
 }
 
-size_t AndroidAAssetManager::file_size(const std::string &file_path)
+size_t AndroidAAssetManager::file_size(const std::string &file_path) const
 {
 	if (!asset_manager)
 	{
-		return 0;
+		throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "AAsset Manager not initialized");
 	}
 
 	std::string real_path = get_path(file_path);
@@ -152,7 +149,7 @@ size_t AndroidAAssetManager::file_size(const std::string &file_path)
 
 	if (!asset)
 	{
-		return status::FileNotFound;
+		throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "failed to find file: " + file_path);
 	}
 
 	size_t size = AAsset_getLength(asset);
@@ -164,27 +161,27 @@ size_t AndroidAAssetManager::file_size(const std::string &file_path)
 
 StackErrorPtr AndroidAAssetManager::write_file(const std::string &file_path, const void *data, size_t size)
 {
-	return StackError::unique("not implemented", "vfs/android_aasset_manager.cpp", __LINE__);
+	throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "write_file not implemented");
 }
 
-StackErrorPtr AndroidAAssetManager::enumerate_files(const std::string &file_path, std::vector<std::string> *files)
+std::vector<std::string> AndroidAAssetManager::enumerate_files(const std::string &folder_path) const
 {
-	return StackError::unique("not implemented", "vfs/android_aasset_manager.cpp", __LINE__);
+	throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "enumerate_files not implemented");
 }
 
-StackErrorPtr AndroidAAssetManager::enumerate_folders(const std::string &file_path, std::vector<std::string> *folders)
+std::vector<std::string> AndroidAAssetManager::enumerate_folders(const std::string &folderPath) const
 {
-	return StackError::unique("not implemented", "vfs/android_aasset_manager.cpp", __LINE__);
+	throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "enumerate_folders not implemented");
 }
 
 void AndroidAAssetManager::make_directory(const std::string &path)
 {
-	assert(false && "not implemented");
+	throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "make_directory not implemented");
 }
 
 bool AndroidAAssetManager::remove(const std::string &path)
 {
-	assert(false && "not implemented");
+	throw std::runtime_error("vfs/android_aasset_manager.cpp line" + std::to_string(__LINE__) + "remove not implemented");
 	return false;
 }
 

--- a/components/vfs/src/root_file_system.cpp
+++ b/components/vfs/src/root_file_system.cpp
@@ -276,6 +276,8 @@ StackErrorPtr RootFileSystem::enumerate_folders_recursive(const std::string &fol
 
 		dirs_to_visit.insert(dirs_to_visit.end(), dirs.begin(), dirs.end());
 		all_dirs.insert(all_dirs.end(), dirs.begin(), dirs.end());
+
+		all_dirs.insert(dirs.begin(), dirs.end());
 	}
 
 	std::vector<std::string> all_folders{all_dirs.begin(), all_dirs.end()};

--- a/components/vfs/tests/basic.test.cpp
+++ b/components/vfs/tests/basic.test.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include <components/vfs/filesystem.hpp>
+#include <components/vfs/helpers.hpp>
 
 using namespace components;
 
@@ -15,6 +16,13 @@ using namespace components;
 		REQUIRE(err == nullptr); \
 	}
 
+#define CATCH_ERROR()            \
+	catch (std::exception & err) \
+	{                            \
+		INFO(err.what());        \
+		REQUIRE(false);          \
+	}
+
 TEST_CASE("Create and delete a temporary file", "[vfs]")
 {
 	auto &fs = vfs::_default();
@@ -23,90 +31,95 @@ TEST_CASE("Create and delete a temporary file", "[vfs]")
 	std::string          file_contents = "this is the file contents";
 	std::vector<uint8_t> file_data{file_contents.begin(), file_contents.end()};
 
-	auto err = fs.write_file(file_path, file_data.data(), file_data.size());
-	CHECK_ERROR(err);
+	try
+	{
+		fs.write_file(file_path, file_data.data(), file_data.size());
 
-	std::shared_ptr<vfs::Blob> blob;
-	err = fs.read_file(file_path, &blob);
-	CHECK_ERROR(err);
+		std::vector<uint8_t> blob = fs.read_file(file_path);
 
-	REQUIRE(blob->ascii() == file_contents);
+		REQUIRE(file_contents == std::string{blob.begin(), blob.end()});
 
-	REQUIRE(fs.remove(file_path));
+		REQUIRE(fs.remove(file_path));
+	}
+	CATCH_ERROR()
 }
 
 TEST_CASE("Search for folders", "[vfs]")
 {
 	auto &fs = vfs::_default();
 
-	std::vector<std::string> folders;
+	try
+	{
+		std::vector<std::string> folders = fs.enumerate_folders("/bldsys");
 
-	auto err = fs.enumerate_folders("/bldsys", &folders);
-	CHECK_ERROR(err);
+		std::set<std::string> individual_folders{folders.begin(), folders.end()};
 
-	std::set<std::string> individual_folders{folders.begin(), folders.end()};
+		REQUIRE(individual_folders.find("/bldsys/cmake") != individual_folders.end());
+		REQUIRE(individual_folders.find("/bldsys/scripts") != individual_folders.end());
 
-	REQUIRE(individual_folders.find("/bldsys/cmake") != individual_folders.end());
-	REQUIRE(individual_folders.find("/bldsys/scripts") != individual_folders.end());
-
-	REQUIRE(folders.size() == 2);
+		REQUIRE(folders.size() == 2);
+	}
+	CATCH_ERROR()
 }
 
 TEST_CASE("Search for folders recursive", "[vfs]")
 {
 	auto &fs = vfs::_default();
 
-	std::vector<std::string> folders;
+	try
+	{
+		std::vector<std::string> folders = fs.enumerate_folders_recursive("/bldsys");
 
-	auto err = fs.enumerate_folders_recursive("/bldsys", &folders);
-	CHECK_ERROR(err);
+		std::set<std::string> individual_folders{folders.begin(), folders.end()};
 
-	std::set<std::string> individual_folders{folders.begin(), folders.end()};
+		REQUIRE(individual_folders.find("/bldsys/cmake") != individual_folders.end());
+		REQUIRE(individual_folders.find("/bldsys/cmake/module") != individual_folders.end());
+		REQUIRE(individual_folders.find("/bldsys/cmake/template") != individual_folders.end());
+		REQUIRE(individual_folders.find("/bldsys/cmake/template/sample") != individual_folders.end());
+		REQUIRE(individual_folders.find("/bldsys/scripts") != individual_folders.end());
 
-	REQUIRE(individual_folders.find("/bldsys/cmake") != individual_folders.end());
-	REQUIRE(individual_folders.find("/bldsys/cmake/module") != individual_folders.end());
-	REQUIRE(individual_folders.find("/bldsys/cmake/template") != individual_folders.end());
-	REQUIRE(individual_folders.find("/bldsys/cmake/template/sample") != individual_folders.end());
-	REQUIRE(individual_folders.find("/bldsys/scripts") != individual_folders.end());
-
-	REQUIRE(folders.size() == 5);
+		REQUIRE(folders.size() == 5);
+	}
+	CATCH_ERROR()
 }
 
 TEST_CASE("Search for files", "[vfs]")
 {
 	auto &fs = vfs::_default();
 
-	std::vector<std::string> files;
+	try
+	{
+		std::vector<std::string> files = fs.enumerate_files("/bldsys/cmake/module");
 
-	auto err = fs.enumerate_files("/bldsys/cmake/module", &files);
-	CHECK_ERROR(err);
+		std::set<std::string> individual_files{files.begin(), files.end()};
 
-	std::set<std::string> individual_files{files.begin(), files.end()};
+		REQUIRE(individual_files.find("/bldsys/cmake/module/FindAdb.cmake") != individual_files.end());
+		REQUIRE(individual_files.find("/bldsys/cmake/module/FindGradle.cmake") != individual_files.end());
 
-	REQUIRE(individual_files.find("/bldsys/cmake/module/FindAdb.cmake") != individual_files.end());
-	REQUIRE(individual_files.find("/bldsys/cmake/module/FindGradle.cmake") != individual_files.end());
-
-	REQUIRE(files.size() == 2);
+		REQUIRE(files.size() == 2);
+	}
+	CATCH_ERROR()
 }
 
 TEST_CASE("Search for files recursive", "[vfs]")
 {
 	auto &fs = vfs::_default();
 
-	std::vector<std::string> files;
+	std::string file_extension{"cmake"};
 
-	std::string file_extension{".cmake"};
-
-	auto err = fs.enumerate_files_recursive("/bldsys", file_extension, &files);
-	CHECK_ERROR(err);
-
-	for (auto &file_path : files)
+	try
 	{
-		REQUIRE(file_path.substr(file_path.size() - file_extension.size()) == file_extension);
+		std::vector<std::string> files = fs.enumerate_files_recursive("/bldsys", file_extension);
+
+		for (auto const &file_path : files)
+		{
+			REQUIRE(vfs::helpers::get_file_extension(file_path) == file_extension);
+		}
+
+		std::set<std::string> individual_files{files.begin(), files.end()};
+		REQUIRE(individual_files.find("/bldsys/cmake/check_atomic.cmake") != individual_files.end());
+
+		REQUIRE(files.size() == 8);
 	}
-
-	std::set<std::string> individual_files{files.begin(), files.end()};
-	REQUIRE(individual_files.find("/bldsys/cmake/check_atomic.cmake") != individual_files.end());
-
-	REQUIRE(files.size() == 8);
+	CATCH_ERROR()
 }


### PR DESCRIPTION
## Description

This PR shows how exceptions could be used in the new framework -> see #505.

All functions in vfs/filesystem.hpp that previously returned a StackErrorPtr have been changed to throw an exception on failure.
Besides that, the non-modifying functions have been marked as const, and some enumeration functions have been moved from RootFileSystem to FileSystem.

Note that
- in order to get the virtual_file_system_tests succeed, I had to manually adjust the base path `cwd` in default.cpp. That test failed in my environment even before any of my changes.
- all test were done on Windows; android_aasset_manager.cpp is just edited, not compiled.