### PR TITLE
Refactored API sample hpp_compute_nbody.

### DIFF
--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -90,6 +90,50 @@ inline void set_image_layout(vk::CommandBuffer         command_buffer,
 	                      static_cast<VkImageSubresourceRange>(subresource_range),
 	                      static_cast<VkPipelineStageFlags>(src_mask),
 	                      static_cast<VkPipelineStageFlags>(dst_mask));
+}
+
+// helper functions not backed by vk_common.h
+inline vk::DescriptorSet allocate_descriptor_set(vk::Device device, vk::DescriptorPool descriptor_pool, vk::DescriptorSetLayout descriptor_set_layout)
+{
+#if defined(ANDROID)
+	vk::DescriptorSetAllocateInfo descriptor_set_allocate_info(descriptor_pool, 1, &descriptor_set_layout);
+#else
+	vk::DescriptorSetAllocateInfo descriptor_set_allocate_info(descriptor_pool, descriptor_set_layout);
+#endif
+	return device.allocateDescriptorSets(descriptor_set_allocate_info).front();
+}
+
+inline vk::PipelineLayout create_pipeline_layout(vk::Device device, vk::DescriptorSetLayout descriptor_set_layout)
+{
+#if defined(ANDROID)
+	vk::PipelineLayoutCreateInfo pipeline_layout_create_info({}, 1, &descriptor_set_layout);
+#else
+	vk::PipelineLayoutCreateInfo  pipeline_layout_create_info({}, descriptor_set_layout);
+#endif
+	return device.createPipelineLayout(pipeline_layout_create_info);
+}
+
+inline void submit_and_wait(vk::Device device, vk::Queue queue, std::vector<vk::CommandBuffer> command_buffers, std::vector<vk::Semaphore> semaphores = {})
+{
+	// Submit command_buffer
+	vk::SubmitInfo submit_info(nullptr, {}, command_buffers, semaphores);
+
+	// Create fence to ensure that command_buffer has finished executing
+	vk::Fence fence = device.createFence({});
+
+	// Submit to the queue
+	queue.submit(submit_info, fence);
+
+	// Wait for the fence to signal that command_buffer has finished executing
+	vk::Result result = device.waitForFences(fence, true, DEFAULT_FENCE_TIMEOUT);
+	if (result != vk::Result::eSuccess)
+	{
+		LOGE("Vulkan error on waitForFences: {}", vk::to_string(result));
+		abort();
+	}
+
+	// Destroy the fence
+	device.destroyFence(fence);
 }
 
 }        // namespace common

--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -17,8 +17,10 @@
 
 #pragma once
 
-#include <common/vk_common.h>
-#include <vulkan/vulkan.hpp>
+#include "common/vk_common.h"
+
+#include "common/logging.h"
+#include "vulkan/vulkan.hpp"
 
 namespace vkb
 {

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -16,24 +16,19 @@
  */
 
 /*
-  * Compute shader N-body simulation using two passes and shared compute shader memory, using vulkan.hpp
-  */
+ * Compute shader N-body simulation using two passes and shared compute shader memory, using vulkan.hpp
+ */
 
 #include <hpp_compute_nbody.h>
 
 #include <benchmark_mode/benchmark_mode.h>
+#include <core/hpp_command_pool.h>
 #include <random>
 
 HPPComputeNBody::HPPComputeNBody()
 {
-	title       = "Compute shader N-body system";
-	camera.type = vkb::CameraType::LookAt;
-
-	// Note: Using Reversed depth-buffer for increased precision, so Z-Near and Z-Far are flipped
-	camera.set_perspective(60.0f, (float) extent.width / (float) extent.height, 512.0f, 0.1f);
-	camera.set_rotation(glm::vec3(-26.0f, 75.0f, 0.0f));
-	camera.set_translation(glm::vec3(0.0f, 0.0f, -14.0f));
-	camera.translation_speed = 2.5f;
+	title = "Compute shader N-body system";
+	initializeCamera();
 }
 
 HPPComputeNBody::~HPPComputeNBody()
@@ -64,6 +59,29 @@ HPPComputeNBody::~HPPComputeNBody()
 	}
 }
 
+bool HPPComputeNBody::prepare(vkb::platform::HPPPlatform &platform)
+{
+	if (!HPPApiVulkanSample::prepare(platform))
+	{
+		return false;
+	}
+
+	load_assets();
+	create_descriptor_pool();
+	prepare_graphics();
+	prepare_compute();
+	build_command_buffers();
+	prepared = true;
+	return true;
+}
+
+bool HPPComputeNBody::resize(const uint32_t width, const uint32_t height)
+{
+	HPPApiVulkanSample::resize(width, height);
+	update_graphics_uniform_buffers();
+	return true;
+}
+
 void HPPComputeNBody::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 {
 	// Enable anisotropic filtering if supported
@@ -71,12 +89,6 @@ void HPPComputeNBody::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 	{
 		gpu.get_mutable_requested_features().samplerAnisotropy = VK_TRUE;
 	}
-}
-
-void HPPComputeNBody::load_assets()
-{
-	textures.particle = load_texture("textures/particle_rgba.ktx", vkb::sg::Image::Color);
-	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx", vkb::sg::Image::Color);
 }
 
 void HPPComputeNBody::build_command_buffers()
@@ -88,9 +100,8 @@ void HPPComputeNBody::build_command_buffers()
 		create_command_buffers();
 	}
 
-	std::array<vk::ClearValue, 2> clear_values =
-	    {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 1.0f}})),
-	      vk::ClearDepthStencilValue(0.0f, 0)}};
+	std::array<vk::ClearValue, 2> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 1.0f}})),
+	                                               vk::ClearDepthStencilValue(0.0f, 0)}};
 
 	vk::RenderPassBeginInfo render_pass_begin_info(render_pass, {}, {{0, 0}, extent}, clear_values);
 
@@ -99,7 +110,8 @@ void HPPComputeNBody::build_command_buffers()
 		// Set target frame buffer
 		render_pass_begin_info.framebuffer = framebuffers[i];
 
-		draw_cmd_buffers[i].begin(vk::CommandBufferBeginInfo());
+		vk::CommandBuffer command_buffer = draw_cmd_buffers[i];
+		command_buffer.begin(vk::CommandBufferBeginInfo());
 
 		// Acquire
 		if (graphics.queue_family_index != compute.queue_family_index)
@@ -112,20 +124,20 @@ void HPPComputeNBody::build_command_buffers()
 			                                       0,
 			                                       compute.storage_buffer->get_size());
 
-			draw_cmd_buffers[i].pipelineBarrier(
+			command_buffer.pipelineBarrier(
 			    vk::PipelineStageFlagBits::eComputeShader, vk::PipelineStageFlagBits::eVertexInput, {}, nullptr, buffer_barrier, nullptr);
 		}
 
 		// Draw the particle system using the update vertex buffer
