### PR TITLE
Reduce memory footprint during gltf loading

### DIFF
--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -501,10 +501,6 @@ sg::Scene GLTFLoader::load_scene(int scene_index)
 	}
 
 	std::vector<std::unique_ptr<sg::Image>> image_components;
-	for (auto &fut : image_component_futures)
-	{
-		image_components.push_back(fut.get());
-	}
 
 	// Upload images to GPU. We do this in batches of 64MB of data to avoid needing
 	// double the amount of memory (all the images and all the corresponding buffers).
@@ -523,6 +519,9 @@ sg::Scene GLTFLoader::load_scene(int scene_index)
 		// Deal with 64MB of image data at a time to keep memory footprint low
 		while (image_index < image_count && batch_size < 64 * 1024 * 1024)
 		{
+			// Wait for this image to complete loading, then stage for upload
+			image_components.push_back(image_component_futures.at(image_index).get());
+
 			auto &image = image_components.at(image_index);
 
 			core::Buffer stage_buffer{device,


### PR DESCRIPTION
## Description

The GLTF loader was loading all the image data into system memory and then attempting to upload that via staging buffers to device images all at once. That required device allocations for all the staging buffers and the destination images to exist at the same time. On small memory systems that easily blew the budget when running descriptor_management (Bonza4x) for example.

This change does the uploads in batches of ~64MB of image data. The staging buffers only need to cover that 64MB at any one time in that case.

Also made a small change to allow the GPU buffer->image conversions to overlap the CPU image loading. Rather than get()ing all the image load futures up-front, it now does them in the staging loop. Once 64KB of data is ready it will start the GPU conversion whilst continuing to load the remaining image on the CPU. This might also reduce the memory footprint slightly too since the image data and staging data should be finished with sooner.

Fixes #557

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
