### PR TITLE
Add new descriptor management strategy: create descriptors directly; …

### DIFF
--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -623,9 +623,6 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 
 			std::vector<uint32_t> dynamic_offsets;
 
-			// The bindings we want to update before binding, if empty we update all bindings
-			std::vector<uint32_t> bindings_to_update;
-
 			// Iterate over all resource bindings
 			for (auto &binding_it : resource_set.get_resource_bindings())
 			{
@@ -635,12 +632,6 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 				// Check if binding exists in the pipeline layout
 				if (auto binding_info = descriptor_set_layout.get_layout_binding(binding_index))
 				{
-					// If update after bind is enabled, we store the binding index of each binding that need to be updated before being bound
-					if (update_after_bind && !(descriptor_set_layout.get_layout_binding_flag(binding_index) & VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT))
-					{
-						bindings_to_update.push_back(binding_index);
-					}
-
 					// Iterate over all binding resources
 					for (auto &element_it : binding_resources)
 					{
@@ -716,7 +707,7 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 			    command_pool.get_render_frame()->request_descriptor_set(descriptor_set_layout,
 			                                                            buffer_infos,
 			                                                            image_infos,
-			                                                            bindings_to_update,
+			                                                            update_after_bind,
 			                                                            command_pool.get_thread_index());
 
 			// Bind descriptor set

--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -723,12 +723,11 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 			else
 			{
 				// Request a descriptor pool, allocate a descriptor set, write buffer and image data to it
-				auto &descriptor_pool = command_pool.get_render_frame()->request_descriptor_pool(descriptor_set_layout, command_pool.get_thread_index());
+				auto &        descriptor_pool = command_pool.get_render_frame()->request_descriptor_pool(descriptor_set_layout, command_pool.get_thread_index());
 				DescriptorSet descriptor_set{command_pool.get_render_frame()->get_device(), descriptor_set_layout, descriptor_pool, buffer_infos, image_infos};
 				descriptor_set.apply_writes();
 				descriptor_set_handle = descriptor_set.get_handle();
 			}
-
 
 			// Bind descriptor set
 			vkCmdBindDescriptorSets(get_handle(),

--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -663,7 +663,7 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 						}
 
 						// Get image info
-						else if (image_view != nullptr || sampler != VK_NULL_HANDLE)
+						else if (image_view != nullptr || sampler != nullptr)
 						{
 							// Can be null for input attachments
 							VkDescriptorImageInfo image_info{};

--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -712,22 +712,12 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 				}
 			}
 
-			VkDescriptorSet descriptor_set_handle;
-			if (command_pool.get_render_frame()->get_descriptor_management_strategy() == DescriptorManagementStrategy::StoreInCache)
-			{
-				// Request a descriptor set from the render frame, and write the buffer infos and image infos of all the specified bindings
-				auto &descriptor_set = command_pool.get_render_frame()->request_descriptor_set(descriptor_set_layout, buffer_infos, image_infos, command_pool.get_thread_index());
-				descriptor_set.update(bindings_to_update);
-				descriptor_set_handle = descriptor_set.get_handle();
-			}
-			else
-			{
-				// Request a descriptor pool, allocate a descriptor set, write buffer and image data to it
-				auto &        descriptor_pool = command_pool.get_render_frame()->request_descriptor_pool(descriptor_set_layout, command_pool.get_thread_index());
-				DescriptorSet descriptor_set{command_pool.get_render_frame()->get_device(), descriptor_set_layout, descriptor_pool, buffer_infos, image_infos};
-				descriptor_set.apply_writes();
-				descriptor_set_handle = descriptor_set.get_handle();
-			}
+			VkDescriptorSet descriptor_set_handle =
+			    command_pool.get_render_frame()->request_descriptor_set(descriptor_set_layout,
+			                                                            buffer_infos,
+			                                                            image_infos,
+			                                                            bindings_to_update,
+			                                                            command_pool.get_thread_index());
 
 			// Bind descriptor set
 			vkCmdBindDescriptorSets(get_handle(),

--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -659,7 +659,7 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 								buffer_info.offset = 0;
 							}
 
-							buffer_infos[binding_index][array_element] = std::move(buffer_info);
+							buffer_infos[binding_index][array_element] = buffer_info;
 						}
 
 						// Get image info
@@ -697,9 +697,13 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 								}
 							}
 