-		draw_cmd_buffers[i].beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
-		draw_cmd_buffers[i].setViewport(0, {{0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f}});
-		draw_cmd_buffers[i].setScissor(0, {{{0, 0}, extent}});
-		draw_cmd_buffers[i].bindPipeline(vk::PipelineBindPoint::eGraphics, graphics.pipeline);
-		draw_cmd_buffers[i].bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphics.pipeline_layout, 0, graphics.descriptor_set, nullptr);
-		draw_cmd_buffers[i].bindVertexBuffers(0, compute.storage_buffer->get_handle(), {0});
-		draw_cmd_buffers[i].draw(num_particles, 1, 0, 0);
-		draw_ui(draw_cmd_buffers[i]);
-		draw_cmd_buffers[i].endRenderPass();
+		command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+		command_buffer.setViewport(0, {{0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f}});
+		command_buffer.setScissor(0, {{{0, 0}, extent}});
+		command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, graphics.pipeline);
+		command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphics.pipeline_layout, 0, graphics.descriptor_set, nullptr);
+		command_buffer.bindVertexBuffers(0, compute.storage_buffer->get_handle(), {0});
+		command_buffer.draw(compute.ubo.particle_count, 1, 0, 0);
+		draw_ui(command_buffer);
+		command_buffer.endRenderPass();
 
 		// Release barrier
 		if (graphics.queue_family_index != compute.queue_family_index)
@@ -138,11 +150,23 @@ void HPPComputeNBody::build_command_buffers()
 			                                       0,
 			                                       compute.storage_buffer->get_size());
 
-			draw_cmd_buffers[i].pipelineBarrier(
+			command_buffer.pipelineBarrier(
 			    vk::PipelineStageFlagBits::eVertexInput, vk::PipelineStageFlagBits::eComputeShader, {}, nullptr, buffer_barrier, nullptr);
 		}
 
-		draw_cmd_buffers[i].end();
+		command_buffer.end();
+	}
+}
+
+void HPPComputeNBody::render(float delta_time)
+{
+	if (!prepared)
+		return;
+	draw();
+	update_compute_uniform_buffers(delta_time);
+	if (camera.updated)
+	{
+		update_graphics_uniform_buffers();
 	}
 }
 
@@ -169,7 +193,7 @@ void HPPComputeNBody::build_compute_command_buffer()
 	// -------------------------------------------------------------------------------------------------------
 	compute.command_buffer.bindPipeline(vk::PipelineBindPoint::eCompute, compute.pipeline_calculate);
 	compute.command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eCompute, compute.pipeline_layout, 0, compute.descriptor_set, nullptr);
-	compute.command_buffer.dispatch(num_particles / work_group_size, 1, 1);
+	compute.command_buffer.dispatch(compute.ubo.particle_count / compute.work_group_size, 1, 1);
 
 	// Add memory barrier to ensure that the computer shader has finished writing to the buffer
 	vk::BufferMemoryBarrier memory_barrier(vk::AccessFlagBits::eShaderWrite,
@@ -186,7 +210,7 @@ void HPPComputeNBody::build_compute_command_buffer()
 	// Second pass: Integrate particles
 	// -------------------------------------------------------------------------------------------------------
 	compute.command_buffer.bindPipeline(vk::PipelineBindPoint::eCompute, compute.pipeline_integrate);
-	compute.command_buffer.dispatch(num_particles / work_group_size, 1, 1);
+	compute.command_buffer.dispatch(compute.ubo.particle_count / compute.work_group_size, 1, 1);
 
 	// Release
 	if (graphics.queue_family_index != compute.queue_family_index)
@@ -206,8 +230,126 @@ void HPPComputeNBody::build_compute_command_buffer()
 	compute.command_buffer.end();
 }
 
+void HPPComputeNBody::build_compute_transfer_command_buffer(vk::CommandBuffer command_buffer) const
+{
+	command_buffer.begin(vk::CommandBufferBeginInfo());
+
+	vk::BufferMemoryBarrier acquire_buffer_barrier({},
+	                                               vk::AccessFlagBits::eShaderWrite,
+	                                               graphics.queue_family_index,
+	                                               compute.queue_family_index,
+	                                               compute.storage_buffer->get_handle(),
+	                                               0,
+	                                               compute.storage_buffer->get_size());
+	command_buffer.pipelineBarrier(
+	    vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eComputeShader, {}, nullptr, acquire_buffer_barrier, nullptr);
+
+	vk::BufferMemoryBarrier release_buffer_barrier(vk::AccessFlagBits::eShaderWrite,
+	                                               {},
+	                                               compute.queue_family_index,
+	                                               graphics.queue_family_index,
+	                                               compute.storage_buffer->get_handle(),
+	                                               0,
+	                                               compute.storage_buffer->get_size());
+	command_buffer.pipelineBarrier(
+	    vk::PipelineStageFlagBits::eComputeShader, vk::PipelineStageFlagBits::eTransfer, {}, nullptr, release_buffer_barrier, nullptr);
+
+	// Copied from Device::flush_command_buffer, which we can't use because it would be
+	// working with the wrong command pool
+	command_buffer.end();
+}
+
+void HPPComputeNBody::build_copy_command_buffer(vk::CommandBuffer command_buffer, vk::Buffer staging_buffer, vk::DeviceSize buffer_size) const
+{
+	command_buffer.begin(vk::CommandBufferBeginInfo());
+	command_buffer.copyBuffer(staging_buffer, compute.storage_buffer->get_handle(), {{0, 0, buffer_size}});
+	// Execute a transfer to the compute queue, if necessary
+	if (graphics.queue_family_index != compute.queue_family_index)
+	{
+		vk::BufferMemoryBarrier buffer_barrier(vk::AccessFlagBits::eVertexAttributeRead,
+		                                       {},
+		                                       graphics.queue_family_index,
+		                                       compute.queue_family_index,
+		                                       compute.storage_buffer->get_handle(),
+		                                       0,
+		                                       compute.storage_buffer->get_size());
+
+		command_buffer.pipelineBarrier(vk::PipelineStageFlagBits::eVertexInput, vk::PipelineStageFlagBits::eComputeShader, {}, nullptr, buffer_barrier, nullptr);
+	}
+	command_buffer.end();
+}
+
+void HPPComputeNBody::create_compute_descriptor_set_layout()
+{
+	std::array<vk::DescriptorSetLayoutBinding, 2> set_layout_bindings = {{{0, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute},
+	                                                                      {1, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eCompute}}};
+
+	compute.descriptor_set_layout = get_device()->get_handle().createDescriptorSetLayout({{}, set_layout_bindings});
+}
+
+void HPPComputeNBody::create_compute_pipeline_particle_integration()
+{
+	// 2nd pass - Particle integration
+	vk::ComputePipelineCreateInfo compute_pipeline_create_info({}, {}, compute.pipeline_layout);
+
+	compute_pipeline_create_info.stage = load_shader("compute_nbody/particle_integrate.comp", vk::ShaderStageFlagBits::eCompute);
+
+	vk::SpecializationMapEntry integration_specialization_entry(0, 0, sizeof(compute.work_group_size));
+	vk::SpecializationInfo     specialization_info(1, &integration_specialization_entry, sizeof(compute.work_group_size), &compute.work_group_size);
+
+	compute_pipeline_create_info.stage.pSpecializationInfo = &specialization_info;
+
+	vk::Result result;
+	std::tie(result, compute.pipeline_integrate) = get_device()->get_handle().createComputePipeline(pipeline_cache, compute_pipeline_create_info);
+	assert(result == vk::Result::eSuccess);
+}
+
+void HPPComputeNBody::create_compute_pipeline_particle_movement()
+{
+	// 1st pass - Particle movement calculations
+	vk::ComputePipelineCreateInfo compute_pipeline_create_info({}, {}, compute.pipeline_layout);
+
+	compute_pipeline_create_info.stage = load_shader("compute_nbody/particle_calculate.comp", vk::ShaderStageFlagBits::eCompute);
+
+	// Set some shader parameters via specialization constants
+	struct MovementSpecializationData
+	{
+		uint32_t workgroup_size;
+		uint32_t shared_data_size;
+		float    gravity;
+		float    power;
+		float    soften;
+	};
+
+	std::array<vk::SpecializationMapEntry, 5> movement_specialization_map_entries = {
+	    {{0, offsetof(MovementSpecializationData, workgroup_size), sizeof(uint32_t)},
+	     {1, offsetof(MovementSpecializationData, shared_data_size), sizeof(uint32_t)},
+	     {2, offsetof(MovementSpecializationData, gravity), sizeof(float)},
+	     {3, offsetof(MovementSpecializationData, power), sizeof(float)},
+	     {4, offsetof(MovementSpecializationData, soften), sizeof(float)}}};
+
+	MovementSpecializationData movement_specialization_data{compute.work_group_size, compute.shared_data_size, 0.002f, 0.75f, 0.05f};
+
+	vk::SpecializationInfo specialization_info(static_cast<uint32_t>(movement_specialization_map_entries.size()),
+	                                           movement_specialization_map_entries.data(),
+	                                           sizeof(movement_specialization_data),
+	                                           &movement_specialization_data);
+
+	compute_pipeline_create_info.stage.pSpecializationInfo = &specialization_info;
+
+	vk::Result result;
+	std::tie(result, compute.pipeline_calculate) = get_device()->get_handle().createComputePipeline(pipeline_cache, compute_pipeline_create_info);
+	assert(result == vk::Result::eSuccess);
+}
+
+void HPPComputeNBody::create_compute_pipelines()
+{
+	create_compute_pipeline_particle_movement();
+	create_compute_pipeline_particle_integration();
+}
+
 // Setup and fill the compute shader storage buffers containing the particles
