### PR TITLE
Change vkb::core::HPPCommandPool from a facade over vkb::CommandPool to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -279,6 +279,7 @@ set(CORE_FILES
     core/acceleration_structure.cpp
     core/shader_binding_table.cpp
     core/vulkan_resource.cpp
+    core/hpp_command_pool.cpp
     core/hpp_device.cpp
     core/hpp_instance.cpp
     core/hpp_physical_device.cpp

--- a/framework/core/hpp_command_buffer.h
+++ b/framework/core/hpp_command_buffer.h
@@ -26,6 +26,8 @@ namespace vkb
 {
 namespace core
 {
+class HPPCommandPool;
+
 /**
  * @brief facade class around vkb::CommandBuffer, providing a vulkan.hpp-based interface
  *
@@ -43,6 +45,10 @@ class HPPCommandBuffer : private vkb::CommandBuffer
 		AlwaysAllocate,
 	};
 
+	HPPCommandBuffer(HPPCommandPool &command_pool, vk::CommandBufferLevel level) :
+	    vkb::CommandBuffer(reinterpret_cast<vkb::CommandPool &>(command_pool), static_cast<VkCommandBufferLevel>(level))
+	{}
+
 	vk::CommandBuffer get_handle() const
 	{
 		return static_cast<vk::CommandBuffer>(vkb::CommandBuffer::get_handle());
@@ -52,6 +58,15 @@ class HPPCommandBuffer : private vkb::CommandBuffer
 	{
 		vkb::CommandBuffer::image_memory_barrier(reinterpret_cast<vkb::core::ImageView const &>(image_view),
 		                                         reinterpret_cast<vkb::ImageMemoryBarrier const &>(memory_barrier));
+	}
+
+	void reset(ResetMode reset_mode)
+	{
+		VkResult result = vkb::CommandBuffer::reset(static_cast<CommandBuffer::ResetMode>(reset_mode));
+		if (result != VK_SUCCESS)
+		{
+			throw std::runtime_error("vkCommandBufferReset failed with errorCode " + vk::to_string(static_cast<vk::Result>(result)));
+		}
 	}
 };
 }        // namespace core

--- a/framework/core/hpp_command_pool.cpp
+++ b/framework/core/hpp_command_pool.cpp
@@ -1,0 +1,174 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core/hpp_command_pool.h>
+#include <core/hpp_device.h>
+
+namespace vkb
+{
+namespace core
+{
+HPPCommandPool::HPPCommandPool(
+    HPPDevice const &d, uint32_t queue_family_index, HPPRenderFrame const *render_frame, size_t thread_index, HPPCommandBuffer::ResetMode reset_mode) :
+    device{d}, render_frame{render_frame}, thread_index{thread_index}, reset_mode{reset_mode}
+{
+	vk::CommandPoolCreateFlags flags;
+	switch (reset_mode)
+	{
+		case HPPCommandBuffer::ResetMode::ResetIndividually:
+		case HPPCommandBuffer::ResetMode::AlwaysAllocate:
+			flags = vk::CommandPoolCreateFlagBits::eResetCommandBuffer;
+			break;
+		case HPPCommandBuffer::ResetMode::ResetPool:
+		default:
+			flags = vk::CommandPoolCreateFlagBits::eTransient;
+			break;
+	}
+
+	vk::CommandPoolCreateInfo command_pool_create_info(flags, queue_family_index);
+
+	handle = device.get_handle().createCommandPool(command_pool_create_info);
+}
+
+HPPCommandPool::HPPCommandPool(HPPCommandPool &&other) :
+    device(other.device),
+    handle(std::exchange(other.handle, {})),
+    queue_family_index(std::exchange(other.queue_family_index, {})),
+    primary_command_buffers{std::move(other.primary_command_buffers)},
+    active_primary_command_buffer_count(std::exchange(other.active_primary_command_buffer_count, {})),
+    secondary_command_buffers{std::move(other.secondary_command_buffers)},
+    active_secondary_command_buffer_count(std::exchange(other.active_secondary_command_buffer_count, {})),
+    render_frame(std::exchange(other.render_frame, {})),
+    thread_index(std::exchange(other.thread_index, {})),
+    reset_mode(std::exchange(other.reset_mode, {}))
+{
+}
+
+HPPCommandPool::~HPPCommandPool()
+{
+	// clear command buffers before destroying the command pool
+	primary_command_buffers.clear();
+	secondary_command_buffers.clear();
+
+	// Destroy command pool
+	if (handle)
+	{
+		device.get_handle().destroyCommandPool(handle);
+	}
+}
+
+HPPDevice const &HPPCommandPool::get_device() const
+{
+	return device;
+}
+
+vk::CommandPool HPPCommandPool::get_handle() const
+{
+	return handle;
+}
+
+uint32_t HPPCommandPool::get_queue_family_index() const
+{
+	return queue_family_index;
+}
+
+HPPRenderFrame const *HPPCommandPool::get_render_frame() const
+{
+	return render_frame;
+}
+
+size_t HPPCommandPool::get_thread_index() const
+{
+	return thread_index;
+}
+
+void HPPCommandPool::reset_pool()
+{
+	switch (reset_mode)
+	{
+		case HPPCommandBuffer::ResetMode::ResetIndividually:
+			reset_command_buffers();
+			break;
+
+		case HPPCommandBuffer::ResetMode::ResetPool:
+			device.get_handle().resetCommandPool(handle);
+			reset_command_buffers();
+			break;
+
+		case HPPCommandBuffer::ResetMode::AlwaysAllocate:
+			primary_command_buffers.clear();
+			active_primary_command_buffer_count = 0;
+			secondary_command_buffers.clear();
+			active_secondary_command_buffer_count = 0;
+			break;
+
+		default:
+			throw std::runtime_error("Unknown reset mode for command pools");
+	}
+}
+
+HPPCommandBuffer const &HPPCommandPool::request_command_buffer(vk::CommandBufferLevel level)
+{
+	if (level == vk::CommandBufferLevel::ePrimary)
+	{
+		if (active_primary_command_buffer_count < primary_command_buffers.size())
+		{
+			return *primary_command_buffers[active_primary_command_buffer_count++];
+		}
+
+		primary_command_buffers.emplace_back(std::make_unique<HPPCommandBuffer>(*this, level));
+
+		active_primary_command_buffer_count++;
+
+		return *primary_command_buffers.back();
+	}
+	else
+	{
+		if (active_secondary_command_buffer_count < secondary_command_buffers.size())
+		{
+			return *secondary_command_buffers[active_secondary_command_buffer_count++];
+		}
+
+		secondary_command_buffers.emplace_back(std::make_unique<HPPCommandBuffer>(*this, level));
+
+		active_secondary_command_buffer_count++;
+
+		return *secondary_command_buffers.back();
+	}
+}
+
+HPPCommandBuffer::ResetMode HPPCommandPool::get_reset_mode() const
+{
+	return reset_mode;
+}
+
+void HPPCommandPool::reset_command_buffers()
+{
+	for (auto &cmd_buf : primary_command_buffers)
+	{
+		cmd_buf->reset(reset_mode);
+	}
+	active_primary_command_buffer_count = 0;
+
+	for (auto &cmd_buf : secondary_command_buffers)
+	{
+		cmd_buf->reset(reset_mode);
+	}
+	active_secondary_command_buffer_count = 0;
+}
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_command_pool.h
+++ b/framework/core/hpp_command_pool.h
@@ -17,46 +17,53 @@
 
 #pragma once
 
-#include <core/command_pool.h>
+#include <core/hpp_command_buffer.h>
 
 namespace vkb
 {
-namespace rendering
-{
-class HPPRenderFrame;
-}
-
 namespace core
 {
-/**
- * @brief facade class around vkb::CommandPool, providing a vulkan.hpp-based interface
- *
- * See vkb::CommandPool for documentation
- */
-class HPPCommandPool : private vkb::CommandPool
+class HPPDevice;
+class HPPRenderFrame;
+
+class HPPCommandPool
 {
   public:
-	HPPCommandPool(vkb::core::HPPDevice &                 device,
-	               uint32_t                               queue_family_index,
-	               vkb::rendering::HPPRenderFrame *       render_frame = nullptr,
-	               size_t                                 thread_index = 0,
-	               vkb::core::HPPCommandBuffer::ResetMode reset_mode   = vkb::core::HPPCommandBuffer::ResetMode::ResetPool) :
-	    vkb::CommandPool(reinterpret_cast<vkb::Device &>(device),
-	                     queue_family_index,
-	                     reinterpret_cast<vkb::RenderFrame *>(render_frame),
-	                     thread_index,
-	                     static_cast<vkb::CommandBuffer::ResetMode>(reset_mode))
-	{}
+	HPPCommandPool(HPPDevice const &           device,
+	               uint32_t                    queue_family_index,
+	               HPPRenderFrame const *      render_frame = nullptr,
+	               size_t                      thread_index = 0,
+	               HPPCommandBuffer::ResetMode reset_mode   = HPPCommandBuffer::ResetMode::ResetPool);
+	HPPCommandPool(const HPPCommandPool &) = delete;
+	HPPCommandPool(HPPCommandPool &&other);
+	~HPPCommandPool();
 
-	vk::CommandPool get_handle() const
-	{
-		return static_cast<vk::CommandPool>(vkb::CommandPool::get_handle());
-	}
+	HPPCommandPool &operator=(const HPPCommandPool &) = delete;
+	HPPCommandPool &operator=(HPPCommandPool &&) = delete;
 
-	vkb::core::HPPCommandBuffer &request_command_buffer(vk::CommandBufferLevel level = vk::CommandBufferLevel::ePrimary)
-	{
-		return reinterpret_cast<vkb::core::HPPCommandBuffer &>(vkb::CommandPool::request_command_buffer(static_cast<VkCommandBufferLevel>(level)));
-	}
+	HPPDevice const &           get_device() const;
+	vk::CommandPool             get_handle() const;
+	uint32_t                    get_queue_family_index() const;
+	HPPRenderFrame const *      get_render_frame() const;
+	HPPCommandBuffer::ResetMode get_reset_mode() const;
+	size_t                      get_thread_index() const;
+	HPPCommandBuffer const &    request_command_buffer(vk::CommandBufferLevel level = vk::CommandBufferLevel::ePrimary);
+	void                        reset_pool();
+
+  private:
+	void reset_command_buffers();
+
+  private:
+	HPPDevice const &                              device;
+	vk::CommandPool                                handle             = nullptr;
+	HPPRenderFrame const *                         render_frame       = nullptr;
+	size_t                                         thread_index       = 0;
+	uint32_t                                       queue_family_index = 0;
+	std::vector<std::unique_ptr<HPPCommandBuffer>> primary_command_buffers;
+	uint32_t                                       active_primary_command_buffer_count = 0;
+	std::vector<std::unique_ptr<HPPCommandBuffer>> secondary_command_buffers;
+	uint32_t                                       active_secondary_command_buffer_count = 0;
+	HPPCommandBuffer::ResetMode                    reset_mode                            = HPPCommandBuffer::ResetMode::ResetPool;
 };
 }        // namespace core
 }        // namespace vkb


### PR DESCRIPTION
## Description

Transcoding this part of the framework using Vulkan-Hpp.

I have tested it on Window10 on nvidia HW.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
