### PR TITLE
Update and standardise sRGB usage

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -171,9 +171,9 @@ vkb::Device &ApiVulkanSample::get_device()
 
 void ApiVulkanSample::create_render_context(vkb::Platform &platform)
 {
-	auto surface_priority_list = std::vector<VkSurfaceFormatKHR>{{VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                             {VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                             {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	// We always want an sRGB surface to match the display.
+	// If we used a UNORM surface, we'd have to do the conversion to sRGB ourselves at the end of our fragment shaders.
+	auto surface_priority_list = std::vector<VkSurfaceFormatKHR>{{VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
 	                                                             {VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
 
 	render_context = platform.create_render_context(*device.get(), surface, surface_priority_list);
@@ -959,11 +959,11 @@ VkDescriptorImageInfo ApiVulkanSample::create_descriptor(Texture &texture, VkDes
 	return descriptor;
 }
 
-Texture ApiVulkanSample::load_texture(const std::string &file)
+Texture ApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::ContentType content_type)
 {
 	Texture texture{};
 
-	texture.image = vkb::sg::Image::load(file, file);
+	texture.image = vkb::sg::Image::load(file, file, content_type);
 	texture.image->create_vk_image(*device);
 
 	const auto &queue = device->get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0);
@@ -1057,11 +1057,11 @@ Texture ApiVulkanSample::load_texture(const std::string &file)
 	return texture;
 }
 
-Texture ApiVulkanSample::load_texture_array(const std::string &file)
+Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type)
 {
 	Texture texture{};
 
-	texture.image = vkb::sg::Image::load(file, file);
+	texture.image = vkb::sg::Image::load(file, file, content_type);
 	texture.image->create_vk_image(*device, VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
 	const auto &queue = device->get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0);
@@ -1158,11 +1158,11 @@ Texture ApiVulkanSample::load_texture_array(const std::string &file)
 	return texture;
 }
 
-Texture ApiVulkanSample::load_texture_cubemap(const std::string &file)
+Texture ApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type)
 {
 	Texture texture{};
 
-	texture.image = vkb::sg::Image::load(file, file);
+	texture.image = vkb::sg::Image::load(file, file, content_type);
 	texture.image->create_vk_image(*device, VK_IMAGE_VIEW_TYPE_CUBE, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT);
 
 	const auto &queue = device->get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0);

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -369,7 +369,7 @@ class ApiVulkanSample : public vkb::VulkanSample
 		bool vsync = false;
 	} settings;
 
-	VkClearColorValue default_clear_color = {{0.004f, 0.004f, 0.004f, 1.0f}};
+	VkClearColorValue default_clear_color = {{0.002f, 0.002f, 0.002f, 1.0f}};
 
 	float zoom = 0;
 

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -192,20 +192,23 @@ class ApiVulkanSample : public vkb::VulkanSample
 	/**
 	 * @brief Loads in a ktx 2D texture
 	 * @param file The filename of the texture to load
+	 * @param content_type The type of content in the image file
 	 */
-	Texture load_texture(const std::string &file);
+	Texture load_texture(const std::string &file, vkb::sg::Image::ContentType content_type);
 
 	/**
 	 * @brief Laods in a ktx 2D texture array
 	 * @param file The filename of the texture to load
+	 * @param content_type The type of content in the image file
 	 */
-	Texture load_texture_array(const std::string &file);
+	Texture load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type);
 
 	/**
 	 * @brief Loads in a ktx 2D texture cubemap
 	 * @param file The filename of the texture to load
+	 * @param content_type The type of content in the image file
 	 */
-	Texture load_texture_cubemap(const std::string &file);
+	Texture load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type);
 
 	/**
 	 * @brief Loads in a single model from a GLTF file
@@ -366,7 +369,7 @@ class ApiVulkanSample : public vkb::VulkanSample
 		bool vsync = false;
 	} settings;
 
-	VkClearColorValue default_clear_color = {{0.025f, 0.025f, 0.025f, 1.0f}};
+	VkClearColorValue default_clear_color = {{0.004f, 0.004f, 0.004f, 1.0f}};
 
 	float zoom = 0;
 

--- a/framework/core/swapchain.h
+++ b/framework/core/swapchain.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -163,9 +163,7 @@ class Swapchain
 	// A list of surface formats in order of priority (vector[0] has high priority, vector[size-1] has low priority)
 	std::vector<VkSurfaceFormatKHR> surface_format_priority_list = {
 	    {VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	    {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	    {VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	    {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
+	    {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
 
 	std::set<VkImageUsageFlagBits> image_usage_flags;
 };

--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -327,6 +327,7 @@ static inline bool texture_needs_srgb_colorspace(const std::string &name)
 		return true;
 
 	// metallicRoughnessTexture, normalTexture & occlusionTexture must be linear
+	assert(name == "metallicRoughnessTexture" || name == "normalTexture" || name == "occlusionTexture");
 	return false;
 }
 

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2021, Arm Limited and Contributors
- * Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2018-2022, Arm Limited and Contributors
+ * Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -106,6 +106,7 @@ Gui::Gui(VulkanSample &sample_, const Window &window, const Stats *stats,
 	ImGuiStyle &style = ImGui::GetStyle();
 
 	// Color scheme
+	style.Colors[ImGuiCol_WindowBg]         = ImVec4(0.0f, 0.0f, 0.0f, 0.94f);
 	style.Colors[ImGuiCol_TitleBg]          = ImVec4(1.0f, 0.0f, 0.0f, 0.6f);
 	style.Colors[ImGuiCol_TitleBgActive]    = ImVec4(1.0f, 0.0f, 0.0f, 0.8f);
 	style.Colors[ImGuiCol_MenuBarBg]        = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -106,7 +106,7 @@ Gui::Gui(VulkanSample &sample_, const Window &window, const Stats *stats,
 	ImGuiStyle &style = ImGui::GetStyle();
 
 	// Color scheme
-	style.Colors[ImGuiCol_WindowBg]         = ImVec4(0.0f, 0.0f, 0.0f, 0.94f);
+	style.Colors[ImGuiCol_WindowBg]         = ImVec4(0.005f, 0.005f, 0.005f, 0.94f);
 	style.Colors[ImGuiCol_TitleBg]          = ImVec4(1.0f, 0.0f, 0.0f, 0.6f);
 	style.Colors[ImGuiCol_TitleBgActive]    = ImVec4(1.0f, 0.0f, 0.0f, 0.8f);
 	style.Colors[ImGuiCol_MenuBarBg]        = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -158,6 +158,8 @@ bool HPPApiVulkanSample::resize(const uint32_t, const uint32_t)
 
 void HPPApiVulkanSample::create_render_context(vkb::platform::HPPPlatform const &platform)
 {
+	// We always want an sRGB surface to match the display.
+	// If we used a UNORM surface, we'd have to do the conversion to sRGB ourselves at the end of our fragment shaders.
 	auto surface_priority_list = std::vector<vk::SurfaceFormatKHR>{{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
 	                                                               {vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}};
 

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -158,9 +158,7 @@ bool HPPApiVulkanSample::resize(const uint32_t, const uint32_t)
 
 void HPPApiVulkanSample::create_render_context(vkb::platform::HPPPlatform const &platform)
 {
-	auto surface_priority_list = std::vector<vk::SurfaceFormatKHR>{{vk::Format::eB8G8R8A8Unorm, vk::ColorSpaceKHR::eSrgbNonlinear},
-	                                                               {vk::Format::eR8G8B8A8Unorm, vk::ColorSpaceKHR::eSrgbNonlinear},
-	                                                               {vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
+	auto surface_priority_list = std::vector<vk::SurfaceFormatKHR>{{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
 	                                                               {vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}};
 
 	render_context = platform.create_render_context(*device, surface, surface_priority_list);
@@ -839,11 +837,11 @@ vk::ImageLayout HPPApiVulkanSample::descriptor_type_to_image_layout(vk::Descript
 	}
 }
 
-HPPTexture HPPApiVulkanSample::load_texture(const std::string &file)
+HPPTexture HPPApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::ContentType content_type)
 {
 	HPPTexture texture;
 
-	texture.image = vkb::scene_graph::components::HPPImage::load(file, file);
+	texture.image = vkb::scene_graph::components::HPPImage::load(file, file, content_type);
 	texture.image->create_vk_image(*get_device());
 
 	const auto &queue = get_device()->get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);
@@ -920,11 +918,11 @@ HPPTexture HPPApiVulkanSample::load_texture(const std::string &file)
 	return texture;
 }
 
-HPPTexture HPPApiVulkanSample::load_texture_array(const std::string &file)
+HPPTexture HPPApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type)
 {
 	HPPTexture texture{};
 
-	texture.image = vkb::scene_graph::components::HPPImage::load(file, file);
+	texture.image = vkb::scene_graph::components::HPPImage::load(file, file, content_type);
 	texture.image->create_vk_image(*get_device(), vk::ImageViewType::e2DArray);
 
 	const auto &queue = get_device()->get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);
@@ -1004,11 +1002,11 @@ HPPTexture HPPApiVulkanSample::load_texture_array(const std::string &file)
 	return texture;
 }
 
-HPPTexture HPPApiVulkanSample::load_texture_cubemap(const std::string &file)
+HPPTexture HPPApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type)
 {
 	HPPTexture texture{};
 
-	texture.image = vkb::scene_graph::components::HPPImage::load(file, file);
+	texture.image = vkb::scene_graph::components::HPPImage::load(file, file, content_type);
 	texture.image->create_vk_image(*get_device(), vk::ImageViewType::eCube, vk::ImageCreateFlagBits::eCubeCompatible);
 
 	const auto &queue = get_device()->get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);

--- a/framework/hpp_api_vulkan_sample.h
+++ b/framework/hpp_api_vulkan_sample.h
@@ -340,7 +340,7 @@ class HPPApiVulkanSample : public vkb::HPPVulkanSample
 		bool vsync = false;
 	} settings;
 
-	vk::ClearColorValue default_clear_color = std::array<float, 4>({{0.004f, 0.004f, 0.004f, 1.0f}});
+	vk::ClearColorValue default_clear_color = std::array<float, 4>({{0.002f, 0.002f, 0.002f, 1.0f}});
 
 	float zoom = 0;
 

--- a/framework/hpp_api_vulkan_sample.h
+++ b/framework/hpp_api_vulkan_sample.h
@@ -165,20 +165,23 @@ class HPPApiVulkanSample : public vkb::HPPVulkanSample
 	/**
    * @brief Loads in a ktx 2D texture
    * @param file The filename of the texture to load
+   * @param content_type The type of content in the image file
    */
-	HPPTexture load_texture(const std::string &file);
+	HPPTexture load_texture(const std::string &file, vkb::sg::Image::ContentType content_type);
 
 	/**
    * @brief Laods in a ktx 2D texture array
    * @param file The filename of the texture to load
+   * @param content_type The type of content in the image file
    */
-	HPPTexture load_texture_array(const std::string &file);
+	HPPTexture load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type);
 
 	/**
    * @brief Loads in a ktx 2D texture cubemap
    * @param file The filename of the texture to load
+   * @param content_type The type of content in the image file
    */