-void HPPComputeNBody::prepare_storage_buffers()
+void HPPComputeNBody::prepare_compute_storage_buffers()
 {
 #if 0
 	std::vector<glm::vec3> attractors = {
@@ -225,10 +367,10 @@ void HPPComputeNBody::prepare_storage_buffers()
 	};
 #endif
 
-	num_particles = static_cast<uint32_t>(attractors.size()) * PARTICLES_PER_ATTRACTOR;
+	compute.ubo.particle_count = static_cast<uint32_t>(attractors.size()) * PARTICLES_PER_ATTRACTOR;
 
 	// Initial particle positions
-	std::vector<Particle> particle_buffer(num_particles);
+	std::vector<Particle> particle_buffer(compute.ubo.particle_count);
 
 	std::default_random_engine      rnd_engine(platform->using_plugin<::plugins::BenchmarkMode>() ? 0 : (unsigned) time(nullptr));
 	std::normal_distribution<float> rnd_distribution(0.0f, 1.0f);
@@ -248,13 +390,15 @@ void HPPComputeNBody::prepare_storage_buffers()
 			else
 			{
 				// Position
-				glm::vec3 position(attractors[i] + glm::vec3(rnd_distribution(rnd_engine), rnd_distribution(rnd_engine), rnd_distribution(rnd_engine)) * 0.75f);
+				glm::vec3 position(attractors[i] +
+				                   glm::vec3(rnd_distribution(rnd_engine), rnd_distribution(rnd_engine), rnd_distribution(rnd_engine)) * 0.75f);
 				float     len = glm::length(glm::normalize(position - attractors[i]));
 				position.y *= 2.0f - (len * len);
 
 				// Velocity
 				glm::vec3 angular  = glm::vec3(0.5f, 1.5f, 0.5f) * (((i % 2) == 0) ? 1.0f : -1.0f);
-				glm::vec3 velocity = glm::cross((position - attractors[i]), angular) + glm::vec3(rnd_distribution(rnd_engine), rnd_distribution(rnd_engine), rnd_distribution(rnd_engine) * 0.025f);
+				glm::vec3 velocity = glm::cross((position - attractors[i]), angular) +
+				                     glm::vec3(rnd_distribution(rnd_engine), rnd_distribution(rnd_engine), rnd_distribution(rnd_engine) * 0.025f);
 
 				float mass   = (rnd_distribution(rnd_engine) * 0.5f + 0.5f) * 75.0f;
 				particle.pos = glm::vec4(position, mass);
@@ -265,8 +409,6 @@ void HPPComputeNBody::prepare_storage_buffers()
 			particle.vel.w = (float) i * 1.0f / static_cast<uint32_t>(attractors.size());
 		}
 	}
-
-	compute.ubo.particle_count = num_particles;
 
 	vk::DeviceSize storage_buffer_size = particle_buffer.size() * sizeof(Particle);
 
@@ -282,26 +424,18 @@ void HPPComputeNBody::prepare_storage_buffers()
 	                                                                VMA_MEMORY_USAGE_GPU_ONLY);
 
 	// Copy from staging buffer to storage buffer
-	vk::CommandBuffer copy_command = device->create_command_buffer(vk::CommandBufferLevel::ePrimary, true);
-	copy_command.copyBuffer(staging_buffer.get_handle(), compute.storage_buffer->get_handle(), {{0, 0, storage_buffer_size}});
-	// Execute a transfer to the compute queue, if necessary
-	if (graphics.queue_family_index != compute.queue_family_index)
-	{
-		vk::BufferMemoryBarrier buffer_barrier(vk::AccessFlagBits::eVertexAttributeRead,
-		                                       {},
-		                                       graphics.queue_family_index,
-		                                       compute.queue_family_index,
-		                                       compute.storage_buffer->get_handle(),
-		                                       0,
-		                                       compute.storage_buffer->get_size());
+	vk::Device device = get_device()->get_handle();
 
-		copy_command.pipelineBarrier(vk::PipelineStageFlagBits::eVertexInput, vk::PipelineStageFlagBits::eComputeShader, {}, nullptr, buffer_barrier, nullptr);
-	}
+	vk::CommandBuffer copy_command = device.allocateCommandBuffers({get_device()->get_command_pool().get_handle(), vk::CommandBufferLevel::ePrimary, 1}).front();
 
