### PR TITLE
Change vkb::core::HPPImageView from a facade over vkb::core::ImageView to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -285,6 +285,7 @@ set(CORE_FILES
     core/hpp_command_pool.cpp
     core/hpp_device.cpp
     core/hpp_image.cpp
+    core/hpp_image_view.cpp
     core/hpp_instance.cpp
     core/hpp_physical_device.cpp
     core/hpp_queue.cpp

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, Arm Limited and Contributors
+# Copyright (c) 2019-2023, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/framework/core/hpp_image_view.cpp
+++ b/framework/core/hpp_image_view.cpp
@@ -21,9 +21,6 @@
 #include "core/hpp_device.h"
 #include <vulkan/vulkan_format_traits.hpp>
 
-//#include "core/image.h"
-//#include "device.h"
-
 namespace vkb
 {
 namespace core

--- a/framework/core/hpp_image_view.cpp
+++ b/framework/core/hpp_image_view.cpp
@@ -1,0 +1,108 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/hpp_image_view.h"
+
+#include "common/hpp_vk_common.h"
+#include "core/hpp_device.h"
+#include <vulkan/vulkan_format_traits.hpp>
+
+//#include "core/image.h"
+//#include "device.h"
+
+namespace vkb
+{
+namespace core
+{
+HPPImageView::HPPImageView(vkb::core::HPPImage &img,
+                           vk::ImageViewType    view_type,
+                           vk::Format           format,
+                           uint32_t             mip_level,
+                           uint32_t             array_layer,
+                           uint32_t             n_mip_levels,
+                           uint32_t             n_array_layers) :
+    HPPVulkanResource{nullptr, &img.get_device()}, image{&img}, format{format}
+{
+	if (format == vk::Format::eUndefined)
+	{
+		this->format = format = image->get_format();
+	}
+
+	subresource_range =
+	    vk::ImageSubresourceRange((std::string(vk::componentName(format, 0)) == "D") ? vk::ImageAspectFlagBits::eDepth : vk::ImageAspectFlagBits::eColor,
+	                              mip_level,
+	                              n_mip_levels == 0 ? image->get_subresource().mipLevel : n_mip_levels,
+	                              array_layer,
+	                              n_array_layers == 0 ? image->get_subresource().arrayLayer : n_array_layers);
+
+	vk::ImageViewCreateInfo image_view_create_info({}, image->get_handle(), view_type, format, {}, subresource_range);
+
+	set_handle(get_device().get_handle().createImageView(image_view_create_info));
+
+	// Register this image view to its image
+	// in order to be notified when it gets moved
+	image->get_views().emplace(this);
+}
+
+HPPImageView::HPPImageView(HPPImageView &&other) :
+    HPPVulkanResource{std::move(other)}, image{other.image}, format{other.format}, subresource_range{other.subresource_range}
+{
+	// Remove old view from image set and add this new one
+	auto &views = image->get_views();
+	views.erase(&other);
+	views.emplace(this);
+
+	other.set_handle(nullptr);
+}
+
+HPPImageView::~HPPImageView()
+{
+	if (get_handle())
+	{
+		get_device().get_handle().destroyImageView(get_handle());
+	}
+}
+
+vk::Format HPPImageView::get_format() const
+{
+	return format;
+}
+
+const vkb::core::HPPImage &HPPImageView::get_image() const
+{
+	assert(image && "vkb::core::HPPImage view is referring an invalid image");
+	return *image;
+}
+
+void HPPImageView::set_image(vkb::core::HPPImage &img)
+{
+	image = &img;
+}
+
+vk::ImageSubresourceLayers HPPImageView::get_subresource_layers() const
+{
+	return vk::ImageSubresourceLayers(
+	    subresource_range.aspectMask, subresource_range.baseMipLevel, subresource_range.baseArrayLayer, subresource_range.layerCount);
+}
+
+vk::ImageSubresourceRange HPPImageView::get_subresource_range() const
+{
+	return subresource_range;
+}
+
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_image_view.cpp
+++ b/framework/core/hpp_image_view.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/core/hpp_image_view.h
+++ b/framework/core/hpp_image_view.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,52 +17,42 @@
 
 #pragma once
 
-#include <core/image_view.h>
+#include "core/hpp_image.h"
+#include "core/hpp_vulkan_resource.h"
 
 namespace vkb
 {
 namespace core
 {
-class HPPImage;
-
-/**
- * @brief facade class around vkb::core::ImageView, providing a vulkan.hpp-based interface
- *
- * See vkb::core::ImageView for documentation
- */
-class HPPImageView : private vkb::core::ImageView
+class HPPImageView : public vkb::core::HPPVulkanResource<vk::ImageView>
 {
   public:
-	HPPImageView(HPPImage &image, vk::ImageViewType view_type, vk::Format format = vk::Format::eUndefined,
-	             uint32_t base_mip_level = 0, uint32_t base_array_layer = 0,
-	             uint32_t n_mip_levels = 0, uint32_t n_array_layers = 0) :
-	    vkb::core::ImageView(reinterpret_cast<vkb::core::Image &>(image), static_cast<VkImageViewType>(view_type), static_cast<VkFormat>(format), base_mip_level, base_array_layer, n_mip_levels, n_array_layers)
-	{}
+	HPPImageView(vkb::core::HPPImage &image,
+	             vk::ImageViewType    view_type,
+	             vk::Format           format           = vk::Format::eUndefined,
+	             uint32_t             base_mip_level   = 0,
+	             uint32_t             base_array_layer = 0,
+	             uint32_t             n_mip_levels     = 0,
+	             uint32_t             n_array_layers   = 0);
 
-	vk::Format get_format() const
-	{
-		return static_cast<vk::Format>(vkb::core::ImageView::get_format());
-	}
+	HPPImageView(HPPImageView &) = delete;
+	HPPImageView(HPPImageView &&other);
 
-	vk::ImageView get_handle() const
-	{
-		return static_cast<vk::ImageView>(vkb::core::ImageView::get_handle());
-	}
+	~HPPImageView() override;
 
-	const HPPImage &get_image() const
-	{
-		return reinterpret_cast<HPPImage const &>(ImageView::get_image());
-	}
+	HPPImageView &operator=(const HPPImageView &) = delete;
+	HPPImageView &operator=(HPPImageView &&)      = delete;
 
-	vk::ImageSubresourceRange get_subresource_range() const
-	{
-		return static_cast<vk::ImageSubresourceRange>(vkb::core::ImageView::get_subresource_range());
-	}
+	vk::Format                 get_format() const;
+	vkb::core::HPPImage const &get_image() const;
+	void                       set_image(vkb::core::HPPImage &image);
+	vk::ImageSubresourceLayers get_subresource_layers() const;
+	vk::ImageSubresourceRange  get_subresource_range() const;
 
-	void set_image(HPPImage &image)
-	{
-		vkb::core::ImageView::set_image(reinterpret_cast<vkb::core::Image &>(image));
-	}
+  private:
+	vkb::core::HPPImage      *image = nullptr;
+	vk::Format                format;
+	vk::ImageSubresourceRange subresource_range;
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_image_view.h
+++ b/framework/core/hpp_image_view.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -92,7 +92,6 @@ class HPPVulkanResource
 
 	inline void set_handle(HPPHandle hdl)
 	{
-		assert(!handle && hdl);
 		handle = hdl;
 	}
 


### PR DESCRIPTION
## Description

Transcoding this part of the framework using Vulkan-Hpp, tested on Win10 and nvidia HW.
Needed a minor adjustment in `vkb::core::HPPVulkanResource`.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
