### PR TITLE
Change vkb::core::HPPCommandBuffer from a facade over vkb::CommandBuffer to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -44,6 +44,7 @@ set(FRAMEWORK_FILES
     hpp_glsl_compiler.h
     hpp_gltf_loader.h
     hpp_gui.h
+    hpp_resource_binding_state.h
     hpp_resource_cache.h
     hpp_vulkan_sample.h
     # Source Files
@@ -113,6 +114,7 @@ set(RENDERING_FILES
     rendering/hpp_render_frame.h
     rendering/hpp_render_pipeline.h
     rendering/hpp_render_target.h
+    rendering/hpp_subpass.h
     # Source files
     rendering/pipeline_state.cpp
     rendering/postprocessing_pipeline.cpp
@@ -247,14 +249,20 @@ set(CORE_FILES
     core/hpp_command_buffer.h
     core/hpp_command_pool.h
     core/hpp_debug.h
+    core/hpp_descriptor_set_layout.h
     core/hpp_device.h
+    core/hpp_framebuffer.h
     core/hpp_image.h
     core/hpp_image_view.h
     core/hpp_instance.h
     core/hpp_physical_device.h
+    core/hpp_pipeline.h
     core/hpp_pipeline_layout.h
+    core/hpp_query_pool.h
     core/hpp_queue.h
+	core/hpp_render_pass.h
     core/hpp_sampler.h
+    core/hpp_shader_module.h
     core/hpp_swapchain.h
     core/hpp_vulkan_resource.h
     core/vulkan_resource.h
@@ -288,6 +296,7 @@ set(CORE_FILES
     core/shader_binding_table.cpp
     core/vulkan_resource.cpp
     core/hpp_buffer.cpp
+    core/hpp_command_buffer.cpp
     core/hpp_command_pool.cpp
     core/hpp_device.cpp
     core/hpp_image.cpp

--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -29,6 +29,15 @@ namespace common
 /**
  * @brief facade helper functions and structs around the functions and structs in common/vk_common, providing a vulkan.hpp-based interface
  */
+
+struct HPPBufferMemoryBarrier
+{
+	vk::PipelineStageFlags src_stage_mask  = vk::PipelineStageFlagBits::eBottomOfPipe;
+	vk::PipelineStageFlags dst_stage_mask  = vk::PipelineStageFlagBits::eTopOfPipe;
+	vk::AccessFlags        src_access_mask = {};
+	vk::AccessFlags        dst_access_mask = {};
+};
+
 struct HPPImageMemoryBarrier
 {
 	vk::PipelineStageFlags src_stage_mask = vk::PipelineStageFlagBits::eBottomOfPipe;
@@ -39,6 +48,12 @@ struct HPPImageMemoryBarrier
 	vk::ImageLayout        new_layout       = vk::ImageLayout::eUndefined;
 	uint32_t               old_queue_family = VK_QUEUE_FAMILY_IGNORED;
 	uint32_t               new_queue_family = VK_QUEUE_FAMILY_IGNORED;
+};
+
+struct HPPLoadStoreInfo
+{
+	vk::AttachmentLoadOp  load_op  = vk::AttachmentLoadOp::eClear;
+	vk::AttachmentStoreOp store_op = vk::AttachmentStoreOp::eStore;
 };
 
 inline int32_t get_bits_per_pixel(vk::Format format)
@@ -55,6 +70,11 @@ inline vk::Format get_suitable_depth_format(vk::PhysicalDevice             physi
 	    vkb::get_suitable_depth_format(physical_device, depth_only, reinterpret_cast<std::vector<VkFormat> const &>(depth_format_priority_list)));
 }
 
+inline bool is_buffer_descriptor_type(vk::DescriptorType descriptor_type)
+{
+	return vkb::is_buffer_descriptor_type(static_cast<VkDescriptorType>(descriptor_type));
+}
+
 inline bool is_depth_only_format(vk::Format format)
 {
 	return vkb::is_depth_only_format(static_cast<VkFormat>(format));
@@ -63,6 +83,11 @@ inline bool is_depth_only_format(vk::Format format)
 inline bool is_depth_stencil_format(vk::Format format)
 {
 	return vkb::is_depth_stencil_format(static_cast<VkFormat>(format));
+}
+
+inline bool is_dynamic_buffer_descriptor_type(vk::DescriptorType descriptor_type)
+{
+	return vkb::is_dynamic_buffer_descriptor_type(static_cast<VkDescriptorType>(descriptor_type));
 }
 
 inline vk::ShaderModule load_shader(const std::string &filename, vk::Device device, vk::ShaderStageFlagBits stage)

--- a/framework/core/hpp_buffer.cpp
+++ b/framework/core/hpp_buffer.cpp
@@ -23,7 +23,7 @@ namespace vkb
 {
 namespace core
 {
-HPPBuffer::HPPBuffer(vkb::core::HPPDevice const  &device,
+HPPBuffer::HPPBuffer(vkb::core::HPPDevice        &device,
                      vk::DeviceSize               size_,
                      vk::BufferUsageFlags         buffer_usage,
                      VmaMemoryUsage               memory_usage,

--- a/framework/core/hpp_buffer.h
+++ b/framework/core/hpp_buffer.h
@@ -38,7 +38,7 @@ class HPPBuffer : public vkb::core::HPPVulkanResource<vk::Buffer>
 	 * @param flags The allocation create flags
 	 * @param queue_family_indices optional queue family indices
 	 */
-	HPPBuffer(vkb::core::HPPDevice const  &device,
+	HPPBuffer(vkb::core::HPPDevice        &device,
 	          vk::DeviceSize               size,
 	          vk::BufferUsageFlags         buffer_usage,
 	          VmaMemoryUsage               memory_usage,

--- a/framework/core/hpp_command_buffer.cpp
+++ b/framework/core/hpp_command_buffer.cpp
@@ -1,0 +1,820 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/hpp_command_buffer.h"
+#include <core/hpp_command_pool.h>
+#include <core/hpp_device.h>
+#include <core/hpp_pipeline.h>
+#include <rendering/hpp_render_frame.h>
+
+namespace vkb
+{
+namespace core
+{
+HPPCommandBuffer::HPPCommandBuffer(vkb::core::HPPCommandPool &command_pool, vk::CommandBufferLevel level) :
+    HPPVulkanResource(nullptr, &command_pool.get_device()),
+    level(level),
+    command_pool(command_pool),
+    max_push_constants_size(get_device().get_gpu().get_properties().limits.maxPushConstantsSize)
+{
+	vk::CommandBufferAllocateInfo allocate_info(command_pool.get_handle(), level, 1);
+
+	set_handle(get_device().get_handle().allocateCommandBuffers(allocate_info).front());
+}
+
+HPPCommandBuffer::HPPCommandBuffer(HPPCommandBuffer &&other) :
+    HPPVulkanResource(std::move(other)),
+    level(other.level),
+    state(std::exchange(other.state, State::Invalid)),
+    command_pool(other.command_pool),
+    current_render_pass(std::exchange(other.current_render_pass, {})),
+    pipeline_state(std::exchange(other.pipeline_state, {})),
+    resource_binding_state(std::exchange(other.resource_binding_state, {})),
+    stored_push_constants(std::exchange(other.stored_push_constants, {})),
+    max_push_constants_size(std::exchange(other.max_push_constants_size, {})),
+    last_framebuffer_extent(std::exchange(other.last_framebuffer_extent, {})),
+    last_render_area_extent(std::exchange(other.last_render_area_extent, {})),
+    update_after_bind(std::exchange(other.update_after_bind, {})),
+    descriptor_set_layout_binding_state(std::exchange(other.descriptor_set_layout_binding_state, {}))
+{
+}
+
+HPPCommandBuffer::~HPPCommandBuffer()
+{
+	// Destroy command buffer
+	if (get_handle())
+	{
+		get_device().get_handle().freeCommandBuffers(command_pool.get_handle(), get_handle());
+	}
+}
+
+vk::Result HPPCommandBuffer::begin(vk::CommandBufferUsageFlags flags, HPPCommandBuffer *primary_cmd_buf)
+{
+	if (level == vk::CommandBufferLevel::eSecondary)
+	{
+		assert(primary_cmd_buf && "A primary command buffer pointer must be provided when calling begin from a secondary one");
+		auto const &render_pass_binding = primary_cmd_buf->get_current_render_pass();
+
+		return begin(flags, render_pass_binding.render_pass, render_pass_binding.framebuffer, primary_cmd_buf->get_current_subpass_index());
+	}
+
+	return begin(flags, nullptr, nullptr, 0);
+}
+
+vk::Result HPPCommandBuffer::begin(vk::CommandBufferUsageFlags flags, const vkb::core::HPPRenderPass *render_pass, const vkb::core::HPPFramebuffer *framebuffer, uint32_t subpass_index)
+{
+	if (is_recording())
+	{
+		assert("Command buffer is already recording, please call end before beginning again");
+		return vk::Result::eNotReady;
+	}
+
+	state = State::Recording;
+
+	// Reset state
+	pipeline_state.reset();
+	resource_binding_state.reset();
+	descriptor_set_layout_binding_state.clear();
+	stored_push_constants.clear();
+
+	vk::CommandBufferBeginInfo       begin_info(flags);
+	vk::CommandBufferInheritanceInfo inheritance;
+
+	if (level == vk::CommandBufferLevel::eSecondary)
+	{
+		assert((render_pass && framebuffer) && "Render pass and framebuffer must be provided when calling begin from a secondary one");
+
+		current_render_pass.render_pass = render_pass;
+		current_render_pass.framebuffer = framebuffer;
+
+		inheritance.renderPass  = current_render_pass.render_pass->get_handle();
+		inheritance.framebuffer = current_render_pass.framebuffer->get_handle();
+		inheritance.subpass     = subpass_index;
+
+		begin_info.pInheritanceInfo = &inheritance;
+	}
+
+	get_handle().begin(begin_info);
+	return vk::Result::eSuccess;
+}
+
+void HPPCommandBuffer::begin_query(const vkb::core::HPPQueryPool &query_pool, uint32_t query, vk::QueryControlFlags flags)
+{
+	assert(is_recording());
+	get_handle().beginQuery(query_pool.get_handle(), query, flags);
+}
+
+void HPPCommandBuffer::begin_render_pass(const vkb::rendering::HPPRenderTarget                          &render_target,
+                                         const std::vector<vkb::common::HPPLoadStoreInfo>               &load_store_infos,
+                                         const std::vector<vk::ClearValue>                              &clear_values,
+                                         const std::vector<std::unique_ptr<vkb::rendering::HPPSubpass>> &subpasses,
+                                         vk::SubpassContents                                             contents)
+{
+	// Reset state
+	pipeline_state.reset();
+	resource_binding_state.reset();
+	descriptor_set_layout_binding_state.clear();
+
+	auto &render_pass = get_render_pass(render_target, load_store_infos, subpasses);
+	auto &framebuffer = get_device().get_resource_cache().request_framebuffer(render_target, render_pass);
+
+	begin_render_pass(render_target, render_pass, framebuffer, clear_values, contents);
+}
+
+void HPPCommandBuffer::begin_render_pass(const vkb::rendering::HPPRenderTarget &render_target,
+                                         const vkb::core::HPPRenderPass        &render_pass,
+                                         const vkb::core::HPPFramebuffer       &framebuffer,
+                                         const std::vector<vk::ClearValue>     &clear_values,
+                                         vk::SubpassContents                    contents)
+{
+	assert(is_recording());
+	current_render_pass.render_pass = &render_pass;
+	current_render_pass.framebuffer = &framebuffer;
+
+	// Begin render pass
+	vk::RenderPassBeginInfo begin_info(
+	    current_render_pass.render_pass->get_handle(), current_render_pass.framebuffer->get_handle(), {{}, render_target.get_extent()}, clear_values);
+
+	const auto &framebuffer_extent = current_render_pass.framebuffer->get_extent();
+
+	// Test the requested render area to confirm that it is optimal and could not cause a performance reduction
+	if (!is_render_size_optimal(framebuffer_extent, begin_info.renderArea))
+	{
+		// Only prints the warning if the framebuffer or render area are different since the last time the render size was not optimal
+		if ((framebuffer_extent != last_framebuffer_extent) || (begin_info.renderArea.extent != last_render_area_extent))
+		{
+			LOGW("Render target extent is not an optimal size, this may result in reduced performance.");
+		}
+
+		last_framebuffer_extent = framebuffer_extent;
+		last_render_area_extent = begin_info.renderArea.extent;
+	}
+
+	get_handle().beginRenderPass(begin_info, contents);
+
+	// Update blend state attachments for first subpass
+	auto blend_state = pipeline_state.get_color_blend_state();
+	blend_state.attachments.resize(current_render_pass.render_pass->get_color_output_count(pipeline_state.get_subpass_index()));
+	pipeline_state.set_color_blend_state(blend_state);
+}
+
+void HPPCommandBuffer::bind_buffer(
+    const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, vk::DeviceSize range, uint32_t set, uint32_t binding, uint32_t array_element)
+{
+	resource_binding_state.bind_buffer(buffer, offset, range, set, binding, array_element);
+}
+
+void HPPCommandBuffer::bind_image(
+    const vkb::core::HPPImageView &image_view, const vkb::core::HPPSampler &sampler, uint32_t set, uint32_t binding, uint32_t array_element)
+{
+	resource_binding_state.bind_image(image_view, sampler, set, binding, array_element);
+}
+
+void HPPCommandBuffer::bind_image(const vkb::core::HPPImageView &image_view, uint32_t set, uint32_t binding, uint32_t array_element)
+{
+	resource_binding_state.bind_image(image_view, set, binding, array_element);
+}
+
+void HPPCommandBuffer::bind_index_buffer(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, vk::IndexType index_type)
+{
+	assert(is_recording());
+	get_handle().bindIndexBuffer(buffer.get_handle(), offset, index_type);
+}
+
+void HPPCommandBuffer::bind_input(const vkb::core::HPPImageView &image_view, uint32_t set, uint32_t binding, uint32_t array_element)
+{
+	resource_binding_state.bind_input(image_view, set, binding, array_element);
+}
+
+void HPPCommandBuffer::bind_lighting(vkb::rendering::HPPLightingState &lighting_state, uint32_t set, uint32_t binding)
+{
+	bind_buffer(lighting_state.light_buffer.get_buffer(), lighting_state.light_buffer.get_offset(), lighting_state.light_buffer.get_size(), set, binding, 0);
+
+	set_specialization_constant(0, to_u32(lighting_state.directional_lights.size()));
+	set_specialization_constant(1, to_u32(lighting_state.point_lights.size()));
+	set_specialization_constant(2, to_u32(lighting_state.spot_lights.size()));
+}
+
+void HPPCommandBuffer::bind_pipeline_layout(vkb::core::HPPPipelineLayout &pipeline_layout)
+{
+	pipeline_state.set_pipeline_layout(pipeline_layout);
+}
+
+void HPPCommandBuffer::bind_vertex_buffers(uint32_t                                                               first_binding,
+                                           const std::vector<std::reference_wrapper<const vkb::core::HPPBuffer>> &buffers,
+                                           const std::vector<vk::DeviceSize>                                     &offsets)
+{
+	assert(is_recording());
+	std::vector<vk::Buffer> buffer_handles(buffers.size(), nullptr);
+	std::transform(buffers.begin(), buffers.end(), buffer_handles.begin(), [](const vkb::core::HPPBuffer &buffer) { return buffer.get_handle(); });
+	get_handle().bindVertexBuffers(first_binding, buffer_handles, offsets);
+}
+
+void HPPCommandBuffer::blit_image(const vkb::core::HPPImage &src_img, const vkb::core::HPPImage &dst_img, const std::vector<vk::ImageBlit> &regions)
+{
+	assert(is_recording());
+	get_handle().blitImage(
+	    src_img.get_handle(), vk::ImageLayout::eTransferSrcOptimal, dst_img.get_handle(), vk::ImageLayout::eTransferDstOptimal, regions, vk::Filter::eNearest);
+}
+
+void HPPCommandBuffer::buffer_memory_barrier(const vkb::core::HPPBuffer                &buffer,
+                                             vk::DeviceSize                             offset,
+                                             vk::DeviceSize                             size,
+                                             const vkb::common::HPPBufferMemoryBarrier &memory_barrier)
+{
+	assert(is_recording());
+	vk::BufferMemoryBarrier buffer_memory_barrier(memory_barrier.src_access_mask, memory_barrier.dst_access_mask, {}, {}, buffer.get_handle(), offset, size);
+
+	vk::PipelineStageFlags src_stage_mask = memory_barrier.src_stage_mask;
+	vk::PipelineStageFlags dst_stage_mask = memory_barrier.dst_stage_mask;
+
+	get_handle().pipelineBarrier(src_stage_mask, dst_stage_mask, {}, {}, buffer_memory_barrier, {});
+}
+
+void HPPCommandBuffer::clear(vk::ClearAttachment attachment, vk::ClearRect rect)
+{
+	assert(is_recording());
+	get_handle().clearAttachments(attachment, rect);
+}
+
+void HPPCommandBuffer::copy_buffer(const vkb::core::HPPBuffer &src_buffer, const vkb::core::HPPBuffer &dst_buffer, vk::DeviceSize size)
+{
+	assert(is_recording());
+	vk::BufferCopy copy_region({}, {}, size);
+	get_handle().copyBuffer(src_buffer.get_handle(), dst_buffer.get_handle(), copy_region);
+}
+
+void HPPCommandBuffer::copy_buffer_to_image(const vkb::core::HPPBuffer             &buffer,
+                                            const vkb::core::HPPImage              &image,
+                                            const std::vector<vk::BufferImageCopy> &regions)
+{
+	assert(is_recording());
+	get_handle().copyBufferToImage(buffer.get_handle(), image.get_handle(), vk::ImageLayout::eTransferDstOptimal, regions);
+}
+
+void HPPCommandBuffer::copy_image(const vkb::core::HPPImage &src_img, const vkb::core::HPPImage &dst_img, const std::vector<vk::ImageCopy> &regions)
+{
+	assert(is_recording());
+	get_handle().copyImage(src_img.get_handle(), vk::ImageLayout::eTransferSrcOptimal, dst_img.get_handle(), vk::ImageLayout::eTransferDstOptimal, regions);
+}
+
+void HPPCommandBuffer::copy_image_to_buffer(const vkb::core::HPPImage              &image,
+                                            vk::ImageLayout                         image_layout,
+                                            const vkb::core::HPPBuffer             &buffer,
+                                            const std::vector<vk::BufferImageCopy> &regions)
+{
+	assert(is_recording());
+	get_handle().copyImageToBuffer(image.get_handle(), image_layout, buffer.get_handle(), regions);
+}
+
+void HPPCommandBuffer::dispatch(uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z)
+{
+	assert(is_recording());
+	flush(vk::PipelineBindPoint::eCompute);
+	get_handle().dispatch(group_count_x, group_count_y, group_count_z);
+}
+
+void HPPCommandBuffer::dispatch_indirect(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset)
+{
+	assert(is_recording());
+	flush(vk::PipelineBindPoint::eCompute);
+	get_handle().dispatchIndirect(buffer.get_handle(), offset);
+}
+
+void HPPCommandBuffer::draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex, uint32_t first_instance)
+{
+	assert(is_recording());
+	flush(vk::PipelineBindPoint::eGraphics);
+	get_handle().draw(vertex_count, instance_count, first_vertex, first_instance);
+}
+
+void HPPCommandBuffer::draw_indexed(uint32_t index_count, uint32_t instance_count, uint32_t first_index, int32_t vertex_offset, uint32_t first_instance)
+{
+	assert(is_recording());
+	flush(vk::PipelineBindPoint::eGraphics);
+	get_handle().drawIndexed(index_count, instance_count, first_index, vertex_offset, first_instance);
+}
+
+void HPPCommandBuffer::draw_indexed_indirect(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, uint32_t draw_count, uint32_t stride)
+{
+	assert(is_recording());
+	flush(vk::PipelineBindPoint::eGraphics);
+	get_handle().drawIndexedIndirect(buffer.get_handle(), offset, draw_count, stride);
+}
+
+vk::Result HPPCommandBuffer::end()
+{
+	assert(is_recording() && "Command buffer is not recording, please call begin before end");
+
+	if (!is_recording())
+	{
+		return vk::Result::eNotReady;
+	}
+
+	get_handle().end();
+
+	state = State::Executable;
+
+	return vk::Result::eSuccess;
+}
+
+void HPPCommandBuffer::end_query(const vkb::core::HPPQueryPool &query_pool, uint32_t query)
+{
+	assert(is_recording());
+	get_handle().endQuery(query_pool.get_handle(), query);
+}
+
+void HPPCommandBuffer::end_render_pass()
+{
+	assert(is_recording());
+	get_handle().endRenderPass();
+}
+
+void HPPCommandBuffer::execute_commands(HPPCommandBuffer &secondary_command_buffer)
+{
+	assert(is_recording());
+	get_handle().executeCommands(secondary_command_buffer.get_handle());
+}
+
+void HPPCommandBuffer::execute_commands(std::vector<HPPCommandBuffer *> &secondary_command_buffers)
+{
+	assert(is_recording());
+	std::vector<vk::CommandBuffer> sec_cmd_buf_handles(secondary_command_buffers.size(), nullptr);
+	std::transform(secondary_command_buffers.begin(),
+	               secondary_command_buffers.end(),
+	               sec_cmd_buf_handles.begin(),
+	               [](const vkb::core::HPPCommandBuffer *sec_cmd_buf) { return sec_cmd_buf->get_handle(); });
+	get_handle().executeCommands(sec_cmd_buf_handles);
+}
+
+vkb::core::HPPRenderPass &HPPCommandBuffer::get_render_pass(const vkb::rendering::HPPRenderTarget                          &render_target,
+                                                            const std::vector<vkb::common::HPPLoadStoreInfo>               &load_store_infos,
+                                                            const std::vector<std::unique_ptr<vkb::rendering::HPPSubpass>> &subpasses)
+{
+	// Create render pass
+	assert(subpasses.size() > 0 && "Cannot create a render pass without any subpass");
+
+	std::vector<vkb::core::HPPSubpassInfo> subpass_infos(subpasses.size());
+	auto                                   subpass_info_it = subpass_infos.begin();
+	for (auto &subpass : subpasses)
+	{
+		subpass_info_it->input_attachments                = subpass->get_input_attachments();
+		subpass_info_it->output_attachments               = subpass->get_output_attachments();
+		subpass_info_it->color_resolve_attachments        = subpass->get_color_resolve_attachments();
+		subpass_info_it->disable_depth_stencil_attachment = subpass->get_disable_depth_stencil_attachment();
+		subpass_info_it->depth_stencil_resolve_mode       = subpass->get_depth_stencil_resolve_mode();
+		subpass_info_it->depth_stencil_resolve_attachment = subpass->get_depth_stencil_resolve_attachment();
+		subpass_info_it->debug_name                       = subpass->get_debug_name();
+
+		++subpass_info_it;
+	}
+
+	return get_device().get_resource_cache().request_render_pass(render_target.get_attachments(), load_store_infos, subpass_infos);
+}
+
+void HPPCommandBuffer::image_memory_barrier(const vkb::core::HPPImageView &image_view, const vkb::common::HPPImageMemoryBarrier &memory_barrier) const
+{
+	assert(is_recording());
+	// Adjust barrier's subresource range for depth images
+	auto subresource_range = image_view.get_subresource_range();
+	auto format            = image_view.get_format();
+	if (vkb::common::is_depth_only_format(format))
+	{
+		subresource_range.aspectMask = vk::ImageAspectFlagBits::eDepth;
+	}
+	else if (vkb::common::is_depth_stencil_format(format))
+	{
+		subresource_range.aspectMask = vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
+	}
+
+	vk::ImageMemoryBarrier image_memory_barrier(memory_barrier.src_access_mask,
+	                                            memory_barrier.dst_access_mask,
+	                                            memory_barrier.old_layout,
+	                                            memory_barrier.new_layout,
+	                                            memory_barrier.old_queue_family,
+	                                            memory_barrier.new_queue_family,
+	                                            image_view.get_image().get_handle(),
+	                                            subresource_range);
+
+	vk::PipelineStageFlags src_stage_mask = memory_barrier.src_stage_mask;
+	vk::PipelineStageFlags dst_stage_mask = memory_barrier.dst_stage_mask;
+
+	get_handle().pipelineBarrier(src_stage_mask, dst_stage_mask, {}, {}, {}, image_memory_barrier);
+}
+
+void HPPCommandBuffer::next_subpass()
+{
+	assert(is_recording());
+	// Increment subpass index
+	pipeline_state.set_subpass_index(pipeline_state.get_subpass_index() + 1);
+
+	// Update blend state attachments
+	auto blend_state = pipeline_state.get_color_blend_state();
+	blend_state.attachments.resize(current_render_pass.render_pass->get_color_output_count(pipeline_state.get_subpass_index()));
+	pipeline_state.set_color_blend_state(blend_state);
+
+	// Reset descriptor sets
+	resource_binding_state.reset();
+	descriptor_set_layout_binding_state.clear();
+
+	// Clear stored push constants
+	stored_push_constants.clear();
+
+	get_handle().nextSubpass(vk::SubpassContents::eInline);
+}
+
+void HPPCommandBuffer::push_constants(const std::vector<uint8_t> &values)
+{
+	uint32_t push_constant_size = to_u32(stored_push_constants.size() + values.size());
+
+	if (push_constant_size > max_push_constants_size)
+	{
+		LOGE("Push constant limit of {} exceeded (pushing {} bytes for a total of {} bytes)", max_push_constants_size, values.size(), push_constant_size);
+		throw std::runtime_error("Push constant limit exceeded.");
+	}
+	else
+	{
+		stored_push_constants.insert(stored_push_constants.end(), values.begin(), values.end());
+	}
+}
+
+vk::Result HPPCommandBuffer::reset(ResetMode reset_mode)
+{
+	assert(reset_mode == command_pool.get_reset_mode() && "Command buffer reset mode must match the one used by the pool to allocate it");
+
+	state = State::Initial;
+
+	if (reset_mode == ResetMode::ResetIndividually)
+	{
+		get_handle().reset(vk::CommandBufferResetFlagBits::eReleaseResources);
+	}
+
+	return vk::Result::eSuccess;
+}
+
+void HPPCommandBuffer::reset_query_pool(const vkb::core::HPPQueryPool &query_pool, uint32_t first_query, uint32_t query_count)
+{
+	assert(is_recording());
+	get_handle().resetQueryPool(query_pool.get_handle(), first_query, query_count);
+}
+
+void HPPCommandBuffer::resolve_image(const vkb::core::HPPImage &src_img, const vkb::core::HPPImage &dst_img, const std::vector<vk::ImageResolve> &regions)
+{
+	assert(is_recording());
+	get_handle().resolveImage(src_img.get_handle(), vk::ImageLayout::eTransferSrcOptimal, dst_img.get_handle(), vk::ImageLayout::eTransferDstOptimal, regions);
+}
+
+void HPPCommandBuffer::set_blend_constants(const std::array<float, 4> &blend_constants)
+{
+	assert(is_recording());
+	get_handle().setBlendConstants(blend_constants.data());
+}
+
+void HPPCommandBuffer::set_color_blend_state(const vkb::rendering::HPPColorBlendState &state_info)
+{
+	pipeline_state.set_color_blend_state(state_info);
+}
+
+void HPPCommandBuffer::set_depth_bias(float depth_bias_constant_factor, float depth_bias_clamp, float depth_bias_slope_factor)
+{
+	assert(is_recording());
+	get_handle().setDepthBias(depth_bias_constant_factor, depth_bias_clamp, depth_bias_slope_factor);
+}
+
+void HPPCommandBuffer::set_depth_bounds(float min_depth_bounds, float max_depth_bounds)
+{
+	assert(is_recording());
+	get_handle().setDepthBounds(min_depth_bounds, max_depth_bounds);
+}
+
+void HPPCommandBuffer::set_depth_stencil_state(const vkb::rendering::HPPDepthStencilState &state_info)
+{
+	pipeline_state.set_depth_stencil_state(state_info);
+}
+
+void HPPCommandBuffer::set_input_assembly_state(const vkb::rendering::HPPInputAssemblyState &state_info)
+{
+	pipeline_state.set_input_assembly_state(state_info);
+}
+
+void HPPCommandBuffer::set_line_width(float line_width)
+{
+	assert(is_recording());
+	get_handle().setLineWidth(line_width);
+}
+
+void HPPCommandBuffer::set_multisample_state(const vkb::rendering::HPPMultisampleState &state_info)
+{
+	pipeline_state.set_multisample_state(state_info);
+}
+
+void HPPCommandBuffer::set_rasterization_state(const vkb::rendering::HPPRasterizationState &state_info)
+{
+	pipeline_state.set_rasterization_state(state_info);
+}
+
+void HPPCommandBuffer::set_scissor(uint32_t first_scissor, const std::vector<vk::Rect2D> &scissors)
+{
+	assert(is_recording());
+	get_handle().setScissor(first_scissor, scissors);
+}
+
+void HPPCommandBuffer::set_specialization_constant(uint32_t constant_id, const std::vector<uint8_t> &data)
+{
+	pipeline_state.set_specialization_constant(constant_id, data);
+}
+
+void HPPCommandBuffer::set_update_after_bind(bool update_after_bind_)
+{
+	update_after_bind = update_after_bind_;
+}
+
+void HPPCommandBuffer::set_vertex_input_state(const vkb::rendering::HPPVertexInputState &state_info)
+{
+	pipeline_state.set_vertex_input_state(state_info);
+}
+
+void HPPCommandBuffer::set_viewport(uint32_t first_viewport, const std::vector<vk::Viewport> &viewports)
+{
+	assert(is_recording());
+	get_handle().setViewport(first_viewport, viewports);
+}
+
+void HPPCommandBuffer::set_viewport_state(const vkb::rendering::HPPViewportState &state_info)
+{
+	pipeline_state.set_viewport_state(state_info);
+}
+
+void HPPCommandBuffer::update_buffer(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, const std::vector<uint8_t> &data)
+{
+	assert(is_recording());
+	get_handle().updateBuffer<uint8_t>(buffer.get_handle(), offset, data);
+}
+
+void HPPCommandBuffer::write_timestamp(vk::PipelineStageFlagBits pipeline_stage, const vkb::core::HPPQueryPool &query_pool, uint32_t query)
+{
+	assert(is_recording());
+	get_handle().writeTimestamp(pipeline_stage, query_pool.get_handle(), query);
+}
+
+void HPPCommandBuffer::flush(vk::PipelineBindPoint pipeline_bind_point)
+{
+	flush_pipeline_state(pipeline_bind_point);
+	flush_push_constants();
+	flush_descriptor_state(pipeline_bind_point);
+}
+
+void HPPCommandBuffer::flush_descriptor_state(vk::PipelineBindPoint pipeline_bind_point)
+{
+	assert(command_pool.get_render_frame() && "The command pool must be associated to a render frame");
+
+	const auto &pipeline_layout = pipeline_state.get_pipeline_layout();
+
+	std::unordered_set<uint32_t> update_descriptor_sets;
+
+	// Iterate over the shader sets to check if they have already been bound
+	// If they have, add the set so that the command buffer later updates it
+	for (auto &set_it : pipeline_layout.get_shader_sets())
+	{
+		uint32_t descriptor_set_id = set_it.first;
+
+		auto descriptor_set_layout_it = descriptor_set_layout_binding_state.find(descriptor_set_id);
+
+		if (descriptor_set_layout_it != descriptor_set_layout_binding_state.end())
+		{
+			if (descriptor_set_layout_it->second->get_handle() != pipeline_layout.get_descriptor_set_layout(descriptor_set_id).get_handle())
+			{
+				update_descriptor_sets.emplace(descriptor_set_id);
+			}
+		}
+	}
+
+	// Validate that the bound descriptor set layouts exist in the pipeline layout
+	for (auto set_it = descriptor_set_layout_binding_state.begin(); set_it != descriptor_set_layout_binding_state.end();)
+	{
+		if (!pipeline_layout.has_descriptor_set_layout(set_it->first))
+		{
+			set_it = descriptor_set_layout_binding_state.erase(set_it);
+		}
+		else
+		{
+			++set_it;
+		}
+	}
+
+	// Check if a descriptor set needs to be created
+	if (resource_binding_state.is_dirty() || !update_descriptor_sets.empty())
+	{
+		resource_binding_state.clear_dirty();
+
+		// Iterate over all of the resource sets bound by the command buffer
+		for (auto &resource_set_it : resource_binding_state.get_resource_sets())
+		{
+			uint32_t descriptor_set_id = resource_set_it.first;
+			auto    &resource_set      = resource_set_it.second;
+
+			// Don't update resource set if it's not in the update list OR its state hasn't changed
+			if (!resource_set.is_dirty() && (update_descriptor_sets.find(descriptor_set_id) == update_descriptor_sets.end()))
+			{
+				continue;
+			}
+
+			// Clear dirty flag for resource set
+			resource_binding_state.clear_dirty(descriptor_set_id);
+
+			// Skip resource set if a descriptor set layout doesn't exist for it
+			if (!pipeline_layout.has_descriptor_set_layout(descriptor_set_id))
+			{
+				continue;
+			}
+
+			auto &descriptor_set_layout = pipeline_layout.get_descriptor_set_layout(descriptor_set_id);
+
+			// Make descriptor set layout bound for current set
+			descriptor_set_layout_binding_state[descriptor_set_id] = &descriptor_set_layout;
+
+			BindingMap<vk::DescriptorBufferInfo> buffer_infos;
+			BindingMap<vk::DescriptorImageInfo>  image_infos;
+
+			std::vector<uint32_t> dynamic_offsets;
+
+			// Iterate over all resource bindings
+			for (auto &binding_it : resource_set.get_resource_bindings())
+			{
+				auto  binding_index     = binding_it.first;
+				auto &binding_resources = binding_it.second;
+
+				// Check if binding exists in the pipeline layout
+				if (auto binding_info = descriptor_set_layout.get_layout_binding(binding_index))
+				{
+					// Iterate over all binding resources
+					for (auto &element_it : binding_resources)
+					{
+						auto  array_element = element_it.first;
+						auto &resource_info = element_it.second;
+
+						// Pointer references
+						auto &buffer     = resource_info.buffer;
+						auto &sampler    = resource_info.sampler;
+						auto &image_view = resource_info.image_view;
+
+						// Get buffer info
+						if (buffer != nullptr && vkb::common::is_buffer_descriptor_type(binding_info->descriptorType))
+						{
+							vk::DescriptorBufferInfo buffer_info(resource_info.buffer->get_handle(), resource_info.offset, resource_info.range);
+
+							if (vkb::common::is_dynamic_buffer_descriptor_type(binding_info->descriptorType))
+							{
+								dynamic_offsets.push_back(to_u32(buffer_info.offset));
+								buffer_info.offset = 0;
+							}
+
+							buffer_infos[binding_index][array_element] = buffer_info;
+						}
+
+						// Get image info
+						else if (image_view != nullptr || sampler != nullptr)
+						{
+							// Can be null for input attachments
+							vk::DescriptorImageInfo image_info(sampler ? sampler->get_handle() : nullptr, image_view->get_handle());
+
+							if (image_view != nullptr)
+							{
+								// Add image layout info based on descriptor type
+								switch (binding_info->descriptorType)
+								{
+									case vk::DescriptorType::eCombinedImageSampler:
+										image_info.imageLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
+										break;
+									case vk::DescriptorType::eInputAttachment:
+										image_info.imageLayout = vkb::common::is_depth_stencil_format(image_view->get_format()) ? vk::ImageLayout::eDepthStencilReadOnlyOptimal : vk::ImageLayout::eShaderReadOnlyOptimal;
+										break;
+									case vk::DescriptorType::eStorageImage:
+										image_info.imageLayout = vk::ImageLayout::eGeneral;
+										break;
+									default:
+										continue;
+								}
+							}
+
+							image_infos[binding_index][array_element] = image_info;
+						}
+					}
+
+					assert((!update_after_bind ||
+					        (buffer_infos.count(binding_index) > 0 || (image_infos.count(binding_index) > 0))) &&
+					       "binding index with no buffer or image infos can't be checked for adding to bindings_to_update");
+				}
+			}
+
+			vk::DescriptorSet descriptor_set_handle = command_pool.get_render_frame()->request_descriptor_set(
+			    descriptor_set_layout, buffer_infos, image_infos, update_after_bind, command_pool.get_thread_index());
+
+			// Bind descriptor set
+			assert(is_recording());
+			get_handle().bindDescriptorSets(pipeline_bind_point, pipeline_layout.get_handle(), descriptor_set_id, descriptor_set_handle, dynamic_offsets);
+		}
+	}
+}
+
+void HPPCommandBuffer::flush_pipeline_state(vk::PipelineBindPoint pipeline_bind_point)
+{
+	// Create a new pipeline only if the graphics state changed
+	if (!pipeline_state.is_dirty())
+	{
+		return;
+	}
+
+	pipeline_state.clear_dirty();
+
+	// Create and bind pipeline
+	if (pipeline_bind_point == vk::PipelineBindPoint::eGraphics)
+	{
+		pipeline_state.set_render_pass(*current_render_pass.render_pass);
+		auto &pipeline = get_device().get_resource_cache().request_graphics_pipeline(pipeline_state);
+
+		assert(is_recording());
+		get_handle().bindPipeline(pipeline_bind_point, pipeline.get_handle());
+	}
+	else if (pipeline_bind_point == vk::PipelineBindPoint::eCompute)
+	{
+		auto &pipeline = get_device().get_resource_cache().request_compute_pipeline(pipeline_state);
+
+		assert(is_recording());
+		get_handle().bindPipeline(pipeline_bind_point, pipeline.get_handle());
+	}
+	else
+	{
+		throw "Only graphics and compute pipeline bind points are supported now";
+	}
+}
+
+void HPPCommandBuffer::flush_push_constants()
+{
+	if (stored_push_constants.empty())
+	{
+		return;
+	}
+
+	const vkb::core::HPPPipelineLayout &pipeline_layout = pipeline_state.get_pipeline_layout();
+
+	vk::ShaderStageFlags shader_stage = pipeline_layout.get_push_constant_range_stage(to_u32(stored_push_constants.size()));
+
+	if (shader_stage)
+	{
+		assert(is_recording());
+		get_handle().pushConstants<uint8_t>(pipeline_layout.get_handle(), shader_stage, 0, stored_push_constants);
+	}
+	else
+	{
+		LOGW("Push constant range [{}, {}] not found", 0, stored_push_constants.size());
+	}
+
+	stored_push_constants.clear();
+}
+
+const HPPCommandBuffer::RenderPassBinding &HPPCommandBuffer::get_current_render_pass() const
+{
+	return current_render_pass;
+}
+
+const uint32_t HPPCommandBuffer::get_current_subpass_index() const
+{
+	return pipeline_state.get_subpass_index();
+}
+
+const HPPCommandBuffer::State HPPCommandBuffer::get_state() const
+{
+	return state;
+}
+
+bool HPPCommandBuffer::is_recording() const
+{
+	return state == State::Recording;
+}
+
+const bool HPPCommandBuffer::is_render_size_optimal(const vk::Extent2D &framebuffer_extent, const vk::Rect2D &render_area)
+{
+	auto render_area_granularity = current_render_pass.render_pass->get_render_area_granularity();
+
+	return ((render_area.offset.x % render_area_granularity.width == 0) && (render_area.offset.y % render_area_granularity.height == 0) &&
+	        ((render_area.extent.width % render_area_granularity.width == 0) || (render_area.offset.x + render_area.extent.width == framebuffer_extent.width)) &&
+	        ((render_area.extent.height % render_area_granularity.height == 0) || (render_area.offset.y + render_area.extent.height == framebuffer_extent.height)));
+}
+
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_command_buffer.h
+++ b/framework/core/hpp_command_buffer.h
@@ -17,33 +17,32 @@
 
 #pragma once
 
-#include <core/command_buffer.h>
-
 #include <common/hpp_vk_common.h>
-#include <core/hpp_image_view.h>
-#include <core/hpp_pipeline_layout.h>
-#include <core/hpp_sampler.h>
+#include <core/hpp_framebuffer.h>
+#include <core/hpp_query_pool.h>
+#include <hpp_resource_binding_state.h>
 #include <rendering/hpp_pipeline_state.h>
+#include <rendering/hpp_render_target.h>
+#include <rendering/hpp_subpass.h>
 
 namespace vkb
 {
 namespace core
 {
-class HPPBuffer;
 class HPPCommandPool;
 
 /**
- * @brief facade class around vkb::CommandBuffer, providing a vulkan.hpp-based interface
- *
- * See vkb::CommandBuffer for documentation
+ * @brief Helper class to manage and record a command buffer, building and
+ *        keeping track of pipeline state and resource bindings
  */
-class HPPCommandBuffer : private vkb::CommandBuffer
+class HPPCommandBuffer : public core::HPPVulkanResource<vk::CommandBuffer>
 {
   public:
-	using vkb::CommandBuffer::draw_indexed;
-	using vkb::CommandBuffer::end;
-	using vkb::CommandBuffer::end_render_pass;
-	using vkb::CommandBuffer::push_constants;
+	struct RenderPassBinding
+	{
+		const vkb::core::HPPRenderPass  *render_pass;
+		const vkb::core::HPPFramebuffer *framebuffer;
+	};
 
 	enum class ResetMode
 	{
@@ -52,92 +51,208 @@ class HPPCommandBuffer : private vkb::CommandBuffer
 		AlwaysAllocate,
 	};
 
-	HPPCommandBuffer(HPPCommandPool &command_pool, vk::CommandBufferLevel level) :
-	    vkb::CommandBuffer(reinterpret_cast<vkb::CommandPool &>(command_pool), static_cast<VkCommandBufferLevel>(level))
-	{}
-
-	vk::Result begin(vk::CommandBufferUsageFlags flags, HPPCommandBuffer *primary_cmd_buf = nullptr)
+	enum class State
 	{
-		return static_cast<vk::Result>(vkb::CommandBuffer::begin(static_cast<VkCommandBufferUsageFlags>(flags), reinterpret_cast<CommandBuffer *>(primary_cmd_buf)));
-	}
+		Invalid,
+		Initial,
+		Recording,
+		Executable,
+	};
 
-	void bind_image(const vkb::core::HPPImageView &image_view, const vkb::core::HPPSampler &sampler, uint32_t set, uint32_t binding, uint32_t array_element)
-	{
-		vkb::CommandBuffer::bind_image(
-		    reinterpret_cast<vkb::core::ImageView const &>(image_view), reinterpret_cast<vkb::core::Sampler const &>(sampler), set, binding, array_element);
-	}
+  public:
+	HPPCommandBuffer(vkb::core::HPPCommandPool &command_pool, vk::CommandBufferLevel level);
+	HPPCommandBuffer(HPPCommandBuffer &&other);
+	~HPPCommandBuffer();
 
-	void bind_index_buffer(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, vk::IndexType index_type)
-	{
-		vkb::CommandBuffer::bind_index_buffer(
-		    reinterpret_cast<vkb::core::Buffer const &>(buffer), static_cast<VkDeviceSize>(offset), static_cast<VkIndexType>(index_type));
-	}
+	HPPCommandBuffer(const HPPCommandBuffer &)            = delete;
+	HPPCommandBuffer &operator=(const HPPCommandBuffer &) = delete;
+	HPPCommandBuffer &operator=(HPPCommandBuffer &&)      = delete;
 
-	void bind_pipeline_layout(vkb::core::HPPPipelineLayout &pipeline_layout)
-	{
-		vkb::CommandBuffer::bind_pipeline_layout(reinterpret_cast<vkb::PipelineLayout &>(pipeline_layout));
-	}
+	/**
+	 * @brief Sets the command buffer so that it is ready for recording
+	 *        If it is a secondary command buffer, a pointer to the
+	 *        primary command buffer it inherits from must be provided
+	 * @param flags Usage behavior for the command buffer
+	 * @param primary_cmd_buf (optional)
+	 * @return Whether it succeded or not
+	 */
+	vk::Result begin(vk::CommandBufferUsageFlags flags, HPPCommandBuffer *primary_cmd_buf = nullptr);
 
-	void bind_vertex_buffers(uint32_t                                                               first_binding,
-	                         const std::vector<std::reference_wrapper<const vkb::core::HPPBuffer>> &buffers,
-	                         const std::vector<vk::DeviceSize>                                     &offsets)
-	{
-		vkb::CommandBuffer::bind_vertex_buffers(first_binding,
-		                                        reinterpret_cast<std::vector<std::reference_wrapper<vkb::core::Buffer const>> const &>(buffers),
-		                                        reinterpret_cast<std::vector<VkDeviceSize> const &>(offsets));
-	}
+	/**
+	 * @brief Sets the command buffer so that it is ready for recording
+	 *        If it is a secondary command buffer, pointers to the
+	 *        render pass and framebuffer as well as subpass index must be provided
+	 * @param flags Usage behavior for the command buffer
+	 * @param render_pass
+	 * @param framebuffer
+	 * @param subpass_index
+	 * @return Whether it succeded or not
+	 */
+	vk::Result begin(vk::CommandBufferUsageFlags flags, const vkb::core::HPPRenderPass *render_pass, const vkb::core::HPPFramebuffer *framebuffer, uint32_t subpass_index);
 
-	void copy_buffer_to_image(const vkb::core::HPPBuffer &buffer, const vkb::core::HPPImage &image, const std::vector<vk::BufferImageCopy> &regions)
-	{
-		vkb::CommandBuffer::copy_buffer_to_image(reinterpret_cast<vkb::core::Buffer const &>(buffer),
-		                                         reinterpret_cast<vkb::core::Image const &>(image),
-		                                         reinterpret_cast<std::vector<VkBufferImageCopy> const &>(regions));
-	}
+	void                      begin_query(const vkb::core::HPPQueryPool &query_pool, uint32_t query, vk::QueryControlFlags flags);
+	void                      begin_render_pass(const vkb::rendering::HPPRenderTarget                          &render_target,
+	                                            const std::vector<vkb::common::HPPLoadStoreInfo>               &load_store_infos,
+	                                            const std::vector<vk::ClearValue>                              &clear_values,
+	                                            const std::vector<std::unique_ptr<vkb::rendering::HPPSubpass>> &subpasses,
+	                                            vk::SubpassContents                                             contents = vk::SubpassContents::eInline);
+	void                      begin_render_pass(const vkb::rendering::HPPRenderTarget &render_target,
+	                                            const vkb::core::HPPRenderPass        &render_pass,
+	                                            const vkb::core::HPPFramebuffer       &framebuffer,
+	                                            const std::vector<vk::ClearValue>     &clear_values,
+	                                            vk::SubpassContents                    contents = vk::SubpassContents::eInline);
+	void                      bind_buffer(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, vk::DeviceSize range, uint32_t set, uint32_t binding, uint32_t array_element);
+	void                      bind_image(const vkb::core::HPPImageView &image_view, const vkb::core::HPPSampler &sampler, uint32_t set, uint32_t binding, uint32_t array_element);
+	void                      bind_image(const vkb::core::HPPImageView &image_view, uint32_t set, uint32_t binding, uint32_t array_element);
+	void                      bind_index_buffer(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, vk::IndexType index_type);
+	void                      bind_input(const vkb::core::HPPImageView &image_view, uint32_t set, uint32_t binding, uint32_t array_element);
+	void                      bind_lighting(vkb::rendering::HPPLightingState &lighting_state, uint32_t set, uint32_t binding);
+	void                      bind_pipeline_layout(vkb::core::HPPPipelineLayout &pipeline_layout);
+	void                      bind_vertex_buffers(uint32_t                                                               first_binding,
+	                                              const std::vector<std::reference_wrapper<const vkb::core::HPPBuffer>> &buffers,
+	                                              const std::vector<vk::DeviceSize>                                     &offsets);
+	void                      blit_image(const vkb::core::HPPImage &src_img, const vkb::core::HPPImage &dst_img, const std::vector<vk::ImageBlit> &regions);
+	void                      buffer_memory_barrier(const vkb::core::HPPBuffer                &buffer,
+	                                                vk::DeviceSize                             offset,
+	                                                vk::DeviceSize                             size,
+	                                                const vkb::common::HPPBufferMemoryBarrier &memory_barrier);
+	void                      clear(vk::ClearAttachment info, vk::ClearRect rect);
+	void                      copy_buffer(const vkb::core::HPPBuffer &src_buffer, const vkb::core::HPPBuffer &dst_buffer, vk::DeviceSize size);
+	void                      copy_buffer_to_image(const vkb::core::HPPBuffer &buffer, const vkb::core::HPPImage &image, const std::vector<vk::BufferImageCopy> &regions);
+	void                      copy_image(const vkb::core::HPPImage &src_img, const vkb::core::HPPImage &dst_img, const std::vector<vk::ImageCopy> &regions);
+	void                      copy_image_to_buffer(const vkb::core::HPPImage              &image,
+	                                               vk::ImageLayout                         image_layout,
+	                                               const vkb::core::HPPBuffer             &buffer,
+	                                               const std::vector<vk::BufferImageCopy> &regions);
+	void                      dispatch(uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);
+	void                      dispatch_indirect(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset);
+	void                      draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex, uint32_t first_instance);
+	void                      draw_indexed(uint32_t index_count, uint32_t instance_count, uint32_t first_index, int32_t vertex_offset, uint32_t first_instance);
+	void                      draw_indexed_indirect(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, uint32_t draw_count, uint32_t stride);
+	vk::Result                end();
+	void                      end_query(const vkb::core::HPPQueryPool &query_pool, uint32_t query);
+	void                      end_render_pass();
+	void                      execute_commands(HPPCommandBuffer &secondary_command_buffer);
+	void                      execute_commands(std::vector<HPPCommandBuffer *> &secondary_command_buffers);
+	vkb::core::HPPRenderPass &get_render_pass(const vkb::rendering::HPPRenderTarget                          &render_target,
+	                                          const std::vector<vkb::common::HPPLoadStoreInfo>               &load_store_infos,
+	                                          const std::vector<std::unique_ptr<vkb::rendering::HPPSubpass>> &subpasses);
+	void                      image_memory_barrier(const vkb::core::HPPImageView &image_view, const vkb::common::HPPImageMemoryBarrier &memory_barrier) const;
+	void                      next_subpass();
 
-	vk::CommandBuffer get_handle() const
+	/**
+	 * @brief Records byte data into the command buffer to be pushed as push constants to each draw call
+	 * @param values The byte data to store
+	 */
+	void push_constants(const std::vector<uint8_t> &values);
+	template <typename T>
+	void push_constants(const T &value)
 	{
-		return static_cast<vk::CommandBuffer>(vkb::CommandBuffer::get_handle());
-	}
+		auto data = to_bytes(value);
 
-	void image_memory_barrier(const vkb::core::HPPImageView &image_view, const vkb::common::HPPImageMemoryBarrier &memory_barrier) const
-	{
-		vkb::CommandBuffer::image_memory_barrier(reinterpret_cast<vkb::core::ImageView const &>(image_view),
-		                                         reinterpret_cast<vkb::ImageMemoryBarrier const &>(memory_barrier));
-	}
+		uint32_t size = to_u32(stored_push_constants.size() + data.size());
 
-	void reset(ResetMode reset_mode)
-	{
-		VkResult result = vkb::CommandBuffer::reset(static_cast<CommandBuffer::ResetMode>(reset_mode));
-		if (result != VK_SUCCESS)
+		if (size > max_push_constants_size)
 		{
-			throw std::runtime_error("vkCommandBufferReset failed with errorCode " + vk::to_string(static_cast<vk::Result>(result)));
+			LOGE("Push constant limit exceeded ({} / {} bytes)", size, max_push_constants_size);
+			throw std::runtime_error("Cannot overflow push constant limit");
 		}
+
+		stored_push_constants.insert(stored_push_constants.end(), data.begin(), data.end());
 	}
 
-	void set_color_blend_state(const vkb::rendering::HPPColorBlendState &state_info)
-	{
-		vkb::CommandBuffer::set_color_blend_state(reinterpret_cast<vkb::ColorBlendState const &>(state_info));
-	}
+	/**
+	 * @brief Reset the command buffer to a state where it can be recorded to
+	 * @param reset_mode How to reset the buffer, should match the one used by the pool to allocate it
+	 */
+	vk::Result reset(ResetMode reset_mode);
 
-	void set_depth_stencil_state(const vkb::rendering::HPPDepthStencilState &state_info)
-	{
-		vkb::CommandBuffer::set_depth_stencil_state(reinterpret_cast<vkb::DepthStencilState const &>(state_info));
-	}
+	void reset_query_pool(const vkb::core::HPPQueryPool &query_pool, uint32_t first_query, uint32_t query_count);
+	void resolve_image(const vkb::core::HPPImage &src_img, const vkb::core::HPPImage &dst_img, const std::vector<vk::ImageResolve> &regions);
+	void set_blend_constants(const std::array<float, 4> &blend_constants);
+	void set_color_blend_state(const vkb::rendering::HPPColorBlendState &state_info);
+	void set_depth_bias(float depth_bias_constant_factor, float depth_bias_clamp, float depth_bias_slope_factor);
+	void set_depth_bounds(float min_depth_bounds, float max_depth_bounds);
+	void set_depth_stencil_state(const vkb::rendering::HPPDepthStencilState &state_info);
+	void set_input_assembly_state(const vkb::rendering::HPPInputAssemblyState &state_info);
+	void set_line_width(float line_width);
+	void set_multisample_state(const vkb::rendering::HPPMultisampleState &state_info);
+	void set_rasterization_state(const vkb::rendering::HPPRasterizationState &state_info);
+	void set_scissor(uint32_t first_scissor, const std::vector<vk::Rect2D> &scissors);
 
-	void set_rasterization_state(const vkb::rendering::HPPRasterizationState &state_info)
-	{
-		vkb::CommandBuffer::set_rasterization_state(reinterpret_cast<vkb::RasterizationState const &>(state_info));
-	}
+	template <class T>
+	void set_specialization_constant(uint32_t constant_id, const T &data);
 
-	void set_scissor(uint32_t first_scissor, const std::vector<vk::Rect2D> &scissors)
-	{
-		vkb::CommandBuffer::set_scissor(first_scissor, reinterpret_cast<std::vector<VkRect2D> const &>(scissors));
-	}
+	void set_specialization_constant(uint32_t constant_id, const std::vector<uint8_t> &data);
 
-	void set_vertex_input_state(const vkb::rendering::HPPVertexInputState &state_info)
-	{
-		vkb::CommandBuffer::set_vertex_input_state(reinterpret_cast<vkb::VertexInputState const &>(state_info));
-	}
+	void set_update_after_bind(bool update_after_bind_);
+	void set_vertex_input_state(const vkb::rendering::HPPVertexInputState &state_info);
+	void set_viewport(uint32_t first_viewport, const std::vector<vk::Viewport> &viewports);
+	void set_viewport_state(const vkb::rendering::HPPViewportState &state_info);
+	void update_buffer(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, const std::vector<uint8_t> &data);
+	void write_timestamp(vk::PipelineStageFlagBits pipeline_stage, const vkb::core::HPPQueryPool &query_pool, uint32_t query);
+
+  private:
+	/**
+	 * @brief Flushes the command buffer, pushing the new changes
+	 * @param pipeline_bind_point The type of pipeline we want to flush
+	 */
+	void flush(vk::PipelineBindPoint pipeline_bind_point);
+
+	/**
+	 * @brief Flush the descriptor set state
+	 */
+	void flush_descriptor_state(vk::PipelineBindPoint pipeline_bind_point);
+
+	/**
+	 * @brief Flush the piplines state
+	 */
+	void flush_pipeline_state(vk::PipelineBindPoint pipeline_bind_point);
+
+	/**
+	 * @brief Flush the push constant state
+	 */
+	void flush_push_constants();
+
+	const RenderPassBinding &get_current_render_pass() const;
+	const uint32_t           get_current_subpass_index() const;
+	const State              get_state() const;
+	bool                     is_recording() const;
+
+	/**
+	 * @brief Check that the render area is an optimal size by comparing to the render area granularity
+	 */
+	const bool is_render_size_optimal(const vk::Extent2D &extent, const vk::Rect2D &render_area);
+
+  private:
+	const vk::CommandBufferLevel     level = {};
+	State                            state = State::Initial;
+	vkb::core::HPPCommandPool       &command_pool;
+	RenderPassBinding                current_render_pass     = {};
+	vkb::rendering::HPPPipelineState pipeline_state          = {};
+	vkb::HPPResourceBindingState     resource_binding_state  = {};
+	std::vector<uint8_t>             stored_push_constants   = {};
+	uint32_t                         max_push_constants_size = {};
+	vk::Extent2D                     last_framebuffer_extent = {};
+	vk::Extent2D                     last_render_area_extent = {};
+
+	// If true, it becomes the responsibility of the caller to update ANY descriptor bindings
+	// that contain update after bind, as they wont be implicitly updated
+	bool update_after_bind = false;
+
+	std::unordered_map<uint32_t, vkb::core::HPPDescriptorSetLayout *> descriptor_set_layout_binding_state;
 };
+
+template <class T>
+inline void HPPCommandBuffer::set_specialization_constant(uint32_t constant_id, const T &data)
+{
+	set_specialization_constant(constant_id, to_bytes(data));
+}
+
+template <>
+inline void HPPCommandBuffer::set_specialization_constant<bool>(std::uint32_t constant_id, const bool &data)
+{
+	set_specialization_constant(constant_id, to_bytes(to_u32(data)));
+}
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_command_pool.cpp
+++ b/framework/core/hpp_command_pool.cpp
@@ -22,11 +22,11 @@ namespace vkb
 {
 namespace core
 {
-HPPCommandPool::HPPCommandPool(HPPDevice const                      &d,
-                               uint32_t                              queue_family_index,
-                               vkb::rendering::HPPRenderFrame const *render_frame,
-                               size_t                                thread_index,
-                               HPPCommandBuffer::ResetMode           reset_mode) :
+HPPCommandPool::HPPCommandPool(HPPDevice                      &d,
+                               uint32_t                        queue_family_index,
+                               vkb::rendering::HPPRenderFrame *render_frame,
+                               size_t                          thread_index,
+                               HPPCommandBuffer::ResetMode     reset_mode) :
     device{d}, render_frame{render_frame}, thread_index{thread_index}, reset_mode{reset_mode}
 {
 	vk::CommandPoolCreateFlags flags;
@@ -74,7 +74,7 @@ HPPCommandPool::~HPPCommandPool()
 	}
 }
 
-HPPDevice const &HPPCommandPool::get_device() const
+HPPDevice &HPPCommandPool::get_device()
 {
 	return device;
 }
@@ -89,7 +89,7 @@ uint32_t HPPCommandPool::get_queue_family_index() const
 	return queue_family_index;
 }
 
-vkb::rendering::HPPRenderFrame const *HPPCommandPool::get_render_frame() const
+vkb::rendering::HPPRenderFrame *HPPCommandPool::get_render_frame()
 {
 	return render_frame;
 }

--- a/framework/core/hpp_command_pool.h
+++ b/framework/core/hpp_command_pool.h
@@ -18,10 +18,15 @@
 #pragma once
 
 #include <core/hpp_command_buffer.h>
-#include <rendering/hpp_render_frame.h>
+#include <cstdint>
 
 namespace vkb
 {
+namespace rendering
+{
+class HPPRenderFrame;
+}
+
 namespace core
 {
 class HPPDevice;
@@ -29,11 +34,11 @@ class HPPDevice;
 class HPPCommandPool
 {
   public:
-	HPPCommandPool(HPPDevice const                      &device,
-	               uint32_t                              queue_family_index,
-	               vkb::rendering::HPPRenderFrame const *render_frame = nullptr,
-	               size_t                                thread_index = 0,
-	               HPPCommandBuffer::ResetMode           reset_mode   = HPPCommandBuffer::ResetMode::ResetPool);
+	HPPCommandPool(HPPDevice                      &device,
+	               uint32_t                        queue_family_index,
+	               vkb::rendering::HPPRenderFrame *render_frame = nullptr,
+	               size_t                          thread_index = 0,
+	               HPPCommandBuffer::ResetMode     reset_mode   = HPPCommandBuffer::ResetMode::ResetPool);
 	HPPCommandPool(const HPPCommandPool &) = delete;
 	HPPCommandPool(HPPCommandPool &&other);
 	~HPPCommandPool();
@@ -41,22 +46,22 @@ class HPPCommandPool
 	HPPCommandPool &operator=(const HPPCommandPool &) = delete;
 	HPPCommandPool &operator=(HPPCommandPool &&)      = delete;
 
-	HPPDevice const                      &get_device() const;
-	vk::CommandPool                       get_handle() const;
-	uint32_t                              get_queue_family_index() const;
-	vkb::rendering::HPPRenderFrame const *get_render_frame() const;
-	HPPCommandBuffer::ResetMode           get_reset_mode() const;
-	size_t                                get_thread_index() const;
-	HPPCommandBuffer                     &request_command_buffer(vk::CommandBufferLevel level = vk::CommandBufferLevel::ePrimary);
-	void                                  reset_pool();
+	HPPDevice                      &get_device();
+	vk::CommandPool                 get_handle() const;
+	uint32_t                        get_queue_family_index() const;
+	vkb::rendering::HPPRenderFrame *get_render_frame();
+	HPPCommandBuffer::ResetMode     get_reset_mode() const;
+	size_t                          get_thread_index() const;
+	HPPCommandBuffer               &request_command_buffer(vk::CommandBufferLevel level = vk::CommandBufferLevel::ePrimary);
+	void                            reset_pool();
 
   private:
 	void reset_command_buffers();
 
   private:
-	HPPDevice const                               &device;
+	HPPDevice                                     &device;
 	vk::CommandPool                                handle             = nullptr;
-	vkb::rendering::HPPRenderFrame const          *render_frame       = nullptr;
+	vkb::rendering::HPPRenderFrame                *render_frame       = nullptr;
 	size_t                                         thread_index       = 0;
 	uint32_t                                       queue_family_index = 0;
 	std::vector<std::unique_ptr<HPPCommandBuffer>> primary_command_buffers;

--- a/framework/core/hpp_descriptor_set_layout.h
+++ b/framework/core/hpp_descriptor_set_layout.h
@@ -1,0 +1,47 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "core/descriptor_set_layout.h"
+#include <vulkan/vulkan.hpp>
+
+namespace vkb
+{
+namespace core
+{
+/**
+ * @brief facade class around vkb::DescriptorSetLayout, providing a vulkan.hpp-based interface
+ *
+ * See vkb::DescriptorSetLayout for documentation
+ */
+class HPPDescriptorSetLayout : private vkb::DescriptorSetLayout
+{
+  public:
+	vk::DescriptorSetLayout get_handle() const
+	{
+		return static_cast<vk::DescriptorSetLayout>(vkb::DescriptorSetLayout::get_handle());
+	}
+
+	std::unique_ptr<vk::DescriptorSetLayoutBinding> get_layout_binding(const uint32_t binding_index) const
+	{
+		return std::unique_ptr<vk::DescriptorSetLayoutBinding>(
+		    reinterpret_cast<vk::DescriptorSetLayoutBinding *>(vkb::DescriptorSetLayout::get_layout_binding(binding_index).release()));
+	}
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_framebuffer.h
+++ b/framework/core/hpp_framebuffer.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "core/framebuffer.h"
+#include <vulkan/vulkan.hpp>
+
+namespace vkb
+{
+namespace core
+{
+/**
+ * @brief facade class around vkb::Framebuffer, providing a vulkan.hpp-based interface
+ *
+ * See vkb::Framebuffer for documentation
+ */
+class HPPFramebuffer : private vkb::Framebuffer
+{
+  public:
+	const vk::Extent2D &get_extent() const
+	{
+		return reinterpret_cast<vk::Extent2D const &>(vkb::Framebuffer::get_extent());
+	}
+
+	vk::Framebuffer get_handle() const
+	{
+		return static_cast<vk::Framebuffer>(vkb::Framebuffer::get_handle());
+	}
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_image.cpp
+++ b/framework/core/hpp_image.cpp
@@ -43,7 +43,7 @@ inline vk::ImageType find_image_type(vk::Extent3D const &extent)
 
 namespace core
 {
-HPPImage::HPPImage(HPPDevice const        &device,
+HPPImage::HPPImage(HPPDevice              &device,
                    const vk::Extent3D     &extent,
                    vk::Format              format,
                    vk::ImageUsageFlags     image_usage,
@@ -100,7 +100,7 @@ HPPImage::HPPImage(HPPDevice const        &device,
 	}
 }
 
-HPPImage::HPPImage(HPPDevice const        &device,
+HPPImage::HPPImage(HPPDevice              &device,
                    vk::Image               handle,
                    const vk::Extent3D     &extent,
                    vk::Format              format,

--- a/framework/core/hpp_image.h
+++ b/framework/core/hpp_image.h
@@ -31,14 +31,14 @@ class HPPImageView;
 class HPPImage : public vkb::core::HPPVulkanResource<vk::Image>
 {
   public:
-	HPPImage(HPPDevice const        &device,
+	HPPImage(HPPDevice              &device,
 	         vk::Image               handle,
 	         const vk::Extent3D     &extent,
 	         vk::Format              format,
 	         vk::ImageUsageFlags     image_usage,
 	         vk::SampleCountFlagBits sample_count = vk::SampleCountFlagBits::e1);
 
-	HPPImage(HPPDevice const        &device,
+	HPPImage(HPPDevice              &device,
 	         const vk::Extent3D     &extent,
 	         vk::Format              format,
 	         vk::ImageUsageFlags     image_usage,

--- a/framework/core/hpp_pipeline.h
+++ b/framework/core/hpp_pipeline.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "core/pipeline.h"
+
+namespace vkb
+{
+namespace core
+{
+/**
+ * @brief facade class around vkb::Pipeline, providing a vulkan.hpp-based interface
+ *
+ * See vkb::Pipeline for documentation
+ */
+class HPPPipeline : private vkb::Pipeline
+{
+  public:
+	vk::Pipeline get_handle() const
+	{
+		return static_cast<vk::Pipeline>(vkb::Pipeline::get_handle());
+	}
+};
+
+class HPPComputePipeline : public HPPPipeline
+{
+};
+
+class HPPGraphicsPipeline : public HPPPipeline
+{
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_pipeline_layout.h
+++ b/framework/core/hpp_pipeline_layout.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include "core/pipeline_layout.h"
+#include <core/hpp_descriptor_set_layout.h>
+#include <core/hpp_shader_module.h>
 
 namespace vkb
 {
@@ -31,9 +33,27 @@ namespace core
 class HPPPipelineLayout : private vkb::PipelineLayout
 {
   public:
+	using vkb::PipelineLayout::has_descriptor_set_layout;
+
+  public:
+	vkb::core::HPPDescriptorSetLayout &get_descriptor_set_layout(const uint32_t set_index) const
+	{
+		return reinterpret_cast<vkb::core::HPPDescriptorSetLayout &>(vkb::PipelineLayout::get_descriptor_set_layout(set_index));
+	}
+
 	vk::PipelineLayout get_handle() const
 	{
 		return static_cast<vk::PipelineLayout>(vkb::PipelineLayout::get_handle());
+	}
+
+	vk::ShaderStageFlags get_push_constant_range_stage(uint32_t size, uint32_t offset = 0) const
+	{
+		return static_cast<vk::ShaderStageFlags>(vkb::PipelineLayout::get_push_constant_range_stage(size, offset));
+	}
+
+	const std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> &get_shader_sets() const
+	{
+		return reinterpret_cast<std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> const &>(vkb::PipelineLayout::get_shader_sets());
 	}
 };
 }        // namespace core

--- a/framework/core/hpp_query_pool.h
+++ b/framework/core/hpp_query_pool.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "core/query_pool.h"
+
+namespace vkb
+{
+namespace core
+{
+/**
+ * @brief facade class around vkb::QueryPool, providing a vulkan.hpp-based interface
+ *
+ * See vkb::QueryPool for documentation
+ */
+class HPPQueryPool : private vkb::QueryPool
+{
+  public:
+	vk::QueryPool get_handle() const
+	{
+		return static_cast<vk::QueryPool>(vkb::QueryPool::get_handle());
+	}
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_render_pass.h
+++ b/framework/core/hpp_render_pass.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "core/render_pass.h"
+#include <vulkan/vulkan.hpp>
+
+namespace vkb
+{
+namespace core
+{
+/**
+ * @brief facade class around vkb::RenderPass, providing a vulkan.hpp-based interface
+ *
+ * See vkb::RenderPass for documentation
+ */
+
+struct HPPSubpassInfo
+{
+	std::vector<uint32_t>   input_attachments;
+	std::vector<uint32_t>   output_attachments;
+	std::vector<uint32_t>   color_resolve_attachments;
+	bool                    disable_depth_stencil_attachment;
+	uint32_t                depth_stencil_resolve_attachment;
+	vk::ResolveModeFlagBits depth_stencil_resolve_mode;
+	std::string             debug_name;
+};
+
+class HPPRenderPass : private vkb::RenderPass
+{
+  public:
+	using vkb::RenderPass::get_color_output_count;
+
+  public:
+	vk::RenderPass get_handle() const
+	{
+		return static_cast<vk::RenderPass>(vkb::RenderPass::get_handle());
+	}
+
+	const vk::Extent2D get_render_area_granularity() const
+	{
+		return static_cast<vk::Extent2D>(vkb::RenderPass::get_render_area_granularity());
+	}
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_shader_module.h
+++ b/framework/core/hpp_shader_module.h
@@ -1,0 +1,80 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "core/shader_module.h"
+#include <vulkan/vulkan.hpp>
+
+namespace vkb
+{
+namespace core
+{
+/**
+ * @brief facade class around vkb::ShaderModule, providing a vulkan.hpp-based interface
+ *
+ * See vkb::ShaderModule for documentation
+ */
+
+/// This determines the type and method of how descriptor set should be created and bound
+enum class HPPShaderResourceMode
+{
+	Static,
+	Dynamic,
+	UpdateAfterBind
+};
+
+/// Types of shader resources
+enum class HPPShaderResourceType
+{
+	Input,
+	InputAttachment,
+	Output,
+	Image,
+	ImageSampler,
+	ImageStorage,
+	Sampler,
+	BufferUniform,
+	BufferStorage,
+	PushConstant,
+	SpecializationConstant,
+	All
+};
+
+/// Store shader resource data.
+/// Used by the shader module.
+struct HPPShaderResource
+{
+	vk::ShaderStageFlags  stages;
+	HPPShaderResourceType type;
+	HPPShaderResourceMode mode;
+	uint32_t              set;
+	uint32_t              binding;
+	uint32_t              location;
+	uint32_t              input_attachment_index;
+	uint32_t              vec_size;
+	uint32_t              columns;
+	uint32_t              array_size;
+	uint32_t              offset;
+	uint32_t              size;
+	uint32_t              constant_id;
+	uint32_t              qualifiers;
+	std::string           name;
+};
+
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -39,7 +39,7 @@ template <typename HPPHandle, typename VKBDevice = vkb::core::HPPDevice>
 class HPPVulkanResource
 {
   public:
-	HPPVulkanResource(HPPHandle handle = nullptr, VKBDevice const *device = nullptr) :
+	HPPVulkanResource(HPPHandle handle = nullptr, VKBDevice *device = nullptr) :
 	    handle{handle}, device{device}
 	{
 	}
@@ -70,6 +70,12 @@ class HPPVulkanResource
 	}
 
 	inline VKBDevice const &get_device() const
+	{
+		assert(device && "VKBDevice handle not set");
+		return *device;
+	}
+
+	inline VKBDevice &get_device()
 	{
 		assert(device && "VKBDevice handle not set");
 		return *device;
@@ -112,9 +118,9 @@ class HPPVulkanResource
 	}
 
   private:
-	HPPHandle        handle;
-	VKBDevice const *device;
-	std::string      debug_name;
+	HPPHandle   handle;
+	VKBDevice  *device;
+	std::string debug_name;
 };
 
 }        // namespace core

--- a/framework/hpp_buffer_pool.h
+++ b/framework/hpp_buffer_pool.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "buffer_pool.h"
+#include <core/hpp_buffer.h>
 
 namespace vkb
 {
@@ -40,6 +41,11 @@ class HPPBufferAllocation : private vkb::BufferAllocation
 	vk::DeviceSize get_offset() const
 	{
 		return static_cast<vk::DeviceSize>(vkb::BufferAllocation::get_offset());
+	}
+
+	vk::DeviceSize get_size() const
+	{
+		return static_cast<vk::DeviceSize>(vkb::BufferAllocation::get_size());
 	}
 };
 

--- a/framework/hpp_resource_binding_state.h
+++ b/framework/hpp_resource_binding_state.h
@@ -1,0 +1,93 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "resource_binding_state.h"
+#include <core/hpp_buffer.h>
+#include <core/hpp_image_view.h>
+#include <core/hpp_sampler.h>
+
+namespace vkb
+{
+/**
+ * @brief facade class around vkb::ResourceBindingState, providing a vulkan.hpp-based interface
+ *
+ * See vkb::ResourceBindingState for documentation
+ */
+struct HPPResourceInfo
+{
+	bool                           dirty      = false;
+	const vkb::core::HPPBuffer    *buffer     = nullptr;
+	vk::DeviceSize                 offset     = 0;
+	vk::DeviceSize                 range      = 0;
+	const vkb::core::HPPImageView *image_view = nullptr;
+	const vkb::core::HPPSampler   *sampler    = nullptr;
+};
+
+class HPPResourceSet : private vkb::ResourceSet
+{
+  public:
+	using vkb::ResourceSet::is_dirty;
+
+  public:
+	const BindingMap<HPPResourceInfo> &get_resource_bindings() const
+	{
+		return reinterpret_cast<BindingMap<HPPResourceInfo> const &>(vkb::ResourceSet::get_resource_bindings());
+	}
+};
+
+class HPPResourceBindingState : private vkb::ResourceBindingState
+{
+  public:
+	using vkb::ResourceBindingState::clear_dirty;
+	using vkb::ResourceBindingState::is_dirty;
+	using vkb::ResourceBindingState::reset;
+
+  public:
+	void bind_buffer(const vkb::core::HPPBuffer &buffer, vk::DeviceSize offset, vk::DeviceSize range, uint32_t set, uint32_t binding, uint32_t array_element)
+	{
+		vkb::ResourceBindingState::bind_buffer(reinterpret_cast<vkb::core::Buffer const &>(buffer),
+		                                       static_cast<VkDeviceSize>(offset),
+		                                       static_cast<VkDeviceSize>(range),
+		                                       set,
+		                                       binding,
+		                                       array_element);
+	}
+
+	void bind_image(const vkb::core::HPPImageView &image_view, const vkb::core::HPPSampler &sampler, uint32_t set, uint32_t binding, uint32_t array_element)
+	{
+		vkb::ResourceBindingState::bind_image(
+		    reinterpret_cast<vkb::core::ImageView const &>(image_view), reinterpret_cast<vkb::core::Sampler const &>(sampler), set, binding, array_element);
+	}
+
+	void bind_image(const vkb::core::HPPImageView &image_view, uint32_t set, uint32_t binding, uint32_t array_element)
+	{
+		vkb::ResourceBindingState::bind_image(reinterpret_cast<vkb::core::ImageView const &>(image_view), set, binding, array_element);
+	}
+
+	void bind_input(const vkb::core::HPPImageView &image_view, uint32_t set, uint32_t binding, uint32_t array_element)
+	{
+		vkb::ResourceBindingState::bind_input(reinterpret_cast<vkb::core::ImageView const &>(image_view), set, binding, array_element);
+	}
+
+	const std::unordered_map<uint32_t, vkb::HPPResourceSet> &get_resource_sets()
+	{
+		return reinterpret_cast<std::unordered_map<uint32_t, vkb::HPPResourceSet> const &>(vkb::ResourceBindingState::get_resource_sets());
+	}
+};
+}        // namespace vkb

--- a/framework/hpp_resource_cache.h
+++ b/framework/hpp_resource_cache.h
@@ -23,10 +23,17 @@ namespace vkb
 {
 namespace core
 {
+class HPPComputePipeline;
 class HPPDevice;
+class HPPGraphicsPipeline;
 class HPPPipelineLayout;
 class HPPShaderModule;
 }        // namespace core
+
+namespace rendering
+{
+struct HPPAttachment;
+}
 
 /**
  * @brief facade class around vkb::ResourceCache, providing a vulkan.hpp-based interface
@@ -46,10 +53,38 @@ class HPPResourceCache : private vkb::ResourceCache
 	    vkb::ResourceCache(reinterpret_cast<vkb::Device &>(device))
 	{}
 
+	vkb::core::HPPComputePipeline &request_compute_pipeline(vkb::rendering::HPPPipelineState &pipeline_state)
+	{
+		return reinterpret_cast<vkb::core::HPPComputePipeline &>(
+		    vkb::ResourceCache::request_compute_pipeline(reinterpret_cast<vkb::PipelineState &>(pipeline_state)));
+	}
+
+	vkb::core::HPPFramebuffer &request_framebuffer(const vkb::rendering::HPPRenderTarget &render_target, const vkb::core::HPPRenderPass &render_pass)
+	{
+		return reinterpret_cast<vkb::core::HPPFramebuffer &>(vkb::ResourceCache::request_framebuffer(reinterpret_cast<vkb::RenderTarget const &>(render_target),
+		                                                                                             reinterpret_cast<vkb::RenderPass const &>(render_pass)));
+	}
+
+	vkb::core::HPPGraphicsPipeline &request_graphics_pipeline(vkb::rendering::HPPPipelineState &pipeline_state)
+	{
+		return reinterpret_cast<vkb::core::HPPGraphicsPipeline &>(
+		    vkb::ResourceCache::request_graphics_pipeline(reinterpret_cast<vkb::PipelineState &>(pipeline_state)));
+	}
+
 	vkb::core::HPPPipelineLayout &request_pipeline_layout(const std::vector<vkb::core::HPPShaderModule *> &shader_modules)
 	{
 		return reinterpret_cast<vkb::core::HPPPipelineLayout &>(
 		    vkb::ResourceCache::request_pipeline_layout(reinterpret_cast<std::vector<vkb::ShaderModule *> const &>(shader_modules)));
+	}
+
+	vkb::core::HPPRenderPass &request_render_pass(const std::vector<vkb::rendering::HPPAttachment> &attachments,
+	                                              const std::vector<vkb::common::HPPLoadStoreInfo> &load_store_infos,
+	                                              const std::vector<vkb::core::HPPSubpassInfo>     &subpasses)
+	{
+		return reinterpret_cast<vkb::core::HPPRenderPass &>(
+		    vkb::ResourceCache::request_render_pass(reinterpret_cast<std::vector<vkb::Attachment> const &>(attachments),
+		                                            reinterpret_cast<std::vector<vkb::LoadStoreInfo> const &>(load_store_infos),
+		                                            reinterpret_cast<std::vector<vkb::SubpassInfo> const &>(subpasses)));
 	}
 
 	vkb::core::HPPShaderModule &request_shader_module(vk::ShaderStageFlagBits stage, const ShaderSource &glsl_source, const ShaderVariant &shader_variant = {})

--- a/framework/rendering/hpp_pipeline_state.h
+++ b/framework/rendering/hpp_pipeline_state.h
@@ -18,7 +18,8 @@
 #pragma once
 
 #include "pipeline_state.h"
-
+#include <core/hpp_pipeline_layout.h>
+#include <core/hpp_render_pass.h>
 #include <vulkan/vulkan.hpp>
 
 namespace vkb
@@ -44,14 +45,6 @@ struct HPPColorBlendState
 	std::vector<HPPColorBlendAttachmentState> attachments;
 };
 
-struct HPPStencilOpState
-{
-	vk::StencilOp fail_op       = vk::StencilOp::eReplace;
-	vk::StencilOp pass_op       = vk::StencilOp::eReplace;
-	vk::StencilOp depth_fail_op = vk::StencilOp::eReplace;
-	vk::CompareOp compare_op    = vk::CompareOp::eNever;
-};
-
 struct HPPDepthStencilState
 {
 	vk::Bool32     depth_test_enable        = true;
@@ -61,6 +54,22 @@ struct HPPDepthStencilState
 	vk::Bool32     stencil_test_enable      = false;
 	StencilOpState front;
 	StencilOpState back;
+};
+
+struct HPPInputAssemblyState
+{
+	vk::PrimitiveTopology topology                 = vk::PrimitiveTopology::eTriangleList;
+	vk::Bool32            primitive_restart_enable = false;
+};
+
+struct HPPMultisampleState
+{
+	vk::SampleCountFlagBits rasterization_samples    = vk::SampleCountFlagBits::e1;
+	vk::Bool32              sample_shading_enable    = false;
+	float                   min_sample_shading       = 0.0f;
+	vk::SampleMask          sample_mask              = 0;
+	vk::Bool32              alpha_to_coverage_enable = false;
+	vk::Bool32              alpha_to_one_enable      = false;
 };
 
 struct HPPRasterizationState
@@ -73,10 +82,92 @@ struct HPPRasterizationState
 	vk::Bool32        depth_bias_enable         = false;
 };
 
+struct HPPStencilOpState
+{
+	vk::StencilOp fail_op       = vk::StencilOp::eReplace;
+	vk::StencilOp pass_op       = vk::StencilOp::eReplace;
+	vk::StencilOp depth_fail_op = vk::StencilOp::eReplace;
+	vk::CompareOp compare_op    = vk::CompareOp::eNever;
+};
+
 struct HPPVertexInputState
 {
 	std::vector<vk::VertexInputBindingDescription>   bindings;
 	std::vector<vk::VertexInputAttributeDescription> attributes;
 };
+
+struct HPPViewportState
+{
+	uint32_t viewport_count = 1;
+	uint32_t scissor_count  = 1;
+};
+
+class HPPPipelineState : private vkb::PipelineState
+{
+  public:
+	using vkb::PipelineState::clear_dirty;
+	using vkb::PipelineState::get_subpass_index;
+	using vkb::PipelineState::is_dirty;
+	using vkb::PipelineState::reset;
+	using vkb::PipelineState::set_specialization_constant;
+	using vkb::PipelineState::set_subpass_index;
+
+  public:
+	const vkb::rendering::HPPColorBlendState &get_color_blend_state() const
+	{
+		return reinterpret_cast<vkb::rendering::HPPColorBlendState const &>(vkb::PipelineState::get_color_blend_state());
+	}
+
+	const vkb::core::HPPPipelineLayout &get_pipeline_layout() const
+	{
+		return reinterpret_cast<vkb::core::HPPPipelineLayout const &>(vkb::PipelineState::get_pipeline_layout());
+	}
+
+	void set_color_blend_state(const vkb::rendering::HPPColorBlendState &color_blend_state)
+	{
+		vkb::PipelineState::set_color_blend_state(reinterpret_cast<vkb::ColorBlendState const &>(color_blend_state));
+	}
+
+	void set_depth_stencil_state(const vkb::rendering::HPPDepthStencilState &depth_stencil_state)
+	{
+		vkb::PipelineState::set_depth_stencil_state(reinterpret_cast<vkb::DepthStencilState const &>(depth_stencil_state));
+	}
+
+	void set_input_assembly_state(const vkb::rendering::HPPInputAssemblyState &input_assembly_state)
+	{
+		vkb::PipelineState::set_input_assembly_state(reinterpret_cast<vkb::InputAssemblyState const &>(input_assembly_state));
+	}
+
+	void set_multisample_state(const vkb::rendering::HPPMultisampleState &multisample_state)
+	{
+		vkb::PipelineState::set_multisample_state(reinterpret_cast<vkb::MultisampleState const &>(multisample_state));
+	}
+
+	void set_pipeline_layout(vkb::core::HPPPipelineLayout &pipeline_layout)
+	{
+		vkb::PipelineState::set_pipeline_layout(reinterpret_cast<vkb::PipelineLayout &>(pipeline_layout));
+	}
+
+	void set_rasterization_state(const vkb::rendering::HPPRasterizationState &rasterization_state)
+	{
+		vkb::PipelineState::set_rasterization_state(reinterpret_cast<vkb::RasterizationState const &>(rasterization_state));
+	}
+
+	void set_render_pass(const vkb::core::HPPRenderPass &render_pass)
+	{
+		vkb::PipelineState::set_render_pass(reinterpret_cast<vkb::RenderPass const &>(render_pass));
+	}
+
+	void set_vertex_input_state(const vkb::rendering::HPPVertexInputState &vertex_input_state)
+	{
+		vkb::PipelineState::set_vertex_input_state(reinterpret_cast<vkb::VertexInputState const &>(vertex_input_state));
+	}
+
+	void set_viewport_state(const vkb::rendering::HPPViewportState &viewport_state)
+	{
+		vkb::PipelineState::set_viewport_state(reinterpret_cast<vkb::ViewportState const &>(viewport_state));
+	}
+};
+
 }        // namespace rendering
 }        // namespace vkb

--- a/framework/rendering/hpp_render_frame.h
+++ b/framework/rendering/hpp_render_frame.h
@@ -17,8 +17,7 @@
 
 #pragma once
 
-#include <rendering/render_frame.h>
-
+#include "rendering/render_frame.h"
 #include <core/hpp_command_buffer.h>
 #include <core/hpp_queue.h>
 #include <hpp_buffer_pool.h>
@@ -70,6 +69,19 @@ class HPPRenderFrame : private vkb::RenderFrame
 		                                             static_cast<vkb::CommandBuffer::ResetMode>(reset_mode),
 		                                             static_cast<VkCommandBufferLevel>(level),
 		                                             thread_index));
+	}
+
+	vk::DescriptorSet request_descriptor_set(const vkb::core::HPPDescriptorSetLayout    &descriptor_set_layout,
+	                                         const BindingMap<vk::DescriptorBufferInfo> &buffer_infos,
+	                                         const BindingMap<vk::DescriptorImageInfo>  &image_infos,
+	                                         bool                                        update_after_bind,
+	                                         size_t                                      thread_index = 0)
+	{
+		return static_cast<vk::DescriptorSet>(vkb::RenderFrame::request_descriptor_set(reinterpret_cast<vkb::DescriptorSetLayout const &>(descriptor_set_layout),
+		                                                                               reinterpret_cast<BindingMap<VkDescriptorBufferInfo> const &>(buffer_infos),
+		                                                                               reinterpret_cast<BindingMap<VkDescriptorImageInfo> const &>(image_infos),
+		                                                                               update_after_bind,
+		                                                                               thread_index));
 	}
 
 	vk::Fence request_fence()

--- a/framework/rendering/hpp_subpass.h
+++ b/framework/rendering/hpp_subpass.h
@@ -1,0 +1,66 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "rendering/subpass.h"
+#include <hpp_buffer_pool.h>
+
+namespace vkb
+{
+namespace rendering
+{
+struct alignas(16) HPPLight
+{
+	glm::vec4 position;         // position.w represents type of light
+	glm::vec4 color;            // color.w represents light intensity
+	glm::vec4 direction;        // direction.w represents range
+	glm::vec2 info;             // (only used for spot lights) info.x represents light inner cone angle, info.y represents light outer cone angle
+};
+
+struct HPPLightingState
+{
+	std::vector<HPPLight>    directional_lights;
+	std::vector<HPPLight>    point_lights;
+	std::vector<HPPLight>    spot_lights;
+	vkb::HPPBufferAllocation light_buffer;
+};
+
+/**
+ * @brief facade class around vkb::Subpass, providing a vulkan.hpp-based interface
+ *
+ * See vkb::Subpass for documentation
+ */
+class HPPSubpass : private vkb::Subpass
+{
+  public:
+	using vkb::Subpass::get_color_resolve_attachments;
+	using vkb::Subpass::get_debug_name;
+	using vkb::Subpass::get_depth_stencil_resolve_attachment;
+	using vkb::Subpass::get_disable_depth_stencil_attachment;
+	using vkb::Subpass::get_input_attachments;
+	using vkb::Subpass::get_output_attachments;
+
+  public:
+	const vk::ResolveModeFlagBits get_depth_stencil_resolve_mode() const
+	{
+		return static_cast<vk::ResolveModeFlagBits>(vkb::Subpass::get_depth_stencil_resolve_mode());
+	}
+};
+
+}        // namespace rendering
+}        // namespace vkb


### PR DESCRIPTION
## Description

Transcoding of `vkb::CommandBuffer` using Vulkan-Hpp, tested on Win10 and nvidia HW.
This change also include
- some adjustments of the classes `vkb::core::HPPBuffer`, `vkb::core::HPPCommandPool`, `vkb::core::HPPImage`, `vkb::core::HPPVulkanResource`
- some additions to the helper functions in `common/hpp_vk_common.h`
- some extensions of the facade classes `vkb::core::HPPPipelineLayout`, `vkb::HPPBufferPool`, `vkb::HPPResourceCache`, `vkb::rendering::HPPPipelineState`, `vkb::rendering::HPPRenderFrame`
- introduction of new facade classes `vkb::core::HPPDescriptorSetLayout`, `vkb::core::HPPFramebuffer`, `vkb::core::HPPPipeline`, `vkb::core::HPPQueryPool`, `vkb::core::HPPRenderPass`, `vkb::core::HPPShaderModule`, `vkb::HPPResourceBindingState`, `vkb::rendering::HPPSubpass`

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