-	device->flush_command_buffer(copy_command, queue, true);
+	build_copy_command_buffer(copy_command, staging_buffer.get_handle(), storage_buffer_size);
+
+	vkb::common::submit_and_wait(device, queue, {copy_command});
+
+	device.freeCommandBuffers(get_device()->get_command_pool().get_handle(), copy_command);
 }
 
-void HPPComputeNBody::setup_descriptor_pool()
+void HPPComputeNBody::create_descriptor_pool()
 {
 	std::array<vk::DescriptorPoolSize, 3> pool_sizes = {
 	    {{vk::DescriptorType::eUniformBuffer, 2}, {vk::DescriptorType::eStorageBuffer, 1}, {vk::DescriptorType::eCombinedImageSampler, 2}}};
@@ -309,7 +443,7 @@ void HPPComputeNBody::setup_descriptor_pool()
 	descriptor_pool = get_device()->get_handle().createDescriptorPool({{}, 2, pool_sizes});
 }
 
-void HPPComputeNBody::setup_descriptor_set_layout()
+void HPPComputeNBody::create_graphics_descriptor_set_layout()
 {
 	std::array<vk::DescriptorSetLayoutBinding, 3> set_layout_bindings = {
 	    {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
@@ -317,51 +451,14 @@ void HPPComputeNBody::setup_descriptor_set_layout()
 	     {2, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex}}};
 
 	graphics.descriptor_set_layout = get_device()->get_handle().createDescriptorSetLayout({{}, set_layout_bindings});
-
-#if defined(ANDROID)
-	vk::PipelineLayoutCreateInfo pipeline_layout_create_info({}, 1, &graphics.descriptor_set_layout);
-#else
-	vk::PipelineLayoutCreateInfo  pipeline_layout_create_info({}, graphics.descriptor_set_layout);
-#endif
-
-	graphics.pipeline_layout = get_device()->get_handle().createPipelineLayout(pipeline_layout_create_info);
 }
 
