### PR TITLE
Update ndk and cmake version for Android build to match CI's versions

### DIFF
--- a/bldsys/cmake/create_gradle_project.cmake
+++ b/bldsys/cmake/create_gradle_project.cmake
@@ -175,7 +175,7 @@ endif()
 if(EXISTS ${NATIVE_SCRIPT})
 	file(RELATIVE_PATH NATIVE_SCRIPT_TMP ${OUTPUT_DIR}/app ${NATIVE_SCRIPT})
 
-	set(CMAKE_PATH "cmake {\n\t\t\tpath '${NATIVE_SCRIPT_TMP}'\n\t\t\tbuildStagingDirectory \'build-native\'\n\t\t} ")
+	set(CMAKE_PATH "path '${NATIVE_SCRIPT_TMP}'\n\t\t\tbuildStagingDirectory \'build-native\'")
 endif()
 
 # cmake.arguments

--- a/bldsys/cmake/template/gradle/app.build.gradle.in
+++ b/bldsys/cmake/template/gradle/app.build.gradle.in
@@ -4,6 +4,7 @@ plugins {
 
 android {
 	compileSdk 32
+	ndkVersion "25.1.8937393"
 
 	defaultConfig {
 		applicationId "com.khronos.vulkan_samples"
@@ -53,7 +54,10 @@ android {
 	}
 
 	externalNativeBuild {
-		@CMAKE_PATH@
+		cmake {
+			version "3.22.1"
+			@CMAKE_PATH@
+		}
 	}
 
 	lintOptions {


### PR DESCRIPTION
## Description
Step 2 for https://github.com/KhronosGroup/Vulkan-Samples/issues/553: update the current sample build to use CI's latest versions, there is no Vulkan functionality changes/impact.

This CL depends on #564.

Fixes  (Related to, but not really fixes) #553

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
