### PR TITLE
Use <vulkan/vulkan.hpp> as precompiled header.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 project(vulkan_samples)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, Arm Limited and Contributors
+# Copyright (c) 2020-2022, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, Arm Limited and Contributors
+# Copyright (c) 2019-2022, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 include(android_package)
 
 # create sample app project

--- a/app/apps/CMakeLists.txt
+++ b/app/apps/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 project(apps)
 
 # Generate apps.cpp

--- a/app/apps/CMakeLists.txt
+++ b/app/apps/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, Arm Limited and Contributors
+# Copyright (c) 2020-2022, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/plugins/CMakeLists.txt
+++ b/app/plugins/CMakeLists.txt
@@ -17,7 +17,7 @@
 
  ]]
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 # Snake case to Pascal case helper
 

--- a/app/plugins/CMakeLists.txt
+++ b/app/plugins/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[[
- Copyright (c) 2019-2021, Arm Limited and Contributors
+ Copyright (c) 2019-2022, Arm Limited and Contributors
 
  SPDX-License-Identifier: Apache-2.0
 

--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -31,6 +31,19 @@ else()
     set(TARGET_ARCH ${CMAKE_SYSTEM_PROCESSOR})
 endif()
 
+if(APPLE)
+    # attempt to use Find_Vulkan at least of version 1.3 or greater.  If this is found, then enable the required portability extension so instance.cpp can get created correctly.
+    # prior to 1.3 Find_Vulkan should not return a Vulkan_FOUND variable, so should not set an extension that doesn't exist in legacy Vulkan.
+    # Note that this is only required for moltenVK implementations.  NB: this does create a warning in CMake that the range isn't supported in FindVulkan.
+    cmake_minimum_required(VERSION 3.19)
+    find_package(Vulkan 1.3...<2.0)
+    if(Vulkan_FOUND)
+        set(VKB_ENABLE_PORTABILITY ON CACHE BOOL "Enable portability extension enumeration in the framework.  This is required to be set if running MoltenVK and Vulkan 1.3+" FORCE)
+    else()
+        set(VKB_ENABLE_PORTABILITY OFF CACHE BOOL "Enable portability extension enumeration in the framework.  This is required to be off if running Vulkan less than 1.3" FORCE)
+    endif()
+endif()
+
 set(VKB_WARNINGS_AS_ERRORS ON CACHE BOOL "Enable Warnings as Errors")
 set(VKB_VALIDATION_LAYERS OFF CACHE BOOL "Enable validation layers for every application.")
 set(VKB_VALIDATION_LAYERS_GPU_ASSISTED OFF CACHE BOOL "Enable GPU assisted validation layers for every application.")

--- a/docs/build.md
+++ b/docs/build.md
@@ -261,9 +261,9 @@ cmake --build build/mac --config Release --target vulkan_samples -- -j4
 
 For all dependencies set the following environment variables.
 
-- CMake v3.10+
+- CMake v3.16+
 - JDK 8+ `JAVA_HOME=<SYSTEM_DIR>/java`
-- Android NDK r18+ `ANDROID_NDK_HOME=<WORK_DIR>/android-ndk`
+- Android NDK r23+ `ANDROID_NDK_HOME=<WORK_DIR>/android-ndk`
 - Android SDK `ANDROID_HOME=<WORK_DIR>/android-sdk`
 - Gradle 5+ `GRADLE_HOME=<WORK_DIR>/gradle`
 - [CMake Options](#cmake-options)

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 project(framework LANGUAGES C CXX)
 
@@ -428,13 +428,8 @@ else()
     endif()
 endif()
 
-# mask out the min/max macros from minwindef.h
-if(MSVC)
-    add_definitions(-DNOMINMAX)
-endif()
-
 # Pre compiled headers
-# vulkan_samples_pch(PROJECT_FILES pch.cpp)
+vulkan_samples_pch(PROJECT_FILES pch.cpp)
 
 add_library(${PROJECT_NAME} STATIC ${PROJECT_FILES})
 

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -459,6 +459,11 @@ if(${VKB_VULKAN_DEBUG})
     target_compile_definitions(${PROJECT_NAME} PUBLIC VKB_VULKAN_DEBUG)
 endif()
 
+if(${VKB_ENABLE_PORTABILITY})
+    message(STATUS "Vulkan Portability extension is enabled")
+    target_compile_definitions(${PROJECT_NAME} PUBLIC VKB_ENABLE_PORTABILITY)
+endif()
+
 if(${VKB_WARNINGS_AS_ERRORS})
     message(STATUS "Warnings as Errors Enabled")
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -510,3 +510,5 @@ else()
         target_link_libraries(${PROJECT_NAME} PRIVATE glfw)
     endif()
 endif()
+
+target_precompile_headers(${PROJECT_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -505,3 +505,5 @@ else()
         target_link_libraries(${PROJECT_NAME} PRIVATE glfw)
     endif()
 endif()
+
+target_precompile_headers(${PROJECT_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -428,8 +428,13 @@ else()
     endif()
 endif()
 
+# mask out the min/max macros from minwindef.h
+if(MSVC)
+    add_definitions(-DNOMINMAX)
+endif()
+
 # Pre compiled headers
-vulkan_samples_pch(PROJECT_FILES pch.cpp)
+# vulkan_samples_pch(PROJECT_FILES pch.cpp)
 
 add_library(${PROJECT_NAME} STATIC ${PROJECT_FILES})
 

--- a/framework/core/hpp_instance.cpp
+++ b/framework/core/hpp_instance.cpp
@@ -199,6 +199,11 @@ HPPInstance::HPPInstance(const std::string &                           applicati
 	}
 #endif
 
+#if (defined(VKB_ENABLE_PORTABILITY))
+	enable_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, available_instance_extensions, enabled_extensions);
+	enable_extension(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, available_instance_extensions, enabled_extensions);
+#endif
+
 #if (defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)) && defined(VKB_VALIDATION_LAYERS_GPU_ASSISTED)
 	bool validation_features = false;
 	{
@@ -308,6 +313,10 @@ HPPInstance::HPPInstance(const std::string &                           applicati
 
 		instance_info.pNext = &debug_report_create_info;
 	}
+#endif
+
+#if (defined(VKB_ENABLE_PORTABILITY))
+	instance_info.flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
 #endif
 
 #if (defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)) && defined(VKB_VALIDATION_LAYERS_GPU_ASSISTED)

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -203,6 +203,11 @@ Instance::Instance(const std::string &                           application_nam
 	}
 #endif
 
+#if (defined(VKB_ENABLE_PORTABILITY))
+	enable_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, available_instance_extensions, enabled_extensions);
+	enable_extension(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, available_instance_extensions, enabled_extensions);
+#endif
+
 #if (defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)) && defined(VKB_VALIDATION_LAYERS_GPU_ASSISTED)
 	bool validation_features = false;
 	{

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -106,6 +106,7 @@ set(ORDER_LIST
 	"hpp_instancing"
 	"hpp_hdr"
     "hpp_hello_triangle"
+	"hpp_hlsl_shaders"
 	"hpp_texture_loading")
 
 # Orders the sample ids by the order list above

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 # Creates a list of the subdirectories within this folder
 scan_dirs(

--- a/samples/README.md
+++ b/samples/README.md
@@ -129,6 +129,9 @@ A transcoded version of the API sample [High dynamic range](#hdr)that illustrate
 ### [HPP Hello Triangle](./api/hpp_hello_triangle)<br/>
 A transcoded version of the API sample [Hello Triangle](#hello_triangle) that illustrates the usage of the C++ bindings of vulkan provided by vulkan.hpp.
 
+### [HPP HLSL shaders](./api/hpp_hlsl_shaders)<br/>
+A transcoded version of the API sample [HLSL Shaders](#hlsl_shaders) that illustrates the usage of the C++ bindings of vulkan provided by vulkan.hpp.
+
 ### [HPP Instancing](./api/hpp_instancing)<br/>
 A transcoded version of the API sample [Instancing](#instancing) that illustrates the usage of the C++ bindings of vulkan provided by vulkan.hpp.
 

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2021, Arm Limited and Contributors
+/* Copyright (c) 2018-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -179,6 +179,11 @@ void HelloTriangle::init_instance(Context &                        context,
 	active_instance_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 #endif
 
+#if (defined(VKB_ENABLE_PORTABILITY))
+	active_instance_extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+	active_instance_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+#endif
+
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 	active_instance_extensions.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
 #elif defined(VK_USE_PLATFORM_WIN32_KHR)
@@ -247,6 +252,10 @@ void HelloTriangle::init_instance(Context &                        context,
 	debug_report_create_info.pfnCallback                        = debug_callback;
 
 	instance_info.pNext = &debug_report_create_info;
+#endif
+
+#if (defined(VKB_ENABLE_PORTABILITY))
+	instance_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 #endif
 
 	// Create the Vulkan instance

--- a/samples/api/hpp_compute_nbody/CMakeLists.txt
+++ b/samples/api/hpp_compute_nbody/CMakeLists.txt
@@ -31,4 +31,4 @@ add_sample_with_tags(
         "compute_nbody/particle_calculate.comp"
         "compute_nbody/particle_integrate.comp")
 
-target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)
+target_precompile_headers(${FOLDER_NAME} REUSE_FROM framework)

--- a/samples/api/hpp_compute_nbody/CMakeLists.txt
+++ b/samples/api/hpp_compute_nbody/CMakeLists.txt
@@ -30,3 +30,5 @@ add_sample_with_tags(
         "compute_nbody/particle.frag"
         "compute_nbody/particle_calculate.comp"
         "compute_nbody/particle_integrate.comp")
+
+target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/samples/api/hpp_dynamic_uniform_buffers/CMakeLists.txt
+++ b/samples/api/hpp_dynamic_uniform_buffers/CMakeLists.txt
@@ -29,4 +29,4 @@ add_sample_with_tags(
         "dynamic_uniform_buffers/base.vert"
         "dynamic_uniform_buffers/base.frag")
 
-target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)
+target_precompile_headers(${FOLDER_NAME} REUSE_FROM framework)

--- a/samples/api/hpp_dynamic_uniform_buffers/CMakeLists.txt
+++ b/samples/api/hpp_dynamic_uniform_buffers/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -28,3 +28,5 @@ add_sample_with_tags(
     SHADER_FILES_GLSL
         "dynamic_uniform_buffers/base.vert"
         "dynamic_uniform_buffers/base.frag")
+
+target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/samples/api/hpp_hdr/CMakeLists.txt
+++ b/samples/api/hpp_hdr/CMakeLists.txt
@@ -32,3 +32,5 @@ add_sample_with_tags(
         "hdr/bloom.frag"
         "hdr/gbuffer.vert"
         "hdr/gbuffer.frag")
+
+target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/samples/api/hpp_hdr/CMakeLists.txt
+++ b/samples/api/hpp_hdr/CMakeLists.txt
@@ -33,4 +33,4 @@ add_sample_with_tags(
         "hdr/gbuffer.vert"
         "hdr/gbuffer.frag")
 
-target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)
+target_precompile_headers(${FOLDER_NAME} REUSE_FROM framework)

--- a/samples/api/hpp_hello_triangle/CMakeLists.txt
+++ b/samples/api/hpp_hello_triangle/CMakeLists.txt
@@ -30,3 +30,4 @@ add_sample(
         "triangle.frag")
 
 target_compile_definitions(${FOLDER_NAME} PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/samples/api/hpp_hello_triangle/CMakeLists.txt
+++ b/samples/api/hpp_hello_triangle/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -30,3 +30,4 @@ add_sample(
         "triangle.frag")
 
 target_compile_definitions(${FOLDER_NAME} PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -193,6 +193,11 @@ void HPPHelloTriangle::init_instance(Context &                        context,
 	active_instance_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 #endif
 
+#if (defined(VKB_ENABLE_PORTABILITY))
+	active_instance_extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+	active_instance_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+#endif
+
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 	active_instance_extensions.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
 #elif defined(VK_USE_PLATFORM_WIN32_KHR)
@@ -247,6 +252,10 @@ void HPPHelloTriangle::init_instance(Context &                        context,
 	vk::DebugReportCallbackCreateInfoEXT debug_report_create_info(vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning, debug_callback);
 
 	instance_info.pNext = &debug_report_create_info;
+#endif
+
+#if (defined(VKB_ENABLE_PORTABILITY))
+	instance_info.flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
 #endif
 
 	// Create the Vulkan instance

--- a/samples/api/hpp_hlsl_shaders/CMakeLists.txt
+++ b/samples/api/hpp_hlsl_shaders/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,14 +19,12 @@ get_filename_component(FOLDER_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 get_filename_component(PARENT_DIR ${CMAKE_CURRENT_LIST_DIR} PATH)
 get_filename_component(CATEGORY_NAME ${PARENT_DIR} NAME)
 
-add_sample(
+add_sample_with_tags(
     ID ${FOLDER_NAME}
     CATEGORY ${CATEGORY_NAME}
-    AUTHOR "Arm"
-    NAME "HPP Hello Triangle"
-    DESCRIPTION "An introduction into Vulkan and its respective objects using vulkan.hpp."
+    AUTHOR "Sascha Willems"
+    NAME "HPP Using HLSL shaders in Vulkan with glslang"
+    DESCRIPTION "Shows how to generate SPIR-V from HLSL shaders that can be used in Vulkan, using vulkan.hpp"
     SHADER_FILES_GLSL
-        "triangle.vert"
-        "triangle.frag")
-
-target_compile_definitions(${FOLDER_NAME} PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+        "hlsl_shaders/hlsl_shader.vert"
+        "hlsl_shaders/hlsl_shader.frag")

--- a/samples/api/hpp_hlsl_shaders/README.md
+++ b/samples/api/hpp_hlsl_shaders/README.md
@@ -1,0 +1,123 @@
+<!--
+- Copyright (c) 2022, The Khronos Group
+-
+- SPDX-License-Identifier: Apache-2.0
+-
+- Licensed under the Apache License, Version 2.0 the "License";
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-
+-->
+
+# Using HLSL shaders in Vulkan with Vulkan-Hpp
+
+This tutorial, along with the accompanying example code, shows how to use shaders written in the High Level Shading Language (HLSL) in Vulkan at runtime, using Vulkan-Hpp.
+
+Vulkan does not directly consume shaders in a human-readable text format, but instead uses SPIR-V as an intermediate representation. This opens the option to use shader languages other than e.g. GLSL, as long as they can target the Vulkan SPIR-V environment. One such language is Microsoft's HLSL, which is the shading language for DirectX.
+
+Details on how HLSL fits into the Vulkan ecosystem can be found in  this [Vulkan guide chapter](https://github.com/KhronosGroup/Vulkan-Guide/blob/master/chapters/hlsl.adoc).
+
+# HLSL Syntax
+
+HLSL is a bit more object-oriented than GLSL, but the general structure of a shader is similar Vulkan-specific functions are marked with the [implicit ```vk``` namespace](https://github.com/microsoft/DirectXShaderCompiler/blob/master/docs/SPIR-V.rst#the-implicit-vk-namespace):
+
+```hlsl
+struct VSInput
+{
+[[vk::location(0)]] float3 Pos : POSITION0;
+[[vk::location(1)]] float2 UV : TEXCOORD0;
+[[vk::location(2)]] float3 Normal : NORMAL0;
+};
+
+struct UBO
+{
+	float4x4 projection;
+	float4x4 model;
+	float4 viewPos;
+};
+
+cbuffer ubo : register(b0, space0) { UBO ubo; }
+
+struct VSOutput
+{
+	float4 Pos : SV_POSITION;
+[[vk::location(0)]] float2 UV : TEXCOORD0;
+};
+
+VSOutput main(VSInput input)
+{
+	VSOutput output = (VSOutput)0;
+	output.UV = input.UV;
+	output.Pos = mul(ubo.projection, mul(ubo.model, float4(input.Pos.xyz, 1.0)));
+	return output;
+}
+```
+
+# Glslang
+
+The Vulkan samples use [Glslang](https://github.com/KhronosGroup/glslang) for converting shaders to SPIR-V at runtime. Glslang is the reference GLSL validator and translator, but also supports HLSL as an input language. 
+
+HLSL support in Glslang limited though and for a more feature complete HLSL to SPIR-V compiler, you can also use the [DirectX shader compiler](https://github.com/microsoft/DirectXShaderCompiler).
+
+For the basic shader in this tutorial, we can go with Glslang though, as it supports all features we require.
+
+# Converting HLSL to SPIR-V
+
+Loading HLSL with Glslang is similar to loading GLSL, but requires different parameters. Here are the relevant parts that differ from loading HLSL from the ```HlslShaders::load_hlsl_shader``` function of the sample:
+
+```cpp
+std::vector<uint32_t> spirvCode;
+
+// Use HLSL parsing rules and semantics (EShMsgReadHlsl)
+EShMessages messages = static_cast<EShMessages>(EShMsgReadHlsl | ...);
+...
+
+// Language needs to be selected based on the shader stage
+EShLanguage language = EShLangVertex;
+glslang::TShader shader(language);
+...
+
+// Set the source language to HLSL
+shader.setEnvInput(glslang::EShSourceHlsl, language, glslang::EShClientVulkan, 1);
+...
+
+// Parse the HLSL input
+if (!shader.parse(&glslang::DefaultTBuiltInResource, 100, false, messages))
+{
+	...
+}
+
+// Add shader to new program object.
+glslang::TProgram program;
+program.addShader(&shader);
+
+// Link program.
+if (!program.link(messages))
+{
+	...
+}
+...
+
+// Translate to SPIRV
+glslang::TIntermediate *intermediate = program.getIntermediate(language);
+...
+glslang::GlslangToSpv(*intermediate, spirvCode, &logger);
+...
+```
+
+# Creating the shader module
+
+The call to ```glslang::GlslangToSpv``` will generate the SPIR-V bytecode that we can use to create the Vulkan shader module from:
+
+```cpp
+vk::ShaderModuleCreateInfo module_create_info({}, spirvCode);
+vk::ShaderModule           shader_module = get_device()->get_handle().createShaderModule(module_create_info);
+```

--- a/samples/api/hpp_hlsl_shaders/hpp_hlsl_shaders.cpp
+++ b/samples/api/hpp_hlsl_shaders/hpp_hlsl_shaders.cpp
@@ -1,0 +1,420 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Using HLSL shaders in Vulkan with the glslang library, using vulkan.hpp
+ */
+
+#include "hpp_hlsl_shaders.h"
+
+#include "common/vk_initializers.h"
+
+VKBP_DISABLE_WARNINGS()
+#include <SPIRV/GlslangToSpv.h>
+#include <StandAlone/ResourceLimits.h>
+VKBP_ENABLE_WARNINGS()
+
+vk::PipelineShaderStageCreateInfo HPPHlslShaders::load_hlsl_shader(const std::string &file, vk::ShaderStageFlagBits stage)
+{
+	std::string info_log;
+
+	// Compile HLSL to SPIR-V
+
+	// Initialize glslang library
+	glslang::InitializeProcess();
+
+	auto messages = static_cast<EShMessages>(EShMsgReadHlsl | EShMsgDefault | EShMsgVulkanRules | EShMsgSpvRules);
+
+	EShLanguage language{};
+	switch (stage)
+	{
+		case vk::ShaderStageFlagBits::eVertex:
+			language = EShLangVertex;
+			break;
+		case vk::ShaderStageFlagBits::eFragment:
+			language = EShLangFragment;
+			break;
+		default:
+			assert(false);
+	}
+
+	std::string source        = vkb::fs::read_shader(file);
+	const char *shader_source = source.data();
+
+	glslang::TShader shader(language);
+	shader.setStringsWithLengths(&shader_source, nullptr, 1);
+	shader.setEnvInput(glslang::EShSourceHlsl, language, glslang::EShClientVulkan, 1);
+	shader.setEntryPoint("main");
+	shader.setSourceEntryPoint("main");
+	shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_0);
+	shader.setEnvTarget(glslang::EshTargetSpv, glslang::EShTargetSpv_1_0);
+
+	if (!shader.parse(&glslang::DefaultTBuiltInResource, 100, false, messages))
+	{
+		LOGE("Failed to parse HLSL shader, Error: {}", std::string(shader.getInfoLog()) + "\n" + std::string(shader.getInfoDebugLog()));
+		throw std::runtime_error("Failed to parse HLSL shader");
+	}
+
+	// Add shader to new program object
+	glslang::TProgram program;
+	program.addShader(&shader);
+
+	// Link program
+	if (!program.link(messages))
+	{
+		LOGE("Failed to compile HLSL shader, Error: {}", std::string(program.getInfoLog()) + "\n" + std::string(program.getInfoDebugLog()));
+		throw std::runtime_error("Failed to compile HLSL shader");
+	}
+
+	if (shader.getInfoLog())
+	{
+		info_log += std::string(shader.getInfoLog()) + "\n" + std::string(shader.getInfoDebugLog()) + "\n";
+	}
+	if (program.getInfoLog())
+	{
+		info_log += std::string(program.getInfoLog()) + "\n" + std::string(program.getInfoDebugLog());
+	}
+
+	// Translate to SPIRV
+	glslang::TIntermediate *intermediate = program.getIntermediate(language);
+	if (!intermediate)
+	{
+		LOGE("Failed to get shared intermediate code.");
+		throw std::runtime_error("Failed to compile HLSL shader");
+	}
+
+	spv::SpvBuildLogger logger;
+
+	std::vector<uint32_t> spirvCode;
+	glslang::GlslangToSpv(*intermediate, spirvCode, &logger);
+
+	info_log += logger.getAllMessages() + "\n";
+
+	glslang::FinalizeProcess();
+
+	// Create shader module from generated SPIR-V
+	vk::ShaderModuleCreateInfo module_create_info({}, spirvCode);
+	vk::ShaderModule           shader_module = get_device()->get_handle().createShaderModule(module_create_info);
+	shader_modules.push_back(shader_module);
+
+	return vk::PipelineShaderStageCreateInfo({}, stage, shader_module, "main");
+}
+
+HPPHlslShaders::HPPHlslShaders()
+{
+	zoom     = -2.0f;
+	rotation = {0.0f, 0.0f, 0.0f};
+	title    = "HPP HLSL shaders";
+}
+
+HPPHlslShaders::~HPPHlslShaders()
+{
+	if (get_device() && get_device()->get_handle())
+	{
+		// Clean up used Vulkan resources
+		// Note : Inherited destructor cleans up resources stored in base class
+
+		vk::Device device = get_device()->get_handle();
+		device.destroyPipeline(pipeline);
+		device.destroyPipelineLayout(pipeline_layout);
+		device.destroyDescriptorSetLayout(base_descriptor_set_layout);
+		device.destroyDescriptorSetLayout(sampler_descriptor_set_layout);
+		// Delete the implicitly created sampler for the texture loaded via the framework
+		device.destroySampler(texture.sampler);
+	}
+}
+
+// Enable physical device features required for this example
+void HPPHlslShaders::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
+{
+	// Enable anisotropic filtering if supported
+	if (gpu.get_features().samplerAnisotropy)
+	{
+		gpu.get_mutable_requested_features().samplerAnisotropy = true;
+	}
+}
+
+void HPPHlslShaders::build_command_buffers()
+{
+	vk::CommandBufferBeginInfo command_buffer_begin_info;
+
+	std::array<vk::ClearValue, 2> clear_values = {{default_clear_color, vk::ClearDepthStencilValue(0.0f, 0)}};
+
+	vk::RenderPassBeginInfo render_pass_begin_info(render_pass, {}, {{0, 0}, extent}, clear_values);
+
+	for (int32_t i = 0; i < draw_cmd_buffers.size(); ++i)
+	{
+		// Set target frame buffer
+		render_pass_begin_info.framebuffer = framebuffers[i];
+
+		auto command_buffer = draw_cmd_buffers[i];
+		command_buffer.begin(command_buffer_begin_info);
+
+		command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+
+		vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f);
+		command_buffer.setViewport(0, viewport);
+
+		vk::Rect2D scissor({0, 0}, extent);
+		command_buffer.setScissor(0, scissor);
+
+		// Bind the uniform buffer and sampled image to set 0
+		command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layout, 0, base_descriptor_set, {});
+		command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline);
+
+		vk::DeviceSize offset = 0;
+		command_buffer.bindVertexBuffers(0, vertex_buffer->get_handle(), offset);
+		command_buffer.bindIndexBuffer(index_buffer->get_handle(), 0, vk::IndexType::eUint32);
+
+		command_buffer.drawIndexed(static_cast<uint32_t>(index_buffer->get_size() / sizeof(uint32_t)), 1, 0, 0, 0);
+
+		draw_ui(command_buffer);
+
+		command_buffer.endRenderPass();
+
+		command_buffer.end();
+	}
+}
+
+void HPPHlslShaders::load_assets()
+{
+	texture = load_texture("textures/metalplate01_rgba.ktx");
+}
+
+void HPPHlslShaders::draw()
+{
+	HPPApiVulkanSample::prepare_frame();
+
+	// Command buffer to be submitted to the queue
+	submit_info.setCommandBuffers(draw_cmd_buffers[current_buffer]);
+
+	// Submit to queue
+	queue.submit(submit_info);
+
+	HPPApiVulkanSample::submit_frame();
+}
+
+void HPPHlslShaders::generate_quad()
+{
+	// Setup vertices for a single uv-mapped quad made from two triangles
+	std::vector<VertexStructure> vertices =
+	    {
+	        {{1.0f, 1.0f, 0.0f}, {1.0f, 1.0f}, {0.0f, 0.0f, 1.0f}},
+	        {{-1.0f, 1.0f, 0.0f}, {0.0f, 1.0f}, {0.0f, 0.0f, 1.0f}},
+	        {{-1.0f, -1.0f, 0.0f}, {0.0f, 0.0f}, {0.0f, 0.0f, 1.0f}},
+	        {{1.0f, -1.0f, 0.0f}, {1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}}};
+
+	// Setup indices
+	std::vector<uint32_t> indices = {0, 1, 2, 2, 3, 0};
+
+	auto vertex_buffer_size = vkb::to_u32(vertices.size() * sizeof(VertexStructure));
+	auto index_buffer_size  = vkb::to_u32(indices.size() * sizeof(uint32_t));
+
+	// Create buffers
+	// For the sake of simplicity we won't stage the vertex data to the gpu memory
+	// Vertex buffer
+	vertex_buffer = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
+	                                                       vertex_buffer_size,
+	                                                       vk::BufferUsageFlagBits::eTransferDst | vk::BufferUsageFlagBits::eVertexBuffer,
+	                                                       VMA_MEMORY_USAGE_CPU_TO_GPU);
+	vertex_buffer->update(vertices.data(), vertex_buffer_size);
+
+	index_buffer = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
+	                                                      index_buffer_size,
+	                                                      vk::BufferUsageFlagBits::eTransferDst | vk::BufferUsageFlagBits::eIndexBuffer,
+	                                                      VMA_MEMORY_USAGE_CPU_TO_GPU);
+
+	index_buffer->update(indices.data(), index_buffer_size);
+}
+
+void HPPHlslShaders::setup_descriptor_pool()
+{
+	std::array<vk::DescriptorPoolSize, 3> pool_sizes = {{{vk::DescriptorType::eUniformBuffer, 1}, {vk::DescriptorType::eCombinedImageSampler, 1}, {vk::DescriptorType::eSampler, 2}}};
+
+	vk::DescriptorPoolCreateInfo descriptor_pool_create_info({}, 3, pool_sizes);
+	descriptor_pool = get_device()->get_handle().createDescriptorPool(descriptor_pool_create_info);
+}
+
+void HPPHlslShaders::setup_descriptor_set_layout()
+{
+	// We separate the descriptor sets for the uniform buffer + image and samplers, so we don't need to duplicate the descriptors for the former
+	std::array<vk::DescriptorSetLayoutBinding, 2> base_set_layout_bindings = {
+	    {{0, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex},                   // Binding 0 : Vertex shader uniform buffer
+	     {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}}};        // Binding 1 : Fragment shader combined sampler
+
+	vk::DescriptorSetLayoutCreateInfo descriptor_layout_create_info({}, base_set_layout_bindings);
+
+	base_descriptor_set_layout = get_device()->get_handle().createDescriptorSetLayout(descriptor_layout_create_info);
+
+	// Set layout for the samplers
+	vk::DescriptorSetLayoutBinding sampler_set_layout_binding(0, vk::DescriptorType::eSampler, 1, vk::ShaderStageFlagBits::eFragment);        // Binding 0: Fragment shader sampler
+	descriptor_layout_create_info.setBindings(sampler_set_layout_binding);
+	sampler_descriptor_set_layout = get_device()->get_handle().createDescriptorSetLayout(descriptor_layout_create_info);
+
+	// Pipeline layout
+	// Set layout for the base descriptors in set 0 and set layout for the sampler descriptors in set 1
+	std::array<vk::DescriptorSetLayout, 2> set_layouts = {{base_descriptor_set_layout, sampler_descriptor_set_layout}};
+	vk::PipelineLayoutCreateInfo           pipeline_layout_create_info({}, set_layouts);
+	pipeline_layout = get_device()->get_handle().createPipelineLayout(pipeline_layout_create_info);
+}
+
+void HPPHlslShaders::setup_descriptor_set()
+{
+	// We separate the descriptor sets for the uniform buffer + image and samplers, so we don't need to duplicate the descriptors for the former
+#if defined(ANDROID)
+	vk::DescriptorSetAllocateInfo descriptor_set_alloc_info(descriptor_pool, 1, &base_descriptor_set_layout);
+#else
+	vk::DescriptorSetAllocateInfo descriptor_set_alloc_info(descriptor_pool, base_descriptor_set_layout);
+#endif
+	base_descriptor_set = get_device()->get_handle().allocateDescriptorSets(descriptor_set_alloc_info).front();
+
+	vk::DescriptorBufferInfo buffer_descriptor(uniform_buffer_vs->get_handle(), 0, VK_WHOLE_SIZE);
+
+	// Combined image descriptor for the texture
+	vk::DescriptorImageInfo image_descriptor(
+	    texture.sampler,
+	    texture.image->get_vk_image_view().get_handle(),
+	    descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, texture.image->get_vk_image_view().get_format()));
+
+	std::array<vk::WriteDescriptorSet, 2> write_descriptor_sets = {
+	    {{base_descriptor_set, 0, 0, vk::DescriptorType::eUniformBuffer, {}, buffer_descriptor},            // Binding 0 : Vertex shader uniform buffer
+	     {base_descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, image_descriptor}}};        // Binding 1 : Color map
+
+	get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
+}
+
+void HPPHlslShaders::prepare_pipelines()
+{
+	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
+	    load_hlsl_shader("hlsl_shaders/hlsl_shader.vert", vk::ShaderStageFlagBits::eVertex),
+	    load_hlsl_shader("hlsl_shaders/hlsl_shader.frag", vk::ShaderStageFlagBits::eFragment)};
+
+	vk::PipelineInputAssemblyStateCreateInfo input_assembly_state({}, vk::PrimitiveTopology::eTriangleList, false);
+
+	vk::PipelineViewportStateCreateInfo viewport_state({}, 1, nullptr, 1, nullptr);
+
+	vk::PipelineRasterizationStateCreateInfo rasterization_state;
+	rasterization_state.polygonMode = vk::PolygonMode::eFill;
+	rasterization_state.cullMode    = vk::CullModeFlagBits::eNone;
+	rasterization_state.frontFace   = vk::FrontFace::eCounterClockwise;
+	rasterization_state.lineWidth   = 1.0f;
+
+	vk::PipelineMultisampleStateCreateInfo multisample_state({}, vk::SampleCountFlagBits::e1);
+
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state({}, true, true, vk::CompareOp::eGreater);
+	depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
+
+	vk::PipelineColorBlendAttachmentState blend_attachment_state;
+	blend_attachment_state.colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+
+	vk::PipelineColorBlendStateCreateInfo color_blend_state({}, false, {}, blend_attachment_state);
+
+	std::array<vk::DynamicState, 2>    dynamic_state_enables = {vk::DynamicState::eViewport, vk::DynamicState::eScissor};
+	vk::PipelineDynamicStateCreateInfo dynamic_state({}, dynamic_state_enables);
+
+	// Vertex bindings and attributes
+	vk::VertexInputBindingDescription                  vertex_input_binding(0, sizeof(VertexStructure), vk::VertexInputRate::eVertex);
+	std::array<vk::VertexInputAttributeDescription, 3> vertex_input_attributes = {
+	    {{0, 0, vk::Format::eR32G32B32Sfloat, offsetof(VertexStructure, pos)},             // Location 0 : Position
+	     {1, 0, vk::Format::eR32G32Sfloat, offsetof(VertexStructure, uv)},                 // Location 1: Texture Coordinates
+	     {2, 0, vk::Format::eR32G32B32Sfloat, offsetof(VertexStructure, normal)}}};        // Location 2 : Normal
+	vk::PipelineVertexInputStateCreateInfo vertex_input_state({}, vertex_input_binding, vertex_input_attributes);
+
+	vk::GraphicsPipelineCreateInfo pipeline_create_info({},
+	                                                    shader_stages,
+	                                                    &vertex_input_state,
+	                                                    &input_assembly_state,
+	                                                    {},
+	                                                    &viewport_state,
+	                                                    &rasterization_state,
+	                                                    &multisample_state,
+	                                                    &depth_stencil_state,
+	                                                    &color_blend_state,
+	                                                    &dynamic_state,
+	                                                    pipeline_layout,
+	                                                    render_pass,
+	                                                    {},
+	                                                    {},
+	                                                    -1);
+
+	pipeline = get_device()->get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info).value;
+}
+
+// Prepare and initialize uniform buffer containing shader uniforms
+void HPPHlslShaders::prepare_uniform_buffers()
+{
+	// Vertex shader uniform buffer block
+	uniform_buffer_vs = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
+	                                                           sizeof(ubo_vs),
+	                                                           vk::BufferUsageFlagBits::eUniformBuffer,
+	                                                           VMA_MEMORY_USAGE_CPU_TO_GPU);
+
+	update_uniform_buffers();
+}
+
+void HPPHlslShaders::update_uniform_buffers()
+{
+	// Vertex shader
+	ubo_vs.projection     = glm::perspective(glm::radians(60.0f), (float) extent.width / (float) extent.height, 0.001f, 256.0f);
+	glm::mat4 view_matrix = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, zoom));
+
+	ubo_vs.model = view_matrix * glm::translate(glm::mat4(1.0f), camera_pos);
+	ubo_vs.model = glm::rotate(ubo_vs.model, glm::radians(rotation.x), glm::vec3(1.0f, 0.0f, 0.0f));
+	ubo_vs.model = glm::rotate(ubo_vs.model, glm::radians(rotation.y), glm::vec3(0.0f, 1.0f, 0.0f));
+	ubo_vs.model = glm::rotate(ubo_vs.model, glm::radians(rotation.z), glm::vec3(0.0f, 0.0f, 1.0f));
+
+	ubo_vs.view_pos = glm::vec4(0.0f, 0.0f, -zoom, 0.0f);
+
+	uniform_buffer_vs->convert_and_update(ubo_vs);
+}
+
+bool HPPHlslShaders::prepare(vkb::platform::HPPPlatform &platform)
+{
+	if (!HPPApiVulkanSample::prepare(platform))
+	{
+		return false;
+	}
+	load_assets();
+	generate_quad();
+	prepare_uniform_buffers();
+	setup_descriptor_set_layout();
+	prepare_pipelines();
+	setup_descriptor_pool();
+	setup_descriptor_set();
+	build_command_buffers();
+	prepared = true;
+	return true;
+}
+
+void HPPHlslShaders::render(float delta_time)
+{
+	if (!prepared)
+		return;
+	draw();
+}
+
+void HPPHlslShaders::view_changed()
+{
+	update_uniform_buffers();
+}
+
+std::unique_ptr<vkb::Application> create_hpp_hlsl_shaders()
+{
+	return std::make_unique<HPPHlslShaders>();
+}