-							image_infos[binding_index][array_element] = std::move(image_info);
+							image_infos[binding_index][array_element] = image_info;
 						}
 					}
+
+					assert((!update_after_bind ||
+					        (buffer_infos.count(binding_index) > 0 || (image_infos.count(binding_index) > 0))) &&
+					       "binding index with no buffer or image infos can't be checked for adding to bindings_to_update");
 				}
 			}
 

--- a/framework/core/descriptor_set.cpp
+++ b/framework/core/descriptor_set.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/core/descriptor_set.cpp
+++ b/framework/core/descriptor_set.cpp
@@ -26,7 +26,7 @@
 namespace vkb
 {
 DescriptorSet::DescriptorSet(Device &                                  device,
-                             DescriptorSetLayout &                     descriptor_set_layout,
+                             const DescriptorSetLayout &               descriptor_set_layout,
                              DescriptorPool &                          descriptor_pool,
                              const BindingMap<VkDescriptorBufferInfo> &buffer_infos,
                              const BindingMap<VkDescriptorImageInfo> & image_infos) :

--- a/framework/core/descriptor_set.cpp
+++ b/framework/core/descriptor_set.cpp
@@ -214,6 +214,15 @@ void DescriptorSet::update(const std::vector<uint32_t> &bindings_to_update)
 	}
 }
 
+void DescriptorSet::apply_writes() const
+{
+	vkUpdateDescriptorSets(device.get_handle(),
+	                       to_u32(write_descriptor_sets.size()),
+	                       write_descriptor_sets.data(),
+	                       0,
+	                       nullptr);
+}
+
 DescriptorSet::DescriptorSet(DescriptorSet &&other) :
     device{other.device},
     descriptor_set_layout{other.descriptor_set_layout},

--- a/framework/core/descriptor_set.h
+++ b/framework/core/descriptor_set.h
@@ -62,7 +62,7 @@ class DescriptorSet
 	DescriptorSet &operator=(DescriptorSet &&) = delete;
 
 	/**
-	 * @brief Resets the DescriptorSet state 
+	 * @brief Resets the DescriptorSet state
 	 *        Optionally prepares a new set of buffer infos and/or image infos
 	 * @param new_buffer_infos A map of buffer descriptors and their respective bindings
 	 * @param new_image_infos A map of image descriptors and their respective bindings
@@ -77,7 +77,7 @@ class DescriptorSet
 	void update(const std::vector<uint32_t> &bindings_to_update = {});
 
 	/**
-	 * @brief Appies pending write operations without updating the state
+	 * @brief Applies pending write operations without updating the state
 	 */
 	void apply_writes() const;
 

--- a/framework/core/descriptor_set.h
+++ b/framework/core/descriptor_set.h
@@ -45,7 +45,7 @@ class DescriptorSet
 	 * @param image_infos The descriptors that describe image data
 	 */
 	DescriptorSet(Device &                                  device,
-	              DescriptorSetLayout &                     descriptor_set_layout,
+	              const DescriptorSetLayout &               descriptor_set_layout,
 	              DescriptorPool &                          descriptor_pool,
 	              const BindingMap<VkDescriptorBufferInfo> &buffer_infos = {},
 	              const BindingMap<VkDescriptorImageInfo> & image_infos  = {});
@@ -99,7 +99,7 @@ class DescriptorSet
   private:
 	Device &device;
 
-	DescriptorSetLayout &descriptor_set_layout;
+	const DescriptorSetLayout &descriptor_set_layout;
 
 	DescriptorPool &descriptor_pool;
 

--- a/framework/core/descriptor_set.h
+++ b/framework/core/descriptor_set.h
@@ -76,6 +76,11 @@ class DescriptorSet
 	 */
 	void update(const std::vector<uint32_t> &bindings_to_update = {});
 