-	HPPTexture load_texture_cubemap(const std::string &file);
+	HPPTexture load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type);
 
 	/**
    * @brief Loads in a single model from a GLTF file
@@ -337,7 +340,7 @@ class HPPApiVulkanSample : public vkb::HPPVulkanSample
 		bool vsync = false;
 	} settings;
 
-	vk::ClearColorValue default_clear_color = std::array<float, 4>({{0.025f, 0.025f, 0.025f, 1.0f}});
+	vk::ClearColorValue default_clear_color = std::array<float, 4>({{0.004f, 0.004f, 0.004f, 1.0f}});
 
 	float zoom = 0;
 

--- a/framework/hpp_vulkan_sample.cpp
+++ b/framework/hpp_vulkan_sample.cpp
@@ -167,9 +167,7 @@ bool HPPVulkanSample::prepare(vkb::platform::HPPPlatform &platform)
 void HPPVulkanSample::create_render_context(vkb::platform::HPPPlatform const &platform)
 {
 	auto surface_priority_list = std::vector<vk::SurfaceFormatKHR>{{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
-	                                                               {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
-	                                                               {vk::Format::eR8G8B8A8Unorm, vk::ColorSpaceKHR::eSrgbNonlinear},
-	                                                               {vk::Format::eB8G8R8A8Unorm, vk::ColorSpaceKHR::eSrgbNonlinear}};
+	                                                               {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}};
 
 	render_context = platform.create_render_context(*device, surface, surface_priority_list);
 }

--- a/framework/rendering/render_context.h
+++ b/framework/rendering/render_context.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -255,9 +255,7 @@ class RenderContext
 	// A list of surface formats in order of priority (vector[0] has high priority, vector[size-1] has low priority)
 	std::vector<VkSurfaceFormatKHR> surface_format_priority_list = {
 	    {VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	    {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	    {VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	    {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
+	    {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
 
 	std::vector<std::unique_ptr<RenderFrame>> frames;
 

--- a/framework/scene_graph/components/hpp_image.h
+++ b/framework/scene_graph/components/hpp_image.h
@@ -41,9 +41,9 @@ class HPPImage : private vkb::sg::Image
 	using vkb::sg::Image::get_mipmaps;
 	using vkb::sg::Image::get_offsets;
 
-	static std::unique_ptr<HPPImage> load(std::string const &name, std::string const &uri)
+	static std::unique_ptr<HPPImage> load(std::string const &name, std::string const &uri, vkb::sg::Image::ContentType content_type)
 	{
-		return std::unique_ptr<HPPImage>(reinterpret_cast<HPPImage *>(vkb::sg::Image::load(name, uri).release()));
+		return std::unique_ptr<HPPImage>(reinterpret_cast<HPPImage *>(vkb::sg::Image::load(name, uri, content_type).release()));
 	}
 
 	void create_vk_image(vkb::core::HPPDevice const &device, vk::ImageViewType image_view_type = vk::ImageViewType::e2D, vk::ImageCreateFlags flags = {})

--- a/framework/scene_graph/components/image.cpp
+++ b/framework/scene_graph/components/image.cpp
@@ -68,6 +68,11 @@ bool is_astc(const VkFormat format)
 	        format == VK_FORMAT_ASTC_12x12_SRGB_BLOCK);
 }
 
+// When the color-space of a loaded image is unknown (from KTX1 for example) we
+// may want to assume that the loaded data is in sRGB format (since it usually is).
+// In those cases, this helper will get called which will force an existing unorm
+// format to become an srgb format where one exists. If none exist, the format will
+// remain unmodified.
 static VkFormat maybe_coerce_to_srgb(VkFormat fmt)
 {
 	switch (fmt)

--- a/framework/scene_graph/components/image.cpp
+++ b/framework/scene_graph/components/image.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2021, Arm Limited and Contributors
+/* Copyright (c) 2018-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -66,6 +66,81 @@ bool is_astc(const VkFormat format)
 	        format == VK_FORMAT_ASTC_12x10_SRGB_BLOCK ||
 	        format == VK_FORMAT_ASTC_12x12_UNORM_BLOCK ||
 	        format == VK_FORMAT_ASTC_12x12_SRGB_BLOCK);
+}
+
+static VkFormat maybe_coerce_to_srgb(VkFormat fmt)
+{
+	switch (fmt)
+	{
+		case VK_FORMAT_R8_UNORM:
+			return VK_FORMAT_R8_SRGB;
+		case VK_FORMAT_R8G8_UNORM:
+			return VK_FORMAT_R8G8_SRGB;
+		case VK_FORMAT_R8G8B8_UNORM:
+			return VK_FORMAT_R8G8B8_SRGB;
+		case VK_FORMAT_B8G8R8_UNORM:
+			return VK_FORMAT_B8G8R8_SRGB;
+		case VK_FORMAT_R8G8B8A8_UNORM:
+			return VK_FORMAT_R8G8B8A8_SRGB;
+		case VK_FORMAT_B8G8R8A8_UNORM:
+			return VK_FORMAT_B8G8R8A8_SRGB;
+		case VK_FORMAT_A8B8G8R8_UNORM_PACK32:
+			return VK_FORMAT_A8B8G8R8_SRGB_PACK32;
+		case VK_FORMAT_BC1_RGB_UNORM_BLOCK:
+			return VK_FORMAT_BC1_RGB_SRGB_BLOCK;
+		case VK_FORMAT_BC1_RGBA_UNORM_BLOCK:
+			return VK_FORMAT_BC1_RGBA_SRGB_BLOCK;
+		case VK_FORMAT_BC2_UNORM_BLOCK:
+			return VK_FORMAT_BC2_SRGB_BLOCK;
+		case VK_FORMAT_BC3_UNORM_BLOCK:
+			return VK_FORMAT_BC3_SRGB_BLOCK;
+		case VK_FORMAT_BC7_UNORM_BLOCK:
+			return VK_FORMAT_BC7_SRGB_BLOCK;
+		case VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK:
+			return VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK;
+		case VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK:
+			return VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK;
+		case VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK:
+			return VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_4x4_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_4x4_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_5x4_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_5x4_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_5x5_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_5x5_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_6x5_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_6x5_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_6x6_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_6x6_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_8x5_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_8x5_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_8x6_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_8x6_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_8x8_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_8x8_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_10x5_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_10x5_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_10x6_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_10x6_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_10x8_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_10x8_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_10x10_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_10x10_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_12x10_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_12x10_SRGB_BLOCK;
+		case VK_FORMAT_ASTC_12x12_UNORM_BLOCK:
+			return VK_FORMAT_ASTC_12x12_SRGB_BLOCK;
+		case VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG:
+			return VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG;
+		case VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG:
+			return VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG;
+		case VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG:
+			return VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG;
+		case VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG:
+			return VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG;
+		default:
+			return fmt;
+	}
 }
 
 Image::Image(const std::string &name, std::vector<uint8_t> &&d, std::vector<Mipmap> &&m) :
@@ -246,7 +321,13 @@ void Image::set_offsets(const std::vector<std::vector<VkDeviceSize>> &o)
 	offsets = o;
 }
 
-std::unique_ptr<Image> Image::load(const std::string &name, const std::string &uri)
+void Image::coerce_format_to_srgb()
+{
+	format = maybe_coerce_to_srgb(format);
+}
+
+std::unique_ptr<Image> Image::load(const std::string &name, const std::string &uri,
+                                   ContentType content_type)
 {
 	std::unique_ptr<Image> image{nullptr};
 
@@ -257,7 +338,7 @@ std::unique_ptr<Image> Image::load(const std::string &name, const std::string &u
 
 	if (extension == "png" || extension == "jpg")
 	{
-		image = std::make_unique<Stb>(name, data);
+		image = std::make_unique<Stb>(name, data, content_type);
 	}
 	else if (extension == "astc")
 	{
@@ -265,11 +346,11 @@ std::unique_ptr<Image> Image::load(const std::string &name, const std::string &u
 	}
 	else if (extension == "ktx")
 	{
-		image = std::make_unique<Ktx>(name, data);
+		image = std::make_unique<Ktx>(name, data, content_type);
 	}
 	else if (extension == "ktx2")
 	{
-		image = std::make_unique<Ktx>(name, data);
+		image = std::make_unique<Ktx>(name, data, content_type);
 	}
 
 	return image;

--- a/framework/scene_graph/components/image.h
+++ b/framework/scene_graph/components/image.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2021, Arm Limited and Contributors
+/* Copyright (c) 2018-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -56,9 +56,23 @@ struct Mipmap
 class Image : public Component
 {
   public:
+	/**
+		 * @brief Type of content held in image.
+		 * This helps to steer the image loaders when deciding what the format should be.
+		 * Some image containers don't know whether the data they contain is sRGB or not.
+		 * Since most applications save color images in sRGB, knowing that an image
+		 * contains color data helps us to better guess its format when unknown.
+		 */
+	enum ContentType
+	{
+		Unknown,
+		Color,
+		Other
+	};
+
 	Image(const std::string &name, std::vector<uint8_t> &&data = {}, std::vector<Mipmap> &&mipmaps = {{}});
 