--- a/samples/api/hpp_hlsl_shaders/hpp_hlsl_shaders.h
+++ b/samples/api/hpp_hlsl_shaders/hpp_hlsl_shaders.h
@@ -1,0 +1,91 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Using HLSL shaders in Vulkan with the glslang library, using vulkan.hpp
+ */
+
+#pragma once
+
+#include <ktx.h>
+
+#include <glslang/Public/ShaderLang.h>
+
+#include "common/vk_common.h"
+#include "core/shader_module.h"
+
+#include "hpp_api_vulkan_sample.h"
+
+class HPPHlslShaders : public HPPApiVulkanSample
+{
+  public:
+	HPPHlslShaders();
+	~HPPHlslShaders() override;
+
+  private:
+	struct UBOVS
+	{
+		glm::mat4 projection;
+		glm::mat4 model;
+		glm::vec4 view_pos;
+	};
+
+	// Vertex layout for this example
+	struct VertexStructure
+	{
+		float pos[3];
+		float uv[2];
+		float normal[3];
+	};
+
+  private:
+	// from platform::HPPApplication
+	bool prepare(vkb::platform::HPPPlatform &platform) override;
+
+	// from HPPVulkanSample
+	void request_gpu_features(vkb::core::HPPPhysicalDevice &gpu) override;
+
+	// from HPPApiVulkanSample
+	void build_command_buffers() override;
+	void render(float delta_time) override;
+	void view_changed() override;
+
+	void                              draw();
+	void                              generate_quad();
+	void                              load_assets();
+	vk::PipelineShaderStageCreateInfo load_hlsl_shader(const std::string &file, vk::ShaderStageFlagBits stage);
+	void                              prepare_pipelines();
+	void                              prepare_uniform_buffers();
+	void                              setup_descriptor_pool();
+	void                              setup_descriptor_set();
+	void                              setup_descriptor_set_layout();
+	void                              update_uniform_buffers();
+
+  private:
+	vk::DescriptorSet                     base_descriptor_set;
+	vk::DescriptorSetLayout               base_descriptor_set_layout;
+	std::unique_ptr<vkb::core::HPPBuffer> index_buffer;
+	vk::Pipeline                          pipeline;
+	vk::PipelineLayout                    pipeline_layout;
+	vk::DescriptorSetLayout               sampler_descriptor_set_layout;
+	HPPTexture                            texture;
+	UBOVS                                 ubo_vs;
+	std::unique_ptr<vkb::core::HPPBuffer> uniform_buffer_vs;
+	std::unique_ptr<vkb::core::HPPBuffer> vertex_buffer;
+};
+
+std::unique_ptr<vkb::Application> create_hpp_hlsl_shaders();