+	/**
+	 * @brief Appies pending write operations without updating the state
+	 */
+	void apply_writes() const;
+
 	const DescriptorSetLayout &get_layout() const;
 
 	VkDescriptorSet get_handle() const;

--- a/framework/core/descriptor_set.h
+++ b/framework/core/descriptor_set.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/rendering/render_frame.cpp
+++ b/framework/rendering/render_frame.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/rendering/render_frame.cpp
+++ b/framework/rendering/render_frame.cpp
@@ -181,7 +181,7 @@ CommandBuffer &RenderFrame::request_command_buffer(const Queue &queue, CommandBu
 	return (*command_pool_it)->request_command_buffer(level);
 }
 
-DescriptorSet &RenderFrame::request_descriptor_set(DescriptorSetLayout &descriptor_set_layout, const BindingMap<VkDescriptorBufferInfo> &buffer_infos, const BindingMap<VkDescriptorImageInfo> &image_infos, size_t thread_index)
+DescriptorSet &RenderFrame::request_descriptor_set(const DescriptorSetLayout &descriptor_set_layout, const BindingMap<VkDescriptorBufferInfo> &buffer_infos, const BindingMap<VkDescriptorImageInfo> &image_infos, size_t thread_index)
 {
 	assert(thread_index < thread_count && "Thread index is out of bounds");
 
@@ -189,7 +189,7 @@ DescriptorSet &RenderFrame::request_descriptor_set(DescriptorSetLayout &descript
 	return request_resource(device, nullptr, *descriptor_sets.at(thread_index), descriptor_set_layout, descriptor_pool, buffer_infos, image_infos);
 }
 
-DescriptorPool &RenderFrame::request_descriptor_pool(DescriptorSetLayout &descriptor_set_layout, size_t thread_index)
+DescriptorPool &RenderFrame::request_descriptor_pool(const DescriptorSetLayout &descriptor_set_layout, size_t thread_index)
 {
 	assert(thread_index < thread_count && "Thread index is out of bounds");
 

--- a/framework/rendering/render_frame.h
+++ b/framework/rendering/render_frame.h
@@ -123,13 +123,13 @@ class RenderFrame
 	                                      VkCommandBufferLevel     level        = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
 	                                      size_t                   thread_index = 0);
 
-	DescriptorSet &request_descriptor_set(DescriptorSetLayout &                     descriptor_set_layout,
+	DescriptorSet &request_descriptor_set(const DescriptorSetLayout &               descriptor_set_layout,
 	                                      const BindingMap<VkDescriptorBufferInfo> &buffer_infos,
 	                                      const BindingMap<VkDescriptorImageInfo> & image_infos,
 	                                      size_t                                    thread_index = 0);
 
-	DescriptorPool &request_descriptor_pool(DescriptorSetLayout &descriptor_set_layout,
-	                                        size_t               thread_index = 0);
+	DescriptorPool &request_descriptor_pool(const DescriptorSetLayout &descriptor_set_layout,
+	                                        size_t                     thread_index = 0);
 
 	void clear_descriptors();
 

--- a/framework/rendering/render_frame.h
+++ b/framework/rendering/render_frame.h
@@ -128,8 +128,8 @@ class RenderFrame
 	                                      const BindingMap<VkDescriptorImageInfo> & image_infos,
 	                                      size_t                                    thread_index = 0);
 
-	DescriptorPool &request_descriptor_pool(DescriptorSetLayout &                     descriptor_set_layout,
-	                                        size_t                                    thread_index = 0);
+	DescriptorPool &request_descriptor_pool(DescriptorSetLayout &descriptor_set_layout,
+	                                        size_t               thread_index = 0);
 
 	void clear_descriptors();
 
@@ -192,7 +192,7 @@ class RenderFrame
 
 	std::unique_ptr<RenderTarget> swapchain_render_target;
 
-	BufferAllocationStrategy buffer_allocation_strategy{BufferAllocationStrategy::MultipleAllocationsPerBuffer};
+	BufferAllocationStrategy     buffer_allocation_strategy{BufferAllocationStrategy::MultipleAllocationsPerBuffer};
 	DescriptorManagementStrategy descriptor_management_strategy{DescriptorManagementStrategy::StoreInCache};
 
 	std::map<VkBufferUsageFlags, std::vector<std::pair<BufferPool, BufferBlock *>>> buffer_pools;

--- a/framework/rendering/render_frame.h
+++ b/framework/rendering/render_frame.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/rendering/render_frame.h
+++ b/framework/rendering/render_frame.h
@@ -126,7 +126,7 @@ class RenderFrame
 	VkDescriptorSet request_descriptor_set(const DescriptorSetLayout &               descriptor_set_layout,
 	                                       const BindingMap<VkDescriptorBufferInfo> &buffer_infos,
 	                                       const BindingMap<VkDescriptorImageInfo> & image_infos,
-	                                       const std::vector<uint32_t> &             bindings_to_update,
+	                                       bool                                      update_after_bind,
 	                                       size_t                                    thread_index = 0);
 
 	void clear_descriptors();
@@ -189,5 +189,7 @@ class RenderFrame
 	DescriptorManagementStrategy descriptor_management_strategy{DescriptorManagementStrategy::StoreInCache};
 
 	std::map<VkBufferUsageFlags, std::vector<std::pair<BufferPool, BufferBlock *>>> buffer_pools;
+
+	static std::vector<uint32_t> collect_bindings_to_update(const DescriptorSetLayout &descriptor_set_layout, const BindingMap<VkDescriptorBufferInfo> &buffer_infos, const BindingMap<VkDescriptorImageInfo> &image_infos);
 };
 }        // namespace vkb

