### PR TITLE
Add Logger

### DIFF
--- a/components/common/CMakeLists.txt
+++ b/components/common/CMakeLists.txt
@@ -18,6 +18,7 @@ vkb__register_headers(
     FOLDER
         common
     HEADERS
+        logging.hpp
         stack_error.hpp
         strings.hpp
     OUTPUT
@@ -26,8 +27,21 @@ vkb__register_headers(
 
 vkb__register_component(
     NAME common
-    HEADERS ${COMMON_HEADERS}
-    INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+    HEADERS
+        ${COMMON_HEADERS}
+    INCLUDE_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    LINK_LIBS
+        spdlog
+
+)
+
+vkb__register_tests(
+    NAME "logging_tests"
+    SRC
+        tests/logging.test.cpp
+    LIBS
+        vkb__common
 )
 
 vkb__register_tests(

--- a/components/common/include/components/common/logging.hpp
+++ b/components/common/include/components/common/logging.hpp
@@ -1,0 +1,42 @@
+/* Copyright (c) 2018-2022, Arm Limited and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+#define PROJECT_NAME "VulkanSamples"
+
+#define LOGT(...) spdlog::trace(__VA_ARGS__);
+#define LOGI(...) spdlog::info(__VA_ARGS__);
+#define LOGW(...) spdlog::warn(__VA_ARGS__);
+#define LOGE(...) spdlog::error(__VA_ARGS__);
+#define LOGD(...) spdlog::debug(__VA_ARGS__);
+
+namespace logging
+{
+inline void init_default_logger()
+{
+	// TODO: Add android support
+	auto console = spdlog::stdout_color_mt("console");
+	spdlog::set_default_logger(console);
+	spdlog::set_level(spdlog::level::trace);
+	spdlog::set_pattern("[%^%l%$] %v");
+}
+}        // namespace logging

--- a/components/common/tests/logging.test.cpp
+++ b/components/common/tests/logging.test.cpp
@@ -22,6 +22,8 @@ int main(int /* argc */, char ** /* argv */)
 {
 	logging::init_default_logger();
 
+	// Currently no testing in place
+	// The logging_tests executable can be used to experiment with different logging formats
 	LOGT("trace log");
 	LOGI("info log");
 	LOGW("warning log");

--- a/components/common/tests/logging.test.cpp
+++ b/components/common/tests/logging.test.cpp
@@ -1,0 +1,32 @@
+/* Copyright (c) 2022, Khronos Group and Contributors
+ * Copyright (c) 2022, Tom Atkinson
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "components/common/logging.hpp"
+
+int main(int /* argc */, char ** /* argv */)
+{
+	logging::init_default_logger();
+
+	LOGT("trace log");
+	LOGI("info log");
+	LOGW("warning log");
+	LOGE("error log");
+	LOGD("debug log");
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Add spdlog to framework v2.

- Implements the same setup as framework v1
- Removes file paths in logs for now ([we should be able to solve this with spdlog](https://github.com/gabime/spdlog/wiki/3.-Custom-formatting#pattern-flags) but I haven't been able to get this to work yet)
- Adds a test to play around with formats in the future for the different log types
- Updates spdlog