--- a/samples/api/hpp_instancing/CMakeLists.txt
+++ b/samples/api/hpp_instancing/CMakeLists.txt
@@ -33,4 +33,4 @@ add_sample_with_tags(
         "instancing/starfield.vert"
         "instancing/starfield.frag")
 
-target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)
+target_precompile_headers(${FOLDER_NAME} REUSE_FROM framework)

--- a/samples/api/hpp_instancing/CMakeLists.txt
+++ b/samples/api/hpp_instancing/CMakeLists.txt
@@ -32,3 +32,5 @@ add_sample_with_tags(
         "instancing/planet.frag"
         "instancing/starfield.vert"
         "instancing/starfield.frag")
+
+target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/samples/api/hpp_terrain_tessellation/CMakeLists.txt
+++ b/samples/api/hpp_terrain_tessellation/CMakeLists.txt
@@ -33,4 +33,4 @@ add_sample_with_tags(
         "terrain_tessellation/skysphere.vert"
         "terrain_tessellation/skysphere.frag")
 
-target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)
+target_precompile_headers(${FOLDER_NAME} REUSE_FROM framework)

--- a/samples/api/hpp_terrain_tessellation/CMakeLists.txt
+++ b/samples/api/hpp_terrain_tessellation/CMakeLists.txt
@@ -32,3 +32,5 @@ add_sample_with_tags(
         "terrain_tessellation/terrain.tese"
         "terrain_tessellation/skysphere.vert"
         "terrain_tessellation/skysphere.frag")