--- a/framework/rendering/render_frame.h
+++ b/framework/rendering/render_frame.h
@@ -123,13 +123,11 @@ class RenderFrame
 	                                      VkCommandBufferLevel     level        = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
 	                                      size_t                   thread_index = 0);
 
-	DescriptorSet &request_descriptor_set(const DescriptorSetLayout &               descriptor_set_layout,
-	                                      const BindingMap<VkDescriptorBufferInfo> &buffer_infos,
-	                                      const BindingMap<VkDescriptorImageInfo> & image_infos,
-	                                      size_t                                    thread_index = 0);
-
-	DescriptorPool &request_descriptor_pool(const DescriptorSetLayout &descriptor_set_layout,
-	                                        size_t                     thread_index = 0);
+	VkDescriptorSet request_descriptor_set(const DescriptorSetLayout &               descriptor_set_layout,
+	                                       const BindingMap<VkDescriptorBufferInfo> &buffer_infos,
+	                                       const BindingMap<VkDescriptorImageInfo> & image_infos,
+	                                       const std::vector<uint32_t> &             bindings_to_update,
+	                                       size_t                                    thread_index = 0);
 
 	void clear_descriptors();
 
@@ -144,11 +142,6 @@ class RenderFrame
 	 * @param new_strategy The new descriptor set management strategy
 	 */
 	void set_descriptor_management_strategy(DescriptorManagementStrategy new_strategy);
-
-	/**
-	 * @brief Gets descriptor set management strategy
-	 */
-	DescriptorManagementStrategy get_descriptor_management_strategy() const;
 
 	/**
 	 * @param usage Usage of the buffer

--- a/framework/rendering/render_frame.h
+++ b/framework/rendering/render_frame.h
@@ -40,6 +40,12 @@ enum BufferAllocationStrategy
 	MultipleAllocationsPerBuffer
 };
 
+enum DescriptorManagementStrategy
+{
+	StoreInCache,
+	CreateDirectly
+};
+
 /**
  * @brief RenderFrame is a container for per-frame data, including BufferPool objects,
  * synchronization primitives (semaphores, fences) and the swapchain RenderTarget.
@@ -122,6 +128,9 @@ class RenderFrame
 	                                      const BindingMap<VkDescriptorImageInfo> & image_infos,
 	                                      size_t                                    thread_index = 0);
 
+	DescriptorPool &request_descriptor_pool(DescriptorSetLayout &                     descriptor_set_layout,
+	                                        size_t                                    thread_index = 0);
+
 	void clear_descriptors();
 
 	/**
@@ -129,6 +138,17 @@ class RenderFrame
 	 * @param new_strategy The new buffer allocation strategy
 	 */
 	void set_buffer_allocation_strategy(BufferAllocationStrategy new_strategy);