-void HPPComputeNBody::setup_descriptor_set()
-{
-#if defined(ANDROID)
-	vk::DescriptorSetAllocateInfo descriptor_set_allocate_info(descriptor_pool, 1, &graphics.descriptor_set_layout);
-#else
-	vk::DescriptorSetAllocateInfo descriptor_set_allocate_info(descriptor_pool, graphics.descriptor_set_layout);
-#endif
-	graphics.descriptor_set = get_device()->get_handle().allocateDescriptorSets(descriptor_set_allocate_info).front();
-
-	vk::DescriptorBufferInfo buffer_descriptor(graphics.uniform_buffer->get_handle(), 0, VK_WHOLE_SIZE);
-	vk::DescriptorImageInfo  particle_image_descriptor(
-        textures.particle.sampler,
-        textures.particle.image->get_vk_image_view().get_handle(),
-        descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.particle.image->get_vk_image_view().get_format()));
-	vk::DescriptorImageInfo gradient_image_descriptor(
-	    textures.gradient.sampler,
-	    textures.gradient.image->get_vk_image_view().get_handle(),
-	    descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.gradient.image->get_vk_image_view().get_format()));
-
-	std::array<vk::WriteDescriptorSet, 3> write_descriptor_sets = {
-	    {{graphics.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, particle_image_descriptor},
-	     {graphics.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, gradient_image_descriptor},
-	     {graphics.descriptor_set, 2, 0, vk::DescriptorType::eUniformBuffer, {}, buffer_descriptor}}};
-	get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, nullptr);
-}
-
-void HPPComputeNBody::prepare_pipelines()
+void HPPComputeNBody::create_graphics_pipeline()
 {
 	vk::PipelineInputAssemblyStateCreateInfo input_assembly_state({}, vk::PrimitiveTopology::ePointList);
 
-	vk::PipelineRasterizationStateCreateInfo rasterization_state;
-	rasterization_state.polygonMode = vk::PolygonMode::eFill;
-	rasterization_state.cullMode    = vk::CullModeFlagBits::eNone;
-	rasterization_state.frontFace   = vk::FrontFace::eCounterClockwise;
-	rasterization_state.lineWidth   = 1.0f;
+	vk::PipelineRasterizationStateCreateInfo rasterization_state(
+	    {}, {}, {}, vk::PolygonMode::eFill, vk::CullModeFlagBits::eNone, vk::FrontFace::eCounterClockwise, {}, {}, {}, {}, 1.0f);
 
 	// Additive blending
 	vk::PipelineColorBlendAttachmentState blend_attachment_state(true,
@@ -376,11 +473,7 @@ void HPPComputeNBody::prepare_pipelines()
 
 	vk::PipelineColorBlendStateCreateInfo color_blend_state({}, {}, {}, blend_attachment_state);
 
-	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
-	depth_stencil_state.depthTestEnable  = false;
-	depth_stencil_state.depthWriteEnable = false;
-	depth_stencil_state.depthCompareOp   = vk::CompareOp::eAlways;
-	depth_stencil_state.back.compareOp   = vk::CompareOp::eAlways;
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state({}, false, false, vk::CompareOp::eAlways, {}, {}, {}, {{}, {}, {}, vk::CompareOp::eAlways});
 
 	vk::PipelineViewportStateCreateInfo viewport_state({}, 1, nullptr, 1, nullptr);
 
@@ -423,201 +516,12 @@ void HPPComputeNBody::prepare_pipelines()
 	assert(result == vk::Result::eSuccess);
 }
 
-void HPPComputeNBody::prepare_graphics()
-{
-	prepare_storage_buffers();
-	prepare_uniform_buffers();
-	setup_descriptor_set_layout();
-	prepare_pipelines();
-	setup_descriptor_set();
-
-	// Semaphore for compute & graphics sync
-	graphics.semaphore = get_device()->get_handle().createSemaphore({});
-}
-
-void HPPComputeNBody::prepare_compute()
-{
-	// Get compute queue
-	compute.queue = get_device()->get_handle().getQueue(compute.queue_family_index, 0);
-
-	// Create compute pipeline
-	// Compute pipelines are created separate from graphics pipelines even if they use the same queue (family index)
-
-	std::array<vk::DescriptorSetLayoutBinding, 2> set_layout_bindings = {{{0, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute},
-	                                                                      {1, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eCompute}}};
-
-	compute.descriptor_set_layout = get_device()->get_handle().createDescriptorSetLayout({{}, set_layout_bindings});
-
-#if defined(ANDROID)
-	vk::PipelineLayoutCreateInfo pipeline_layout_create_info({}, 1, &compute.descriptor_set_layout);
-#else
-	vk::PipelineLayoutCreateInfo  pipeline_layout_create_info({}, compute.descriptor_set_layout);
-#endif
-	compute.pipeline_layout = get_device()->get_handle().createPipelineLayout(pipeline_layout_create_info);
-
-#if defined(ANDROID)
-	vk::DescriptorSetAllocateInfo descriptor_set_allocate_info(descriptor_pool, 1, &compute.descriptor_set_layout);
-#else
-	vk::DescriptorSetAllocateInfo descriptor_set_allocate_info(descriptor_pool, compute.descriptor_set_layout);
-#endif
-	compute.descriptor_set = get_device()->get_handle().allocateDescriptorSets(descriptor_set_allocate_info).front();
-
-	vk::DescriptorBufferInfo              storage_buffer_descriptor(compute.storage_buffer->get_handle(), 0, VK_WHOLE_SIZE);
-	vk::DescriptorBufferInfo              uniform_buffer_descriptor(compute.uniform_buffer->get_handle(), 0, VK_WHOLE_SIZE);
-	std::array<vk::WriteDescriptorSet, 2> compute_write_descriptor_sets = {
-	    {// Binding 0 : Particle position storage buffer
-	     {compute.descriptor_set, 0, {}, vk::DescriptorType::eStorageBuffer, {}, storage_buffer_descriptor},
-	     // Binding 1 : Uniform buffer
-	     {compute.descriptor_set, 1, {}, vk::DescriptorType::eUniformBuffer, {}, uniform_buffer_descriptor}}};
-
-	get_device()->get_handle().updateDescriptorSets(compute_write_descriptor_sets, nullptr);
-
-	// Create pipelines
-	vk::ComputePipelineCreateInfo compute_pipeline_create_info({}, {}, compute.pipeline_layout);
-
-	// 1st pass - Particle movement calculations
-	compute_pipeline_create_info.stage = load_shader("compute_nbody/particle_calculate.comp", vk::ShaderStageFlagBits::eCompute);
-
-	// Set some shader parameters via specialization constants
-	struct MovementSpecializationData
-	{
-		uint32_t workgroup_size;
-		uint32_t shared_data_size;
-		float    gravity;
-		float    power;
-		float    soften;
-	} movement_specialization_data{work_group_size, shared_data_size, 0.002f, 0.75f, 0.05f};
-
-	std::array<vk::SpecializationMapEntry, 5> movement_specialization_map_entries = {
-	    {{0, offsetof(MovementSpecializationData, workgroup_size), sizeof(uint32_t)},
-	     {1, offsetof(MovementSpecializationData, shared_data_size), sizeof(uint32_t)},
-	     {2, offsetof(MovementSpecializationData, gravity), sizeof(float)},
-	     {3, offsetof(MovementSpecializationData, power), sizeof(float)},
-	     {4, offsetof(MovementSpecializationData, soften), sizeof(float)}}};
-	vk::SpecializationInfo specialization_info(static_cast<uint32_t>(movement_specialization_map_entries.size()),
-	                                           movement_specialization_map_entries.data(),
-	                                           sizeof(movement_specialization_data),
-	                                           &movement_specialization_data);
-
-	compute_pipeline_create_info.stage.pSpecializationInfo = &specialization_info;
-
-	compute.pipeline_calculate = get_device()->get_handle().createComputePipeline(pipeline_cache, compute_pipeline_create_info).value;
-
-	// 2nd pass - Particle integration
-	compute_pipeline_create_info.stage = load_shader("compute_nbody/particle_integrate.comp", vk::ShaderStageFlagBits::eCompute);
-
-	vk::SpecializationMapEntry integration_specialization_entry(0, 0, sizeof(work_group_size));
-	specialization_info = {1, &integration_specialization_entry, sizeof(work_group_size), &work_group_size};
-
-	compute_pipeline_create_info.stage.pSpecializationInfo = &specialization_info;
-	compute.pipeline_integrate                             = get_device()->get_handle().createComputePipeline(pipeline_cache, compute_pipeline_create_info).value;
-
-	// Separate command pool as queue family for compute may be different than graphics
-	vk::CommandPoolCreateInfo command_pool_create_info(vk::CommandPoolCreateFlagBits::eResetCommandBuffer,
-	                                                   get_device()->get_queue_family_index(vk::QueueFlagBits::eCompute));
-	compute.command_pool = get_device()->get_handle().createCommandPool(command_pool_create_info);
-
-	// Create a command buffer for compute operations
-	vk::CommandBufferAllocateInfo command_buffer_allocate_info(compute.command_pool, vk::CommandBufferLevel::ePrimary, 1);
-
-	compute.command_buffer = get_device()->get_handle().allocateCommandBuffers(command_buffer_allocate_info).front();
-
-	// Semaphore for compute & graphics sync
-	compute.semaphore = get_device()->get_handle().createSemaphore({});
-
-	// Signal the semaphore
-	vk::SubmitInfo submit_info(nullptr, {}, {}, compute.semaphore);
-	queue.submit(submit_info);
-	queue.waitIdle();
-
-	// Build a single command buffer containing the compute dispatch commands
-	build_compute_command_buffer();
-
-	// If necessary, acquire and immediately release the storage buffer, so that the initial acquire
-	// from the graphics command buffers are matched up properly.
-	if (graphics.queue_family_index != compute.queue_family_index)
-	{
-		// Create a transient command buffer for setting up the initial buffer transfer state
-		vk::CommandBufferAllocateInfo command_buffer_allocate_info(compute.command_pool, vk::CommandBufferLevel::ePrimary, 1);
-
-		vk::CommandBuffer transfer_command = get_device()->get_handle().allocateCommandBuffers(command_buffer_allocate_info).front();
-
-		transfer_command.begin(vk::CommandBufferBeginInfo());
-
-		vk::BufferMemoryBarrier acquire_buffer_barrier({},
-		                                               vk::AccessFlagBits::eShaderWrite,
-		                                               graphics.queue_family_index,
-		                                               compute.queue_family_index,
-		                                               compute.storage_buffer->get_handle(),
-		                                               0,
-		                                               compute.storage_buffer->get_size());
-		transfer_command.pipelineBarrier(
-		    vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eComputeShader, {}, nullptr, acquire_buffer_barrier, nullptr);
-
-		vk::BufferMemoryBarrier release_buffer_barrier(vk::AccessFlagBits::eShaderWrite,
-		                                               {},
-		                                               compute.queue_family_index,
-		                                               graphics.queue_family_index,
-		                                               compute.storage_buffer->get_handle(),
-		                                               0,
-		                                               compute.storage_buffer->get_size());
-		transfer_command.pipelineBarrier(
-		    vk::PipelineStageFlagBits::eComputeShader, vk::PipelineStageFlagBits::eTransfer, {}, nullptr, release_buffer_barrier, nullptr);
-
-		// Copied from Device::flush_command_buffer, which we can't use because it would be
-		// working with the wrong command pool
-		transfer_command.end();
-
-		// Submit compute commands
-		vk::SubmitInfo submit_info(nullptr, {}, transfer_command);
-
-		// Create fence to ensure that the command buffer has finished executing
-		vk::Fence fence = get_device()->get_handle().createFence({});
-		// Submit to the *compute* queue
-		compute.queue.submit(submit_info, fence);
-		// Wait for the fence to signal that command buffer has finished executing
-		get_device()->get_handle().waitForFences(fence, true, DEFAULT_FENCE_TIMEOUT);
-		get_device()->get_handle().destroyFence(fence);
-
-		get_device()->get_handle().freeCommandBuffers(compute.command_pool, transfer_command);
-	}
-}
-
-// Prepare and initialize uniform buffer containing shader uniforms
-void HPPComputeNBody::prepare_uniform_buffers()
-{
-	// Compute shader uniform buffer block
-	compute.uniform_buffer =
-	    std::make_unique<vkb::core::HPPBuffer>(*get_device(), sizeof(compute.ubo), vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
-
-	// Vertex shader uniform buffer block
-	graphics.uniform_buffer =
-	    std::make_unique<vkb::core::HPPBuffer>(*get_device(), sizeof(graphics.ubo), vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
-
-	update_compute_uniform_buffers(1.0f);
-	update_graphics_uniform_buffers();
-}
-
-void HPPComputeNBody::update_compute_uniform_buffers(float delta_time)
-{
-	compute.ubo.delta_time = paused ? 0.0f : delta_time;
-	compute.uniform_buffer->convert_and_update(compute.ubo);
-}
-
-void HPPComputeNBody::update_graphics_uniform_buffers()
-{
-	graphics.ubo.projection = camera.matrices.perspective;
-	graphics.ubo.view       = camera.matrices.view;
-	graphics.ubo.screenDim  = glm::vec2(static_cast<float>(extent.width), static_cast<float>(extent.height));
-	graphics.uniform_buffer->convert_and_update(graphics.ubo);
-}
-
 void HPPComputeNBody::draw()
 {
 	HPPApiVulkanSample::prepare_frame();
 
 	std::array<vk::PipelineStageFlags, 2> graphics_wait_stage_masks  = {vk::PipelineStageFlagBits::eVertexInput,
-                                                                       vk::PipelineStageFlagBits::eColorAttachmentOutput};
+	                                                                    vk::PipelineStageFlagBits::eColorAttachmentOutput};
 	std::array<vk::Semaphore, 2>          graphics_wait_semaphores   = {compute.semaphore, semaphores.acquired_image_ready};
 	std::array<vk::Semaphore, 2>          graphics_signal_semaphores = {graphics.semaphore, semaphores.render_complete};
 
@@ -630,55 +534,158 @@ void HPPComputeNBody::draw()
 
 	HPPApiVulkanSample::submit_frame();
 
-	// Wait for rendering finished
+	// Submit compute commands, waiting for rendering finished
 	vk::PipelineStageFlags wait_stage_mask = vk::PipelineStageFlagBits::eComputeShader;
-
-	// Submit compute commands
-	vk::SubmitInfo compute_submit_info(graphics.semaphore, wait_stage_mask, compute.command_buffer, compute.semaphore);
+	vk::SubmitInfo         compute_submit_info(graphics.semaphore, wait_stage_mask, compute.command_buffer, compute.semaphore);
 	compute.queue.submit(compute_submit_info);
 }
 
-bool HPPComputeNBody::prepare(vkb::platform::HPPPlatform &platform)
+void HPPComputeNBody::initializeCamera()
 {
-	if (!HPPApiVulkanSample::prepare(platform))
+	camera.type = vkb::CameraType::LookAt;
+
+	// Note: Using Reversed depth-buffer for increased precision, so Z-Near and Z-Far are flipped
+	camera.set_perspective(60.0f, (float) extent.width / (float) extent.height, 512.0f, 0.1f);
+	camera.set_rotation(glm::vec3(-26.0f, 75.0f, 0.0f));
+	camera.set_translation(glm::vec3(0.0f, 0.0f, -14.0f));
+	camera.translation_speed = 2.5f;
+}
+
+void HPPComputeNBody::load_assets()
+{
+	textures.particle = load_texture("textures/particle_rgba.ktx", vkb::sg::Image::Color);
+	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx", vkb::sg::Image::Color);
+}
+
+void HPPComputeNBody::prepare_compute()
+{
+	vk::Device device = get_device()->get_handle();
+
+	compute.queue_family_index = get_device()->get_queue_family_index(vk::QueueFlagBits::eCompute);
+
+	vk::PhysicalDeviceLimits const &limits = get_device()->get_gpu().get_properties().limits;
+	// Not all implementations support a work group size of 256, so we need to check with the device limits
+	compute.work_group_size = std::min<uint32_t>(256, limits.maxComputeWorkGroupSize[0]);
+	// Same for shared data size for passing data between shader invocations
+	compute.shared_data_size = std::min<uint32_t>(1024, limits.maxComputeSharedMemorySize / sizeof(glm::vec4));
+
+	prepare_compute_storage_buffers();
+
+	// Compute shader uniform buffer block
+	compute.uniform_buffer =
+	    std::make_unique<vkb::core::HPPBuffer>(*get_device(), sizeof(compute.ubo), vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	update_compute_uniform_buffers(1.0f);
+
+	// Get compute queue
+	// Compute pipelines are created separate from graphics pipelines even if they use the same queue (family index)
+	compute.queue = device.getQueue(compute.queue_family_index, 0);
+
+	create_compute_descriptor_set_layout();
+	compute.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, compute.descriptor_set_layout);
+	update_compute_descriptor_set();
+
+	compute.pipeline_layout = vkb::common::create_pipeline_layout(device, compute.descriptor_set_layout);
+	create_compute_pipelines();
+
+	// Separate command pool as queue family for compute may be different than graphics
+	compute.command_pool = device.createCommandPool({vk::CommandPoolCreateFlagBits::eResetCommandBuffer, compute.queue_family_index});
+
+	// Create a command buffer for compute operations
+	compute.command_buffer = device.allocateCommandBuffers({compute.command_pool, vk::CommandBufferLevel::ePrimary, 1}).front();
+
+	// Semaphore for compute & graphics sync
+	compute.semaphore = device.createSemaphore({});
+
+	// Signal the semaphore
+	vkb::common::submit_and_wait(device, queue, {}, {compute.semaphore});
+
+	// Build a single command buffer containing the compute dispatch commands
+	build_compute_command_buffer();
+
+	// If necessary, acquire and immediately release the storage buffer, so that the initial acquire
+	// from the graphics command buffers are matched up properly.
+	if (graphics.queue_family_index != compute.queue_family_index)
 	{
-		return false;
+		// Create a transient command buffer for setting up the initial buffer transfer state
+		vk::CommandBuffer transfer_command = device.allocateCommandBuffers({compute.command_pool, vk::CommandBufferLevel::ePrimary, 1}).front();
+
+		build_compute_transfer_command_buffer(transfer_command);
+
+		// Submit and wait for compute commands
+		vkb::common::submit_and_wait(device, compute.queue, {transfer_command});
+
+		// free the transfer command buffer
+		device.freeCommandBuffers(compute.command_pool, transfer_command);
 	}
+}
+
+void HPPComputeNBody::prepare_graphics()
+{
+	vk::Device device = get_device()->get_handle();
 
 	graphics.queue_family_index = get_device()->get_queue_family_index(vk::QueueFlagBits::eGraphics);
-	compute.queue_family_index  = get_device()->get_queue_family_index(vk::QueueFlagBits::eCompute);
 
-	// Not all implementations support a work group size of 256, so we need to check with the device limits
-	work_group_size = std::min<uint32_t>(256, get_device()->get_gpu().get_properties().limits.maxComputeWorkGroupSize[0]);
-	// Same for shared data size for passing data between shader invocations
-	shared_data_size = std::min<uint32_t>(1024, get_device()->get_gpu().get_properties().limits.maxComputeSharedMemorySize / sizeof(glm::vec4));
-
-	load_assets();
-	setup_descriptor_pool();
-	prepare_graphics();
-	prepare_compute();
-	build_command_buffers();
-	prepared = true;
-	return true;
-}
-
-void HPPComputeNBody::render(float delta_time)
-{
-	if (!prepared)
-		return;
-	draw();
-	update_compute_uniform_buffers(delta_time);
-	if (camera.updated)
-	{
-		update_graphics_uniform_buffers();
-	}
-}
-
-bool HPPComputeNBody::resize(const uint32_t width, const uint32_t height)
-{
-	HPPApiVulkanSample::resize(width, height);
+	// Vertex shader uniform buffer block
+	graphics.uniform_buffer =
+	    std::make_unique<vkb::core::HPPBuffer>(*get_device(), sizeof(graphics.ubo), vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
 	update_graphics_uniform_buffers();
-	return true;
+
+	create_graphics_descriptor_set_layout();
+	graphics.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, graphics.descriptor_set_layout);
+	update_graphics_descriptor_set();
+
+	graphics.pipeline_layout = vkb::common::create_pipeline_layout(device, graphics.descriptor_set_layout);
+	create_graphics_pipeline();
+
+	// Semaphore for compute & graphics sync
+	graphics.semaphore = device.createSemaphore({});
+}
+
+void HPPComputeNBody::update_compute_descriptor_set()
+{
+	vk::DescriptorBufferInfo              storage_buffer_descriptor(compute.storage_buffer->get_handle(), 0, VK_WHOLE_SIZE);
+	vk::DescriptorBufferInfo              uniform_buffer_descriptor(compute.uniform_buffer->get_handle(), 0, VK_WHOLE_SIZE);
+	std::array<vk::WriteDescriptorSet, 2> compute_write_descriptor_sets = {
+	    {// Binding 0 : Particle position storage buffer
+	     {compute.descriptor_set, 0, {}, vk::DescriptorType::eStorageBuffer, {}, storage_buffer_descriptor},
+	     // Binding 1 : Uniform buffer
+	     {compute.descriptor_set, 1, {}, vk::DescriptorType::eUniformBuffer, {}, uniform_buffer_descriptor}}};
+
+	get_device()->get_handle().updateDescriptorSets(compute_write_descriptor_sets, nullptr);
+}
+
+void HPPComputeNBody::update_compute_uniform_buffers(float delta_time)
+{
+	compute.ubo.delta_time = paused ? 0.0f : delta_time;
+	compute.uniform_buffer->convert_and_update(compute.ubo);
+}
+
+void HPPComputeNBody::update_graphics_descriptor_set()
+{
+	vk::DescriptorBufferInfo buffer_descriptor(graphics.uniform_buffer->get_handle(), 0, VK_WHOLE_SIZE);
+	vk::DescriptorImageInfo  particle_image_descriptor(
+	     textures.particle.sampler,
+	     textures.particle.image->get_vk_image_view().get_handle(),
+	     descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.particle.image->get_vk_image_view().get_format()));
+	vk::DescriptorImageInfo gradient_image_descriptor(
+	    textures.gradient.sampler,
+	    textures.gradient.image->get_vk_image_view().get_handle(),
+	    descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.gradient.image->get_vk_image_view().get_format()));
+
+	std::array<vk::WriteDescriptorSet, 3> write_descriptor_sets = {
+	    {{graphics.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, particle_image_descriptor},
+	     {graphics.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, gradient_image_descriptor},
+	     {graphics.descriptor_set, 2, 0, vk::DescriptorType::eUniformBuffer, {}, buffer_descriptor}}};
+
+	get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, nullptr);
+}
+
+void HPPComputeNBody::update_graphics_uniform_buffers()
+{
+	graphics.ubo.projection = camera.matrices.perspective;
+	graphics.ubo.view       = camera.matrices.view;
+	graphics.ubo.screenDim  = glm::vec2(static_cast<float>(extent.width), static_cast<float>(extent.height));
+	graphics.uniform_buffer->convert_and_update(graphics.ubo);
 }
 
 std::unique_ptr<vkb::Application> create_hpp_compute_nbody()

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
@@ -664,9 +664,9 @@ void HPPComputeNBody::update_graphics_descriptor_set()
 {
 	vk::DescriptorBufferInfo buffer_descriptor(graphics.uniform_buffer->get_handle(), 0, VK_WHOLE_SIZE);
 	vk::DescriptorImageInfo  particle_image_descriptor(
-	     textures.particle.sampler,
-	     textures.particle.image->get_vk_image_view().get_handle(),
-	     descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.particle.image->get_vk_image_view().get_format()));
+        textures.particle.sampler,
+        textures.particle.image->get_vk_image_view().get_handle(),
+        descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.particle.image->get_vk_image_view().get_format()));
 	vk::DescriptorImageInfo gradient_image_descriptor(
 	    textures.gradient.sampler,
 	    textures.gradient.image->get_vk_image_view().get_handle(),

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.h
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -33,59 +33,55 @@
 class HPPComputeNBody : public HPPApiVulkanSample
 {
   public:
-	uint32_t num_particles;
-	uint32_t work_group_size  = 128;
-	uint32_t shared_data_size = 1024;
+	HPPComputeNBody();
+	~HPPComputeNBody();
 
-	struct
-	{
-		HPPTexture particle;
-		HPPTexture gradient;
-	} textures;
-
-	// Resources for the graphics part of the example
-	struct
-	{
-		std::unique_ptr<vkb::core::HPPBuffer> uniform_buffer;               // Contains scene matrices
-		vk::DescriptorSetLayout               descriptor_set_layout;        // Particle system rendering shader binding layout
-		vk::DescriptorSet                     descriptor_set;               // Particle system rendering shader bindings
-		vk::PipelineLayout                    pipeline_layout;              // Layout of the graphics pipeline
-		vk::Pipeline                          pipeline;                     // Particle rendering pipeline
-		vk::Semaphore                         semaphore;                    // Execution dependency between compute & graphic submission
-		uint32_t                              queue_family_index;
-		struct
-		{
-			glm::mat4 projection;
-			glm::mat4 view;
-			glm::vec2 screenDim;
-		} ubo;
-	} graphics;
-
+  private:
 	// Resources for the compute part of the example
-	struct
+	struct ComputeUBO
+	{                              // Compute shader uniform block object
+		float   delta_time;        // Frame delta time
+		int32_t particle_count;
+	};
+
+	struct Compute
 	{
-		std::unique_ptr<vkb::core::HPPBuffer> storage_buffer;               // (Shader) storage buffer object containing the particles
-		std::unique_ptr<vkb::core::HPPBuffer> uniform_buffer;               // Uniform buffer object containing particle system parameters
-		vk::Queue                             queue;                        // Separate queue for compute commands (queue family may differ from the one used for graphics)
-		vk::CommandPool                       command_pool;                 // Use a separate command pool (queue family may differ from the one used for graphics)
 		vk::CommandBuffer                     command_buffer;               // Command buffer storing the dispatch commands and barriers
-		vk::Semaphore                         semaphore;                    // Execution dependency between compute & graphic submission
-		vk::DescriptorSetLayout               descriptor_set_layout;        // Compute shader binding layout
+		vk::CommandPool                       command_pool;                 // Use a separate command pool (queue family may differ from the one used for graphics)
 		vk::DescriptorSet                     descriptor_set;               // Compute shader bindings
-		vk::PipelineLayout                    pipeline_layout;              // Layout of the compute pipeline
+		vk::DescriptorSetLayout               descriptor_set_layout;        // Compute shader binding layout
 		vk::Pipeline                          pipeline_calculate;           // Compute pipeline for N-Body velocity calculation (1st pass)
 		vk::Pipeline                          pipeline_integrate;           // Compute pipeline for euler integration (2nd pass)
-		vk::Pipeline                          blur;
-		vk::PipelineLayout                    pipeline_layout_blur;
-		vk::DescriptorSetLayout               descriptor_set_layout_blur;
-		vk::DescriptorSet                     descriptor_set_blur;
-		uint32_t                              queue_family_index;
-		struct ComputeUBO
-		{                              // Compute shader uniform block object
-			float   delta_time;        // Frame delta time
-			int32_t particle_count;
-		} ubo;
-	} compute;
+		vk::PipelineLayout                    pipeline_layout;              // Layout of the compute pipeline
+		vk::Queue                             queue;                        // Separate queue for compute commands (queue family may differ from the one used for graphics)
+		uint32_t                              queue_family_index = ~0;
+		vk::Semaphore                         semaphore;        // Execution dependency between compute & graphic submission
+		uint32_t                              shared_data_size = 1024;
+		std::unique_ptr<vkb::core::HPPBuffer> storage_buffer;        // (Shader) storage buffer object containing the particles
+		ComputeUBO                            ubo;
+		std::unique_ptr<vkb::core::HPPBuffer> uniform_buffer;        // Uniform buffer object containing particle system parameters
+		uint32_t                              work_group_size = 128;
+	};
+
+	// Resources for the graphics part of the example
+	struct GraphicsUBO
+	{
+		glm::mat4 projection;
+		glm::mat4 view;
+		glm::vec2 screenDim;
+	};
+
+	struct Graphics
+	{
+		vk::DescriptorSet                     descriptor_set;               // Particle system rendering shader bindings
+		vk::DescriptorSetLayout               descriptor_set_layout;        // Particle system rendering shader binding layout
+		vk::Pipeline                          pipeline;                     // Particle rendering pipeline
+		vk::PipelineLayout                    pipeline_layout;              // Layout of the graphics pipeline
+		uint32_t                              queue_family_index = ~0;
+		vk::Semaphore                         semaphore;        // Execution dependency between compute & graphic submission
+		GraphicsUBO                           ubo;
+		std::unique_ptr<vkb::core::HPPBuffer> uniform_buffer;        // Contains scene matrices
+	};
 
 	// SSBO particle declaration
 	struct Particle
@@ -94,26 +90,49 @@ class HPPComputeNBody : public HPPApiVulkanSample
 		glm::vec4 vel;        // xyz = velocity, w = gradient texture position
 	};
 