+
+target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/samples/api/hpp_texture_loading/CMakeLists.txt
+++ b/samples/api/hpp_texture_loading/CMakeLists.txt
@@ -29,4 +29,4 @@ add_sample_with_tags(
         "texture_loading/texture.vert"
         "texture_loading/texture.frag")
 
-target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)
+target_precompile_headers(${FOLDER_NAME} REUSE_FROM framework)

--- a/samples/api/hpp_texture_loading/CMakeLists.txt
+++ b/samples/api/hpp_texture_loading/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -28,3 +28,5 @@ add_sample_with_tags(
     SHADER_FILES_GLSL
         "texture_loading/texture.vert"
         "texture_loading/texture.frag")
+
+target_precompile_headers(${FOLDER_NAME} PRIVATE <vulkan/vulkan.hpp>)

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
@@ -74,6 +74,11 @@ GraphicsPipelineLibrary::~GraphicsPipelineLibrary()
 		{
 			vkDestroyPipeline(get_device().get_handle(), pipeline, nullptr);
 		}
+		for (auto pipeline : pipeline_library.fragment_shaders)
+		{
+			vkDestroyPipeline(get_device().get_handle(), pipeline, nullptr);
+		}
+		vkDestroyPipelineCache(get_device().get_handle(), thread_pipeline_cache, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), pipeline_library.vertex_input_interface, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), pipeline_library.pre_rasterization_shaders, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), pipeline_library.fragment_output_interface, nullptr);
@@ -327,6 +332,7 @@ void GraphicsPipelineLibrary::prepare_pipeline_library()
 		pipeline_library_create_info.pNext             = &library_info;
 		pipeline_library_create_info.layout            = pipeline_layout;
 		pipeline_library_create_info.renderPass        = render_pass;
