### PR TITLE
Fix for graphics pipeline library sample (set required flags for fragment shader output pipeline library)

### DIFF
--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
@@ -74,6 +74,11 @@ GraphicsPipelineLibrary::~GraphicsPipelineLibrary()
 		{
 			vkDestroyPipeline(get_device().get_handle(), pipeline, nullptr);
 		}
+		for (auto pipeline : pipeline_library.fragment_shaders)
+		{
+			vkDestroyPipeline(get_device().get_handle(), pipeline, nullptr);
+		}		
+		vkDestroyPipelineCache(get_device().get_handle(), thread_pipeline_cache, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), pipeline_library.vertex_input_interface, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), pipeline_library.pre_rasterization_shaders, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), pipeline_library.fragment_output_interface, nullptr);
@@ -327,6 +332,7 @@ void GraphicsPipelineLibrary::prepare_pipeline_library()
 		pipeline_library_create_info.pNext             = &library_info;
 		pipeline_library_create_info.layout            = pipeline_layout;
 		pipeline_library_create_info.renderPass        = render_pass;
+		pipeline_library_create_info.flags             = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
 		pipeline_library_create_info.pColorBlendState  = &color_blend_state;
 		pipeline_library_create_info.pMultisampleState = &multisample_state;
 
@@ -419,6 +425,9 @@ void GraphicsPipelineLibrary::prepare_new_pipeline()
 	VK_CHECK(vkCreateGraphicsPipelines(get_device().get_handle(), thread_pipeline_cache, 1, &executable_pipeline_create_info, nullptr, &executable));
 
 	pipelines.push_back(executable);
+
+	// Add the fragment shader we created to a deletion list
+	pipeline_library.fragment_shaders.push_back(fragment_shader);
 }
 
 // Prepare and initialize uniform buffer containing shader uniforms

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
@@ -77,7 +77,7 @@ GraphicsPipelineLibrary::~GraphicsPipelineLibrary()
 		for (auto pipeline : pipeline_library.fragment_shaders)
 		{
 			vkDestroyPipeline(get_device().get_handle(), pipeline, nullptr);
-		}		
+		}
 		vkDestroyPipelineCache(get_device().get_handle(), thread_pipeline_cache, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), pipeline_library.vertex_input_interface, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), pipeline_library.pre_rasterization_shaders, nullptr);

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.h
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.h
@@ -43,7 +43,7 @@ class GraphicsPipelineLibrary : public ApiVulkanSample
 	} ubo_vs;
 
 	std::unique_ptr<vkb::core::Buffer> uniform_buffer{nullptr};
-	
+
 	struct
 	{
 		VkPipeline vertex_input_interface{VK_NULL_HANDLE};

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.h
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.h
@@ -43,12 +43,13 @@ class GraphicsPipelineLibrary : public ApiVulkanSample
 	} ubo_vs;
 
 	std::unique_ptr<vkb::core::Buffer> uniform_buffer{nullptr};
-
+	
 	struct
 	{
 		VkPipeline vertex_input_interface{VK_NULL_HANDLE};
 		VkPipeline pre_rasterization_shaders{VK_NULL_HANDLE};
 		VkPipeline fragment_output_interface{VK_NULL_HANDLE};
+		std::vector<VkPipeline> fragment_shaders;
 	} pipeline_library;
 
 	// Will be dynamically created at runtime from pipeline library


### PR DESCRIPTION
## Description

Recent validation layers added additional validation for the graphics pipeline library, and the sample for this extension now triggers a validation message due to a missing flag. This PR sets this missing flags for the fragment shader output part of the pipeline library and cleans up validation. I also added clean up for the fragment shader pipelines that were created at runtime.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making