### PR TITLE
Add command line option for specifying data path

### DIFF
--- a/app/plugins/data_path/data_path.cpp
+++ b/app/plugins/data_path/data_path.cpp
@@ -1,0 +1,42 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "data_path.h"
+
+namespace plugins
+{
+DataPath::DataPath() :
+    DataPathTags("Data Path Override",
+                 "Specify the folder containing the sample data folders.",
+                 {vkb::Hook::OnAppStart}, {&data_path_flag})
+{
+}
+
+bool DataPath::is_active(const vkb::CommandParser &parser)
+{
+	return parser.contains(&data_path_flag);
+}
+
+void DataPath::init(const vkb::CommandParser &parser)
+{
+	if (parser.contains(&data_path_flag))
+	{
+		vkb::Platform::set_external_storage_directory(parser.as<std::string>(&data_path_flag) + "/");
+	}
+}
+
+}        // namespace plugins

--- a/app/plugins/data_path/data_path.h
+++ b/app/plugins/data_path/data_path.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "platform/plugins/plugin_base.h"
+namespace plugins
+{
+using DataPathTags = vkb::PluginBase<vkb::tags::Passive>;
+
+/**
+ * @brief Data path override
+ *
+ * Controls the root path used to find data files
+ *
+ * Usage: vulkan_sample sample afbc --data-path <folder>
+ *
+ */
+class DataPath : public DataPathTags
+{
+  public:
+	DataPath();
+
+	virtual ~DataPath() = default;
+
+	virtual bool is_active(const vkb::CommandParser &parser) override;
+
+	virtual void init(const vkb::CommandParser &parser) override;
+
+	vkb::FlagCommand data_path_flag = {vkb::FlagType::OneValue, "data-path", "", "Folder containing data files"};
+};
+}        // namespace plugins


### PR DESCRIPTION
## Description

Adds a command line option to change the default data path from "" to something else.

Fixes #531

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
