### PR TITLE
Refactored API sample hpp_dynamic_uniform_buffers.

### DIFF
--- a/framework/core/hpp_command_buffer.h
+++ b/framework/core/hpp_command_buffer.h
@@ -20,7 +20,6 @@
 #include <core/command_buffer.h>
 
 #include <common/hpp_vk_common.h>
-#include <core/hpp_buffer.h>
 #include <core/hpp_image_view.h>
 #include <core/hpp_pipeline_layout.h>
 #include <core/hpp_sampler.h>
@@ -30,6 +29,7 @@ namespace vkb
 {
 namespace core
 {
+class HPPBuffer;
 class HPPCommandPool;
 
 /**

--- a/framework/core/hpp_device.cpp
+++ b/framework/core/hpp_device.cpp
@@ -18,6 +18,7 @@
 #include <core/hpp_device.h>
 
 #include <common/hpp_error.h>
+#include <core/hpp_buffer.h>
 #include <core/hpp_command_pool.h>
 
 namespace vkb

--- a/framework/hpp_gui.cpp
+++ b/framework/hpp_gui.cpp
@@ -16,11 +16,11 @@
  */
 
 #include "hpp_gui.h"
-
-#include "common/hpp_utils.h"
-#include "core/hpp_command_pool.h"
-#include "hpp_vulkan_sample.h"
-#include "imgui_internal.h"
+#include <common/hpp_utils.h>
+#include <core/hpp_buffer.h>
+#include <core/hpp_command_pool.h>
+#include <hpp_vulkan_sample.h>
+#include <imgui_internal.h>
 
 namespace vkb
 {

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
@@ -19,8 +19,7 @@
  * Compute shader N-body simulation using two passes and shared compute shader memory, using vulkan.hpp
  */
 
-#include <hpp_compute_nbody.h>
-
+#include "hpp_compute_nbody.h"
 #include <benchmark_mode/benchmark_mode.h>
 #include <core/hpp_command_pool.h>
 #include <random>
@@ -348,93 +347,6 @@ void HPPComputeNBody::create_compute_pipelines()
 	create_compute_pipeline_particle_integration();
 }
 
-// Setup and fill the compute shader storage buffers containing the particles
-void HPPComputeNBody::prepare_compute_storage_buffers()
-{
-#if 0
-	std::vector<glm::vec3> attractors = {
-		glm::vec3(2.5f, 1.5f, 0.0f),
-		glm::vec3(-2.5f, -1.5f, 0.0f),
-	};
-#else
-	std::vector<glm::vec3> attractors = {
-	    glm::vec3(5.0f, 0.0f, 0.0f),
-	    glm::vec3(-5.0f, 0.0f, 0.0f),
-	    glm::vec3(0.0f, 0.0f, 5.0f),
-	    glm::vec3(0.0f, 0.0f, -5.0f),
-	    glm::vec3(0.0f, 4.0f, 0.0f),
-	    glm::vec3(0.0f, -8.0f, 0.0f),
-	};
-#endif
-
-	compute.ubo.particle_count = static_cast<uint32_t>(attractors.size()) * PARTICLES_PER_ATTRACTOR;
-
-	// Initial particle positions
-	std::vector<Particle> particle_buffer(compute.ubo.particle_count);
-
-	std::default_random_engine      rnd_engine(platform->using_plugin<::plugins::BenchmarkMode>() ? 0 : static_cast<unsigned>(time(nullptr)));
-	std::normal_distribution<float> rnd_distribution(0.0f, 1.0f);
-
-	for (uint32_t i = 0; i < static_cast<uint32_t>(attractors.size()); i++)
-	{
-		for (uint32_t j = 0; j < PARTICLES_PER_ATTRACTOR; j++)
-		{
-			Particle &particle = particle_buffer[i * PARTICLES_PER_ATTRACTOR + j];
-
-			// First particle in group as heavy center of gravity
-			if (j == 0)
-			{
-				particle.pos = glm::vec4(attractors[i] * 1.5f, 90000.0f);
-				particle.vel = glm::vec4(glm::vec4(0.0f));
-			}
-			else
-			{
-				// Position
-				glm::vec3 position(attractors[i] +
-				                   glm::vec3(rnd_distribution(rnd_engine), rnd_distribution(rnd_engine), rnd_distribution(rnd_engine)) * 0.75f);
-				float     len = glm::length(glm::normalize(position - attractors[i]));
-				position.y *= 2.0f - (len * len);
-
-				// Velocity
-				glm::vec3 angular  = glm::vec3(0.5f, 1.5f, 0.5f) * (((i % 2) == 0) ? 1.0f : -1.0f);
-				glm::vec3 velocity = glm::cross((position - attractors[i]), angular) +
-				                     glm::vec3(rnd_distribution(rnd_engine), rnd_distribution(rnd_engine), rnd_distribution(rnd_engine) * 0.025f);
-
-				float mass   = (rnd_distribution(rnd_engine) * 0.5f + 0.5f) * 75.0f;
-				particle.pos = glm::vec4(position, mass);
-				particle.vel = glm::vec4(velocity, 0.0f);
-			}
-
-			// Color gradient offset
-			particle.vel.w = static_cast<float>(i) * 1.0f / static_cast<uint32_t>(attractors.size());
-		}
-	}
-
-	vk::DeviceSize storage_buffer_size = particle_buffer.size() * sizeof(Particle);
-
-	// Staging
-	// SSBO won't be changed on the host after upload so copy to device local memory
-	vkb::core::HPPBuffer staging_buffer(*get_device(), storage_buffer_size, vk::BufferUsageFlagBits::eTransferSrc, VMA_MEMORY_USAGE_CPU_ONLY);
-	staging_buffer.update(particle_buffer.data(), storage_buffer_size);
-
-	compute.storage_buffer = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
-	                                                                storage_buffer_size,
-	                                                                vk::BufferUsageFlagBits::eVertexBuffer | vk::BufferUsageFlagBits::eStorageBuffer |
-	                                                                    vk::BufferUsageFlagBits::eTransferDst,
-	                                                                VMA_MEMORY_USAGE_GPU_ONLY);
-
-	// Copy from staging buffer to storage buffer
-	vk::Device device = get_device()->get_handle();
-
-	vk::CommandBuffer copy_command = device.allocateCommandBuffers({get_device()->get_command_pool().get_handle(), vk::CommandBufferLevel::ePrimary, 1}).front();
-
-	build_copy_command_buffer(copy_command, staging_buffer.get_handle(), storage_buffer_size);
-
-	vkb::common::submit_and_wait(device, queue, {copy_command});
-
-	device.freeCommandBuffers(get_device()->get_command_pool().get_handle(), copy_command);
-}
-
 void HPPComputeNBody::create_descriptor_pool()
 {
 	std::array<vk::DescriptorPoolSize, 3> pool_sizes = {
@@ -617,6 +529,93 @@ void HPPComputeNBody::prepare_compute()
 		// free the transfer command buffer
 		device.freeCommandBuffers(compute.command_pool, transfer_command);
 	}
+}
+
+// Setup and fill the compute shader storage buffers containing the particles
+void HPPComputeNBody::prepare_compute_storage_buffers()
+{
+#if 0
+	std::vector<glm::vec3> attractors = {
+		glm::vec3(2.5f, 1.5f, 0.0f),
+		glm::vec3(-2.5f, -1.5f, 0.0f),
+	};
+#else
+	std::vector<glm::vec3> attractors = {
+	    glm::vec3(5.0f, 0.0f, 0.0f),
+	    glm::vec3(-5.0f, 0.0f, 0.0f),
+	    glm::vec3(0.0f, 0.0f, 5.0f),
+	    glm::vec3(0.0f, 0.0f, -5.0f),
+	    glm::vec3(0.0f, 4.0f, 0.0f),
+	    glm::vec3(0.0f, -8.0f, 0.0f),
+	};
+#endif
+
+	compute.ubo.particle_count = static_cast<uint32_t>(attractors.size()) * PARTICLES_PER_ATTRACTOR;
+
+	// Initial particle positions
+	std::vector<Particle> particle_buffer(compute.ubo.particle_count);
+
+	std::default_random_engine      rnd_engine(platform->using_plugin<::plugins::BenchmarkMode>() ? 0 : (unsigned) time(nullptr));
+	std::normal_distribution<float> rnd_distribution(0.0f, 1.0f);
+
+	for (uint32_t i = 0; i < static_cast<uint32_t>(attractors.size()); i++)
+	{
+		for (uint32_t j = 0; j < PARTICLES_PER_ATTRACTOR; j++)
+		{
+			Particle &particle = particle_buffer[i * PARTICLES_PER_ATTRACTOR + j];
+
+			// First particle in group as heavy center of gravity
+			if (j == 0)
+			{
+				particle.pos = glm::vec4(attractors[i] * 1.5f, 90000.0f);
+				particle.vel = glm::vec4(glm::vec4(0.0f));
+			}
+			else
+			{
+				// Position
+				glm::vec3 position(attractors[i] +
+				                   glm::vec3(rnd_distribution(rnd_engine), rnd_distribution(rnd_engine), rnd_distribution(rnd_engine)) * 0.75f);
+				float     len = glm::length(glm::normalize(position - attractors[i]));
+				position.y *= 2.0f - (len * len);
+
+				// Velocity
+				glm::vec3 angular  = glm::vec3(0.5f, 1.5f, 0.5f) * (((i % 2) == 0) ? 1.0f : -1.0f);
+				glm::vec3 velocity = glm::cross((position - attractors[i]), angular) +
+				                     glm::vec3(rnd_distribution(rnd_engine), rnd_distribution(rnd_engine), rnd_distribution(rnd_engine) * 0.025f);
+
+				float mass   = (rnd_distribution(rnd_engine) * 0.5f + 0.5f) * 75.0f;
+				particle.pos = glm::vec4(position, mass);
+				particle.vel = glm::vec4(velocity, 0.0f);
+			}
+
+			// Color gradient offset
+			particle.vel.w = (float) i * 1.0f / static_cast<uint32_t>(attractors.size());
+		}
+	}
+
+	vk::DeviceSize storage_buffer_size = particle_buffer.size() * sizeof(Particle);
+
+	// Staging
+	// SSBO won't be changed on the host after upload so copy to device local memory
+	vkb::core::HPPBuffer staging_buffer(*get_device(), storage_buffer_size, vk::BufferUsageFlagBits::eTransferSrc, VMA_MEMORY_USAGE_CPU_ONLY);
+	staging_buffer.update(particle_buffer.data(), storage_buffer_size);
+
+	compute.storage_buffer = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
+	                                                                storage_buffer_size,
+	                                                                vk::BufferUsageFlagBits::eVertexBuffer | vk::BufferUsageFlagBits::eStorageBuffer |
+	                                                                    vk::BufferUsageFlagBits::eTransferDst,
+	                                                                VMA_MEMORY_USAGE_GPU_ONLY);
+
+	// Copy from staging buffer to storage buffer
+	vk::Device device = get_device()->get_handle();
+
+	vk::CommandBuffer copy_command = device.allocateCommandBuffers({get_device()->get_command_pool().get_handle(), vk::CommandBufferLevel::ePrimary, 1}).front();
+
+	build_copy_command_buffer(copy_command, staging_buffer.get_handle(), storage_buffer_size);
+
+	vkb::common::submit_and_wait(device, queue, {copy_command});
+
+	device.freeCommandBuffers(get_device()->get_command_pool().get_handle(), copy_command);
 }
 
 void HPPComputeNBody::prepare_graphics()

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.h
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "hpp_api_vulkan_sample.h"
+#include <hpp_api_vulkan_sample.h>
 
 #if defined(__ANDROID__)
 // Lower particle count on Android for performance reasons
