### PR TITLE
Change vkb::core::HPPImage from a facade over vkb::core::Image to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -284,6 +284,7 @@ set(CORE_FILES
     core/vulkan_resource.cpp
     core/hpp_command_pool.cpp
     core/hpp_device.cpp
+    core/hpp_image.cpp
     core/hpp_instance.cpp
     core/hpp_physical_device.cpp
     core/hpp_queue.cpp

--- a/framework/core/hpp_image.cpp
+++ b/framework/core/hpp_image.cpp
@@ -1,0 +1,220 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/hpp_image.h"
+
+#include "core/hpp_device.h"
+
+namespace vkb
+{
+namespace
+{
+inline vk::ImageType find_image_type(vk::Extent3D const &extent)
+{
+	uint32_t dim_num = !!extent.width + !!extent.height + (1 < extent.depth);
+	switch (dim_num)
+	{
+		case 1:
+			return vk::ImageType::e1D;
+		case 2:
+			return vk::ImageType::e2D;
+		case 3:
+			return vk::ImageType::e3D;
+		default:
+			throw std::runtime_error("No image type found.");
+			return vk::ImageType();
+	}
+}
+}        // namespace
+
+namespace core
+{
+HPPImage::HPPImage(HPPDevice const &       device,
+                   const vk::Extent3D &    extent,
+                   vk::Format              format,
+                   vk::ImageUsageFlags     image_usage,
+                   VmaMemoryUsage          memory_usage,
+                   vk::SampleCountFlagBits sample_count,
+                   const uint32_t          mip_levels,
+                   const uint32_t          array_layers,
+                   vk::ImageTiling         tiling,
+                   vk::ImageCreateFlags    flags,
+                   uint32_t                num_queue_families,
+                   const uint32_t *        queue_families) :
+    HPPVulkanResource{nullptr, &device},
+    type{find_image_type(extent)},
+    extent{extent},
+    format{format},
+    sample_count{sample_count},
+    usage{image_usage},
+    array_layer_count{array_layers},
+    tiling{tiling}
+{
+	assert(0 < mip_levels && "HPPImage should have at least one level");
+	assert(0 < array_layers && "HPPImage should have at least one layer");
+
+	subresource.mipLevel   = mip_levels;
+	subresource.arrayLayer = array_layers;
+
+	vk::ImageCreateInfo image_info(flags, type, format, extent, mip_levels, array_layers, sample_count, tiling, image_usage);
+
+	if (num_queue_families != 0)
+	{
+		image_info.sharingMode           = vk::SharingMode::eConcurrent;
+		image_info.queueFamilyIndexCount = num_queue_families;
+		image_info.pQueueFamilyIndices   = queue_families;
+	}
+
+	VmaAllocationCreateInfo memory_info{};
+	memory_info.usage = memory_usage;
+
+	if (image_usage & vk::ImageUsageFlagBits::eTransientAttachment)
+	{
+		memory_info.preferredFlags = VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT;
+	}
+
+	auto result = vmaCreateImage(device.get_memory_allocator(),
+	                             reinterpret_cast<VkImageCreateInfo const *>(&image_info),
+	                             &memory_info,
+	                             const_cast<VkImage *>(reinterpret_cast<VkImage const *>(&get_handle())),
+	                             &memory,
+	                             nullptr);
+
+	if (result != VK_SUCCESS)
+	{
+		throw VulkanException{result, "Cannot create HPPImage"};
+	}
+}
+
+HPPImage::HPPImage(HPPDevice const &       device,
+                   vk::Image               handle,
+                   const vk::Extent3D &    extent,
+                   vk::Format              format,
+                   vk::ImageUsageFlags     image_usage,
+                   vk::SampleCountFlagBits sample_count) :
+    HPPVulkanResource{handle, &device}, type{find_image_type(extent)}, extent{extent}, format{format}, sample_count{sample_count}, usage{image_usage}
+{
+	subresource.mipLevel   = 1;
+	subresource.arrayLayer = 1;
+}
+
+HPPImage::HPPImage(HPPImage &&other) :
+    HPPVulkanResource{std::move(other)},
+    memory(std::exchange(other.memory, {})),
+    type(std::exchange(other.type, {})),
+    extent(std::exchange(other.extent, {})),
+    format(std::exchange(other.format, {})),
+    sample_count(std::exchange(other.sample_count, {})),
+    usage(std::exchange(other.usage, {})),
+    tiling(std::exchange(other.tiling, {})),
+    subresource(std::exchange(other.subresource, {})),
+    views(std::exchange(other.views, {})),
+    mapped_data(std::exchange(other.mapped_data, {})),
+    mapped(std::exchange(other.mapped, {}))
+{
+	// Update image views references to this image to avoid dangling pointers
+	for (auto &view : views)
+	{
+		view->set_image(*this);
+	}
+}
+
+HPPImage::~HPPImage()
+{
+	if (get_handle() && memory)
+	{
+		unmap();
+		vmaDestroyImage(get_device().get_memory_allocator(), get_handle(), memory);
+	}
+}
+
+VmaAllocation HPPImage::get_memory() const
+{
+	return memory;
+}
+
+uint8_t *HPPImage::map()
+{
+	if (!mapped_data)
+	{
+		if (tiling != vk::ImageTiling::eLinear)
+		{
+			LOGW("Mapping image memory that is not linear");
+		}
+		VK_CHECK(vmaMapMemory(get_device().get_memory_allocator(), memory, reinterpret_cast<void **>(&mapped_data)));
+		mapped = true;
+	}
+	return mapped_data;
+}
+
+void HPPImage::unmap()
+{
+	if (mapped)
+	{
+		vmaUnmapMemory(get_device().get_memory_allocator(), memory);
+		mapped_data = nullptr;
+		mapped      = false;
+	}
+}
+
+vk::ImageType HPPImage::get_type() const
+{
+	return type;
+}
+
+const vk::Extent3D &HPPImage::get_extent() const
+{
+	return extent;
+}
+
+vk::Format HPPImage::get_format() const
+{
+	return format;
+}
+
+vk::SampleCountFlagBits HPPImage::get_sample_count() const
+{
+	return sample_count;
+}
+
+vk::ImageUsageFlags HPPImage::get_usage() const
+{
+	return usage;
+}
+
+vk::ImageTiling HPPImage::get_tiling() const
+{
+	return tiling;
+}
+
+vk::ImageSubresource HPPImage::get_subresource() const
+{
+	return subresource;
+}
+
+uint32_t HPPImage::get_array_layer_count() const
+{
+	return array_layer_count;
+}
+
+std::unordered_set<vkb::core::HPPImageView *> &HPPImage::get_views()
+{
+	return views;
+}
+
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_image.h
+++ b/framework/core/hpp_image.h
@@ -17,37 +17,26 @@
 
 #pragma once
 
-#include <core/image.h>
-
-#include <core/hpp_device.h>
+#include "core/hpp_vulkan_resource.h"
+#include <unordered_set>
+#include <vk_mem_alloc.h>
 
 namespace vkb
 {
 namespace core
 {
-/**
- * @brief facade class around vkb::core::Image, providing a vulkan.hpp-based interface
- *
- * See vkb::core::Image for documentation
- */
-class HPPImage : private Image
+class HPPDevice;
+class HPPImageView;
+
+class HPPImage : public vkb::core::HPPVulkanResource<vk::Image>
 {
   public:
-	using Image::get_array_layer_count;
-
 	HPPImage(HPPDevice const &       device,
 	         vk::Image               handle,
 	         const vk::Extent3D &    extent,
 	         vk::Format              format,
 	         vk::ImageUsageFlags     image_usage,
-	         vk::SampleCountFlagBits sample_count = vk::SampleCountFlagBits::e1) :
-	    Image(reinterpret_cast<vkb::Device const &>(device),
-	          handle,
-	          static_cast<VkExtent3D const &>(extent),
-	          static_cast<VkFormat>(format),
-	          static_cast<VkImageUsageFlags>(image_usage),
-	          static_cast<VkSampleCountFlagBits>(sample_count))
-	{}
+	         vk::SampleCountFlagBits sample_count = vk::SampleCountFlagBits::e1);
 
 	HPPImage(HPPDevice const &       device,
 	         const vk::Extent3D &    extent,
@@ -60,25 +49,54 @@ class HPPImage : private Image
 	         vk::ImageTiling         tiling             = vk::ImageTiling::eOptimal,
 	         vk::ImageCreateFlags    flags              = {},
 	         uint32_t                num_queue_families = 0,
-	         const uint32_t *        queue_families     = nullptr) :
-	    Image(reinterpret_cast<vkb::Device const &>(device),
-	          static_cast<VkExtent3D>(extent),
-	          static_cast<VkFormat>(format),
-	          static_cast<VkImageUsageFlags>(image_usage),
-	          memory_usage,
-	          static_cast<VkSampleCountFlagBits>(sample_count),
-	          mip_levels,
-	          array_layers,
-	          static_cast<VkImageTiling>(tiling),
-	          static_cast<VkImageCreateFlags>(flags),
-	          num_queue_families,
-	          queue_families)
-	{}
+	         const uint32_t *        queue_families     = nullptr);
 
-	vk::Image get_handle() const
-	{
-		return Image::get_handle();
-	}
+	HPPImage(const HPPImage &) = delete;
+
+	HPPImage(HPPImage &&other);
+
+	~HPPImage() override;
+
+	HPPImage &operator=(const HPPImage &) = delete;
+
+	HPPImage &operator=(HPPImage &&) = delete;
+
+	VmaAllocation get_memory() const;
+
+	/**
+	 * @brief Maps vulkan memory to an host visible address
+	 * @return Pointer to host visible memory
+	 */
+	uint8_t *map();
+
+	/**
+	 * @brief Unmaps vulkan memory from the host visible address
+	 */
+	void unmap();
+
+	vk::ImageType                                  get_type() const;
+	const vk::Extent3D &                           get_extent() const;
+	vk::Format                                     get_format() const;
+	vk::SampleCountFlagBits                        get_sample_count() const;
+	vk::ImageUsageFlags                            get_usage() const;
+	vk::ImageTiling                                get_tiling() const;
+	vk::ImageSubresource                           get_subresource() const;
+	uint32_t                                       get_array_layer_count() const;
+	std::unordered_set<vkb::core::HPPImageView *> &get_views();
+
+  private:
+	VmaAllocation                                 memory = VK_NULL_HANDLE;
+	vk::ImageType                                 type;
+	vk::Extent3D                                  extent;
+	vk::Format                                    format;
+	vk::ImageUsageFlags                           usage;
+	vk::SampleCountFlagBits                       sample_count;
+	vk::ImageTiling                               tiling;
+	vk::ImageSubresource                          subresource;
+	uint32_t                                      array_layer_count = 0;
+	std::unordered_set<vkb::core::HPPImageView *> views;        /// HPPImage views referring to this image
+	uint8_t *                                     mapped_data = nullptr;
+	bool                                          mapped      = false;        /// Whether it was mapped with vmaMapMemory
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_image_view.h
+++ b/framework/core/hpp_image_view.h
@@ -47,6 +47,11 @@ class HPPImageView : private vkb::core::ImageView
 	{
 		return reinterpret_cast<HPPImage const &>(ImageView::get_image());
 	}
+
+	void set_image(HPPImage &image)
+	{
+		vkb::core::ImageView::set_image(reinterpret_cast<vkb::core::Image &>(image));
+	}
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -39,7 +39,7 @@ template <typename HPPHandle, typename VKBDevice = vkb::core::HPPDevice>
 class HPPVulkanResource
 {
   public:
-	HPPVulkanResource(HPPHandle handle = nullptr, VKBDevice *device = nullptr) :
+	HPPVulkanResource(HPPHandle handle = nullptr, VKBDevice const *device = nullptr) :
 	    handle{handle}, device{device}
 	{
 	}
@@ -69,7 +69,7 @@ class HPPVulkanResource
 		return HPPHandle::NativeType;
 	}
 
-	inline VKBDevice &get_device() const
+	inline VKBDevice const &get_device() const
 	{
 		assert(device && "VKBDevice handle not set");
 		return *device;
@@ -80,14 +80,14 @@ class HPPVulkanResource
 		return handle;
 	}
 
-	inline const uint64_t get_handle_u64() const
+	inline uint64_t get_handle_u64() const
 	{
 		// See https://github.com/KhronosGroup/Vulkan-Docs/issues/368 .
 		// Dispatchable and non-dispatchable handle types are *not* necessarily binary-compatible!
 		// Non-dispatchable handles _might_ be only 32-bit long. This is because, on 32-bit machines, they might be a typedef to a 32-bit pointer.
 		using UintHandle = typename std::conditional<sizeof(HPPHandle) == sizeof(uint32_t), uint32_t, uint64_t>::type;
 
-		return static_cast<uint64_t>(reinterpret_cast<UintHandle>(handle));
+		return static_cast<uint64_t>(*reinterpret_cast<UintHandle const *>(&handle));
 	}
 
 	inline void set_handle(HPPHandle hdl)
@@ -104,13 +104,13 @@ class HPPVulkanResource
 	inline void set_debug_name(const std::string &name)
 	{
 		debug_name = name;
-		detail::set_debug_name(device, HPPHandle::NativeType, get_handle_u64(), debug_name.c_str());
+		detail::set_debug_name(device, HPPHandle::objectType, get_handle_u64(), debug_name.c_str());
 	}
 
   private:
-	HPPHandle   handle;
-	VKBDevice * device;
-	std::string debug_name;
+	HPPHandle        handle;
+	VKBDevice const *device;
+	std::string      debug_name;
 };
 
 }        // namespace core

--- a/framework/core/image.cpp
+++ b/framework/core/image.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -153,6 +153,7 @@ Image::Image(Image &&other) :
     usage{other.usage},
     tiling{other.tiling},
     subresource{other.subresource},
+    views(std::exchange(other.views, {})),
     mapped_data{other.mapped_data},
     mapped{other.mapped}
 {


### PR DESCRIPTION
## Description

Transcoding this part of the framework using Vulkan-Hpp, tested on Win10 and nvidia HW.
In order to make that work I had to slightly adjust `hpp_image_view.h` and `hpp_vulkan_resource.h`.

Besides that, a bug is fixed in `vkb::core::Image`: the views have not been moved in the move constructor.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
