### PR TITLE
docs: improve "-j" parameter in build instructions

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -214,7 +214,7 @@ cmake -G "Unix Makefiles" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release
 `Step 2.` Build the project
 
 ```
-cmake --build build/linux --config Release --target vulkan_samples -- -j$(nproc)
+cmake --build build/linux --config Release --target vulkan_samples -j$(nproc)
 ```
 
 `Step 3.` Run the **Vulkan Samples** application to display the help message
@@ -245,7 +245,7 @@ cmake -H. -Bbuild/mac -DCMAKE_BUILD_TYPE=Release
 `Step 2.` Build the project
 
 ```
-cmake --build build/mac --config Release --target vulkan_samples -- -j4
+cmake --build build/mac --config Release --target vulkan_samples -j4
 ```
 
 `Step 3.` Run the **Vulkan Samples** application to display the help message

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,5 +1,5 @@
 <!--
-- Copyright (c) 2019-2022, Arm Limited and Contributors
+- Copyright (c) 2019-2023, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/docs/build.md
+++ b/docs/build.md
@@ -214,7 +214,7 @@ cmake -G "Unix Makefiles" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release
 `Step 2.` Build the project
 
 ```
-cmake --build build/linux --config Release --target vulkan_samples -- -j4
+cmake --build build/linux --config Release --target vulkan_samples -- -j$(nproc)
 ```
 
 `Step 3.` Run the **Vulkan Samples** application to display the help message


### PR DESCRIPTION
## Description

As CMake 3.16 is the minium required version, use "-j" of CMake. 
Also replace hardcoded "-j4" with "-j$(nproc)" to speed up building on more powerful systems.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making