### PR TITLE
Reduce memory usage for OneAllocationPerBuffer

### DIFF
--- a/framework/buffer_pool.cpp
+++ b/framework/buffer_pool.cpp
@@ -85,7 +85,7 @@ BufferPool::BufferPool(Device &device, VkDeviceSize block_size, VkBufferUsageFla
 {
 }
 
-BufferBlock &BufferPool::request_buffer_block(const VkDeviceSize minimum_size)
+BufferBlock &BufferPool::request_buffer_block(const VkDeviceSize minimum_size, bool minimal)
 {
 	// Find the first block in the range of the inactive blocks
 	// which can fit the minimum size
@@ -101,8 +101,10 @@ BufferBlock &BufferPool::request_buffer_block(const VkDeviceSize minimum_size)
 
 	LOGD("Building #{} buffer block ({})", buffer_blocks.size(), usage);
 
+	VkDeviceSize new_block_size = minimal ? minimum_size : std::max(block_size, minimum_size);
+
 	// Create a new block, store and return it
-	buffer_blocks.emplace_back(std::make_unique<BufferBlock>(device, std::max(block_size, minimum_size), usage, memory_usage));
+	buffer_blocks.emplace_back(std::make_unique<BufferBlock>(device, new_block_size, usage, memory_usage));
 
 	auto &block = buffer_blocks[active_buffer_block_count++];
 

--- a/framework/buffer_pool.h
+++ b/framework/buffer_pool.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2022, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -115,7 +115,7 @@ class BufferPool
   public:
 	BufferPool(Device &device, VkDeviceSize block_size, VkBufferUsageFlags usage, VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_CPU_TO_GPU);
 
-	BufferBlock &request_buffer_block(VkDeviceSize minimum_size);
+	BufferBlock &request_buffer_block(VkDeviceSize minimum_size, bool minimal = false);
 
 	void reset();
 


### PR DESCRIPTION
## Description

OneAllocationPerBuffer is used by the decriptor_management sample. It's intended to show the difference between having one buffer with one allocation, and having multiple allocations per buffer.

The way it was written however, each buffer was a minimum of 256KB regardless of the number of allocations. This sample was making thousands of small allocations, each of which was then trying to get its own 256KB buffer block. This quickly led to memory exhaustion on small memory systems.

This change ensures that buffer blocks are allocated only at the size requested when OneAllocationPerBuffer is active.

Fixes #559

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