@@ -115,7 +115,6 @@ class HPPComputeNBody : public HPPApiVulkanSample
 	void create_compute_pipeline_particle_integration();
 	void create_compute_pipeline_particle_movement();
 	void create_compute_pipelines();
-	void prepare_compute_storage_buffers();
 	void create_descriptor_pool();
 	void create_graphics_descriptor_set_layout();
 	void create_graphics_pipeline();
@@ -123,6 +122,7 @@ class HPPComputeNBody : public HPPApiVulkanSample
 	void initializeCamera();
 	void load_assets();
 	void prepare_compute();
+	void prepare_compute_storage_buffers();
 	void prepare_graphics();
 	void update_compute_descriptor_set();
 	void update_compute_uniform_buffers(float delta_time);

--- a/samples/api/hpp_dynamic_uniform_buffers/hpp_dynamic_uniform_buffers.h
+++ b/samples/api/hpp_dynamic_uniform_buffers/hpp_dynamic_uniform_buffers.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -28,76 +28,82 @@
 
 #pragma once
 
-#include <hpp_api_vulkan_sample.h>
-
 #include <core/hpp_buffer.h>
+#include <hpp_api_vulkan_sample.h>
 
 #define OBJECT_INSTANCES 125
 
 class HPPDynamicUniformBuffers : public HPPApiVulkanSample
 {
-  private:
-	static void *aligned_alloc(size_t size, size_t alignment);
-	static void  aligned_free(void *data);
-
   public:
+	HPPDynamicUniformBuffers();
+	~HPPDynamicUniformBuffers();
+
+  private:
+	// One big uniform buffer that contains all matrices
+	// Note that we need to manually allocate the data to cope for GPU-specific uniform buffer offset alignments
+	struct UboDataDynamic
+	{
+		glm::mat4 *model = nullptr;
+	};
+
+	struct UboVS
+	{
+		glm::mat4 projection;
+		glm::mat4 view;
+	};
+
+	struct UniformBuffers
+	{
+		std::unique_ptr<vkb::core::HPPBuffer> view;
+		std::unique_ptr<vkb::core::HPPBuffer> dynamic;
+	};
+
 	struct Vertex
 	{
 		float pos[3];
 		float color[3];
 	};
 
-	std::unique_ptr<vkb::core::HPPBuffer> vertex_buffer;
+  private:
+	static void *aligned_alloc(size_t size, size_t alignment);
+	static void  aligned_free(void *data);
+
+  private:
+	float                                 animation_timer = 0.0f;
+	vk::DescriptorSet                     descriptor_set;
+	vk::DescriptorSetLayout               descriptor_set_layout;
+	size_t                                dynamic_alignment = 0;
 	std::unique_ptr<vkb::core::HPPBuffer> index_buffer;
 	uint32_t                              index_count = 0;
+	vk::Pipeline                          pipeline;
+	vk::PipelineLayout                    pipeline_layout;
+	glm::vec3                             rotations[OBJECT_INSTANCES];        // Store random per-object rotations
+	glm::vec3                             rotation_speeds[OBJECT_INSTANCES];
+	UboDataDynamic                        ubo_data_dynamic;
+	UboVS                                 ubo_vs;
+	UniformBuffers                        uniform_buffers;
+	std::unique_ptr<vkb::core::HPPBuffer> vertex_buffer;
 
-	struct UniformBuffers
-	{
-		std::unique_ptr<vkb::core::HPPBuffer> view;
-		std::unique_ptr<vkb::core::HPPBuffer> dynamic;
-	} uniform_buffers;
+  private:
+	// from platform::HPPApplication
+	bool prepare(vkb::platform::HPPPlatform &platform) override;
+	bool resize(const uint32_t width, const uint32_t height) override;
 
-	struct UboVS
-	{
-		glm::mat4 projection;
-		glm::mat4 view;
-	} ubo_vs;
+	// from HPPApiVulkanSample
+	void render(float delta_time) override;
 
-	// Store random per-object rotations
-	glm::vec3 rotations[OBJECT_INSTANCES];
-	glm::vec3 rotation_speeds[OBJECT_INSTANCES];
-
-	// One big uniform buffer that contains all matrices
-	// Note that we need to manually allocate the data to cope for GPU-specific uniform buffer offset alignments
-	struct UboDataDynamic
-	{
-		glm::mat4 *model = nullptr;
-	} ubo_data_dynamic;
-
-	vk::Pipeline            pipeline;
-	vk::PipelineLayout      pipeline_layout;
-	vk::DescriptorSet       descriptor_set;
-	vk::DescriptorSetLayout descriptor_set_layout;
-
-	float animation_timer = 0.0f;
-
-	size_t dynamic_alignment = 0;
-
-	HPPDynamicUniformBuffers();
-	~HPPDynamicUniformBuffers();
-	void         build_command_buffers() override;
-	void         generate_cube();
-	void         setup_descriptor_pool();
-	void         setup_descriptor_set_layout();
-	void         setup_descriptor_set();
-	void         prepare_pipelines();
-	void         prepare_uniform_buffers();
-	void         update_uniform_buffers();
-	void         update_dynamic_uniform_buffer(float delta_time, bool force = false);
-	void         draw();
-	bool         prepare(vkb::platform::HPPPlatform &platform) override;
-	virtual void render(float delta_time) override;
-	virtual bool resize(const uint32_t width, const uint32_t height) override;
+	void build_command_buffers() override;
+	void create_descriptor_pool();
+	void create_descriptor_set_layout();
+	void create_pipeline();
+	void draw();
+	void generate_cube();
+	void prepare_camera();
+	void prepare_uniform_buffers();
+	void update_descriptor_set();
+	void update_dynamic_uniform_buffer(float delta_time, bool force = false);
+	void update_uniform_buffers();
 };
 
 std::unique_ptr<vkb::Application> create_hpp_dynamic_uniform_buffers();


### PR DESCRIPTION
## Description

Refactored API sample `hpp_compute_nbody` by reordering and renaming some of functions in order to get some consistent naming scheme.
Includes minor adjustments in `core/hpp_command_buffer.h`, `core/hpp_device.cpp`, `hpp_gui.cpp`, and `samples/api/hpp_compute_nbody[cpp|h]`

Builds and runs on Win10 on NVidia HW.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
