### PR TITLE
Change vkb::rendering::HPPRenderContext from a facade over vkb::RenderContext to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -120,7 +120,9 @@ set(RENDERING_FILES
     rendering/render_frame.cpp
     rendering/render_pipeline.cpp
     rendering/render_target.cpp
-    rendering/subpass.cpp)
+    rendering/subpass.cpp
+    rendering/hpp_render_context.cpp
+    rendering/hpp_render_target.cpp)
 
 set(RENDERING_SUBPASSES_FILES
     # Header files

--- a/framework/core/hpp_command_pool.cpp
+++ b/framework/core/hpp_command_pool.cpp
@@ -22,8 +22,11 @@ namespace vkb
 {
 namespace core
 {
-HPPCommandPool::HPPCommandPool(
-    HPPDevice const &d, uint32_t queue_family_index, HPPRenderFrame const *render_frame, size_t thread_index, HPPCommandBuffer::ResetMode reset_mode) :
+HPPCommandPool::HPPCommandPool(HPPDevice const &                     d,
+                               uint32_t                              queue_family_index,
+                               vkb::rendering::HPPRenderFrame const *render_frame,
+                               size_t                                thread_index,
+                               HPPCommandBuffer::ResetMode           reset_mode) :
     device{d}, render_frame{render_frame}, thread_index{thread_index}, reset_mode{reset_mode}
 {
 	vk::CommandPoolCreateFlags flags;
@@ -86,7 +89,7 @@ uint32_t HPPCommandPool::get_queue_family_index() const
 	return queue_family_index;
 }
 
-HPPRenderFrame const *HPPCommandPool::get_render_frame() const
+vkb::rendering::HPPRenderFrame const *HPPCommandPool::get_render_frame() const
 {
 	return render_frame;
 }

--- a/framework/core/hpp_command_pool.h
+++ b/framework/core/hpp_command_pool.h
@@ -18,22 +18,22 @@
 #pragma once
 
 #include <core/hpp_command_buffer.h>
+#include <rendering/hpp_render_frame.h>
 
 namespace vkb
 {
 namespace core
 {
 class HPPDevice;
-class HPPRenderFrame;
 
 class HPPCommandPool
 {
   public:
-	HPPCommandPool(HPPDevice const &           device,
-	               uint32_t                    queue_family_index,
-	               HPPRenderFrame const *      render_frame = nullptr,
-	               size_t                      thread_index = 0,
-	               HPPCommandBuffer::ResetMode reset_mode   = HPPCommandBuffer::ResetMode::ResetPool);
+	HPPCommandPool(HPPDevice const &                     device,
+	               uint32_t                              queue_family_index,
+	               vkb::rendering::HPPRenderFrame const *render_frame = nullptr,
+	               size_t                                thread_index = 0,
+	               HPPCommandBuffer::ResetMode           reset_mode   = HPPCommandBuffer::ResetMode::ResetPool);
 	HPPCommandPool(const HPPCommandPool &) = delete;
 	HPPCommandPool(HPPCommandPool &&other);
 	~HPPCommandPool();
@@ -41,14 +41,14 @@ class HPPCommandPool
 	HPPCommandPool &operator=(const HPPCommandPool &) = delete;
 	HPPCommandPool &operator=(HPPCommandPool &&) = delete;
 
-	HPPDevice const &           get_device() const;
-	vk::CommandPool             get_handle() const;
-	uint32_t                    get_queue_family_index() const;
-	HPPRenderFrame const *      get_render_frame() const;
-	HPPCommandBuffer::ResetMode get_reset_mode() const;
-	size_t                      get_thread_index() const;
-	HPPCommandBuffer const &    request_command_buffer(vk::CommandBufferLevel level = vk::CommandBufferLevel::ePrimary);
-	void                        reset_pool();
+	HPPDevice const &                     get_device() const;
+	vk::CommandPool                       get_handle() const;
+	uint32_t                              get_queue_family_index() const;
+	vkb::rendering::HPPRenderFrame const *get_render_frame() const;
+	HPPCommandBuffer::ResetMode           get_reset_mode() const;
+	size_t                                get_thread_index() const;
+	HPPCommandBuffer const &              request_command_buffer(vk::CommandBufferLevel level = vk::CommandBufferLevel::ePrimary);
+	void                                  reset_pool();
 
   private:
 	void reset_command_buffers();
@@ -56,7 +56,7 @@ class HPPCommandPool
   private:
 	HPPDevice const &                              device;
 	vk::CommandPool                                handle             = nullptr;
-	HPPRenderFrame const *                         render_frame       = nullptr;
+	vkb::rendering::HPPRenderFrame const *         render_frame       = nullptr;
 	size_t                                         thread_index       = 0;
 	uint32_t                                       queue_family_index = 0;
 	std::vector<std::unique_ptr<HPPCommandBuffer>> primary_command_buffers;

--- a/framework/core/hpp_device.cpp
+++ b/framework/core/hpp_device.cpp
@@ -15,8 +15,10 @@
  * limitations under the License.
  */
 
-#include <common/hpp_error.h>
 #include <core/hpp_device.h>
+
+#include <common/hpp_error.h>
+#include <core/hpp_command_pool.h>
 
 namespace vkb
 {
@@ -498,7 +500,7 @@ vkb::HPPFencePool const &HPPDevice::get_fence_pool() const
 	return *fence_pool;
 }
 
-vkb::HPPResourceCache const &HPPDevice::get_resource_cache() const
+vkb::HPPResourceCache &HPPDevice::get_resource_cache()
 {
 	return resource_cache;
 }

--- a/framework/core/hpp_device.h
+++ b/framework/core/hpp_device.h
@@ -19,7 +19,6 @@
 
 #include <core/hpp_buffer.h>
 #include <core/hpp_command_buffer.h>
-#include <core/hpp_command_pool.h>
 #include <core/hpp_debug.h>
 #include <core/hpp_physical_device.h>
 #include <core/hpp_queue.h>
@@ -32,6 +31,8 @@ namespace vkb
 {
 namespace core
 {
+class HPPCommandPool;
+
 class HPPDevice : public vkb::core::HPPVulkanResource<vk::Device>
 {
   public:
@@ -124,7 +125,7 @@ class HPPDevice : public vkb::core::HPPVulkanResource<vk::Device>
 
 	vkb::HPPFencePool const &get_fence_pool() const;
 
-	vkb::HPPResourceCache const &get_resource_cache() const;
+	vkb::HPPResourceCache &get_resource_cache();
 
   private:
 	vkb::core::HPPPhysicalDevice const &gpu;

--- a/framework/core/hpp_image.h
+++ b/framework/core/hpp_image.h
@@ -19,6 +19,8 @@
 
 #include <core/image.h>
 
+#include <core/hpp_device.h>
+
 namespace vkb
 {
 namespace core
@@ -32,6 +34,46 @@ class HPPImage : private Image
 {
   public:
 	using Image::get_array_layer_count;
+
+	HPPImage(HPPDevice const &       device,
+	         vk::Image               handle,
+	         const vk::Extent3D &    extent,
+	         vk::Format              format,
+	         vk::ImageUsageFlags     image_usage,
+	         vk::SampleCountFlagBits sample_count = vk::SampleCountFlagBits::e1) :
+	    Image(reinterpret_cast<vkb::Device const &>(device),
+	          handle,
+	          static_cast<VkExtent3D const &>(extent),
+	          static_cast<VkFormat>(format),
+	          static_cast<VkImageUsageFlags>(image_usage),
+	          static_cast<VkSampleCountFlagBits>(sample_count))
+	{}
+
+	HPPImage(HPPDevice const &       device,
+	         const vk::Extent3D &    extent,
+	         vk::Format              format,
+	         vk::ImageUsageFlags     image_usage,
+	         VmaMemoryUsage          memory_usage,
+	         vk::SampleCountFlagBits sample_count       = vk::SampleCountFlagBits::e1,
+	         uint32_t                mip_levels         = 1,
+	         uint32_t                array_layers       = 1,
+	         vk::ImageTiling         tiling             = vk::ImageTiling::eOptimal,
+	         vk::ImageCreateFlags    flags              = {},
+	         uint32_t                num_queue_families = 0,
+	         const uint32_t *        queue_families     = nullptr) :
+	    Image(reinterpret_cast<vkb::Device const &>(device),
+	          static_cast<VkExtent3D>(extent),
+	          static_cast<VkFormat>(format),
+	          static_cast<VkImageUsageFlags>(image_usage),
+	          memory_usage,
+	          static_cast<VkSampleCountFlagBits>(sample_count),
+	          mip_levels,
+	          array_layers,
+	          static_cast<VkImageTiling>(tiling),
+	          static_cast<VkImageCreateFlags>(flags),
+	          num_queue_families,
+	          queue_families)
+	{}
 
 	vk::Image get_handle() const
 	{

--- a/framework/core/hpp_image_view.h
+++ b/framework/core/hpp_image_view.h
@@ -23,6 +23,8 @@ namespace vkb
 {
 namespace core
 {
+class HPPImage;
+
 /**
  * @brief facade class around vkb::core::ImageView, providing a vulkan.hpp-based interface
  *
@@ -39,6 +41,11 @@ class HPPImageView : private vkb::core::ImageView
 	vk::ImageView get_handle() const
 	{
 		return static_cast<vk::ImageView>(vkb::core::ImageView::get_handle());
+	}
+
+	const HPPImage &get_image() const
+	{
+		return reinterpret_cast<HPPImage const &>(ImageView::get_image());
 	}
 };
 }        // namespace core

--- a/framework/core/hpp_swapchain.h
+++ b/framework/core/hpp_swapchain.h
@@ -28,9 +28,52 @@ namespace core
  *
  * See vkb::Swapchain for documentation
  */
+struct HPPSwapchainProperties
+{
+	vk::SwapchainKHR                old_swapchain;
+	uint32_t                        image_count{3};
+	vk::Extent2D                    extent{};
+	vk::SurfaceFormatKHR            surface_format;
+	uint32_t                        array_layers;
+	vk::ImageUsageFlags             image_usage;
+	vk::SurfaceTransformFlagBitsKHR pre_transform;
+	vk::CompositeAlphaFlagBitsKHR   composite_alpha;
+	vk::PresentModeKHR              present_mode;
+};
+
 class HPPSwapchain : private vkb::Swapchain
 {
   public:
+	using vkb::Swapchain::create;
+
+	HPPSwapchain(HPPSwapchain &old_swapchain, const vk::Extent2D &extent) :
+	    vkb::Swapchain(reinterpret_cast<vkb::Swapchain &>(old_swapchain), static_cast<VkExtent2D>(extent))
+	{}
+
+	HPPSwapchain(HPPSwapchain &old_swapchain, const std::set<vk::ImageUsageFlagBits> &image_usage_flags) :
+	    vkb::Swapchain(reinterpret_cast<vkb::Swapchain &>(old_swapchain), reinterpret_cast<std::set<VkImageUsageFlagBits> const &>(image_usage_flags))
+	{}
+
+	HPPSwapchain(HPPSwapchain &swapchain, const vk::Extent2D &extent, const vk::SurfaceTransformFlagBitsKHR transform) :
+	    vkb::Swapchain(reinterpret_cast<vkb::Swapchain &>(swapchain), static_cast<VkExtent2D>(extent), static_cast<VkSurfaceTransformFlagBitsKHR>(transform))
+	{}
+
+	HPPSwapchain(HPPDevice &                             device,
+	             vk::SurfaceKHR                          surface,
+	             const vk::Extent2D &                    extent            = {},
+	             const uint32_t                          image_count       = 3,
+	             const vk::SurfaceTransformFlagBitsKHR   transform         = vk::SurfaceTransformFlagBitsKHR::eIdentity,
+	             const vk::PresentModeKHR                present_mode      = vk::PresentModeKHR::eFifo,
+	             const std::set<vk::ImageUsageFlagBits> &image_usage_flags = {vk::ImageUsageFlagBits::eColorAttachment, vk::ImageUsageFlagBits::eTransferSrc}) :
+	    vkb::Swapchain(reinterpret_cast<vkb::Device &>(device),
+	                   static_cast<VkSurfaceKHR>(surface),
+	                   static_cast<VkExtent2D const &>(extent),
+	                   image_count,
+	                   static_cast<VkSurfaceTransformFlagBitsKHR>(transform),
+	                   static_cast<VkPresentModeKHR>(present_mode),
+	                   reinterpret_cast<std::set<VkImageUsageFlagBits> const &>(image_usage_flags))
+	{}
+
 	vk::Result acquire_next_image(uint32_t &image_index, vk::Semaphore image_acquired_semaphore, vk::Fence fence = nullptr) const
 	{
 		return static_cast<vk::Result>(vkb::Swapchain::acquire_next_image(image_index, image_acquired_semaphore, fence));
@@ -51,14 +94,34 @@ class HPPSwapchain : private vkb::Swapchain
 		return vkb::Swapchain::get_handle();
 	}
 
-	std::vector<VkImage> const &get_images() const
+	std::vector<vk::Image> const &get_images() const
 	{
-		return vkb::Swapchain::get_images();
+		return reinterpret_cast<std::vector<vk::Image> const &>(vkb::Swapchain::get_images());
+	}
+
+	HPPSwapchainProperties &get_properties()
+	{
+		return reinterpret_cast<HPPSwapchainProperties &>(vkb::Swapchain::get_properties());
 	}
 
 	vk::SurfaceKHR get_surface() const
 	{
 		return static_cast<vk::SurfaceKHR>(vkb::Swapchain::get_surface());
+	}
+
+	vk::ImageUsageFlags get_usage() const
+	{
+		return static_cast<vk::ImageUsageFlags>(vkb::Swapchain::get_usage());
+	}
+
+	void set_present_mode_priority(const std::vector<vk::PresentModeKHR> &present_mode_priority_list)
+	{
+		vkb::Swapchain::set_present_mode_priority(reinterpret_cast<std::vector<VkPresentModeKHR> const &>(present_mode_priority_list));
+	}
+
+	void set_surface_format_priority(const std::vector<vk::SurfaceFormatKHR> &surface_format_priority_list)
+	{
+		vkb::Swapchain::set_surface_format_priority(reinterpret_cast<std::vector<VkSurfaceFormatKHR> const &>(surface_format_priority_list));
 	}
 };
 }        // namespace core

--- a/framework/rendering/hpp_render_context.cpp
+++ b/framework/rendering/hpp_render_context.cpp
@@ -1,0 +1,534 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hpp_render_context.h"
+
+#include <core/hpp_image.h>
+
+namespace vkb
+{
+namespace rendering
+{
+vk::Format HPPRenderContext::DEFAULT_VK_FORMAT = vk::Format::eR8G8B8A8Srgb;
+
+HPPRenderContext::HPPRenderContext(vkb::core::HPPDevice &device, vk::SurfaceKHR surface, const vkb::platform::HPPWindow &window) :
+    device{device},
+    window{window},
+    queue{device.get_suitable_graphics_queue()},
+    surface_extent{window.get_extent().width, window.get_extent().height}
+{
+	if (surface)
+	{
+		vk::SurfaceCapabilitiesKHR surface_properties = device.get_gpu().get_handle().getSurfaceCapabilitiesKHR(surface);
+
+		if (surface_properties.currentExtent.width == 0xFFFFFFFF)
+		{
+			swapchain = std::make_unique<vkb::core::HPPSwapchain>(device, surface, surface_extent);
+		}
+		else
+		{
+			swapchain = std::make_unique<vkb::core::HPPSwapchain>(device, surface);
+		}
+	}
+}
+
+void HPPRenderContext::request_present_mode(const vk::PresentModeKHR present_mode)
+{
+	if (swapchain)
+	{
+		swapchain->get_properties().present_mode = present_mode;
+	}
+}
+
+void HPPRenderContext::request_image_format(const vk::Format format)
+{
+	if (swapchain)
+	{
+		swapchain->get_properties().surface_format.format = format;
+	}
+}
+
+void HPPRenderContext::prepare(size_t thread_count, vkb::rendering::HPPRenderTarget::CreateFunc create_render_target_func)
+{
+	device.get_handle().waitIdle();
+
+	if (swapchain)
+	{
+		swapchain->set_present_mode_priority(present_mode_priority_list);
+		swapchain->set_surface_format_priority(surface_format_priority_list);
+		swapchain->create();
+
+		surface_extent = swapchain->get_extent();
+
+		vk::Extent3D extent{surface_extent.width, surface_extent.height, 1};
+
+		for (auto &image_handle : swapchain->get_images())
+		{
+			auto swapchain_image = core::HPPImage{device, image_handle, extent, swapchain->get_format(), swapchain->get_usage()};
+			auto render_target   = create_render_target_func(std::move(swapchain_image));
+			frames.emplace_back(std::make_unique<vkb::rendering::HPPRenderFrame>(device, std::move(render_target), thread_count));
+		}
+	}
+	else
+	{
+		// Otherwise, create a single RenderFrame
+		swapchain = nullptr;
+
+		auto color_image = vkb::core::HPPImage{device,
+		                                       vk::Extent3D{surface_extent.width, surface_extent.height, 1},
+		                                       DEFAULT_VK_FORMAT,        // We can use any format here that we like
+		                                       vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eTransferSrc,
+		                                       VMA_MEMORY_USAGE_GPU_ONLY};
+
+		auto render_target = create_render_target_func(std::move(color_image));
+		frames.emplace_back(std::make_unique<vkb::rendering::HPPRenderFrame>(device, std::move(render_target), thread_count));
+	}
+
+	this->create_render_target_func = create_render_target_func;
+	this->thread_count              = thread_count;
+	this->prepared                  = true;
+}
+
+void HPPRenderContext::set_present_mode_priority(const std::vector<vk::PresentModeKHR> &new_present_mode_priority_list)
+{
+	assert(!new_present_mode_priority_list.empty() && "Priority list must not be empty");
+	present_mode_priority_list = new_present_mode_priority_list;
+}
+
+void HPPRenderContext::set_surface_format_priority(const std::vector<vk::SurfaceFormatKHR> &new_surface_format_priority_list)
+{
+	assert(!new_surface_format_priority_list.empty() && "Priority list must not be empty");
+	surface_format_priority_list = new_surface_format_priority_list;
+}
+
+vk::Format HPPRenderContext::get_format() const
+{
+	return swapchain ? swapchain->get_format() : DEFAULT_VK_FORMAT;
+}
+
+void HPPRenderContext::update_swapchain(const vk::Extent2D &extent)
+{
+	if (!swapchain)
+	{
+		LOGW("Can't update the swapchains extent in headless mode, skipping.");
+		return;
+	}
+
+	device.get_resource_cache().clear_framebuffers();
+
+	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, extent);
+
+	recreate();
+}
+
+void HPPRenderContext::update_swapchain(const uint32_t image_count)
+{
+	if (!swapchain)
+	{
+		LOGW("Can't update the swapchains image count in headless mode, skipping.");
+		return;
+	}
+
+	device.get_resource_cache().clear_framebuffers();
+
+	device.get_handle().waitIdle();
+
+	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, image_count);
+
+	recreate();
+}
+
+void HPPRenderContext::update_swapchain(const std::set<vk::ImageUsageFlagBits> &image_usage_flags)
+{
+	if (!swapchain)
+	{
+		LOGW("Can't update the swapchains image usage in headless mode, skipping.");
+		return;
+	}
+
+	device.get_resource_cache().clear_framebuffers();
+
+	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, image_usage_flags);
+
+	recreate();
+}
+
+void HPPRenderContext::update_swapchain(const vk::Extent2D &extent, const vk::SurfaceTransformFlagBitsKHR transform)
+{
+	if (!swapchain)
+	{
+		LOGW("Can't update the swapchains extent and surface transform in headless mode, skipping.");
+		return;
+	}
+
+	device.get_resource_cache().clear_framebuffers();
+
+	auto width  = extent.width;
+	auto height = extent.height;
+	if (transform == vk::SurfaceTransformFlagBitsKHR::eRotate90 || transform == vk::SurfaceTransformFlagBitsKHR::eRotate270)
+	{
+		// Pre-rotation: always use native orientation i.e. if rotated, use width and height of identity transform
+		std::swap(width, height);
+	}
+
+	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, vk::Extent2D{width, height}, transform);
+
+	// Save the preTransform attribute for future rotations
+	pre_transform = transform;
+
+	recreate();
+}
+
+void HPPRenderContext::recreate()
+{
+	LOGI("Recreated swapchain");
+
+	vk::Extent2D swapchain_extent = swapchain->get_extent();
+	vk::Extent3D extent{swapchain_extent.width, swapchain_extent.height, 1};
+
+	auto frame_it = frames.begin();
+
+	for (auto &image_handle : swapchain->get_images())
+	{
+		vkb::core::HPPImage swapchain_image{device, image_handle, extent, swapchain->get_format(), swapchain->get_usage()};
+
+		auto render_target = create_render_target_func(std::move(swapchain_image));
+
+		if (frame_it != frames.end())
+		{
+			(*frame_it)->update_render_target(std::move(render_target));
+		}
+		else
+		{
+			// Create a new frame if the new swapchain has more images than current frames
+			frames.emplace_back(std::make_unique<vkb::rendering::HPPRenderFrame>(device, std::move(render_target), thread_count));
+		}
+
+		++frame_it;
+	}
+
+	device.get_resource_cache().clear_framebuffers();
+}
+
+bool HPPRenderContext::handle_surface_changes(bool force_update)
+{
+	if (!swapchain)
+	{
+		LOGW("Can't handle surface changes in headless mode, skipping.");
+		return false;
+	}
+
+	vk::SurfaceCapabilitiesKHR surface_properties = device.get_gpu().get_handle().getSurfaceCapabilitiesKHR(swapchain->get_surface());
+
+	if (surface_properties.currentExtent.width == 0xFFFFFFFF)
+	{
+		return false;
+	}
+
+	// Only recreate the swapchain if the dimensions have changed;
+	// handle_surface_changes() is called on VK_SUBOPTIMAL_KHR,
+	// which might not be due to a surface resize
+	if (surface_properties.currentExtent.width != surface_extent.width ||
+	    surface_properties.currentExtent.height != surface_extent.height ||
+	    force_update)
+	{
+		// Recreate swapchain
+		device.get_handle().waitIdle();
+
+		update_swapchain(surface_properties.currentExtent, pre_transform);
+
+		surface_extent = surface_properties.currentExtent;
+
+		return true;
+	}
+
+	return false;
+}
+
+vkb::core::HPPCommandBuffer &HPPRenderContext::begin(vkb::core::HPPCommandBuffer::ResetMode reset_mode)
+{
+	assert(prepared && "HPPRenderContext not prepared for rendering, call prepare()");
+
+	if (!frame_active)
+	{
+		begin_frame();
+	}
+
+	if (!acquired_semaphore)
+	{
+		throw std::runtime_error("Couldn't begin frame");
+	}
+
+	const auto &queue = device.get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);
+	return get_active_frame().request_command_buffer(queue, reset_mode);
+}
+
+void HPPRenderContext::submit(vkb::core::HPPCommandBuffer &command_buffer)
+{
+	submit({&command_buffer});
+}
+
+void HPPRenderContext::submit(const std::vector<vkb::core::HPPCommandBuffer *> &command_buffers)
+{
+	assert(frame_active && "HPPRenderContext is inactive, cannot submit command buffer. Please call begin()");
+
+	vk::Semaphore render_semaphore;
+
+	if (swapchain)
+	{
+		assert(acquired_semaphore && "We do not have acquired_semaphore, it was probably consumed?\n");
+		render_semaphore = submit(queue, command_buffers, acquired_semaphore, vk::PipelineStageFlagBits::eColorAttachmentOutput);
+	}
+	else
+	{
+		submit(queue, command_buffers);
+	}
+
+	end_frame(render_semaphore);
+}
+
+void HPPRenderContext::begin_frame()
+{
+	// Only handle surface changes if a swapchain exists
+	if (swapchain)
+	{
+		handle_surface_changes();
+	}
+
+	assert(!frame_active && "Frame is still active, please call end_frame");
+
+	auto &prev_frame = *frames[active_frame_index];
+
+	// We will use the acquired semaphore in a different frame context,
+	// so we need to hold ownership.
+	acquired_semaphore = prev_frame.request_semaphore_with_ownership();
+
+	if (swapchain)
+	{
+		vk::Result result;
+		try
+		{
+			result = swapchain->acquire_next_image(active_frame_index, acquired_semaphore, nullptr);
+		}
+		catch (vk::OutOfDateKHRError & /*err*/)
+		{
+			result = vk::Result::eErrorOutOfDateKHR;
+		}
+
+		if (result == vk::Result::eSuboptimalKHR || result == vk::Result::eErrorOutOfDateKHR)
+		{
+			bool swapchain_updated = handle_surface_changes(result == vk::Result::eErrorOutOfDateKHR);
+
+			if (swapchain_updated)
+			{
+				result = swapchain->acquire_next_image(active_frame_index, acquired_semaphore, nullptr);
+			}
+		}
+
+		if (result != vk::Result::eSuccess)
+		{
+			prev_frame.reset();
+			return;
+		}
+	}
+
+	// Now the frame is active again
+	frame_active = true;
+
+	// Wait on all resource to be freed from the previous render to this frame
+	wait_frame();
+}
+
+vk::Semaphore HPPRenderContext::submit(const vkb::core::HPPQueue &                       queue,
+                                       const std::vector<vkb::core::HPPCommandBuffer *> &command_buffers,
+                                       vk::Semaphore                                     wait_semaphore,
+                                       vk::PipelineStageFlags                            wait_pipeline_stage)
+{
+	std::vector<vk::CommandBuffer> cmd_buf_handles(command_buffers.size(), nullptr);
+	std::transform(command_buffers.begin(), command_buffers.end(), cmd_buf_handles.begin(), [](const vkb::core::HPPCommandBuffer *cmd_buf) { return cmd_buf->get_handle(); });
+
+	vkb::rendering::HPPRenderFrame &frame = get_active_frame();
+
+	vk::Semaphore signal_semaphore = frame.request_semaphore();
+
+	vk::SubmitInfo submit_info(nullptr, nullptr, cmd_buf_handles, signal_semaphore);
+	if (wait_semaphore)
+	{
+		submit_info.setWaitSemaphores(wait_semaphore);
+		submit_info.pWaitDstStageMask = &wait_pipeline_stage;
+	}
+
+	vk::Fence fence = frame.request_fence();
+
+	queue.get_handle().submit(submit_info, fence);
+
+	return signal_semaphore;
+}
+
+void HPPRenderContext::submit(const vkb::core::HPPQueue &queue, const std::vector<vkb::core::HPPCommandBuffer *> &command_buffers)
+{
+	std::vector<vk::CommandBuffer> cmd_buf_handles(command_buffers.size(), nullptr);
+	std::transform(command_buffers.begin(), command_buffers.end(), cmd_buf_handles.begin(), [](const vkb::core::HPPCommandBuffer *cmd_buf) { return cmd_buf->get_handle(); });
+
+	vkb::rendering::HPPRenderFrame &frame = get_active_frame();
+
+	vk::SubmitInfo submit_info(nullptr, nullptr, cmd_buf_handles);
+
+	vk::Fence fence = frame.request_fence();
+
+	queue.get_handle().submit(submit_info, fence);
+}
+
+void HPPRenderContext::wait_frame()
+{
+	get_active_frame().reset();
+}
+
+void HPPRenderContext::end_frame(vk::Semaphore semaphore)
+{
+	assert(frame_active && "Frame is not active, please call begin_frame");
+
+	if (swapchain)
+	{
+		vk::SwapchainKHR   vk_swapchain = swapchain->get_handle();
+		vk::PresentInfoKHR present_info(semaphore, vk_swapchain, active_frame_index);
+
+		vk::DisplayPresentInfoKHR disp_present_info;
+		if (device.is_extension_supported(VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME) &&
+		    window.get_display_present_info(&disp_present_info, surface_extent.width, surface_extent.height))
+		{
+			// Add display present info if supported and wanted
+			present_info.pNext = &disp_present_info;
+		}
+
+		vk::Result result;
+		try
+		{
+			result = queue.present(present_info);
+		}
+		catch (vk::OutOfDateKHRError & /*err*/)
+		{
+			result = vk::Result::eErrorOutOfDateKHR;
+		}
+
+		if (result == vk::Result::eSuboptimalKHR || result == vk::Result::eErrorOutOfDateKHR)
+		{
+			handle_surface_changes();
+		}
+	}
+
+	// Frame is not active anymore
+	if (acquired_semaphore)
+	{
+		release_owned_semaphore(acquired_semaphore);
+		acquired_semaphore = nullptr;
+	}
+	frame_active = false;
+}
+
+vk::Semaphore HPPRenderContext::consume_acquired_semaphore()
+{
+	assert(frame_active && "Frame is not active, please call begin_frame");
+	return std::exchange(acquired_semaphore, nullptr);
+}
+
+vkb::rendering::HPPRenderFrame &HPPRenderContext::get_active_frame()
+{
+	assert(frame_active && "Frame is not active, please call begin_frame");
+	return *frames[active_frame_index];
+}
+
+uint32_t HPPRenderContext::get_active_frame_index()
+{
+	assert(frame_active && "Frame is not active, please call begin_frame");
+	return active_frame_index;
+}
+
+vkb::rendering::HPPRenderFrame &HPPRenderContext::get_last_rendered_frame()
+{
+	assert(!frame_active && "Frame is still active, please call end_frame");
+	return *frames[active_frame_index];
+}
+
+vk::Semaphore HPPRenderContext::request_semaphore()
+{
+	return get_active_frame().request_semaphore();
+}
+
+vk::Semaphore HPPRenderContext::request_semaphore_with_ownership()
+{
+	return get_active_frame().request_semaphore_with_ownership();
+}
+
+void HPPRenderContext::release_owned_semaphore(vk::Semaphore semaphore)
+{
+	get_active_frame().release_owned_semaphore(semaphore);
+}
+
+vkb::core::HPPDevice &HPPRenderContext::get_device()
+{
+	return device;
+}
+
+void HPPRenderContext::recreate_swapchain()
+{
+	device.get_handle().waitIdle();
+	device.get_resource_cache().clear_framebuffers();
+
+	vk::Extent2D swapchain_extent = swapchain->get_extent();
+	vk::Extent3D extent{swapchain_extent.width, swapchain_extent.height, 1};
+
+	auto frame_it = frames.begin();
+
+	for (auto &image_handle : swapchain->get_images())
+	{
+		vkb::core::HPPImage swapchain_image{device, image_handle, extent, swapchain->get_format(), swapchain->get_usage()};
+		auto                render_target = create_render_target_func(std::move(swapchain_image));
+		(*frame_it)->update_render_target(std::move(render_target));
+
+		++frame_it;
+	}
+}
+
+bool HPPRenderContext::has_swapchain()
+{
+	return swapchain != nullptr;
+}
+
+vkb::core::HPPSwapchain const &HPPRenderContext::get_swapchain() const
+{
+	assert(swapchain && "Swapchain is not valid");
+	return *swapchain;
+}
+
+vk::Extent2D const &HPPRenderContext::get_surface_extent() const
+{
+	return surface_extent;
+}
+
+uint32_t HPPRenderContext::get_active_frame_index() const
+{
+	return active_frame_index;
+}
+
+std::vector<std::unique_ptr<vkb::rendering::HPPRenderFrame>> &HPPRenderContext::get_render_frames()
+{
+	return frames;
+}
+
+}        // namespace rendering
+}        // namespace vkb

--- a/framework/rendering/hpp_render_context.h
+++ b/framework/rendering/hpp_render_context.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,10 +17,9 @@
 
 #pragma once
 
-#include <rendering/render_context.h>
-
-#include <core/hpp_command_buffer.h>
+#include <core/hpp_device.h>
 #include <core/hpp_swapchain.h>
+#include <platform/hpp_window.h>
 #include <rendering/hpp_render_frame.h>
 
 namespace vkb
@@ -28,57 +27,234 @@ namespace vkb
 namespace rendering
 {
 /**
- * @brief facade class around vkb::RenderContext, providing a vulkan.hpp-based interface
- *
- * See vkb::RenderContext for documentation
- */
-class HPPRenderContext : private vkb::RenderContext
+* @brief HPPRenderContext is a transcoded version of vkb::RenderContext from vulkan to vulkan-hpp.
+* 
+* See vkb::RenderContext for documentation
+*/
+class HPPRenderContext
 {
   public:
-	using vkb::RenderContext::get_render_frames;
-	using vkb::RenderContext::handle_surface_changes;
-	using vkb::RenderContext::has_swapchain;
-	using vkb::RenderContext::prepare;
+	// The format to use for the RenderTargets if a swapchain isn't created
+	static vk::Format DEFAULT_VK_FORMAT;
 
-	vkb::core::HPPCommandBuffer &begin(vkb::CommandBuffer::ResetMode reset_mode = vkb::CommandBuffer::ResetMode::ResetPool)
-	{
-		return reinterpret_cast<vkb::core::HPPCommandBuffer &>(vkb::RenderContext::begin(reset_mode));
-	}
+	/**
+	 * @brief Constructor
+	 * @param device A valid device
+	 * @param surface A surface, nullptr if in headless mode
+	 * @param window The window where the surface was created
+	 */
+	HPPRenderContext(vkb::core::HPPDevice &device, vk::SurfaceKHR surface, const vkb::platform::HPPWindow &window);
 
-	vkb::rendering::HPPRenderFrame &get_active_frame()
-	{
-		return reinterpret_cast<vkb::rendering::HPPRenderFrame &>(vkb::RenderContext::get_active_frame());
-	}
+	HPPRenderContext(const HPPRenderContext &) = delete;
 
-	vk::Format get_format() const
-	{
-		return static_cast<vk::Format>(vkb::RenderContext::get_format());
-	}
+	HPPRenderContext(HPPRenderContext &&) = delete;
 
-	vk::Extent2D const &get_surface_extent() const
-	{
-		return *reinterpret_cast<vk::Extent2D const *>(&vkb::RenderContext::get_surface_extent());
-	}
+	virtual ~HPPRenderContext() = default;
 
-	vkb::core::HPPSwapchain const &get_swapchain() const
-	{
-		return reinterpret_cast<vkb::core::HPPSwapchain const &>(vkb::RenderContext::get_swapchain());
-	}
+	HPPRenderContext &operator=(const HPPRenderContext &) = delete;
 
-	void submit(vkb::core::HPPCommandBuffer &command_buffer)
-	{
-		vkb::RenderContext::submit(reinterpret_cast<vkb::CommandBuffer &>(command_buffer));
-	}
+	HPPRenderContext &operator=(HPPRenderContext &&) = delete;
 
-	void update_swapchain(const std::set<vk::ImageUsageFlagBits> &image_usage_flags)
-	{
-		std::set<VkImageUsageFlagBits> flags;
-		for (auto flag : image_usage_flags)
-		{
-			flags.insert(static_cast<VkImageUsageFlagBits>(flag));
-		}
-		vkb::RenderContext::update_swapchain(flags);
-	}
+	/**
+	 * @brief Requests to set the present mode of the swapchain, must be called before prepare
+	 */
+	void request_present_mode(const vk::PresentModeKHR present_mode);
+
+	/**
+	 * @brief Requests to set a specific image format for the swapchain
+	 */
+	void request_image_format(const vk::Format format);
+
+	/**
+	 * @brief Sets the order in which the swapchain prioritizes selecting its present mode
+	 */
+	void set_present_mode_priority(const std::vector<vk::PresentModeKHR> &present_mode_priority_list);
+
+	/**
+	 * @brief Sets the order in which the swapchain prioritizes selecting its surface format
+	 */
+	void set_surface_format_priority(const std::vector<vk::SurfaceFormatKHR> &surface_format_priority_list);
+
+	/**
+	 * @brief Prepares the RenderFrames for rendering
+	 * @param thread_count The number of threads in the application, necessary to allocate this many resource pools for each RenderFrame
+	 * @param create_render_target_func A function delegate, used to create a RenderTarget
+	 */
+	void prepare(size_t thread_count = 1, HPPRenderTarget::CreateFunc create_render_target_func = HPPRenderTarget::DEFAULT_CREATE_FUNC);
+
+	/**
+	 * @brief Updates the swapchains extent, if a swapchain exists
+	 * @param extent The width and height of the new swapchain images
+	 */
+	void update_swapchain(const vk::Extent2D &extent);
+
+	/**
+	 * @brief Updates the swapchains image count, if a swapchain exists
+	 * @param image_count The amount of images in the new swapchain
+	 */
+	void update_swapchain(const uint32_t image_count);
+
+	/**
+	 * @brief Updates the swapchains image usage, if a swapchain exists
+	 * @param image_usage_flags The usage flags the new swapchain images will have
+	 */
+	void update_swapchain(const std::set<vk::ImageUsageFlagBits> &image_usage_flags);
+
+	/**
+	 * @brief Updates the swapchains extent and surface transform, if a swapchain exists
+	 * @param extent The width and height of the new swapchain images
+	 * @param transform The surface transform flags
+	 */
+	void update_swapchain(const vk::Extent2D &extent, const vk::SurfaceTransformFlagBitsKHR transform);
+
+	/**
+	 * @returns True if a valid swapchain exists in the HPPRenderContext
+	 */
+	bool has_swapchain();
+
+	/**
+	 * @brief Recreates the RenderFrames, called after every update
+	 */
+	void recreate();
+
+	/**
+	 * @brief Recreates the swapchain
+	 */
+	void recreate_swapchain();
+
+	/**
+	 * @brief Prepares the next available frame for rendering
+	 * @param reset_mode How to reset the command buffer
+	 * @returns A valid command buffer to record commands to be submitted
+	 * Also ensures that there is an active frame if there is no existing active frame already
+	 */
+	vkb::core::HPPCommandBuffer &begin(vkb::core::HPPCommandBuffer::ResetMode reset_mode = vkb::core::HPPCommandBuffer::ResetMode::ResetPool);
+
+	/**
+	 * @brief Submits the command buffer to the right queue
+	 * @param command_buffer A command buffer containing recorded commands
+	 */
+	void submit(vkb::core::HPPCommandBuffer &command_buffer);
+
+	/**
+	 * @brief Submits multiple command buffers to the right queue
+	 * @param command_buffers Command buffers containing recorded commands
+	 */
+	void submit(const std::vector<vkb::core::HPPCommandBuffer *> &command_buffers);
+
+	/**
+	 * @brief begin_frame
+	 */
+	void begin_frame();
+
+	vk::Semaphore submit(const vkb::core::HPPQueue &                       queue,
+	                     const std::vector<vkb::core::HPPCommandBuffer *> &command_buffers,
+	                     vk::Semaphore                                     wait_semaphore,
+	                     vk::PipelineStageFlags                            wait_pipeline_stage);
+
+	/**
+	 * @brief Submits a command buffer related to a frame to a queue
+	 */
+	void submit(const vkb::core::HPPQueue &queue, const std::vector<vkb::core::HPPCommandBuffer *> &command_buffers);
+
+	/**
+	 * @brief Waits a frame to finish its rendering
+	 */
+	virtual void wait_frame();
+
+	void end_frame(vk::Semaphore semaphore);
+
+	/**
+	 * @brief An error should be raised if the frame is not active.
+	 *        A frame is active after @ref begin_frame has been called.
+	 * @return The current active frame
+	 */
+	HPPRenderFrame &get_active_frame();
+
+	/**
+	 * @brief An error should be raised if the frame is not active.
+	 *        A frame is active after @ref begin_frame has been called.
+	 * @return The current active frame index
+	 */
+	uint32_t get_active_frame_index();
+
+	/**
+	 * @brief An error should be raised if a frame is active.
+	 *        A frame is active after @ref begin_frame has been called.
+	 * @return The previous frame
+	 */
+	HPPRenderFrame &get_last_rendered_frame();
+
+	vk::Semaphore request_semaphore();
+	vk::Semaphore request_semaphore_with_ownership();
+	void          release_owned_semaphore(vk::Semaphore semaphore);
+
+	vkb::core::HPPDevice &get_device();
+
+	/**
+	 * @brief Returns the format that the RenderTargets are created with within the HPPRenderContext
+	 */
+	vk::Format get_format() const;
+
+	vkb::core::HPPSwapchain const &get_swapchain() const;
+
+	vk::Extent2D const &get_surface_extent() const;
+
+	uint32_t get_active_frame_index() const;
+
+	std::vector<std::unique_ptr<HPPRenderFrame>> &get_render_frames();
+
+	/**
+	 * @brief Handles surface changes, only applicable if the render_context makes use of a swapchain
+	 */
+	virtual bool handle_surface_changes(bool force_update = false);
+
+	/**
+	 * @brief Returns the WSI acquire semaphore. Only to be used in very special circumstances.
+	 * @return The WSI acquire semaphore.
+	 */
+	vk::Semaphore consume_acquired_semaphore();
+
+  protected:
+	vk::Extent2D surface_extent;
+
+  private:
+	vkb::core::HPPDevice &device;
+
+	const vkb::platform::HPPWindow &window;
+
+	/// If swapchain exists, then this will be a present supported queue, else a graphics queue
+	const vkb::core::HPPQueue &queue;
+
+	std::unique_ptr<vkb::core::HPPSwapchain> swapchain;
+
+	vkb::core::HPPSwapchainProperties swapchain_properties;
+
+	// A list of present modes in order of priority (vector[0] has high priority, vector[size-1] has low priority)
+	std::vector<vk::PresentModeKHR> present_mode_priority_list = {vk::PresentModeKHR::eFifo, vk::PresentModeKHR::eMailbox};
+
+	// A list of surface formats in order of priority (vector[0] has high priority, vector[size-1] has low priority)
+	std::vector<vk::SurfaceFormatKHR> surface_format_priority_list = {{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
+	                                                                  {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}};
+
+	std::vector<std::unique_ptr<HPPRenderFrame>> frames;
+
+	vk::Semaphore acquired_semaphore;
+
+	bool prepared{false};
+
+	/// Current active frame index
+	uint32_t active_frame_index{0};
+
+	/// Whether a frame is active or not
+	bool frame_active{false};
+
+	HPPRenderTarget::CreateFunc create_render_target_func = HPPRenderTarget::DEFAULT_CREATE_FUNC;
+
+	vk::SurfaceTransformFlagBitsKHR pre_transform{vk::SurfaceTransformFlagBitsKHR::eIdentity};
+
+	size_t thread_count{1};
 };
+
 }        // namespace rendering
 }        // namespace vkb

--- a/framework/rendering/hpp_render_frame.h
+++ b/framework/rendering/hpp_render_frame.h
@@ -19,6 +19,7 @@
 
 #include <rendering/render_frame.h>
 
+#include <core/hpp_queue.h>
 #include <rendering/hpp_render_target.h>
 
 namespace vkb
@@ -33,9 +34,54 @@ namespace rendering
 class HPPRenderFrame : private vkb::RenderFrame
 {
   public:
-	vkb::rendering::HPPRenderTarget &get_render_target()
+	using vkb::RenderFrame::reset;
+
+	HPPRenderFrame(vkb::core::HPPDevice &device, std::unique_ptr<HPPRenderTarget> &&render_target, size_t thread_count = 1) :
+	    RenderFrame(reinterpret_cast<vkb::Device &>(device),
+	                std::unique_ptr<vkb::RenderTarget>(reinterpret_cast<vkb::RenderTarget *>(render_target.release())),
+	                thread_count)
+	{}
+
+	HPPRenderTarget &get_render_target()
 	{
-		return reinterpret_cast<vkb::rendering::HPPRenderTarget &>(vkb::RenderFrame::get_render_target());
+		return reinterpret_cast<HPPRenderTarget &>(vkb::RenderFrame::get_render_target());
+	}
+
+	void release_owned_semaphore(vk::Semaphore semaphore)
+	{
+		vkb::RenderFrame::release_owned_semaphore(static_cast<VkSemaphore>(semaphore));
+	}
+
+	vkb::core::HPPCommandBuffer &request_command_buffer(const vkb::core::HPPQueue &            queue,
+	                                                    vkb::core::HPPCommandBuffer::ResetMode reset_mode   = vkb::core::HPPCommandBuffer::ResetMode::ResetPool,
+	                                                    vk::CommandBufferLevel                 level        = vk::CommandBufferLevel::ePrimary,
+	                                                    size_t                                 thread_index = 0)
+	{
+		return reinterpret_cast<vkb::core::HPPCommandBuffer &>(
+		    vkb::RenderFrame::request_command_buffer(reinterpret_cast<vkb::Queue const &>(queue),
+		                                             static_cast<vkb::CommandBuffer::ResetMode>(reset_mode),
+		                                             static_cast<VkCommandBufferLevel>(level),
+		                                             thread_index));
+	}
+
+	vk::Fence request_fence()
+	{
+		return static_cast<vk::Fence>(vkb::RenderFrame::request_fence());
+	}
+
+	vk::Semaphore request_semaphore()
+	{
+		return static_cast<vk::Semaphore>(vkb::RenderFrame::request_semaphore());
+	}
+
+	vk::Semaphore request_semaphore_with_ownership()
+	{
+		return static_cast<vk::Semaphore>(vkb::RenderFrame::request_semaphore_with_ownership());
+	}
+
+	void update_render_target(std::unique_ptr<HPPRenderTarget> &&render_target)
+	{
+		vkb::RenderFrame::update_render_target(std::unique_ptr<vkb::RenderTarget>(reinterpret_cast<vkb::RenderTarget *>(render_target.release())));
 	}
 };
 }        // namespace rendering

--- a/framework/rendering/hpp_render_target.cpp
+++ b/framework/rendering/hpp_render_target.cpp
@@ -15,31 +15,15 @@
  * limitations under the License.
  */
 
-#pragma once
-
-#include <resource_cache.h>
+#include "rendering/hpp_render_target.h"
 
 namespace vkb
 {
-namespace core
+namespace rendering
 {
-class HPPDevice;
-}
-
-/**
- * @brief facade class around vkb::ResourceCache, providing a vulkan.hpp-based interface
- *
- * See vkb::ResourceCache for documentation
- */
-class HPPResourceCache : private vkb::ResourceCache
-{
-  public:
-	using vkb::ResourceCache::clear;
-	using vkb::ResourceCache::clear_framebuffers;
-
-	HPPResourceCache(vkb::core::HPPDevice &device) :
-	    vkb::ResourceCache(reinterpret_cast<vkb::Device &>(device))
-	{}
+const HPPRenderTarget::CreateFunc HPPRenderTarget::DEFAULT_CREATE_FUNC = [](vkb::core::HPPImage &&swapchain_image) -> std::unique_ptr<HPPRenderTarget> {
+	return std::unique_ptr<HPPRenderTarget>(
+	    reinterpret_cast<HPPRenderTarget *>(vkb::RenderTarget::DEFAULT_CREATE_FUNC(reinterpret_cast<vkb::core::Image &&>(swapchain_image)).release()));
 };
-
+}
 }        // namespace vkb

--- a/framework/rendering/hpp_render_target.h
+++ b/framework/rendering/hpp_render_target.h
@@ -19,6 +19,8 @@
 
 #include <rendering/render_target.h>
 
+#include <core/hpp_image.h>
+
 namespace vkb
 {
 namespace rendering
@@ -31,6 +33,10 @@ namespace rendering
 class HPPRenderTarget : private vkb::RenderTarget
 {
   public:
+	using CreateFunc = std::function<std::unique_ptr<HPPRenderTarget>(vkb::core::HPPImage &&)>;
+
+	static const CreateFunc DEFAULT_CREATE_FUNC;
+
 	const vk::Extent2D &get_extent() const
 	{
 		return reinterpret_cast<vk::Extent2D const &>(vkb::RenderTarget::get_extent());


### PR DESCRIPTION
## Description

Transcoding this part of the framework using Vulkan-Hpp, tested on Win10 and nvidia HW.

In order to make that work I had to
- correct `HPPCommandPool` to use `vkb::rendering::HPPRenderFrame`, instead of just `HPPRenderFrame`
- change the function `vkb::core::HPPDevice::get_resource_cache()` from const to non-const
- extend the facade classes `vkb::core::HPPImage`, `vkb::core::HPPImageView`, `vbk::core::HPPSwapchai`n, `HPPResourceCache`, `vkb::rendering::HPPRenderFrame`, and `vkb::rendering::HPPRenderTarget`
- change the function `vkb::platform::HPPPlatform::create_render_context()` from a facade function to a transcoded version in order to actually create a `vkb::rendering::HPPRenderContext`
- introduce an implementation file for the facade class `vkb::rendering::HPPRenderTarget` in order to provide the resolve the static member `vkb::rendering::HPPRenderTarget::CreateFunc`

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