+
+	/**
+	 * @brief Sets a new descriptor set management strategy
+	 * @param new_strategy The new descriptor set management strategy
+	 */
+	void set_descriptor_management_strategy(DescriptorManagementStrategy new_strategy);
+
+	/**
+	 * @brief Gets descriptor set management strategy
+	 */
+	DescriptorManagementStrategy get_descriptor_management_strategy() const;
 
 	/**
 	 * @param usage Usage of the buffer
@@ -173,6 +193,7 @@ class RenderFrame
 	std::unique_ptr<RenderTarget> swapchain_render_target;
 
 	BufferAllocationStrategy buffer_allocation_strategy{BufferAllocationStrategy::MultipleAllocationsPerBuffer};
+	DescriptorManagementStrategy descriptor_management_strategy{DescriptorManagementStrategy::StoreInCache};
 
 	std::map<VkBufferUsageFlags, std::vector<std::pair<BufferPool, BufferBlock *>>> buffer_pools;
 };

--- a/samples/performance/descriptor_management/descriptor_management.cpp
+++ b/samples/performance/descriptor_management/descriptor_management.cpp
@@ -83,11 +83,11 @@ void DescriptorManagement::update(float delta_time)
 
 	render_context.get_active_frame().set_buffer_allocation_strategy(buffer_alloc_strategy);
 
-	if (descriptor_caching.value == 0)
-	{
-		// Clear descriptor pools for the current frame
-		render_context.get_active_frame().clear_descriptors();
-	}
+	auto descriptor_management_strategy = (descriptor_caching.value == 0) ?
+                                               vkb::DescriptorManagementStrategy::CreateDirectly :
+                                               vkb::DescriptorManagementStrategy::StoreInCache;
+
+	render_context.get_active_frame().set_descriptor_management_strategy(descriptor_management_strategy);
 
 	command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 	stats->begin_sampling(command_buffer);

--- a/samples/performance/descriptor_management/descriptor_management.cpp
+++ b/samples/performance/descriptor_management/descriptor_management.cpp
@@ -84,8 +84,8 @@ void DescriptorManagement::update(float delta_time)
 	render_context.get_active_frame().set_buffer_allocation_strategy(buffer_alloc_strategy);
 
 	auto descriptor_management_strategy = (descriptor_caching.value == 0) ?
-                                               vkb::DescriptorManagementStrategy::CreateDirectly :
-                                               vkb::DescriptorManagementStrategy::StoreInCache;
+	                                          vkb::DescriptorManagementStrategy::CreateDirectly :
+	                                          vkb::DescriptorManagementStrategy::StoreInCache;
 
 	render_context.get_active_frame().set_descriptor_management_strategy(descriptor_management_strategy);
 

--- a/samples/performance/descriptor_management/descriptor_management.cpp
+++ b/samples/performance/descriptor_management/descriptor_management.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
…use it in descriptor_management. (#527)

* Add vkb::DescriptorManagementStrategy enum
* Add new descriptor management strategy: recreating descriptor sets every frame
* Use new strategy in descriptor_management

## Description

This pull request changes the descriptor_management sample in a way that when **Disabled** is chosen for **Descriptor set caching**, using descriptor cache is fully avoided and the descriptor sets are allocated and updated directly.

This allows users to get a more realistic estimation of how much performance can implementing descriptor set cache save.

The difference between the results can be significant. Here are the results from my realme XT (Android 11):
Original:
![image](https://user-images.githubusercontent.com/12236759/193161474-ef331fdc-cc1a-458a-927d-26782518ba30.png)
![image](https://user-images.githubusercontent.com/12236759/193161534-0e40d991-b26e-4306-8ce6-052e5c439f7a.png)
After my changes:
![image](https://user-images.githubusercontent.com/12236759/193161655-60adce65-d109-4980-9743-fe08ce734ed2.png)


Fixes #527

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