-	static std::unique_ptr<Image> load(const std::string &name, const std::string &uri);
+	static std::unique_ptr<Image> load(const std::string &name, const std::string &uri, ContentType content_type);
 
 	virtual ~Image() = default;
 
@@ -85,6 +99,8 @@ class Image : public Component
 	const core::Image &get_vk_image() const;
 
 	const core::ImageView &get_vk_image_view() const;
+
+	void coerce_format_to_srgb();
 
   protected:
 	std::vector<uint8_t> &get_mut_data();

--- a/framework/scene_graph/components/image/ktx.h
+++ b/framework/scene_graph/components/image/ktx.h
@@ -26,7 +26,7 @@ namespace sg
 class Ktx : public Image
 {
   public:
-	Ktx(const std::string &name, const std::vector<uint8_t> &data);
+	Ktx(const std::string &name, const std::vector<uint8_t> &data, ContentType content_type);
 
 	virtual ~Ktx() = default;
 };

--- a/framework/scene_graph/components/image/stb.cpp
+++ b/framework/scene_graph/components/image/stb.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,7 +24,7 @@ namespace vkb
 {
 namespace sg
 {
-Stb::Stb(const std::string &name, const std::vector<uint8_t> &data) :
+Stb::Stb(const std::string &name, const std::vector<uint8_t> &data, ContentType content_type) :
     Image{name}
 {
 	int width;
@@ -45,7 +45,7 @@ Stb::Stb(const std::string &name, const std::vector<uint8_t> &data) :
 	set_data(raw_data, width * height * req_comp);
 	stbi_image_free(raw_data);
 
-	set_format(VK_FORMAT_R8G8B8A8_UNORM);
+	set_format(content_type == Color ? VK_FORMAT_R8G8B8A8_SRGB : VK_FORMAT_R8G8B8A8_UNORM);
 	set_width(to_u32(width));
 	set_height(to_u32(height));
 	set_depth(1u);

--- a/framework/scene_graph/components/image/stb.h
+++ b/framework/scene_graph/components/image/stb.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,7 +26,7 @@ namespace sg
 class Stb : public Image
 {
   public:
-	Stb(const std::string &name, const std::vector<uint8_t> &data);
+	Stb(const std::string &name, const std::vector<uint8_t> &data, ContentType content_type);
 
 	virtual ~Stb() = default;
 };

--- a/framework/vulkan_sample.cpp
+++ b/framework/vulkan_sample.cpp
@@ -212,9 +212,7 @@ void VulkanSample::create_instance()
 void VulkanSample::create_render_context(Platform &platform)
 {
 	auto surface_priority_list = std::vector<VkSurfaceFormatKHR>{{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                             {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                             {VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                             {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
+	                                                             {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
 
 	render_context = platform.create_render_context(*device, surface, surface_priority_list);
 }

--- a/samples/api/compute_nbody/compute_nbody.cpp
+++ b/samples/api/compute_nbody/compute_nbody.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -72,8 +72,8 @@ void ComputeNBody::request_gpu_features(vkb::PhysicalDevice &gpu)
 
 void ComputeNBody::load_assets()
 {
-	textures.particle = load_texture("textures/particle_rgba.ktx");
-	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx");
+	textures.particle = load_texture("textures/particle_rgba.ktx", vkb::sg::Image::Color);
+	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void ComputeNBody::build_command_buffers()

--- a/samples/api/hdr/hdr.cpp
+++ b/samples/api/hdr/hdr.cpp
@@ -519,7 +519,7 @@ void HDR::load_assets()
 	models.transforms.push_back(torus_matrix);
 
 	// Load HDR cube map
-	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx");
+	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::sg::Image::Color);
 }
 
 void HDR::setup_descriptor_pool()

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -443,9 +443,9 @@ void HelloTriangle::init_swapchain(Context &context)
 	VkSurfaceFormatKHR format;
 	if (format_count == 1 && formats[0].format == VK_FORMAT_UNDEFINED)
 	{
-		// There is no preferred format, so pick a default one
+		// Always prefer sRGB for display
 		format        = formats[0];
-		format.format = VK_FORMAT_B8G8R8A8_UNORM;
+		format.format = VK_FORMAT_B8G8R8A8_SRGB;
 	}
 	else
 	{
@@ -459,9 +459,9 @@ void HelloTriangle::init_swapchain(Context &context)
 		{
 			switch (candidate.format)
 			{
-				case VK_FORMAT_R8G8B8A8_UNORM:
-				case VK_FORMAT_B8G8R8A8_UNORM:
-				case VK_FORMAT_A8B8G8R8_UNORM_PACK32:
+				case VK_FORMAT_R8G8B8A8_SRGB:
+				case VK_FORMAT_B8G8R8A8_SRGB:
+				case VK_FORMAT_A8B8G8R8_SRGB_PACK32:
 					format = candidate;
 					break;
 
@@ -888,7 +888,7 @@ void HelloTriangle::render_triangle(Context &context, uint32_t swapchain_index)
 
 	// Set clear color values.
 	VkClearValue clear_value;
-	clear_value.color = {{0.1f, 0.1f, 0.2f, 1.0f}};
+	clear_value.color = {{0.004f, 0.004f, 0.008f, 1.0f}};
 
 	// Begin the render pass.
 	VkRenderPassBeginInfo rp_begin{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -888,7 +888,7 @@ void HelloTriangle::render_triangle(Context &context, uint32_t swapchain_index)
 
 	// Set clear color values.
 	VkClearValue clear_value;
-	clear_value.color = {{0.004f, 0.004f, 0.008f, 1.0f}};
+	clear_value.color = {{0.01f, 0.01f, 0.033f, 1.0f}};
 
 	// Begin the render pass.
 	VkRenderPassBeginInfo rp_begin{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};

--- a/samples/api/hlsl_shaders/hlsl_shaders.cpp
+++ b/samples/api/hlsl_shaders/hlsl_shaders.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Sascha Willems
+/* Copyright (c) 2021-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -208,7 +208,7 @@ void HlslShaders::build_command_buffers()
 
 void HlslShaders::load_assets()
 {
-	texture = load_texture("textures/metalplate01_rgba.ktx");
+	texture = load_texture("textures/metalplate01_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void HlslShaders::draw()

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
@@ -75,8 +75,8 @@ void HPPComputeNBody::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 
 void HPPComputeNBody::load_assets()
 {
-	textures.particle = load_texture("textures/particle_rgba.ktx");
-	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx");
+	textures.particle = load_texture("textures/particle_rgba.ktx", vkb::sg::Image::Color);
+	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void HPPComputeNBody::build_command_buffers()

--- a/samples/api/hpp_hdr/hpp_hdr.cpp
+++ b/samples/api/hpp_hdr/hpp_hdr.cpp
@@ -428,7 +428,7 @@ void HPPHDR::load_assets()
 	models.transforms.push_back(torus_matrix);
 
 	// Load HDR cube map
-	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx");
+	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::sg::Image::Color);
 }
 
 void HPPHDR::setup_descriptor_pool()

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -830,7 +830,7 @@ void HPPHelloTriangle::render_triangle(Context &context, uint32_t swapchain_inde
 
 	// Set clear color values.
 	vk::ClearValue clear_value;
-	clear_value.color = vk::ClearColorValue(std::array<float, 4>({{0.004f, 0.004f, 0.008f, 1.0f}}));
+	clear_value.color = vk::ClearColorValue(std::array<float, 4>({{0.01f, 0.01f, 0.033f, 1.0f}}));
 
 	// Begin the render pass.
 	vk::RenderPassBeginInfo rp_begin(context.render_pass, framebuffer, {{0, 0}, {context.swapchain_dimensions.width, context.swapchain_dimensions.height}},

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -433,9 +433,9 @@ void HPPHelloTriangle::init_swapchain(Context &context)
 	vk::SurfaceFormatKHR format;
 	if (formats.size() == 1 && formats[0].format == vk::Format::eUndefined)
 	{
-		// There is no preferred format, so pick a default one
+		// Always prefer sRGB for display
 		format        = formats[0];
-		format.format = vk::Format::eB8G8R8A8Unorm;
+		format.format = vk::Format::eB8G8R8A8Srgb;
 	}
 	else
 	{
@@ -449,9 +449,9 @@ void HPPHelloTriangle::init_swapchain(Context &context)
 		{
 			switch (candidate.format)
 			{
-				case vk::Format::eR8G8B8A8Unorm:
-				case vk::Format::eB8G8R8A8Unorm:
-				case vk::Format::eA8B8G8R8UnormPack32:
+				case vk::Format::eR8G8B8A8Srgb:
+				case vk::Format::eB8G8R8A8Srgb:
+				case vk::Format::eA8B8G8R8SrgbPack32:
 					format = candidate;
 					break;
 
@@ -830,7 +830,7 @@ void HPPHelloTriangle::render_triangle(Context &context, uint32_t swapchain_inde
 
 	// Set clear color values.
 	vk::ClearValue clear_value;
-	clear_value.color = vk::ClearColorValue(std::array<float, 4>({{0.1f, 0.1f, 0.2f, 1.0f}}));
+	clear_value.color = vk::ClearColorValue(std::array<float, 4>({{0.004f, 0.004f, 0.008f, 1.0f}}));
 
 	// Begin the render pass.
 	vk::RenderPassBeginInfo rp_begin(context.render_pass, framebuffer, {{0, 0}, {context.swapchain_dimensions.width, context.swapchain_dimensions.height}},

--- a/samples/api/hpp_hlsl_shaders/hpp_hlsl_shaders.cpp
+++ b/samples/api/hpp_hlsl_shaders/hpp_hlsl_shaders.cpp
@@ -192,7 +192,7 @@ void HPPHlslShaders::build_command_buffers()
 
 void HPPHlslShaders::load_assets()
 {
-	texture = load_texture("textures/metalplate01_rgba.ktx");
+	texture = load_texture("textures/metalplate01_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void HPPHlslShaders::draw()

--- a/samples/api/hpp_instancing/hpp_instancing.cpp
+++ b/samples/api/hpp_instancing/hpp_instancing.cpp
@@ -77,7 +77,7 @@ void HPPInstancing::build_command_buffers()
 	vk::CommandBufferBeginInfo command_buffer_begin_info;
 
 	std::array<vk::ClearValue, 2> clear_values =
-	    {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.008f, 0.0f}})),
+	    {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.033f, 0.0f}})),
 	      vk::ClearDepthStencilValue(0.0f, 0)}};
 
 	vk::RenderPassBeginInfo render_pass_begin_info(render_pass, {}, {{0, 0}, extent}, clear_values);

--- a/samples/api/hpp_instancing/hpp_instancing.cpp
+++ b/samples/api/hpp_instancing/hpp_instancing.cpp
@@ -77,7 +77,7 @@ void HPPInstancing::build_command_buffers()
 	vk::CommandBufferBeginInfo command_buffer_begin_info;
 
 	std::array<vk::ClearValue, 2> clear_values =
-	    {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.2f, 0.0f}})),
+	    {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.008f, 0.0f}})),
 	      vk::ClearDepthStencilValue(0.0f, 0)}};
 
 	vk::RenderPassBeginInfo render_pass_begin_info(render_pass, {}, {{0, 0}, extent}, clear_values);
@@ -136,8 +136,8 @@ void HPPInstancing::load_assets()
 	models.rock   = load_model("scenes/rock.gltf");
 	models.planet = load_model("scenes/planet.gltf");
 
-	textures.rocks  = load_texture_array("textures/texturearray_rocks_color_rgba.ktx");
-	textures.planet = load_texture("textures/lavaplanet_color_rgba.ktx");
+	textures.rocks  = load_texture_array("textures/texturearray_rocks_color_rgba.ktx", vkb::sg::Image::Color);
+	textures.planet = load_texture("textures/lavaplanet_color_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void HPPInstancing::setup_descriptor_pool()

--- a/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
+++ b/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
@@ -351,12 +351,12 @@ void HPPTerrainTessellation::load_assets()
 {
 	skysphere = load_model("scenes/geosphere.gltf");
 
-	textures.skysphere = load_texture("textures/skysphere_rgba.ktx");
+	textures.skysphere = load_texture("textures/skysphere_rgba.ktx", vkb::sg::Image::Color);
 	// Terrain textures are stored in a texture array with layers corresponding to terrain height
-	textures.terrain_array = load_texture_array("textures/terrain_texturearray_rgba.ktx");
+	textures.terrain_array = load_texture_array("textures/terrain_texturearray_rgba.ktx", vkb::sg::Image::Color);
 
 	// Height data is stored in a one-channel texture
-	textures.heightmap = load_texture("textures/terrain_heightmap_r16.ktx");
+	textures.heightmap = load_texture("textures/terrain_heightmap_r16.ktx", vkb::sg::Image::Other);
 
 	// Setup a mirroring sampler for the height map
 	vk::SamplerCreateInfo sampler_create_info;

--- a/samples/api/hpp_texture_loading/hpp_texture_loading.cpp
+++ b/samples/api/hpp_texture_loading/hpp_texture_loading.cpp
@@ -81,8 +81,8 @@ void HPPTextureLoading::load_texture()
 {
 	// We use the Khronos texture format (https://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/)
 	std::string filename = vkb::fs::path::get(vkb::fs::path::Assets, "textures/metalplate01_rgba.ktx");
-	// Texture data contains 4 channels (RGBA) with unnormalized 8-bit values, this is the most commonly supported format
-	vk::Format format = vk::Format::eR8G8B8A8Unorm;
+	// ktx1 doesn't know whether the content is sRGB or linear, but most tools save in sRGB, so assume that.
+	vk::Format format = vk::Format::eR8G8B8A8Srgb;
 
 	ktxTexture *   ktx_texture;
 	KTX_error_code result = ktxTexture_CreateFromNamedFile(filename.c_str(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, &ktx_texture);

--- a/samples/api/instancing/instancing.cpp
+++ b/samples/api/instancing/instancing.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -73,7 +73,7 @@ void Instancing::build_command_buffers()
 	VkCommandBufferBeginInfo command_buffer_begin_info = vkb::initializers::command_buffer_begin_info();
 
 	VkClearValue clear_values[2];
-	clear_values[0].color        = {{0.0f, 0.0f, 0.2f, 0.0f}};
+	clear_values[0].color        = {{0.0f, 0.0f, 0.008f, 0.0f}};
 	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
@@ -143,8 +143,8 @@ void Instancing::load_assets()
 	//models.rock.loadFromFile(getAssetPath() + "scenes/rock.gltf", device.get(), queue);
 	//models.planet.loadFromFile(getAssetPath() + "scenes/planet.gltf", device.get(), queue);
 
-	textures.rocks  = load_texture_array("textures/texturearray_rocks_color_rgba.ktx");
-	textures.planet = load_texture("textures/lavaplanet_color_rgba.ktx");
+	textures.rocks  = load_texture_array("textures/texturearray_rocks_color_rgba.ktx", vkb::sg::Image::Color);
+	textures.planet = load_texture("textures/lavaplanet_color_rgba.ktx", vkb::sg::Image::Color);
 
 	//textures.rocks.loadFromFile(getAssetPath() + "textures/texturearray_rocks_color_rgba.ktx", device.get(), queue);
 	//textures.planet.loadFromFile(getAssetPath() + "textures/lavaplanet_color_rgba.ktx", device.get(), queue);

--- a/samples/api/instancing/instancing.cpp
+++ b/samples/api/instancing/instancing.cpp
@@ -73,7 +73,7 @@ void Instancing::build_command_buffers()
 	VkCommandBufferBeginInfo command_buffer_begin_info = vkb::initializers::command_buffer_begin_info();
 
 	VkClearValue clear_values[2];
-	clear_values[0].color        = {{0.0f, 0.0f, 0.008f, 0.0f}};
+	clear_values[0].color        = {{0.0f, 0.0f, 0.033f, 0.0f}};
 	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();

--- a/samples/api/separate_image_sampler/separate_image_sampler.cpp
+++ b/samples/api/separate_image_sampler/separate_image_sampler.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Sascha Willems
+/* Copyright (c) 2021-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -150,7 +150,7 @@ void SeparateImageSampler::setup_samplers()
 
 void SeparateImageSampler::load_assets()
 {
-	texture = load_texture("textures/metalplate01_rgba.ktx");
+	texture = load_texture("textures/metalplate01_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void SeparateImageSampler::draw()

--- a/samples/api/terrain_tessellation/terrain_tessellation.cpp
+++ b/samples/api/terrain_tessellation/terrain_tessellation.cpp
@@ -152,12 +152,12 @@ void TerrainTessellation::load_assets()
 {
 	skysphere = load_model("scenes/geosphere.gltf");
 
-	textures.skysphere = load_texture("textures/skysphere_rgba.ktx");
+	textures.skysphere = load_texture("textures/skysphere_rgba.ktx", vkb::sg::Image::Color);
 	// Terrain textures are stored in a texture array with layers corresponding to terrain height
-	textures.terrain_array = load_texture_array("textures/terrain_texturearray_rgba.ktx");
+	textures.terrain_array = load_texture_array("textures/terrain_texturearray_rgba.ktx", vkb::sg::Image::Color);
 
 	// Height data is stored in a one-channel texture
-	textures.heightmap = load_texture("textures/terrain_heightmap_r16.ktx");
+	textures.heightmap = load_texture("textures/terrain_heightmap_r16.ktx", vkb::sg::Image::Other);
 
 	VkSamplerCreateInfo sampler_create_info = vkb::initializers::sampler_create_info();
 

--- a/samples/api/texture_loading/texture_loading.cpp
+++ b/samples/api/texture_loading/texture_loading.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -79,8 +79,8 @@ void TextureLoading::load_texture()
 {
 	// We use the Khronos texture format (https://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/)
 	std::string filename = vkb::fs::path::get(vkb::fs::path::Assets, "textures/metalplate01_rgba.ktx");
-	// Texture data contains 4 channels (RGBA) with unnormalized 8-bit values, this is the most commonly supported format
-	VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+	// ktx1 doesn't know whether the content is sRGB or linear, but most tools save in sRGB, so assume that.
+	VkFormat format = VK_FORMAT_R8G8B8A8_SRGB;
 
 	ktxTexture *   ktx_texture;
 	KTX_error_code result;

--- a/samples/api/texture_mipmap_generation/texture_mipmap_generation.cpp
+++ b/samples/api/texture_mipmap_generation/texture_mipmap_generation.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -59,7 +59,8 @@ void TextureMipMapGeneration::request_gpu_features(vkb::PhysicalDevice &gpu)
 */
 void TextureMipMapGeneration::load_texture_generate_mipmaps(std::string file_name)
 {
-	VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+	// ktx1 doesn't know whether the content is sRGB or linear, but most tools save in sRGB, so assume that.
+	VkFormat format = VK_FORMAT_R8G8B8A8_SRGB;
 
 	ktxTexture *   ktx_texture;
 	KTX_error_code result;

--- a/samples/extensions/buffer_device_address/buffer_device_address.cpp
+++ b/samples/extensions/buffer_device_address/buffer_device_address.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Arm Limited and Contributors
+/* Copyright (c) 2021-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -389,9 +389,9 @@ void BufferDeviceAddress::render(float delta_time)
 	render_pass_begin.renderArea.extent.height = height;
 	render_pass_begin.clearValueCount          = 2;
 	VkClearValue clears[2]                     = {};
-	clears[0].color.float32[0]                 = 0.2f;
-	clears[0].color.float32[1]                 = 0.3f;
-	clears[0].color.float32[2]                 = 0.4f;
+	clears[0].color.float32[0]                 = 0.06f;
+	clears[0].color.float32[1]                 = 0.09f;
+	clears[0].color.float32[2]                 = 0.12f;
 	render_pass_begin.pClearValues             = clears;
 	render_pass_begin.framebuffer              = framebuffers[current_buffer];
 

--- a/samples/extensions/buffer_device_address/buffer_device_address.cpp
+++ b/samples/extensions/buffer_device_address/buffer_device_address.cpp
@@ -389,9 +389,9 @@ void BufferDeviceAddress::render(float delta_time)
 	render_pass_begin.renderArea.extent.height = height;
 	render_pass_begin.clearValueCount          = 2;
 	VkClearValue clears[2]                     = {};
-	clears[0].color.float32[0]                 = 0.06f;
-	clears[0].color.float32[1]                 = 0.09f;
-	clears[0].color.float32[2]                 = 0.12f;
+	clears[0].color.float32[0]                 = 0.033f;
+	clears[0].color.float32[1]                 = 0.073f;
+	clears[0].color.float32[2]                 = 0.133f;
 	render_pass_begin.pClearValues             = clears;
 	render_pass_begin.framebuffer              = framebuffers[current_buffer];
 

--- a/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
+++ b/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -257,7 +257,7 @@ void ConservativeRasterization::build_command_buffers()
 		// First render pass: Render a low res triangle to an offscreen framebuffer to use for visualization in second pass
 		{
 			VkClearValue clear_values[2];
-			clear_values[0].color        = {{0.25f, 0.25f, 0.25f, 0.0f}};
+			clear_values[0].color        = {{0.05f, 0.05f, 0.05f, 0.0f}};
 			clear_values[1].depthStencil = {0.0f, 0};
 
 			VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
@@ -293,7 +293,7 @@ void ConservativeRasterization::build_command_buffers()
 		// Second render pass: Render scene with conservative rasterization
 		{
 			VkClearValue clear_values[2];
-			clear_values[0].color        = {{0.25f, 0.25f, 0.25f, 0.25f}};
+			clear_values[0].color        = {{0.05f, 0.05f, 0.05f, 0.25f}};
 			clear_values[1].depthStencil = {0.0f, 0};
 
 			VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();

--- a/samples/extensions/debug_utils/debug_utils.cpp
+++ b/samples/extensions/debug_utils/debug_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Sascha Willems
+/* Copyright (c) 2020-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -536,8 +536,7 @@ void DebugUtils::prepare_offscreen_buffer()
 		offscreen.width  = width;
 		offscreen.height = height;
 
-		// Color attachments
-
+		// Color attachments (in linear colorspace)
 		create_attachment(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &offscreen.color[0]);
 		create_attachment(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &offscreen.color[1]);
 		// Depth attachment
@@ -738,7 +737,7 @@ void DebugUtils::prepare_offscreen_buffer()
 void DebugUtils::load_assets()
 {
 	models.skysphere   = load_model("scenes/geosphere.gltf");
-	textures.skysphere = load_texture("textures/skysphere_rgba.ktx");
+	textures.skysphere = load_texture("textures/skysphere_rgba.ktx", vkb::sg::Image::Color);
 	models.scene       = load_model("scenes/geosphere.gltf");
 }
 

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Arm Limited and Contributors
+/* Copyright (c) 2021-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -84,9 +84,9 @@ void DescriptorIndexing::render(float delta_time)
 	render_pass_begin.renderArea.extent.height = height;
 	render_pass_begin.clearValueCount          = 2;
 	VkClearValue clears[2]                     = {};
-	clears[0].color.float32[0]                 = 0.2f;
-	clears[0].color.float32[1]                 = 0.3f;
-	clears[0].color.float32[2]                 = 0.4f;
+	clears[0].color.float32[0]                 = 0.06f;
+	clears[0].color.float32[1]                 = 0.09f;
+	clears[0].color.float32[2]                 = 0.12f;
 	render_pass_begin.pClearValues             = clears;
 	render_pass_begin.framebuffer              = framebuffers[current_buffer];
 
@@ -316,6 +316,8 @@ void DescriptorIndexing::create_pipelines()
 DescriptorIndexing::TestImage DescriptorIndexing::create_image(const float rgb[3], unsigned image_seed)
 {
 	// Fairly basic setup, generate some random textures so we can visualize that we are sampling many different textures.
+	// Note: since we're creating the texture data ourselves, it will already be in linear colorspace so we set the format
+	// as unorm, not sRGB.
 	DescriptorIndexing::TestImage test_image;
 
 	VkImageCreateInfo image_info = vkb::initializers::image_create_info();

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -84,9 +84,9 @@ void DescriptorIndexing::render(float delta_time)
 	render_pass_begin.renderArea.extent.height = height;
 	render_pass_begin.clearValueCount          = 2;
 	VkClearValue clears[2]                     = {};
-	clears[0].color.float32[0]                 = 0.06f;
-	clears[0].color.float32[1]                 = 0.09f;
-	clears[0].color.float32[2]                 = 0.12f;
+	clears[0].color.float32[0]                 = 0.033f;
+	clears[0].color.float32[1]                 = 0.073f;
+	clears[0].color.float32[2]                 = 0.133f;
 	render_pass_begin.pClearValues             = clears;
 	render_pass_begin.framebuffer              = framebuffers[current_buffer];
 

--- a/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
+++ b/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Holochip Corporation
+ * Copyright (c) 2021-2022, Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -110,7 +110,7 @@ void DynamicRendering::load_assets()
 	object = load_model("scenes/geosphere.gltf");
 
 	// Load HDR cube map
-	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx");
+	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::sg::Image::Color);
 }
 
 void DynamicRendering::prepare_uniform_buffers()

--- a/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
+++ b/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Sascha Willems
+/* Copyright (c) 2020-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -498,9 +498,9 @@ void FragmentShadingRate::build_command_buffers()
 void FragmentShadingRate::load_assets()
 {
 	models.skysphere   = load_model("scenes/geosphere.gltf");
-	textures.skysphere = load_texture("textures/skysphere_rgba.ktx");
+	textures.skysphere = load_texture("textures/skysphere_rgba.ktx", vkb::sg::Image::Color);
 	models.scene       = load_model("scenes/textured_unit_cube.gltf");
-	textures.scene     = load_texture("textures/metalplate01_rgba.ktx");
+	textures.scene     = load_texture("textures/metalplate01_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void FragmentShadingRate::setup_descriptor_pool()

--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Holochip
+/* Copyright (c) 2021-2022, Holochip
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -620,9 +620,9 @@ void FragmentShadingRateDynamic::build_command_buffers()
 void FragmentShadingRateDynamic::load_assets()
 {
 	models.skysphere   = load_model("scenes/geosphere.gltf");
-	textures.skysphere = load_texture("textures/skysphere_rgba.ktx");
+	textures.skysphere = load_texture("textures/skysphere_rgba.ktx", vkb::sg::Image::Color);
 	models.scene       = load_model("scenes/textured_unit_cube.gltf");
-	textures.scene     = load_texture("textures/vulkan_logo_full.ktx");
+	textures.scene     = load_texture("textures/vulkan_logo_full.ktx", vkb::sg::Image::Color);
 }
 
 void FragmentShadingRateDynamic::setup_descriptor_pool()

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
@@ -92,7 +92,7 @@ void GraphicsPipelineLibrary::build_command_buffers()
 	VkCommandBufferBeginInfo command_buffer_begin_info = vkb::initializers::command_buffer_begin_info();
 
 	VkClearValue clear_values[2];
-	clear_values[0].color        = {{0.0f, 0.0f, 0.2f, 0.0f}};
+	clear_values[0].color        = {{0.0f, 0.0f, 0.03f, 0.0f}};
 	clear_values[1].depthStencil = {1.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info = vkb::initializers::render_pass_begin_info();

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
@@ -92,7 +92,7 @@ void GraphicsPipelineLibrary::build_command_buffers()
 	VkCommandBufferBeginInfo command_buffer_begin_info = vkb::initializers::command_buffer_begin_info();
 
 	VkClearValue clear_values[2];
-	clear_values[0].color        = {{0.0f, 0.0f, 0.03f, 0.0f}};
+	clear_values[0].color        = {{0.0f, 0.0f, 0.033f, 0.0f}};
 	clear_values[1].depthStencil = {1.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info = vkb::initializers::render_pass_begin_info();

--- a/samples/extensions/portability/portability.cpp
+++ b/samples/extensions/portability/portability.cpp
@@ -318,8 +318,7 @@ void Portability::prepare_offscreen_buffer()
 		offscreen.width  = static_cast<int32_t>(width);
 		offscreen.height = static_cast<int32_t>(height);
 
-		// Color attachments
-
+		// Color attachments (in linear colorspace)
 		create_attachment(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &offscreen.color[0]);
 		create_attachment(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &offscreen.color[1]);
 		// Depth attachment
@@ -520,7 +519,7 @@ void Portability::prepare_offscreen_buffer()
 void Portability::load_assets()
 {
 	models.skysphere   = load_model("scenes/geosphere.gltf");
-	textures.skysphere = load_texture("textures/skysphere_rgba.ktx");
+	textures.skysphere = load_texture("textures/skysphere_rgba.ktx", vkb::sg::Image::Color);
 	models.scene       = load_model("scenes/geosphere.gltf");
 }
 

--- a/samples/extensions/push_descriptors/push_descriptors.cpp
+++ b/samples/extensions/push_descriptors/push_descriptors.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
 *
 * SPDX-License-Identifier: Apache-2.0
 *
@@ -158,8 +158,8 @@ void PushDescriptors::build_command_buffers()
 void PushDescriptors::load_assets()
 {
 	models.cube      = load_model("scenes/textured_unit_cube.gltf");
-	cubes[0].texture = load_texture("textures/crate01_color_height_rgba.ktx");
-	cubes[1].texture = load_texture("textures/crate02_color_height_rgba.ktx");
+	cubes[0].texture = load_texture("textures/crate01_color_height_rgba.ktx", vkb::sg::Image::Color);
+	cubes[1].texture = load_texture("textures/crate02_color_height_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void PushDescriptors::setup_descriptor_set_layout()

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * SPDX-FileCopyrightText: Copyright (c) 2014-2021 NVIDIA CORPORATION
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2022 NVIDIA CORPORATION
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -908,7 +908,7 @@ void RaytracingReflection::build_command_buffers()
 			Start a new render pass to draw the UI overlay on top of the ray traced image
 		*/
 		VkClearValue clear_values[2];
-		clear_values[0].color        = {{0.0f, 0.0f, 0.2f, 0.0f}};
+		clear_values[0].color        = {{0.0f, 0.0f, 0.03f, 0.0f}};
 		clear_values[1].depthStencil = {0.0f, 0};
 
 		VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
@@ -908,7 +908,7 @@ void RaytracingReflection::build_command_buffers()
 			Start a new render pass to draw the UI overlay on top of the ray traced image
 		*/
 		VkClearValue clear_values[2];
-		clear_values[0].color        = {{0.0f, 0.0f, 0.03f, 0.0f}};
+		clear_values[0].color        = {{0.0f, 0.0f, 0.033f, 0.0f}};
 		clear_values[1].depthStencil = {0.0f, 0};
 
 		VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();

--- a/samples/extensions/raytracing_basic/raytracing_basic.cpp
+++ b/samples/extensions/raytracing_basic/raytracing_basic.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -785,7 +785,7 @@ void RaytracingBasic::build_command_buffers()
 			Start a new render pass to draw the UI overlay on top of the ray traced image
 		*/
 		VkClearValue clear_values[2];
-		clear_values[0].color        = {{0.0f, 0.0f, 0.2f, 0.0f}};
+		clear_values[0].color        = {{0.0f, 0.0f, 0.03f, 0.0f}};
 		clear_values[1].depthStencil = {0.0f, 0};
 
 		VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();

--- a/samples/extensions/raytracing_basic/raytracing_basic.cpp
+++ b/samples/extensions/raytracing_basic/raytracing_basic.cpp
@@ -785,7 +785,7 @@ void RaytracingBasic::build_command_buffers()
 			Start a new render pass to draw the UI overlay on top of the ray traced image
 		*/
 		VkClearValue clear_values[2];
-		clear_values[0].color        = {{0.0f, 0.0f, 0.03f, 0.0f}};
+		clear_values[0].color        = {{0.0f, 0.0f, 0.033f, 0.0f}};
 		clear_values[1].depthStencil = {0.0f, 0};
 
 		VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();

--- a/samples/extensions/raytracing_extended/raytracing_extended.cpp
+++ b/samples/extensions/raytracing_extended/raytracing_extended.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 Holochip Corporation
+/* Copyright (c) 2021-2022 Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -217,7 +217,7 @@ uint64_t RaytracingExtended::get_buffer_device_address(VkBuffer buffer)
 
 void RaytracingExtended::create_flame_model()
 {
-	flame_texture                   = load_texture("textures/generated_flame.ktx");
+	flame_texture                   = load_texture("textures/generated_flame.ktx", vkb::sg::Image::Color);
 	std::vector<glm::vec3> pts_     = {{0, 0, 0},
                                    {1, 0, 0},
                                    {1, 1, 0},

--- a/samples/extensions/synchronization_2/synchronization_2.cpp
+++ b/samples/extensions/synchronization_2/synchronization_2.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Sascha Willems
+/* Copyright (c) 2021-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -78,8 +78,8 @@ void Synchronization2::request_gpu_features(vkb::PhysicalDevice &gpu)
 
 void Synchronization2::load_assets()
 {
-	textures.particle = load_texture("textures/particle_rgba.ktx");
-	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx");
+	textures.particle = load_texture("textures/particle_rgba.ktx", vkb::sg::Image::Color);
+	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void Synchronization2::build_command_buffers()

--- a/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
+++ b/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
@@ -654,9 +654,9 @@ void TimelineSemaphore::render(float delta_time)
 	render_pass_begin.renderArea.extent.height = height;
 	render_pass_begin.clearValueCount          = 2;
 	VkClearValue clears[2]                     = {};
-	clears[0].color.float32[0]                 = 0.06f;
-	clears[0].color.float32[1]                 = 0.09f;
-	clears[0].color.float32[2]                 = 0.12f;
+	clears[0].color.float32[0]                 = 0.033f;
+	clears[0].color.float32[1]                 = 0.073f;
+	clears[0].color.float32[2]                 = 0.133f;
 	render_pass_begin.pClearValues             = clears;
 	render_pass_begin.framebuffer              = framebuffers[current_buffer];
 

--- a/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
+++ b/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Arm Limited and Contributors
+/* Copyright (c) 2021-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -654,9 +654,9 @@ void TimelineSemaphore::render(float delta_time)
 	render_pass_begin.renderArea.extent.height = height;
 	render_pass_begin.clearValueCount          = 2;
 	VkClearValue clears[2]                     = {};
-	clears[0].color.float32[0]                 = 0.2f;
-	clears[0].color.float32[1]                 = 0.3f;
-	clears[0].color.float32[2]                 = 0.4f;
+	clears[0].color.float32[0]                 = 0.06f;
+	clears[0].color.float32[1]                 = 0.09f;
+	clears[0].color.float32[2]                 = 0.12f;
 	render_pass_begin.pClearValues             = clears;
 	render_pass_begin.framebuffer              = framebuffers[current_buffer];
 

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -314,7 +314,7 @@ void MultiDrawIndirect::load_scene()
 		const size_t texture_index = textures.size();
 		const auto & short_name    = mesh->get_name();
 		auto         image_name    = scene_path + short_name + ".ktx";
-		auto         image         = vkb::sg::Image::load(image_name, image_name);
+		auto         image         = vkb::sg::Image::load(image_name, image_name, vkb::sg::Image::Color);
 
 		image->create_vk_image(*device);
 		Texture texture;

--- a/samples/performance/texture_compression_basisu/texture_compression_basisu.cpp
+++ b/samples/performance/texture_compression_basisu/texture_compression_basisu.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Sascha Willems
+/* Copyright (c) 2021-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -347,7 +347,7 @@ void TextureCompressionBasisu::build_command_buffers()
 	VkCommandBufferBeginInfo command_buffer_begin_info = vkb::initializers::command_buffer_begin_info();
 
 	VkClearValue clear_values[2];
-	clear_values[0].color        = {{0.25f, 0.25f, 0.25f, 1.0f}};
+	clear_values[0].color        = {{0.05f, 0.05f, 0.05f, 1.0f}};
 	clear_values[1].depthStencil = {0.0f, 0};
 
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();

--- a/shaders/dynamic_rendering/gbuffer.frag
+++ b/shaders/dynamic_rendering/gbuffer.frag
@@ -1,5 +1,5 @@
 #version 450
-/* Copyright (c) 2021, Holochip
+/* Copyright (c) 2021-2022, Holochip
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -74,7 +74,8 @@ void main()
 				fresnel *= (1.0 - F0);
 				fresnel += F0;
 		
-				float spec = (fresnel * geoAtt) / (NdotV * NdotL * 3.14);
+				// Note: clamp to zero to mitigate any divide by zero
+				float spec = max((fresnel * geoAtt) / (NdotV * NdotL * 3.14), 0.0);
  
 				color = texture(samplerEnvMap, reflect(-wViewVec, wNormal));	 	
 

--- a/shaders/hdr/gbuffer.frag
+++ b/shaders/hdr/gbuffer.frag
@@ -1,5 +1,5 @@
 #version 450
-/* Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -78,7 +78,8 @@ void main()
 				fresnel *= (1.0 - F0);
 				fresnel += F0;
 		
-				float spec = (fresnel * geoAtt) / (NdotV * NdotL * 3.14);
+				// Note: clamp to zero to mitigate any divide by zero
+				float spec = max((fresnel * geoAtt) / (NdotV * NdotL * 3.14), 0.0);
  
 				color = texture(samplerEnvMap, reflect(-wViewVec, wNormal));	 	
 

--- a/shaders/terrain_tessellation/terrain.frag
+++ b/shaders/terrain_tessellation/terrain.frag
@@ -36,8 +36,8 @@ vec3 sampleTerrainLayer()
 	layers[1] = vec2(5.0, 45.0);
 	layers[2] = vec2(45.0, 80.0);
 	layers[3] = vec2(75.0, 100.0);
-	layers[4] = vec2(95.0, 140.0);
-	layers[5] = vec2(140.0, 190.0);
+	layers[4] = vec2(95.0, 150.0);
+	layers[5] = vec2(140.0, 290.0);
 
 	vec3 color = vec3(0.0);
 	

--- a/shaders/terrain_tessellation/terrain.frag
+++ b/shaders/terrain_tessellation/terrain.frag
@@ -1,5 +1,5 @@
 #version 450
-/* Copyright (c) 2019, Sascha Willems
+/* Copyright (c) 2019-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/shaders/texture_compression_basisu/texture.frag
+++ b/shaders/texture_compression_basisu/texture.frag
@@ -1,5 +1,5 @@
 #version 450
-/* Copyright (c) 2021, Sascha Willems
+/* Copyright (c) 2021-2022, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,10 +22,7 @@ layout (location = 0) in vec2 inUV;
 
 layout (location = 0) out vec4 outFragColor;
 
-void main() 
+void main()
 {
-	vec4 color = texture(samplerColor, inUV);
-	// All images are stored in SRGB color space, the sample uses a linear color space, so we need to apply a gamma correction
-	outFragColor.rgb = pow(color.rgb, vec3(1.0/2.2));
-	outFragColor.a = color.a;
+	outFragColor = texture(samplerColor, inUV);
 }


### PR DESCRIPTION
## Description

Most displays expect to receive sRGB encoded data. This change ensures that all of the samples request sRGB swapchain images. The GPU hardware will then ensure that the linear result of the fragment shader is automatically converted to non-linear sRGB when written to the swapchain.

The performance samples were already selecting sRGB as the priority format, but the API samples were not.

I've removed the UNORM formats from the swapchain format priority lists as it doesn't make much sense to have a UNORM swapchain image unless you want to manually convert to sRGB at the end of your fragment shaders.

Textures that are in UNORM formats are treated as already being linearly encoded and enter the shaders unaltered. SRGB texture values are converted by the GPU into linear space before being seen by shaders. This ensures that the shaders are doing
computations on linear data at all times.

Most image authoring tools will write the data encoded in sRGB. Some file formats don't record a colorspace within them though. In the cases where the disk file doesn't know the encoding the code now assumes that the data is sRGB encoded if, and only if, that image is going to be used as a color texture. For that reason, I needed to pass the intended content of an image down to the loaders. For image formats that know their colorspace, this is preserved.

The gltf loader has been modified slightly. The gltf spec is very clear about which images must be encoded as sRGB and which have to be linear. That knowledge is now in the loader, so the texture images are given the correct format during loading if it's not known from the image file.

I've modified some of the clear colors in the API samples to convert them into linear space. Previously they were effectively in sRGB space since the swapchain was unorm. This ensures that the clear color looks close to how it did previously.

After moving to sRGB output I noticed that the 'hdr' and 'dynamic_rendering' samples had some odd 'always white' areas. Debugging tracked the cause of this down to our h/w handling the clamping of Nan/Inf slightly differently for sRGB than unorms. I traced the root cause of Nan/Inf being produced by these fragment shaders for these samples and fixed it.

To summarise, the samples should now be doing this:

For textures that contain color data:
`sRGB texture -> GPU-conv -> linear shading -> GPU-conv -> sRGB swapchain -> display`

For textures that contain linear data (e.g. normals):
`unorm texture -> linear shading -> GPU-conv -> sRGB swapchain -> display`

Fixes #516

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions] - **only tested on Linux**
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly - **every sample that my h/w supports**
- [x] This PR describes the scope and expected impact of the changes I am making