-	HPPComputeNBody();
-	~HPPComputeNBody();
-	virtual void request_gpu_features(vkb::core::HPPPhysicalDevice &gpu) override;
-	void         load_assets();
-	void         build_command_buffers() override;
-	void         build_compute_command_buffer();
-	void         prepare_storage_buffers();
-	void         setup_descriptor_pool();
-	void         setup_descriptor_set_layout();
-	void         setup_descriptor_set();
-	void         prepare_pipelines();
-	void         prepare_graphics();
-	void         prepare_compute();
-	void         prepare_uniform_buffers();
-	void         update_compute_uniform_buffers(float delta_time);
-	void         update_graphics_uniform_buffers();
-	void         draw();
-	bool         prepare(vkb::platform::HPPPlatform &platform) override;
-	virtual void render(float delta_time) override;
-	virtual bool resize(const uint32_t width, const uint32_t height) override;
+	struct Textures
+	{
+		HPPTexture gradient;
+		HPPTexture particle;
+	};
+
+  private:
+	// from platform::HPPApplication
+	bool prepare(vkb::platform::HPPPlatform &platform) override;
+	bool resize(const uint32_t width, const uint32_t height) override;
+
+	// from HPPVulkanSample
+	void request_gpu_features(vkb::core::HPPPhysicalDevice &gpu) override;
+
+	// from HPPApiVulkanSample
+	void build_command_buffers() override;
+	void render(float delta_time) override;
+
+	void build_compute_command_buffer();
+	void build_compute_transfer_command_buffer(vk::CommandBuffer command_buffer) const;
+	void build_copy_command_buffer(vk::CommandBuffer command_buffer, vk::Buffer staging_buffer, vk::DeviceSize buffer_size) const;
+	void create_compute_descriptor_set_layout();
+	void create_compute_pipeline_particle_integration();
+	void create_compute_pipeline_particle_movement();
+	void create_compute_pipelines();
+	void prepare_compute_storage_buffers();
+	void create_descriptor_pool();
+	void create_graphics_descriptor_set_layout();
+	void create_graphics_pipeline();
+	void draw();
+	void initializeCamera();
+	void load_assets();
+	void prepare_compute();
+	void prepare_graphics();
+	void update_compute_descriptor_set();
+	void update_compute_uniform_buffers(float delta_time);
+	void update_graphics_descriptor_set();
+	void update_graphics_uniform_buffers();
+
+  private:
+	Compute  compute;
+	Graphics graphics;
+	Textures textures;
 };
 
 std::unique_ptr<vkb::Application> create_hpp_compute_nbody();


### PR DESCRIPTION
## Description

Refactored API sample hpp_compute_nbody by reordering and renaming lots of functions in order to get some consistent naming scheme. Added some inlined helper functions to common/hpp_vk_common.h

When this PR is accepted, I plan to also refactor the other hpp-based samples.

Builds and runs on Win10 on NVidia HW.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
