### PR TITLE
Change vkb::rendering::HPPRenderTarget from a facade over vkb::RenderTarget to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/core/hpp_image_view.h
+++ b/framework/core/hpp_image_view.h
@@ -33,6 +33,12 @@ class HPPImage;
 class HPPImageView : private vkb::core::ImageView
 {
   public:
+	HPPImageView(HPPImage &image, vk::ImageViewType view_type, vk::Format format = vk::Format::eUndefined,
+	             uint32_t base_mip_level = 0, uint32_t base_array_layer = 0,
+	             uint32_t n_mip_levels = 0, uint32_t n_array_layers = 0) :
+	    vkb::core::ImageView(reinterpret_cast<vkb::core::Image &>(image), static_cast<VkImageViewType>(view_type), static_cast<VkFormat>(format), base_mip_level, base_array_layer, n_mip_levels, n_array_layers)
+	{}
+
 	vk::Format get_format() const
 	{
 		return static_cast<vk::Format>(vkb::core::ImageView::get_format());
@@ -46,6 +52,11 @@ class HPPImageView : private vkb::core::ImageView
 	const HPPImage &get_image() const
 	{
 		return reinterpret_cast<HPPImage const &>(ImageView::get_image());
+	}
+
+	vk::ImageSubresourceRange get_subresource_range() const
+	{
+		return static_cast<vk::ImageSubresourceRange>(vkb::core::ImageView::get_subresource_range());
 	}
 
 	void set_image(HPPImage &image)

--- a/framework/rendering/hpp_render_target.cpp
+++ b/framework/rendering/hpp_render_target.cpp
@@ -17,13 +17,133 @@
 
 #include "rendering/hpp_render_target.h"
 
+#include "core/hpp_device.h"
+
 namespace vkb
 {
 namespace rendering
 {
-const HPPRenderTarget::CreateFunc HPPRenderTarget::DEFAULT_CREATE_FUNC = [](vkb::core::HPPImage &&swapchain_image) -> std::unique_ptr<HPPRenderTarget> {
-	return std::unique_ptr<HPPRenderTarget>(
-	    reinterpret_cast<HPPRenderTarget *>(vkb::RenderTarget::DEFAULT_CREATE_FUNC(reinterpret_cast<vkb::core::Image &&>(swapchain_image)).release()));
+const HPPRenderTarget::CreateFunc HPPRenderTarget::DEFAULT_CREATE_FUNC = [](core::HPPImage &&swapchain_image) -> std::unique_ptr<HPPRenderTarget> {
+	vk::Format depth_format = common::get_suitable_depth_format(swapchain_image.get_device().get_gpu().get_handle());
+
+	core::HPPImage depth_image{swapchain_image.get_device(), swapchain_image.get_extent(),
+	                           depth_format,
+	                           vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eTransientAttachment,
+	                           VMA_MEMORY_USAGE_GPU_ONLY};
+
+	std::vector<core::HPPImage> images;
+	images.push_back(std::move(swapchain_image));
+	images.push_back(std::move(depth_image));
+
+	return std::make_unique<HPPRenderTarget>(std::move(images));
 };
+
+HPPRenderTarget::HPPRenderTarget(std::vector<core::HPPImage> &&images_) :
+    device{images_.back().get_device()},
+    images{std::move(images_)}
+{
+	assert(!images.empty() && "Should specify at least 1 image");
+
+	// check that every image is 2D
+	auto it = std::find_if(images.begin(), images.end(), [](core::HPPImage const &image) { return image.get_type() != vk::ImageType::e2D; });
+	if (it != images.end())
+	{
+		throw VulkanException{VK_ERROR_INITIALIZATION_FAILED, "Image type is not 2D"};
+	}
+
+	extent.width  = images.front().get_extent().width;
+	extent.height = images.front().get_extent().height;
+
+	// check that every image has the same extent
+	it = std::find_if(std::next(images.begin()),
+	                  images.end(),
+	                  [this](core::HPPImage const &image) { return (extent.width != image.get_extent().width) || (extent.height != image.get_extent().height); });
+	if (it != images.end())
+	{
+		throw VulkanException{VK_ERROR_INITIALIZATION_FAILED, "Extent size is not unique"};
+	}
+
+	for (auto &image : images)
+	{
+		views.emplace_back(image, vk::ImageViewType::e2D);
+		attachments.emplace_back(HPPAttachment{image.get_format(), image.get_sample_count(), image.get_usage()});
+	}
 }
+
+HPPRenderTarget::HPPRenderTarget(std::vector<core::HPPImageView> &&image_views) :
+    device{image_views.back().get_image().get_device()},
+    views{std::move(image_views)}
+{
+	assert(!views.empty() && "Should specify at least 1 image view");
+
+	const uint32_t mip_level = views.front().get_subresource_range().baseMipLevel;
+	extent.width             = views.front().get_image().get_extent().width >> mip_level;
+	extent.height            = views.front().get_image().get_extent().height >> mip_level;
+
+	// check that every image view has the same extent
+	auto it = std::find_if(std::next(views.begin()),
+	                       views.end(),
+	                       [this](core::HPPImageView const &image_view) {
+		                       const uint32_t mip_level = image_view.get_subresource_range().baseMipLevel;
+		                       return (extent.width != image_view.get_image().get_extent().width >> mip_level) ||
+		                              (extent.height != image_view.get_image().get_extent().height >> mip_level);
+	                       });
+	if (it != views.end())
+	{
+		throw VulkanException{VK_ERROR_INITIALIZATION_FAILED, "Extent size is not unique"};
+	}
+
+	for (auto &view : views)
+	{
+		const auto &image = view.get_image();
+		attachments.emplace_back(HPPAttachment{image.get_format(), image.get_sample_count(), image.get_usage()});
+	}
+}
+
+const vk::Extent2D &HPPRenderTarget::get_extent() const
+{
+	return extent;
+}
+
+const std::vector<core::HPPImageView> &HPPRenderTarget::get_views() const
+{
+	return views;
+}
+
+const std::vector<HPPAttachment> &HPPRenderTarget::get_attachments() const
+{
+	return attachments;
+}
+
+void HPPRenderTarget::set_input_attachments(std::vector<uint32_t> &input)
+{
+	input_attachments = input;
+}
+
+const std::vector<uint32_t> &HPPRenderTarget::get_input_attachments() const
+{
+	return input_attachments;
+}
+
+void HPPRenderTarget::set_output_attachments(std::vector<uint32_t> &output)
+{
+	output_attachments = output;
+}
+
+const std::vector<uint32_t> &HPPRenderTarget::get_output_attachments() const
+{
+	return output_attachments;
+}
+
+void HPPRenderTarget::set_layout(uint32_t attachment, vk::ImageLayout layout)
+{
+	attachments[attachment].initial_layout = layout;
+}
+
+vk::ImageLayout HPPRenderTarget::get_layout(uint32_t attachment) const
+{
+	return attachments[attachment].initial_layout;
+}
+
+}        // namespace rendering
 }        // namespace vkb

--- a/framework/rendering/hpp_render_target.h
+++ b/framework/rendering/hpp_render_target.h
@@ -17,35 +17,92 @@
 
 #pragma once
 
-#include <rendering/render_target.h>
-
-#include <core/hpp_image.h>
+#include "core/hpp_image.h"
+#include <functional>
 
 namespace vkb
 {
+namespace core
+{
+class HPPDevice;
+}
+
 namespace rendering
 {
 /**
- * @brief facade class around vkb::RenderTarget, providing a vulkan.hpp-based interface
- *
- * See vkb::RenderTarget for documentation
+ * @brief Description of render pass attachments.
+ * HPPAttachment descriptions can be used to automatically create render target images.
  */
-class HPPRenderTarget : private vkb::RenderTarget
+struct HPPAttachment
+{
+	HPPAttachment() = default;
+
+	HPPAttachment(vk::Format format, vk::SampleCountFlagBits samples, vk::ImageUsageFlags usage) :
+	    format{format},
+	    samples{samples},
+	    usage{usage}
+	{}
+
+	vk::Format              format         = vk::Format::eUndefined;
+	vk::SampleCountFlagBits samples        = vk::SampleCountFlagBits::e1;
+	vk::ImageUsageFlags     usage          = vk::ImageUsageFlagBits::eSampled;
+	vk::ImageLayout         initial_layout = vk::ImageLayout::eUndefined;
+};
+
+/**
+* @brief HPPRenderContext is a transcoded version of vkb::RenderContext from vulkan to vulkan-hpp.
+* 
+* See vkb::RenderContext for documentation
+*/
+class HPPRenderTarget
 {
   public:
-	using CreateFunc = std::function<std::unique_ptr<HPPRenderTarget>(vkb::core::HPPImage &&)>;
+	using CreateFunc = std::function<std::unique_ptr<HPPRenderTarget>(core::HPPImage &&)>;
 
 	static const CreateFunc DEFAULT_CREATE_FUNC;
 
-	const vk::Extent2D &get_extent() const
-	{
-		return reinterpret_cast<vk::Extent2D const &>(vkb::RenderTarget::get_extent());
-	}
+	HPPRenderTarget(std::vector<core::HPPImage> &&images);
 
-	std::vector<vkb::core::HPPImageView> const &get_views() const
-	{
-		return reinterpret_cast<std::vector<vkb::core::HPPImageView> const &>(vkb::RenderTarget::get_views());
-	}
+	HPPRenderTarget(std::vector<core::HPPImageView> &&image_views);
+
+	HPPRenderTarget(const HPPRenderTarget &) = delete;
+
+	HPPRenderTarget(HPPRenderTarget &&) = delete;
+
+	HPPRenderTarget &operator=(const HPPRenderTarget &other) noexcept = delete;
+
+	HPPRenderTarget &operator=(HPPRenderTarget &&other) noexcept = delete;
+
+	const vk::Extent2D &                   get_extent() const;
+	const std::vector<core::HPPImageView> &get_views() const;
+	const std::vector<HPPAttachment> &     get_attachments() const;
+
+	/**
+	 * @brief Sets the current input attachments overwriting the current ones
+	 *        Should be set before beginning the render pass and before starting a new subpass
+	 * @param input Set of attachment reference number to use as input
+	 */
+	void                         set_input_attachments(std::vector<uint32_t> &input);
+	const std::vector<uint32_t> &get_input_attachments() const;
+
+	/**
+	 * @brief Sets the current output attachments overwriting the current ones
+	 *        Should be set before beginning the render pass and before starting a new subpass
+	 * @param output Set of attachment reference number to use as output
+	 */
+	void                         set_output_attachments(std::vector<uint32_t> &output);
+	const std::vector<uint32_t> &get_output_attachments() const;
+	void                         set_layout(uint32_t attachment, vk::ImageLayout layout);
+	vk::ImageLayout              get_layout(uint32_t attachment) const;
+
+  private:
+	core::HPPDevice const &         device;
+	vk::Extent2D                    extent;
+	std::vector<core::HPPImage>     images;
+	std::vector<core::HPPImageView> views;
+	std::vector<HPPAttachment>      attachments;
+	std::vector<uint32_t>           input_attachments  = {};         // By default there are no input attachments
+	std::vector<uint32_t>           output_attachments = {0};        // By default the output attachments is attachment 0
 };
 }        // namespace rendering
 }        // namespace vkb


### PR DESCRIPTION
## Description

Transcoding this part of the framework using Vulkan-Hpp, tested on Win10 and nvidia HW.
Needed to slightly extend facade class `HPPImageView`.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
