### PR TITLE
Fix msaa sync

### DIFF
--- a/framework/rendering/postprocessing_renderpass.h
+++ b/framework/rendering/postprocessing_renderpass.h
@@ -157,6 +157,11 @@ class PostProcessingSubpass : public Subpass
 	PostProcessingSubpass &bind_storage_image(const std::string &name, const core::ImageView &new_image);
 
 	/**
+	 * @brief Removes the sampled image at name for this step.
+	 */
+	void unbind_sampled_image(const std::string &name);
+
+	/**
 	 * @brief Set the constants that are pushed before each fullscreen draw.
 	 */
 	PostProcessingSubpass &set_push_constants(const std::vector<uint8_t> &data);

--- a/samples/performance/msaa/msaa.cpp
+++ b/samples/performance/msaa/msaa.cpp
@@ -496,6 +496,13 @@ void MSAASample::draw(vkb::CommandBuffer &command_buffer, vkb::RenderTarget &ren
 		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
 
+		if (run_postprocessing)
+		{
+			// Synchronize depth with previous depth resolve operation
+			memory_barrier.dst_stage_mask |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+			memory_barrier.dst_access_mask |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		}
+
 		for (auto &i_depth : depth_atts)
 		{
 			assert(i_depth < views.size());

--- a/samples/performance/msaa/msaa.cpp
+++ b/samples/performance/msaa/msaa.cpp
@@ -585,6 +585,10 @@ void MSAASample::postprocessing(vkb::CommandBuffer &command_buffer, vkb::RenderT
 	postprocessing_pass.set_uniform_data(near_far);
 
 	auto &postprocessing_subpass = postprocessing_pass.get_subpass(0);
+	// Unbind sampled images to prevent invalid image transitions on unused images
+	postprocessing_subpass.unbind_sampled_image("depth_sampler");
+	postprocessing_subpass.unbind_sampled_image("ms_depth_sampler");
+
 	postprocessing_subpass.get_fs_variant().clear();
 	if (multisampled_depth)
 	{

--- a/samples/performance/msaa/msaa.cpp
+++ b/samples/performance/msaa/msaa.cpp
@@ -605,10 +605,12 @@ void MSAASample::resolve_color_separate_pass(vkb::CommandBuffer &command_buffer,
 	{
 		// The multisampled color is the source of the resolve operation
 		vkb::ImageMemoryBarrier memory_barrier{};
-		memory_barrier.old_layout     = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-		memory_barrier.new_layout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-		memory_barrier.src_stage_mask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		memory_barrier.dst_stage_mask = VK_PIPELINE_STAGE_TRANSFER_BIT;
+		memory_barrier.old_layout      = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		memory_barrier.new_layout      = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
+		memory_barrier.src_access_mask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		memory_barrier.dst_access_mask = VK_ACCESS_TRANSFER_READ_BIT;
 
 		assert(i_color_ms < views.size());
 		command_buffer.image_memory_barrier(views[i_color_ms], memory_barrier);
@@ -628,10 +630,12 @@ void MSAASample::resolve_color_separate_pass(vkb::CommandBuffer &command_buffer,
 		auto color_new_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 
 		vkb::ImageMemoryBarrier memory_barrier{};
-		memory_barrier.old_layout     = color_layout;
-		memory_barrier.new_layout     = color_new_layout;
-		memory_barrier.src_stage_mask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		memory_barrier.dst_stage_mask = VK_PIPELINE_STAGE_TRANSFER_BIT;
+		memory_barrier.old_layout      = color_layout;
+		memory_barrier.new_layout      = color_new_layout;
+		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
+		memory_barrier.src_access_mask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		memory_barrier.dst_access_mask = VK_ACCESS_TRANSFER_WRITE_BIT;
 
 		color_layout = color_new_layout;
 
@@ -647,10 +651,12 @@ void MSAASample::resolve_color_separate_pass(vkb::CommandBuffer &command_buffer,
 		auto color_new_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
 		vkb::ImageMemoryBarrier memory_barrier{};
-		memory_barrier.old_layout     = color_layout;
-		memory_barrier.new_layout     = color_new_layout;
-		memory_barrier.src_stage_mask = VK_PIPELINE_STAGE_TRANSFER_BIT;
-		memory_barrier.dst_stage_mask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		memory_barrier.old_layout      = color_layout;
+		memory_barrier.new_layout      = color_new_layout;
+		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
+		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		memory_barrier.src_access_mask = VK_ACCESS_TRANSFER_WRITE_BIT;
+		memory_barrier.dst_access_mask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
 
 		color_layout = color_new_layout;
 
@@ -659,10 +665,12 @@ void MSAASample::resolve_color_separate_pass(vkb::CommandBuffer &command_buffer,
 
 	{
 		vkb::ImageMemoryBarrier memory_barrier{};
-		memory_barrier.old_layout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-		memory_barrier.new_layout     = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-		memory_barrier.src_stage_mask = VK_PIPELINE_STAGE_TRANSFER_BIT;
-		memory_barrier.dst_stage_mask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		memory_barrier.old_layout      = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+		memory_barrier.new_layout      = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
+		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		memory_barrier.src_access_mask = VK_ACCESS_TRANSFER_READ_BIT;
+		memory_barrier.dst_access_mask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
 
 		command_buffer.image_memory_barrier(views[i_color_ms], memory_barrier);
 	}


### PR DESCRIPTION
## Description

This PR fixes synchronization errors produced by validation layers in 'msaa' sample.
This sample has few buttons/checkboxes so there are few combinations of states which application can produce.
With this fixes all combinations work (don't produce validation errors).

## Notes:
Tested on:
VulkanSDK: 1.3.239.0
Driver Version: 528.49.0.0
Windows 10
Nvidia Quadro P600
Intel i7-8750H
32 GB RAM

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on **Windows**, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