+		pipeline_library_create_info.flags             = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
 		pipeline_library_create_info.pColorBlendState  = &color_blend_state;
 		pipeline_library_create_info.pMultisampleState = &multisample_state;
 
@@ -419,6 +425,9 @@ void GraphicsPipelineLibrary::prepare_new_pipeline()
 	VK_CHECK(vkCreateGraphicsPipelines(get_device().get_handle(), thread_pipeline_cache, 1, &executable_pipeline_create_info, nullptr, &executable));
 
 	pipelines.push_back(executable);
+
+	// Add the fragment shader we created to a deletion list
+	pipeline_library.fragment_shaders.push_back(fragment_shader);
 }
 
 // Prepare and initialize uniform buffer containing shader uniforms

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.h
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.h
@@ -49,6 +49,7 @@ class GraphicsPipelineLibrary : public ApiVulkanSample
 		VkPipeline vertex_input_interface{VK_NULL_HANDLE};
 		VkPipeline pre_rasterization_shaders{VK_NULL_HANDLE};
 		VkPipeline fragment_output_interface{VK_NULL_HANDLE};
+		std::vector<VkPipeline> fragment_shaders;
 	} pipeline_library;
 
 	// Will be dynamically created at runtime from pipeline library

--- a/samples/extensions/open_gl_interop/open_gl_interop.cpp
+++ b/samples/extensions/open_gl_interop/open_gl_interop.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2020-2021, Bradley Austin Davis
- * Copyright (c) 2020-2021, Arm Limited
+/* Copyright (c) 2020-2022, Bradley Austin Davis
+ * Copyright (c) 2020-2022, Arm Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -773,22 +773,25 @@ void OpenGLInterop::build_command_buffers()
 
 OpenGLInterop::~OpenGLInterop()
 {
-	glFinish();
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-	glBindVertexArray(0);
-	glUseProgram(0);
-	glDeleteFramebuffers(1, &gl_data->fbo);
-	glDeleteTextures(1, &gl_data->color);
-	glDeleteSemaphoresEXT(1, &gl_data->gl_ready);
-	glDeleteSemaphoresEXT(1, &gl_data->gl_complete);
-	glDeleteVertexArrays(1, &gl_data->vao);
-	glDeleteProgram(gl_data->program);
-	glFlush();
-	glFinish();
+	if (gl_context != nullptr)
+	{
+		glFinish();
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+		glBindVertexArray(0);
+		glUseProgram(0);
+		glDeleteFramebuffers(1, &gl_data->fbo);
+		glDeleteTextures(1, &gl_data->color);
+		glDeleteSemaphoresEXT(1, &gl_data->gl_ready);
+		glDeleteSemaphoresEXT(1, &gl_data->gl_complete);
+		glDeleteVertexArrays(1, &gl_data->vao);
+		glDeleteProgram(gl_data->program);
+		glFlush();
+		glFinish();
 
-	// Destroy OpenGl Context
-	delete gl_context;
-	delete gl_data;
+		// Destroy OpenGl Context
+		delete gl_context;
+		delete gl_data;
+	}
 
 	vertex_buffer.reset();
 	index_buffer.reset();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, Arm Limited and Contributors
+# Copyright (c) 2019-2022, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 add_subdirectory(system_test)
 

--- a/tests/external_project/CMakeLists.txt
+++ b/tests/external_project/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, Arm Limited and Contributors
+# Copyright (c) 2019-2022, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/external_project/CMakeLists.txt
+++ b/tests/external_project/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 project(external_project LANGUAGES C CXX)
 

--- a/tests/system_test/CMakeLists.txt
+++ b/tests/system_test/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 scan_dirs(
     DIR ${CMAKE_CURRENT_SOURCE_DIR}/sub_tests/

--- a/tests/system_test/CMakeLists.txt
+++ b/tests/system_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, Arm Limited and Contributors
+# Copyright (c) 2019-2022, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/system_test/sub_tests/bonza/CMakeLists.txt
+++ b/tests/system_test/sub_tests/bonza/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, Arm Limited and Contributors
+# Copyright (c) 2019-2022, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/system_test/sub_tests/bonza/CMakeLists.txt
+++ b/tests/system_test/sub_tests/bonza/CMakeLists.txt
@@ -15,6 +15,6 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 vkb_add_test(ID ${TEST})

--- a/tests/system_test/sub_tests/sponza/CMakeLists.txt
+++ b/tests/system_test/sub_tests/sponza/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, Arm Limited and Contributors
+# Copyright (c) 2019-2022, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/system_test/sub_tests/sponza/CMakeLists.txt
+++ b/tests/system_test/sub_tests/sponza/CMakeLists.txt
@@ -15,6 +15,6 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 vkb_add_test(ID ${TEST})

--- a/tests/system_test/test_framework/CMakeLists.txt
+++ b/tests/system_test/test_framework/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 project(test_framework LANGUAGES C CXX)
 

--- a/tests/system_test/test_framework/CMakeLists.txt
+++ b/tests/system_test/test_framework/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, Arm Limited and Contributors
+# Copyright (c) 2019-2022, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
## Description

Use <vulkan/vulkan.hpp> as precompiled header with all the hpp-based samples and the framework, expecting build times to be reduced.

Tested on Windows 11.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
