### PR TITLE
Fix sync errors in timestamp_queries and hdr samples

### DIFF
--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -680,16 +680,16 @@ void HPPApiVulkanSample::setup_render_pass()
 	dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
 	dependencies[0].dstSubpass      = 0;
 	dependencies[0].srcStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
-	dependencies[0].dstStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-	dependencies[0].srcAccessMask   = vk::AccessFlagBits::eMemoryRead;
-	dependencies[0].dstAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
+	dependencies[0].dstStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests;
+	dependencies[0].srcAccessMask   = vk::AccessFlagBits::eNoneKHR;
+	dependencies[0].dstAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
 	dependencies[0].dependencyFlags = vk::DependencyFlagBits::eByRegion;
 
 	dependencies[1].srcSubpass      = 0;
 	dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
-	dependencies[1].srcStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	dependencies[1].srcStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests;
 	dependencies[1].dstStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
-	dependencies[1].srcAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
+	dependencies[1].srcAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
 	dependencies[1].dstAccessMask   = vk::AccessFlagBits::eMemoryRead;
 	dependencies[1].dependencyFlags = vk::DependencyFlagBits::eByRegion;
 
@@ -744,16 +744,16 @@ void HPPApiVulkanSample::update_render_pass_flags(RenderPassCreateFlags flags)
 	dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
 	dependencies[0].dstSubpass      = 0;
 	dependencies[0].srcStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
-	dependencies[0].dstStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-	dependencies[0].srcAccessMask   = vk::AccessFlagBits::eMemoryWrite;
-	dependencies[0].dstAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
+	dependencies[0].dstStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests;
+	dependencies[0].srcAccessMask   = vk::AccessFlagBits::eNoneKHR;
+	dependencies[0].dstAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
 	dependencies[0].dependencyFlags = vk::DependencyFlagBits::eByRegion;
 
 	dependencies[1].srcSubpass      = 0;
 	dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
-	dependencies[1].srcStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	dependencies[1].srcStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests;
 	dependencies[1].dstStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
-	dependencies[1].srcAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
+	dependencies[1].srcAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
 	dependencies[1].dstAccessMask   = vk::AccessFlagBits::eMemoryRead;
 	dependencies[1].dependencyFlags = vk::DependencyFlagBits::eByRegion;
 

--- a/samples/api/hdr/hdr.cpp
+++ b/samples/api/hdr/hdr.cpp
@@ -316,13 +316,13 @@ void HDR::prepare_offscreen_buffer()
 		// Color attachments
 
 		// We are using two 128-Bit RGBA floating point color buffers for this sample
-		// In a performance or bandwith-limited scenario you should consider using a format with lower precision
+		// In a performance or bandwidth-limited scenario you should consider using a format with lower precision
 		create_attachment(color_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &offscreen.color[0]);
 		create_attachment(color_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &offscreen.color[1]);
 		// Depth attachment
 		create_attachment(depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, &offscreen.depth);
 
-		// Set up separate renderpass with references to the colorand depth attachments
+		// Set up separate renderpass with references to the color and depth attachments
 		std::array<VkAttachmentDescription, 3> attachment_descriptions = {};
 
 		// Init attachment properties
@@ -364,24 +364,31 @@ void HDR::prepare_offscreen_buffer()
 		subpass.colorAttachmentCount    = 2;
 		subpass.pDepthStencilAttachment = &depth_reference;
 
-		// Use subpass dependencies for attachment layput transitions
+		// Use subpass dependencies for attachment layout transitions
 		std::array<VkSubpassDependency, 2> dependencies;
 
 		dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
 		dependencies[0].dstSubpass      = 0;
-		dependencies[0].srcStageMask    = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		dependencies[0].dstStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[0].srcAccessMask   = VK_ACCESS_MEMORY_READ_BIT;
-		dependencies[0].dstAccessMask   = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 		dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+		// End of previous commands
+		dependencies[0].srcStageMask  = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		dependencies[0].srcAccessMask = 0;
+		// Read/write from/to depth
+		dependencies[0].dstStageMask  = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+		dependencies[0].dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+		// Write to attachment
+		dependencies[0].dstStageMask |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[0].dstAccessMask |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 
 		dependencies[1].srcSubpass      = 0;
 		dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
-		dependencies[1].srcStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[1].dstStageMask    = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		dependencies[1].srcAccessMask   = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-		dependencies[1].dstAccessMask   = VK_ACCESS_MEMORY_READ_BIT;
 		dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+		// End of write to attachment
+		dependencies[1].srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		// Attachment later read using sampler in 'composition' pipeline
+		dependencies[1].dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+		dependencies[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
 		VkRenderPassCreateInfo render_pass_create_info = {};
 		render_pass_create_info.sType                  = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -434,7 +441,7 @@ void HDR::prepare_offscreen_buffer()
 		// Floating point color attachment
 		create_attachment(color_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &filter_pass.color[0]);
 
-		// Set up separate renderpass with references to the colorand depth attachments
+		// Set up separate renderpass with references to the color and depth attachments
 		std::array<VkAttachmentDescription, 1> attachment_descriptions = {};
 
 		// Init attachment properties
@@ -455,24 +462,31 @@ void HDR::prepare_offscreen_buffer()
 		subpass.pColorAttachments    = color_references.data();
 		subpass.colorAttachmentCount = 1;
 
-		// Use subpass dependencies for attachment layput transitions
+		// Use subpass dependencies for attachment layout transitions
 		std::array<VkSubpassDependency, 2> dependencies;
 
 		dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
 		dependencies[0].dstSubpass      = 0;
-		dependencies[0].srcStageMask    = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		dependencies[0].dstStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[0].srcAccessMask   = VK_ACCESS_MEMORY_READ_BIT;
-		dependencies[0].dstAccessMask   = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 		dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+		// End of previous commands
+		dependencies[0].srcStageMask  = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		dependencies[0].srcAccessMask = 0;
+		// Read from image in fragment shader
+		dependencies[0].dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+		dependencies[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		// Write to attachment
+		dependencies[0].dstStageMask |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[0].dstAccessMask |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 
 		dependencies[1].srcSubpass      = 0;
 		dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
-		dependencies[1].srcStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[1].dstStageMask    = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		dependencies[1].srcAccessMask   = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-		dependencies[1].dstAccessMask   = VK_ACCESS_MEMORY_READ_BIT;
 		dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+		// End of write to attachment
+		dependencies[1].srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		// Attachment later read using sampler in 'bloom[0]' pipeline
+		dependencies[1].dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+		dependencies[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
 		VkRenderPassCreateInfo render_pass_create_info = {};
 		render_pass_create_info.sType                  = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -885,7 +899,7 @@ bool HDR::prepare(vkb::Platform &platform)
 	camera.set_position(glm::vec3(0.0f, 0.0f, -4.0f));
 	camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
 
-	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
+	// Note: Using reserved depth-buffer for increased precision, so Znear and Zfar are flipped
 	camera.set_perspective(60.0f, static_cast<float>(width) / static_cast<float>(height), 256.0f, 0.1f);
 
 	load_assets();

--- a/samples/api/hpp_hdr/hpp_hdr.cpp
+++ b/samples/api/hpp_hdr/hpp_hdr.cpp
@@ -23,717 +23,722 @@
 
 HPPHDR::HPPHDR()
 {
-	title = "HPP High dynamic range rendering";
+    title = "HPP High dynamic range rendering";
 }
 
 HPPHDR::~HPPHDR()
 {
-	if (get_device() && get_device()->get_handle())
-	{
-		vk::Device device = get_device()->get_handle();
+    if (get_device() && get_device()->get_handle())
+    {
+        vk::Device device = get_device()->get_handle();
 
-		bloom.destroy(device, descriptor_pool);
-		composition.destroy(device, descriptor_pool);
-		filter_pass.destroy(device);
-		models.destroy(device, descriptor_pool);
-		offscreen.destroy(device);
-		textures.destroy(device);
-	}
+        bloom.destroy(device, descriptor_pool);
+        composition.destroy(device, descriptor_pool);
+        filter_pass.destroy(device);
+        models.destroy(device, descriptor_pool);
+        offscreen.destroy(device);
+        textures.destroy(device);
+    }
 }
 
 bool HPPHDR::prepare(vkb::platform::HPPPlatform &platform)
 {
-	if (!HPPApiVulkanSample::prepare(platform))
-	{
-		return false;
-	}
+    if (!HPPApiVulkanSample::prepare(platform))
+    {
+        return false;
+    }
 
-	prepare_camera();
-	load_assets();
-	prepare_uniform_buffers();
-	prepare_offscreen_buffer();
+    prepare_camera();
+    load_assets();
+    prepare_uniform_buffers();
+    prepare_offscreen_buffer();
 
-	std::vector<vk::DescriptorPoolSize> pool_sizes = {{vk::DescriptorType::eUniformBuffer, 4}, {vk::DescriptorType::eCombinedImageSampler, 6}};
-	descriptor_pool                                = vkb::common::create_descriptor_pool(get_device()->get_handle(), 4, pool_sizes);
+    std::vector<vk::DescriptorPoolSize> pool_sizes = {{vk::DescriptorType::eUniformBuffer, 4}, {vk::DescriptorType::eCombinedImageSampler, 6}};
+    descriptor_pool                                = vkb::common::create_descriptor_pool(get_device()->get_handle(), 4, pool_sizes);
 
-	setup_bloom();
-	setup_composition();
-	setup_models();
-	build_command_buffers();
-	prepared = true;
-	return true;
+    setup_bloom();
+    setup_composition();
+    setup_models();
+    build_command_buffers();
+    prepared = true;
+    return true;
 }
 
 bool HPPHDR::resize(const uint32_t width, const uint32_t height)
 {
-	HPPApiVulkanSample::resize(width, height);
-	update_uniform_buffers();
-	return true;
+    HPPApiVulkanSample::resize(width, height);
+    update_uniform_buffers();
+    return true;
 }
 
 void HPPHDR::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 {
-	// Enable anisotropic filtering if supported
-	if (gpu.get_features().samplerAnisotropy)
-	{
-		gpu.get_mutable_requested_features().samplerAnisotropy = true;
-	}
+    // Enable anisotropic filtering if supported
+    if (gpu.get_features().samplerAnisotropy)
+    {
+        gpu.get_mutable_requested_features().samplerAnisotropy = true;
+    }
 }
 
 void HPPHDR::build_command_buffers()
 {
-	vk::CommandBufferBeginInfo command_buffer_begin_info;
+    vk::CommandBufferBeginInfo command_buffer_begin_info;
 
-	for (int32_t i = 0; i < draw_cmd_buffers.size(); ++i)
-	{
-		vk::CommandBuffer command_buffer = draw_cmd_buffers[i];
-		command_buffer.begin(command_buffer_begin_info);
+    for (int32_t i = 0; i < draw_cmd_buffers.size(); ++i)
+    {
+        vk::CommandBuffer command_buffer = draw_cmd_buffers[i];
+        command_buffer.begin(command_buffer_begin_info);
 
-		{
-			/*
-			    First pass: Render scene to offscreen framebuffer
-			*/
-			std::array<vk::ClearValue, 3> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
-			                                               vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
-			                                               vk::ClearDepthStencilValue(0.0f, 0)}};
-			vk::RenderPassBeginInfo       render_pass_begin_info(offscreen.render_pass, offscreen.framebuffer, {{0, 0}, offscreen.extent}, clear_values);
-			command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+        {
+            /*
+                First pass: Render scene to offscreen framebuffer
+            */
+            std::array<vk::ClearValue, 3> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
+                                                           vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
+                                                           vk::ClearDepthStencilValue(0.0f, 0)}};
+            vk::RenderPassBeginInfo       render_pass_begin_info(offscreen.render_pass, offscreen.framebuffer, {{0, 0}, offscreen.extent}, clear_values);
+            command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
 
-			vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(offscreen.extent.width), static_cast<float>(offscreen.extent.height), 0.0f, 1.0f);
-			command_buffer.setViewport(0, viewport);
+            vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(offscreen.extent.width), static_cast<float>(offscreen.extent.height), 0.0f, 1.0f);
+            command_buffer.setViewport(0, viewport);
 
-			vk::Rect2D scissor({0, 0}, offscreen.extent);
-			command_buffer.setScissor(0, scissor);
+            vk::Rect2D scissor({0, 0}, offscreen.extent);
+            command_buffer.setScissor(0, scissor);
 
-			// Skybox
-			if (display_skybox)
-			{
-				command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.skybox.pipeline);
-				command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.skybox.descriptor_set, {});
-				draw_model(models.skybox.meshes[0], command_buffer);
-			}
+            // Skybox
+            if (display_skybox)
+            {
+                command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.skybox.pipeline);
+                command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.skybox.descriptor_set, {});
+                draw_model(models.skybox.meshes[0], command_buffer);
+            }
 
-			// 3D object
-			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.objects.pipeline);
-			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.objects.descriptor_set, {});
-			draw_model(models.objects.meshes[models.object_index], command_buffer);
+            // 3D object
+            command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.objects.pipeline);
+            command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.objects.descriptor_set, {});
+            draw_model(models.objects.meshes[models.object_index], command_buffer);
 
-			command_buffer.endRenderPass();
-		}
+            command_buffer.endRenderPass();
+        }
 
-		/*
-		    Second render pass: First bloom pass
-		*/
-		if (bloom.enabled)
-		{
-			// Bloom filter
-			vk::ClearValue          clear_value(vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})));
-			vk::RenderPassBeginInfo render_pass_begin_info(filter_pass.render_pass, filter_pass.framebuffer, {{0, 0}, filter_pass.extent}, clear_value);
-			command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+        /*
+            Second render pass: First bloom pass
+        */
+        if (bloom.enabled)
+        {
+            // Bloom filter
+            vk::ClearValue          clear_value(vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})));
+            vk::RenderPassBeginInfo render_pass_begin_info(filter_pass.render_pass, filter_pass.framebuffer, {{0, 0}, filter_pass.extent}, clear_value);
+            command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
 
-			vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(filter_pass.extent.width), static_cast<float>(filter_pass.extent.height), 0.0f, 1.0f);
-			command_buffer.setViewport(0, viewport);
+            vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(filter_pass.extent.width), static_cast<float>(filter_pass.extent.height), 0.0f, 1.0f);
+            command_buffer.setViewport(0, viewport);
 
-			vk::Rect2D scissor({0, 0}, filter_pass.extent);
-			command_buffer.setScissor(0, scissor);
+            vk::Rect2D scissor({0, 0}, filter_pass.extent);
+            command_buffer.setScissor(0, scissor);
 
-			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, bloom.pipeline_layout, 0, bloom.descriptor_set, {});
-			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[1]);
-			command_buffer.draw(3, 1, 0, 0);
+            command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, bloom.pipeline_layout, 0, bloom.descriptor_set, {});
+            command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[1]);
+            command_buffer.draw(3, 1, 0, 0);
 
-			command_buffer.endRenderPass();
-		}
+            command_buffer.endRenderPass();
+        }
 
-		/*
-		    Note: Explicit synchronization is not required between the render pass, as this is done implicit via sub pass dependencies
-		*/
+        /*
+            Note: Explicit synchronization is not required between the render pass, as this is done implicit via sub pass dependencies
+        */
 
-		/*
-		    Third render pass: Scene rendering with applied second bloom pass (when enabled)
-		*/
-		{
-			// Final composition
-			std::array<vk::ClearValue, 2> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
-			                                               vk::ClearDepthStencilValue(0.0f, 0)}};
-			vk::RenderPassBeginInfo       render_pass_begin_info(render_pass, framebuffers[i], {{0, 0}, extent}, clear_values);
-			command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+        /*
+            Third render pass: Scene rendering with applied second bloom pass (when enabled)
+        */
+        {
+            // Final composition
+            std::array<vk::ClearValue, 2> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
+                                                           vk::ClearDepthStencilValue(0.0f, 0)}};
+            vk::RenderPassBeginInfo       render_pass_begin_info(render_pass, framebuffers[i], {{0, 0}, extent}, clear_values);
+            command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
 
-			vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f);
-			command_buffer.setViewport(0, viewport);
+            vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f);
+            command_buffer.setViewport(0, viewport);
 
-			vk::Rect2D scissor({0, 0}, extent);
-			command_buffer.setScissor(0, scissor);
+            vk::Rect2D scissor({0, 0}, extent);
+            command_buffer.setScissor(0, scissor);
 
-			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, composition.pipeline_layout, 0, composition.descriptor_set, {});
+            command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, composition.pipeline_layout, 0, composition.descriptor_set, {});
 
-			// Scene
-			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, composition.pipeline);
-			command_buffer.draw(3, 1, 0, 0);
+            // Scene
+            command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, composition.pipeline);
+            command_buffer.draw(3, 1, 0, 0);
 
-			// Bloom
-			if (bloom.enabled)
-			{
-				command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[0]);
-				command_buffer.draw(3, 1, 0, 0);
-			}
+            // Bloom
+            if (bloom.enabled)
+            {
+                command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[0]);
+                command_buffer.draw(3, 1, 0, 0);
+            }
 
-			draw_ui(command_buffer);
+            draw_ui(command_buffer);
 
-			command_buffer.endRenderPass();
-		}
+            command_buffer.endRenderPass();
+        }
 
-		command_buffer.end();
-	}
+        command_buffer.end();
+    }
 }
 
 void HPPHDR::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 {
-	if (drawer.header("Settings"))
-	{
-		if (drawer.combo_box("Object type", &models.object_index, object_names))
-		{
-			update_uniform_buffers();
-			build_command_buffers();
-		}
-		if (drawer.input_float("Exposure", &ubo_params.exposure, 0.025f, 3))
-		{
-			update_params();
-		}
-		if (drawer.checkbox("Bloom", &bloom.enabled))
-		{
-			build_command_buffers();
-		}
-		if (drawer.checkbox("Skybox", &display_skybox))
-		{
-			build_command_buffers();
-		}
-	}
+    if (drawer.header("Settings"))
+    {
+        if (drawer.combo_box("Object type", &models.object_index, object_names))
+        {
+            update_uniform_buffers();
+            build_command_buffers();
+        }
+        if (drawer.input_float("Exposure", &ubo_params.exposure, 0.025f, 3))
+        {
+            update_params();
+        }
+        if (drawer.checkbox("Bloom", &bloom.enabled))
+        {
+            build_command_buffers();
+        }
+        if (drawer.checkbox("Skybox", &display_skybox))
+        {
+            build_command_buffers();
+        }
+    }
 }
 
 void HPPHDR::render(float delta_time)
 {
-	if (!prepared)
-	{
-		return;
-	}
-	draw();
-	if (camera.updated)
-	{
-		update_uniform_buffers();
-	}
+    if (!prepared)
+    {
+        return;
+    }
+    draw();
+    if (camera.updated)
+    {
+        update_uniform_buffers();
+    }
 }
 
 vk::DeviceMemory HPPHDR::allocate_memory(vk::Image image)
 {
-	vk::MemoryRequirements memory_requirements = get_device()->get_handle().getImageMemoryRequirements(image);
+    vk::MemoryRequirements memory_requirements = get_device()->get_handle().getImageMemoryRequirements(image);
 
-	vk::MemoryAllocateInfo memory_allocate_info(memory_requirements.size,
-	                                            get_device()->get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
+    vk::MemoryAllocateInfo memory_allocate_info(memory_requirements.size,
+                                                get_device()->get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
 
-	return get_device()->get_handle().allocateMemory(memory_allocate_info);
+    return get_device()->get_handle().allocateMemory(memory_allocate_info);
 }
 
 HPPHDR::FrameBufferAttachment HPPHDR::create_attachment(vk::Format format, vk::ImageUsageFlagBits usage)
 {
-	vk::Image        image  = create_image(format, usage);
-	vk::DeviceMemory memory = allocate_memory(image);
-	get_device()->get_handle().bindImageMemory(image, memory, 0);
-	vk::ImageView view = create_image_view(format, usage, image);
+    vk::Image        image  = create_image(format, usage);
+    vk::DeviceMemory memory = allocate_memory(image);
+    get_device()->get_handle().bindImageMemory(image, memory, 0);
+    vk::ImageView view = create_image_view(format, usage, image);
 
-	return {format, image, memory, view};
+    return {format, image, memory, view};
 }
 
 void HPPHDR::create_bloom_pipelines()
 {
-	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
-	    load_shader("hdr/bloom.vert", vk::ShaderStageFlagBits::eVertex),
-	    load_shader("hdr/bloom.frag", vk::ShaderStageFlagBits::eFragment)};
+    std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
+        load_shader("hdr/bloom.vert", vk::ShaderStageFlagBits::eVertex),
+        load_shader("hdr/bloom.frag", vk::ShaderStageFlagBits::eFragment)};
 
-	// Set constant parameters via specialization constants
-	vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
+    // Set constant parameters via specialization constants
+    vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
 
-	uint32_t               dir = 1;
-	vk::SpecializationInfo specialization_info(1, &specialization_map_entry, sizeof(uint32_t), &dir);
-	shader_stages[1].pSpecializationInfo = &specialization_info;
+    uint32_t               dir = 1;
+    vk::SpecializationInfo specialization_info(1, &specialization_map_entry, sizeof(uint32_t), &dir);
+    shader_stages[1].pSpecializationInfo = &specialization_info;
 
-	vk::PipelineColorBlendAttachmentState blend_attachment_state;
-	blend_attachment_state.blendEnable         = true;
-	blend_attachment_state.colorBlendOp        = vk::BlendOp::eAdd;
-	blend_attachment_state.srcColorBlendFactor = vk::BlendFactor::eOne;
-	blend_attachment_state.dstColorBlendFactor = vk::BlendFactor::eOne;
-	blend_attachment_state.alphaBlendOp        = vk::BlendOp::eAdd;
-	blend_attachment_state.srcAlphaBlendFactor = vk::BlendFactor::eSrcAlpha;
-	blend_attachment_state.dstAlphaBlendFactor = vk::BlendFactor::eDstAlpha;
-	blend_attachment_state.colorWriteMask =
-	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+    vk::PipelineColorBlendAttachmentState blend_attachment_state;
+    blend_attachment_state.blendEnable         = true;
+    blend_attachment_state.colorBlendOp        = vk::BlendOp::eAdd;
+    blend_attachment_state.srcColorBlendFactor = vk::BlendFactor::eOne;
+    blend_attachment_state.dstColorBlendFactor = vk::BlendFactor::eOne;
+    blend_attachment_state.alphaBlendOp        = vk::BlendOp::eAdd;
+    blend_attachment_state.srcAlphaBlendFactor = vk::BlendFactor::eSrcAlpha;
+    blend_attachment_state.dstAlphaBlendFactor = vk::BlendFactor::eDstAlpha;
+    blend_attachment_state.colorWriteMask =
+        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
 
-	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
-	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
-	depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
-	depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
-	depth_stencil_state.front          = depth_stencil_state.back;
+    // Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
+    vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+    depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
+    depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
+    depth_stencil_state.front          = depth_stencil_state.back;
 
-	// Empty vertex input state, full screen triangles are generated by the vertex shader
-	bloom.pipelines[0] = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-	                                                           pipeline_cache,
-	                                                           shader_stages,
-	                                                           {},
-	                                                           vk::PrimitiveTopology::eTriangleList,
-	                                                           vk::CullModeFlagBits::eFront,
-	                                                           {blend_attachment_state},
-	                                                           depth_stencil_state,
-	                                                           bloom.pipeline_layout,
-	                                                           render_pass);
+    // Empty vertex input state, full screen triangles are generated by the vertex shader
+    bloom.pipelines[0] = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+                                                               pipeline_cache,
+                                                               shader_stages,
+                                                               {},
+                                                               vk::PrimitiveTopology::eTriangleList,
+                                                               vk::CullModeFlagBits::eFront,
+                                                               {blend_attachment_state},
+                                                               depth_stencil_state,
+                                                               bloom.pipeline_layout,
+                                                               render_pass);
 
-	dir                = 0;
-	bloom.pipelines[1] = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-	                                                           pipeline_cache,
-	                                                           shader_stages,
-	                                                           {},
-	                                                           vk::PrimitiveTopology::eTriangleList,
-	                                                           vk::CullModeFlagBits::eFront,
-	                                                           {blend_attachment_state},
-	                                                           depth_stencil_state,
-	                                                           bloom.pipeline_layout,
-	                                                           filter_pass.render_pass);
+    dir                = 0;
+    bloom.pipelines[1] = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+                                                               pipeline_cache,
+                                                               shader_stages,
+                                                               {},
+                                                               vk::PrimitiveTopology::eTriangleList,
+                                                               vk::CullModeFlagBits::eFront,
+                                                               {blend_attachment_state},
+                                                               depth_stencil_state,
+                                                               bloom.pipeline_layout,
+                                                               filter_pass.render_pass);
 }
 
 void HPPHDR::create_composition_pipeline()
 {
-	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{load_shader("hdr/composition.vert", vk::ShaderStageFlagBits::eVertex),
-	                                                               load_shader("hdr/composition.frag", vk::ShaderStageFlagBits::eFragment)};
+    std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{load_shader("hdr/composition.vert", vk::ShaderStageFlagBits::eVertex),
+                                                                   load_shader("hdr/composition.frag", vk::ShaderStageFlagBits::eFragment)};
 
-	vk::PipelineColorBlendAttachmentState blend_attachment_state;
-	blend_attachment_state.colorWriteMask =
-	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+    vk::PipelineColorBlendAttachmentState blend_attachment_state;
+    blend_attachment_state.colorWriteMask =
+        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
 
-	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
-	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
-	depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
-	depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
-	depth_stencil_state.front          = depth_stencil_state.back;
+    // Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
+    vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+    depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
+    depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
+    depth_stencil_state.front          = depth_stencil_state.back;
 
-	// Empty vertex input state, full screen triangles are generated by the vertex shader
-	composition.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-	                                                             pipeline_cache,
-	                                                             shader_stages,
-	                                                             {},
-	                                                             vk::PrimitiveTopology::eTriangleList,
-	                                                             vk::CullModeFlagBits::eFront,
-	                                                             {blend_attachment_state},
-	                                                             depth_stencil_state,
-	                                                             composition.pipeline_layout,
-	                                                             render_pass);
+    // Empty vertex input state, full screen triangles are generated by the vertex shader
+    composition.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+                                                                 pipeline_cache,
+                                                                 shader_stages,
+                                                                 {},
+                                                                 vk::PrimitiveTopology::eTriangleList,
+                                                                 vk::CullModeFlagBits::eFront,
+                                                                 {blend_attachment_state},
+                                                                 depth_stencil_state,
+                                                                 composition.pipeline_layout,
+                                                                 render_pass);
 }
 
 vk::Framebuffer HPPHDR::create_framebuffer(vk::RenderPass render_pass, std::vector<vk::ImageView> const &attachments, vk::Extent2D const &extent)
 {
-	vk::FramebufferCreateInfo framebuffer_create_info({}, render_pass, attachments, extent.width, extent.height, 1);
+    vk::FramebufferCreateInfo framebuffer_create_info({}, render_pass, attachments, extent.width, extent.height, 1);
 
-	return get_device()->get_handle().createFramebuffer(framebuffer_create_info);
+    return get_device()->get_handle().createFramebuffer(framebuffer_create_info);
 }
 
 vk::Image HPPHDR::create_image(vk::Format format, vk::ImageUsageFlagBits usage)
 {
-	vk::ImageCreateInfo image_create_info;
-	image_create_info.imageType   = vk::ImageType::e2D;
-	image_create_info.format      = format;
-	image_create_info.extent      = vk::Extent3D(offscreen.extent, 1);
-	image_create_info.mipLevels   = 1;
-	image_create_info.arrayLayers = 1;
-	image_create_info.samples     = vk::SampleCountFlagBits::e1;
-	image_create_info.tiling      = vk::ImageTiling::eOptimal;
-	image_create_info.usage       = usage | vk::ImageUsageFlagBits::eSampled;
+    vk::ImageCreateInfo image_create_info;
+    image_create_info.imageType   = vk::ImageType::e2D;
+    image_create_info.format      = format;
+    image_create_info.extent      = vk::Extent3D(offscreen.extent, 1);
+    image_create_info.mipLevels   = 1;
+    image_create_info.arrayLayers = 1;
+    image_create_info.samples     = vk::SampleCountFlagBits::e1;
+    image_create_info.tiling      = vk::ImageTiling::eOptimal;
+    image_create_info.usage       = usage | vk::ImageUsageFlagBits::eSampled;
 
-	return get_device()->get_handle().createImage(image_create_info);
+    return get_device()->get_handle().createImage(image_create_info);
 }
 
 vk::ImageView HPPHDR::create_image_view(vk::Format format, vk::ImageUsageFlagBits usage, vk::Image image)
 {
-	vk::ImageAspectFlags aspect_mask = vkb::common::get_image_aspect_flags(usage, format);
+    vk::ImageAspectFlags aspect_mask = vkb::common::get_image_aspect_flags(usage, format);
 
-	vk::ImageViewCreateInfo image_view_create_info({}, image, vk::ImageViewType::e2D, format, {}, {aspect_mask, 0, 1, 0, 1});
+    vk::ImageViewCreateInfo image_view_create_info({}, image, vk::ImageViewType::e2D, format, {}, {aspect_mask, 0, 1, 0, 1});
 
-	return get_device()->get_handle().createImageView(image_view_create_info);
+    return get_device()->get_handle().createImageView(image_view_create_info);
 }
 
 void HPPHDR::create_models_pipelines()
 {
-	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
-	    load_shader("hdr/gbuffer.vert", vk::ShaderStageFlagBits::eVertex),
-	    load_shader("hdr/gbuffer.frag", vk::ShaderStageFlagBits::eFragment)};
+    std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
+        load_shader("hdr/gbuffer.vert", vk::ShaderStageFlagBits::eVertex),
+        load_shader("hdr/gbuffer.frag", vk::ShaderStageFlagBits::eFragment)};
 
-	// Set constant parameters via specialization constants
-	vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
+    // Set constant parameters via specialization constants
+    vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
 
-	// Set constant parameters via specialization constants
-	uint32_t               shadertype          = 0;
-	vk::SpecializationInfo specialization_info = vk::SpecializationInfo(1, &specialization_map_entry, sizeof(uint32_t), &shadertype);
-	shader_stages[0].pSpecializationInfo       = &specialization_info;
-	shader_stages[1].pSpecializationInfo       = &specialization_info;
+    // Set constant parameters via specialization constants
+    uint32_t               shadertype          = 0;
+    vk::SpecializationInfo specialization_info = vk::SpecializationInfo(1, &specialization_map_entry, sizeof(uint32_t), &shadertype);
+    shader_stages[0].pSpecializationInfo       = &specialization_info;
+    shader_stages[1].pSpecializationInfo       = &specialization_info;
 
-	// Vertex bindings an attributes for model rendering
-	// Binding description
-	vk::VertexInputBindingDescription vertex_input_binding(0, sizeof(HPPVertex), vk::VertexInputRate::eVertex);
+    // Vertex bindings an attributes for model rendering
+    // Binding description
+    vk::VertexInputBindingDescription vertex_input_binding(0, sizeof(HPPVertex), vk::VertexInputRate::eVertex);
 
-	// Attribute descriptions
-	std::vector<vk::VertexInputAttributeDescription> vertex_input_attributes = {{0, 0, vk::Format::eR32G32B32Sfloat, 0},
-	                                                                            {1, 0, vk::Format::eR32G32B32Sfloat, 3 * sizeof(float)}};
+    // Attribute descriptions
+    std::vector<vk::VertexInputAttributeDescription> vertex_input_attributes = {{0, 0, vk::Format::eR32G32B32Sfloat, 0},
+                                                                                {1, 0, vk::Format::eR32G32B32Sfloat, 3 * sizeof(float)}};
 
-	vk::PipelineVertexInputStateCreateInfo vertex_input_state({}, vertex_input_binding, vertex_input_attributes);
+    vk::PipelineVertexInputStateCreateInfo vertex_input_state({}, vertex_input_binding, vertex_input_attributes);
 
-	std::vector<vk::PipelineColorBlendAttachmentState> blend_attachment_states(2);
-	blend_attachment_states[0].colorWriteMask =
-	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
-	blend_attachment_states[1].colorWriteMask = blend_attachment_states[0].colorWriteMask;
+    std::vector<vk::PipelineColorBlendAttachmentState> blend_attachment_states(2);
+    blend_attachment_states[0].colorWriteMask =
+        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+    blend_attachment_states[1].colorWriteMask = blend_attachment_states[0].colorWriteMask;
 
-	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
-	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
-	depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
-	depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
-	depth_stencil_state.front          = depth_stencil_state.back;
+    // Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
+    vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+    depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
+    depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
+    depth_stencil_state.front          = depth_stencil_state.back;
 
-	models.skybox.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-	                                                               pipeline_cache,
-	                                                               shader_stages,
-	                                                               vertex_input_state,
-	                                                               vk::PrimitiveTopology::eTriangleList,
-	                                                               vk::CullModeFlagBits::eBack,
-	                                                               blend_attachment_states,
-	                                                               depth_stencil_state,
-	                                                               models.pipeline_layout,
-	                                                               offscreen.render_pass);
+    models.skybox.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+                                                                   pipeline_cache,
+                                                                   shader_stages,
+                                                                   vertex_input_state,
+                                                                   vk::PrimitiveTopology::eTriangleList,
+                                                                   vk::CullModeFlagBits::eBack,
+                                                                   blend_attachment_states,
+                                                                   depth_stencil_state,
+                                                                   models.pipeline_layout,
+                                                                   offscreen.render_pass);
 
-	// Object rendering pipeline
-	shadertype = 1;
+    // Object rendering pipeline
+    shadertype = 1;
 
-	// Enable depth test and write
-	depth_stencil_state.depthWriteEnable = true;
-	depth_stencil_state.depthTestEnable  = true;
+    // Enable depth test and write
+    depth_stencil_state.depthWriteEnable = true;
+    depth_stencil_state.depthTestEnable  = true;
 
-	// Flip cull mode
-	models.objects.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-	                                                                pipeline_cache,
-	                                                                shader_stages,
-	                                                                vertex_input_state,
-	                                                                vk::PrimitiveTopology::eTriangleList,
-	                                                                vk::CullModeFlagBits::eFront,
-	                                                                blend_attachment_states,
-	                                                                depth_stencil_state,
-	                                                                models.pipeline_layout,
-	                                                                offscreen.render_pass);
+    // Flip cull mode
+    models.objects.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+                                                                    pipeline_cache,
+                                                                    shader_stages,
+                                                                    vertex_input_state,
+                                                                    vk::PrimitiveTopology::eTriangleList,
+                                                                    vk::CullModeFlagBits::eFront,
+                                                                    blend_attachment_states,
+                                                                    depth_stencil_state,
+                                                                    models.pipeline_layout,
+                                                                    offscreen.render_pass);
 }
 
 vk::RenderPass HPPHDR::create_render_pass(std::vector<vk::AttachmentDescription> const &attachment_descriptions, vk::SubpassDescription const &subpass_description)
 {
-	// Use subpass dependencies for attachment layput transitions
-	std::array<vk::SubpassDependency, 2> subpass_dependencies;
+    // Use subpass dependencies for attachment layput transitions
+    std::array<vk::SubpassDependency, 2> subpass_dependencies;
 
-	subpass_dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
-	subpass_dependencies[0].dstSubpass      = 0;
-	subpass_dependencies[0].srcStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
-	subpass_dependencies[0].dstStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-	subpass_dependencies[0].srcAccessMask   = vk::AccessFlagBits::eMemoryRead;
-	subpass_dependencies[0].dstAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
-	subpass_dependencies[0].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+    subpass_dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+    subpass_dependencies[0].dstSubpass = 0;
+    // End of previous commands
+    subpass_dependencies[0].srcStageMask  = vk::PipelineStageFlagBits::eBottomOfPipe;
+    subpass_dependencies[0].srcAccessMask = vk::AccessFlagBits::eNoneKHR;
+    // Read/write from/to depth
+    subpass_dependencies[0].dstStageMask  = vk::PipelineStageFlagBits::eEarlyFragmentTests;
+    subpass_dependencies[0].dstAccessMask = vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
+    // Write to attachment
+    subpass_dependencies[0].dstStageMask |= vk::PipelineStageFlagBits::eColorAttachmentOutput;
+    subpass_dependencies[0].dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
 
-	subpass_dependencies[1].srcSubpass      = 0;
-	subpass_dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
-	subpass_dependencies[1].srcStageMask    = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-	subpass_dependencies[1].dstStageMask    = vk::PipelineStageFlagBits::eBottomOfPipe;
-	subpass_dependencies[1].srcAccessMask   = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
-	subpass_dependencies[1].dstAccessMask   = vk::AccessFlagBits::eMemoryRead;
-	subpass_dependencies[1].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+    subpass_dependencies[1].srcSubpass = 0;
+    subpass_dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+    // End of write to attachment
+    subpass_dependencies[1].srcStageMask  = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+    subpass_dependencies[1].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
+    // Attachment later read using sampler in 'bloom[0]' pipeline
+    subpass_dependencies[1].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
+    subpass_dependencies[1].dstAccessMask = vk::AccessFlagBits::eShaderRead;
 
-	vk::RenderPassCreateInfo render_pass_create_info({}, attachment_descriptions, subpass_description, subpass_dependencies);
+    vk::RenderPassCreateInfo render_pass_create_info({}, attachment_descriptions, subpass_description, subpass_dependencies);
 
-	return get_device()->get_handle().createRenderPass(render_pass_create_info);
+    return get_device()->get_handle().createRenderPass(render_pass_create_info);
 }
 
 vk::Sampler HPPHDR::create_sampler()
 {
-	vk::SamplerCreateInfo sampler_create_info;
-	sampler_create_info.magFilter     = vk::Filter::eNearest;
-	sampler_create_info.minFilter     = vk::Filter::eNearest;
-	sampler_create_info.mipmapMode    = vk::SamplerMipmapMode::eLinear;
-	sampler_create_info.addressModeU  = vk::SamplerAddressMode::eClampToEdge;
-	sampler_create_info.addressModeV  = sampler_create_info.addressModeU;
-	sampler_create_info.addressModeW  = sampler_create_info.addressModeU;
-	sampler_create_info.mipLodBias    = 0.0f;
-	sampler_create_info.maxAnisotropy = 1.0f;
-	sampler_create_info.minLod        = 0.0f;
-	sampler_create_info.maxLod        = 1.0f;
-	sampler_create_info.borderColor   = vk::BorderColor::eFloatOpaqueWhite;
+    vk::SamplerCreateInfo sampler_create_info;
+    sampler_create_info.magFilter     = vk::Filter::eNearest;
+    sampler_create_info.minFilter     = vk::Filter::eNearest;
+    sampler_create_info.mipmapMode    = vk::SamplerMipmapMode::eLinear;
+    sampler_create_info.addressModeU  = vk::SamplerAddressMode::eClampToEdge;
+    sampler_create_info.addressModeV  = sampler_create_info.addressModeU;
+    sampler_create_info.addressModeW  = sampler_create_info.addressModeU;
+    sampler_create_info.mipLodBias    = 0.0f;
+    sampler_create_info.maxAnisotropy = 1.0f;
+    sampler_create_info.minLod        = 0.0f;
+    sampler_create_info.maxLod        = 1.0f;
+    sampler_create_info.borderColor   = vk::BorderColor::eFloatOpaqueWhite;
 
-	return get_device()->get_handle().createSampler(sampler_create_info);
+    return get_device()->get_handle().createSampler(sampler_create_info);
 }
 
 void HPPHDR::draw()
 {
-	HPPApiVulkanSample::prepare_frame();
+    HPPApiVulkanSample::prepare_frame();
 
-	submit_info.setCommandBuffers(draw_cmd_buffers[current_buffer]);
-	queue.submit(submit_info);
+    submit_info.setCommandBuffers(draw_cmd_buffers[current_buffer]);
+    queue.submit(submit_info);
 
-	HPPApiVulkanSample::submit_frame();
+    HPPApiVulkanSample::submit_frame();
 }
 
 void HPPHDR::load_assets()
 {
-	// Models
-	models.skybox.meshes.emplace_back(load_model("scenes/cube.gltf"));
-	std::vector<std::string> filenames = {"geosphere.gltf", "teapot.gltf", "torusknot.gltf"};
-	object_names                       = {"Sphere", "Teapot", "Torusknot"};
-	for (auto file : filenames)
-	{
-		models.objects.meshes.emplace_back(load_model("scenes/" + file));
-	}
+    // Models
+    models.skybox.meshes.emplace_back(load_model("scenes/cube.gltf"));
+    std::vector<std::string> filenames = {"geosphere.gltf", "teapot.gltf", "torusknot.gltf"};
+    object_names                       = {"Sphere", "Teapot", "Torusknot"};
+    for (auto file : filenames)
+    {
+        models.objects.meshes.emplace_back(load_model("scenes/" + file));
+    }
 
-	// Transforms
-	auto geosphere_matrix = glm::mat4(1.0f);
-	models.transforms.push_back(geosphere_matrix);
+    // Transforms
+    auto geosphere_matrix = glm::mat4(1.0f);
+    models.transforms.push_back(geosphere_matrix);
 
-	auto teapot_matrix = glm::mat4(1.0f);
-	teapot_matrix      = glm::scale(teapot_matrix, glm::vec3(10.0f, 10.0f, 10.0f));
-	teapot_matrix      = glm::rotate(teapot_matrix, glm::radians(180.0f), glm::vec3(1.0f, 0.0f, 0.0f));
-	models.transforms.push_back(teapot_matrix);
+    auto teapot_matrix = glm::mat4(1.0f);
+    teapot_matrix      = glm::scale(teapot_matrix, glm::vec3(10.0f, 10.0f, 10.0f));
+    teapot_matrix      = glm::rotate(teapot_matrix, glm::radians(180.0f), glm::vec3(1.0f, 0.0f, 0.0f));
+    models.transforms.push_back(teapot_matrix);
 
-	auto torus_matrix = glm::mat4(1.0f);
-	models.transforms.push_back(torus_matrix);
+    auto torus_matrix = glm::mat4(1.0f);
+    models.transforms.push_back(torus_matrix);
 
-	// Load HDR cube map
-	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::sg::Image::Color);
+    // Load HDR cube map
+    textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::sg::Image::Color);
 }
 
 void HPPHDR::prepare_camera()
 {
-	camera.type = vkb::CameraType::LookAt;
-	camera.set_position(glm::vec3(0.0f, 0.0f, -4.0f));
-	camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
+    camera.type = vkb::CameraType::LookAt;
+    camera.set_position(glm::vec3(0.0f, 0.0f, -4.0f));
+    camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
 
-	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
-	camera.set_perspective(60.0f, static_cast<float>(extent.width) / static_cast<float>(extent.height), 256.0f, 0.1f);
+    // Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
+    camera.set_perspective(60.0f, static_cast<float>(extent.width) / static_cast<float>(extent.height), 256.0f, 0.1f);
 }
 
 // Prepare a new framebuffer and attachments for offscreen rendering (G-Buffer)
 void HPPHDR::prepare_offscreen_buffer()
 {
-	// We need to select a format that supports the color attachment blending flag, so we iterate over multiple formats to find one that supports this flag
-	const std::vector<vk::Format> float_format_priority_list = {vk::Format::eR32G32B32A32Sfloat, vk::Format::eR16G16B16A16Sfloat};
+    // We need to select a format that supports the color attachment blending flag, so we iterate over multiple formats to find one that supports this flag
+    const std::vector<vk::Format> float_format_priority_list = {vk::Format::eR32G32B32A32Sfloat, vk::Format::eR16G16B16A16Sfloat};
 
-	auto formatIt = std::find_if(float_format_priority_list.begin(),
-	                             float_format_priority_list.end(),
-	                             [this](vk::Format format) {
-		                             const vk::FormatProperties properties = get_device()->get_gpu().get_handle().getFormatProperties(format);
-		                             return properties.optimalTilingFeatures & vk::FormatFeatureFlagBits::eColorAttachmentBlend;
-	                             });
-	if (formatIt == float_format_priority_list.end())
-	{
-		throw std::runtime_error("No suitable float format could be determined");
-	}
+    auto formatIt = std::find_if(float_format_priority_list.begin(),
+                                 float_format_priority_list.end(),
+                                 [this](vk::Format format) {
+                                     const vk::FormatProperties properties = get_device()->get_gpu().get_handle().getFormatProperties(format);
+                                     return properties.optimalTilingFeatures & vk::FormatFeatureFlagBits::eColorAttachmentBlend;
+                                 });
+    if (formatIt == float_format_priority_list.end())
+    {
+        throw std::runtime_error("No suitable float format could be determined");
+    }
 
-	vk::Format color_format = *formatIt;
+    vk::Format color_format = *formatIt;
 
-	{
-		offscreen.extent = extent;
+    {
+        offscreen.extent = extent;
 
-		// Color attachments
+        // Color attachments
 
-		// We are using two 128-Bit RGBA floating point color buffers for this sample
-		// In a performance or bandwith-limited scenario you should consider using a format with lower precision
-		offscreen.color[0] = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
-		offscreen.color[1] = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
-		// Depth attachment
-		offscreen.depth = create_attachment(depth_format, vk::ImageUsageFlagBits::eDepthStencilAttachment);
+        // We are using two 128-Bit RGBA floating point color buffers for this sample
+        // In a performance or bandwith-limited scenario you should consider using a format with lower precision
+        offscreen.color[0] = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
+        offscreen.color[1] = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
+        // Depth attachment
+        offscreen.depth = create_attachment(depth_format, vk::ImageUsageFlagBits::eDepthStencilAttachment);
 
-		// Set up separate renderpass with references to the colorand depth attachments
-		std::vector<vk::AttachmentDescription> attachment_descriptions(3);
+        // Set up separate renderpass with references to the colorand depth attachments
+        std::vector<vk::AttachmentDescription> attachment_descriptions(3);
 
-		// Init attachment properties
-		for (uint32_t i = 0; i < 3; ++i)
-		{
-			attachment_descriptions[i].samples        = vk::SampleCountFlagBits::e1;
-			attachment_descriptions[i].loadOp         = vk::AttachmentLoadOp::eClear;
-			attachment_descriptions[i].storeOp        = vk::AttachmentStoreOp::eStore;
-			attachment_descriptions[i].stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
-			attachment_descriptions[i].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
-			attachment_descriptions[i].initialLayout  = vk::ImageLayout::eUndefined;
-			attachment_descriptions[i].finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
-		}
-		attachment_descriptions[2].finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
+        // Init attachment properties
+        for (uint32_t i = 0; i < 3; ++i)
+        {
+            attachment_descriptions[i].samples        = vk::SampleCountFlagBits::e1;
+            attachment_descriptions[i].loadOp         = vk::AttachmentLoadOp::eClear;
+            attachment_descriptions[i].storeOp        = vk::AttachmentStoreOp::eStore;
+            attachment_descriptions[i].stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
+            attachment_descriptions[i].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+            attachment_descriptions[i].initialLayout  = vk::ImageLayout::eUndefined;
+            attachment_descriptions[i].finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
+        }
+        attachment_descriptions[2].finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
 
-		// Formats
-		attachment_descriptions[0].format = offscreen.color[0].format;
-		attachment_descriptions[1].format = offscreen.color[1].format;
-		attachment_descriptions[2].format = offscreen.depth.format;
+        // Formats
+        attachment_descriptions[0].format = offscreen.color[0].format;
+        attachment_descriptions[1].format = offscreen.color[1].format;
+        attachment_descriptions[2].format = offscreen.depth.format;
 
-		std::array<vk::AttachmentReference, 2> color_references{{{0, vk::ImageLayout::eColorAttachmentOptimal},
-		                                                         {1, vk::ImageLayout::eColorAttachmentOptimal}}};
+        std::array<vk::AttachmentReference, 2> color_references{{{0, vk::ImageLayout::eColorAttachmentOptimal},
+                                                                 {1, vk::ImageLayout::eColorAttachmentOptimal}}};
 
-		vk::AttachmentReference depth_reference(2, vk::ImageLayout::eDepthStencilAttachmentOptimal);
+        vk::AttachmentReference depth_reference(2, vk::ImageLayout::eDepthStencilAttachmentOptimal);
 
-		vk::SubpassDescription subpass({}, vk::PipelineBindPoint::eGraphics, nullptr, color_references, nullptr, &depth_reference);
+        vk::SubpassDescription subpass({}, vk::PipelineBindPoint::eGraphics, nullptr, color_references, nullptr, &depth_reference);
 
-		offscreen.render_pass = create_render_pass(attachment_descriptions, subpass);
+        offscreen.render_pass = create_render_pass(attachment_descriptions, subpass);
 
-		std::vector<vk::ImageView> attachments = {offscreen.color[0].view, offscreen.color[1].view, offscreen.depth.view};
-		offscreen.framebuffer                  = create_framebuffer(offscreen.render_pass, attachments, offscreen.extent);
+        std::vector<vk::ImageView> attachments = {offscreen.color[0].view, offscreen.color[1].view, offscreen.depth.view};
+        offscreen.framebuffer                  = create_framebuffer(offscreen.render_pass, attachments, offscreen.extent);
 
-		// Create sampler to sample from the color attachments
-		offscreen.sampler = create_sampler();
-	}
+        // Create sampler to sample from the color attachments
+        offscreen.sampler = create_sampler();
+    }
 
-	// Bloom separable filter pass
-	{
-		filter_pass.extent = extent;
+    // Bloom separable filter pass
+    {
+        filter_pass.extent = extent;
 
-		// Color attachments
+        // Color attachments
 
-		// Floating point color attachment
-		filter_pass.color = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
+        // Floating point color attachment
+        filter_pass.color = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
 
-		// Set up separate renderpass with references to the color and depth attachments
-		vk::AttachmentDescription attachment_description;
-		attachment_description.samples        = vk::SampleCountFlagBits::e1;
-		attachment_description.loadOp         = vk::AttachmentLoadOp::eClear;
-		attachment_description.storeOp        = vk::AttachmentStoreOp::eStore;
-		attachment_description.stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
-		attachment_description.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
-		attachment_description.initialLayout  = vk::ImageLayout::eUndefined;
-		attachment_description.finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
-		attachment_description.format         = filter_pass.color.format;
+        // Set up separate renderpass with references to the color and depth attachments
+        vk::AttachmentDescription attachment_description;
+        attachment_description.samples        = vk::SampleCountFlagBits::e1;
+        attachment_description.loadOp         = vk::AttachmentLoadOp::eClear;
+        attachment_description.storeOp        = vk::AttachmentStoreOp::eStore;
+        attachment_description.stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
+        attachment_description.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+        attachment_description.initialLayout  = vk::ImageLayout::eUndefined;
+        attachment_description.finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
+        attachment_description.format         = filter_pass.color.format;
 
-		vk::AttachmentReference color_reference(0, vk::ImageLayout::eColorAttachmentOptimal);
-		vk::SubpassDescription  subpass({}, vk::PipelineBindPoint::eGraphics, {}, color_reference);
+        vk::AttachmentReference color_reference(0, vk::ImageLayout::eColorAttachmentOptimal);
+        vk::SubpassDescription  subpass({}, vk::PipelineBindPoint::eGraphics, {}, color_reference);
 
-		filter_pass.render_pass = create_render_pass({attachment_description}, subpass);
-		filter_pass.framebuffer = create_framebuffer(filter_pass.render_pass, {filter_pass.color.view}, filter_pass.extent);
-		filter_pass.sampler     = create_sampler();
-	}
+        filter_pass.render_pass = create_render_pass({attachment_description}, subpass);
+        filter_pass.framebuffer = create_framebuffer(filter_pass.render_pass, {filter_pass.color.view}, filter_pass.extent);
+        filter_pass.sampler     = create_sampler();
+    }
 }
 
 // Prepare and initialize uniform buffer containing shader uniforms
 void HPPHDR::prepare_uniform_buffers()
 {
-	// Matrices vertex shader uniform buffer
-	uniform_buffers.matrices = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
-	                                                                  sizeof(ubo_matrices),
-	                                                                  vk::BufferUsageFlagBits::eUniformBuffer,
-	                                                                  VMA_MEMORY_USAGE_CPU_TO_GPU);
+    // Matrices vertex shader uniform buffer
+    uniform_buffers.matrices = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
+                                                                      sizeof(ubo_matrices),
+                                                                      vk::BufferUsageFlagBits::eUniformBuffer,
+                                                                      VMA_MEMORY_USAGE_CPU_TO_GPU);
 
-	// Params
-	uniform_buffers.params = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
-	                                                                sizeof(ubo_params),
-	                                                                vk::BufferUsageFlagBits::eUniformBuffer,
-	                                                                VMA_MEMORY_USAGE_CPU_TO_GPU);
+    // Params
+    uniform_buffers.params = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
+                                                                    sizeof(ubo_params),
+                                                                    vk::BufferUsageFlagBits::eUniformBuffer,
+                                                                    VMA_MEMORY_USAGE_CPU_TO_GPU);
 
-	update_uniform_buffers();
-	update_params();
+    update_uniform_buffers();
+    update_params();
 }
 
 void HPPHDR::setup_bloom()
 {
-	std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-	                                                        {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}};
+    std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+                                                            {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}};
 
-	vk::Device device           = get_device()->get_handle();
-	bloom.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
-	bloom.pipeline_layout       = vkb::common::create_pipeline_layout(device, bloom.descriptor_set_layout);
-	create_bloom_pipelines();
-	bloom.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, bloom.descriptor_set_layout);
-	update_bloom_descriptor_set();
+    vk::Device device           = get_device()->get_handle();
+    bloom.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
+    bloom.pipeline_layout       = vkb::common::create_pipeline_layout(device, bloom.descriptor_set_layout);
+    create_bloom_pipelines();
+    bloom.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, bloom.descriptor_set_layout);
+    update_bloom_descriptor_set();
 }
 
 void HPPHDR::setup_composition()
 {
-	std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-	                                                        {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}};
+    std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+                                                            {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}};
 
-	vk::Device device                 = get_device()->get_handle();
-	composition.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
-	composition.pipeline_layout       = vkb::common::create_pipeline_layout(device, composition.descriptor_set_layout);
-	create_composition_pipeline();
-	composition.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, composition.descriptor_set_layout);
-	update_composition_descriptor_set();
+    vk::Device device                 = get_device()->get_handle();
+    composition.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
+    composition.pipeline_layout       = vkb::common::create_pipeline_layout(device, composition.descriptor_set_layout);
+    create_composition_pipeline();
+    composition.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, composition.descriptor_set_layout);
+    update_composition_descriptor_set();
 }
 
 void HPPHDR::setup_models()
 {
-	std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex},
-	                                                        {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-	                                                        {2, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment}};
+    std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex},
+                                                            {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+                                                            {2, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment}};
 
-	vk::Device device            = get_device()->get_handle();
-	models.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
-	models.pipeline_layout       = vkb::common::create_pipeline_layout(device, models.descriptor_set_layout);
-	create_models_pipelines();
+    vk::Device device            = get_device()->get_handle();
+    models.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
+    models.pipeline_layout       = vkb::common::create_pipeline_layout(device, models.descriptor_set_layout);
+    create_models_pipelines();
 
-	// Objects descriptor set
-	models.objects.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
-	update_model_descriptor_set(models.objects.descriptor_set);
+    // Objects descriptor set
+    models.objects.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
+    update_model_descriptor_set(models.objects.descriptor_set);
 
-	// Sky box descriptor set
-	models.skybox.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
-	update_model_descriptor_set(models.skybox.descriptor_set);
+    // Sky box descriptor set
+    models.skybox.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
+    update_model_descriptor_set(models.skybox.descriptor_set);
 }
 
 void HPPHDR::update_composition_descriptor_set()
 {
-	std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
-	                                                             {offscreen.sampler, filter_pass.color.view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
+    std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
+                                                                 {offscreen.sampler, filter_pass.color.view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
 
-	std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
-	    {{composition.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
-	     {composition.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
+    std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
+        {{composition.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
+         {composition.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
 
-	get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
+    get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
 }
 
 void HPPHDR::update_bloom_descriptor_set()
 {
-	std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
-	                                                             {offscreen.sampler, offscreen.color[1].view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
+    std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
+                                                                 {offscreen.sampler, offscreen.color[1].view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
 
-	std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
-	    {{bloom.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
-	     {bloom.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
+    std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
+        {{bloom.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
+         {bloom.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
 
-	get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
+    get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
 }
 
 void HPPHDR::update_model_descriptor_set(vk::DescriptorSet descriptor_set)
 {
-	vk::DescriptorBufferInfo matrix_buffer_descriptor(uniform_buffers.matrices->get_handle(), 0, VK_WHOLE_SIZE);
+    vk::DescriptorBufferInfo matrix_buffer_descriptor(uniform_buffers.matrices->get_handle(), 0, VK_WHOLE_SIZE);
 
-	vk::DescriptorImageInfo environment_image_descriptor(
-	    textures.envmap.sampler,
-	    textures.envmap.image->get_vk_image_view().get_handle(),
-	    descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.envmap.image->get_vk_image_view().get_format()));
+    vk::DescriptorImageInfo environment_image_descriptor(
+        textures.envmap.sampler,
+        textures.envmap.image->get_vk_image_view().get_handle(),
+        descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.envmap.image->get_vk_image_view().get_format()));
 
-	vk::DescriptorBufferInfo params_buffer_descriptor(uniform_buffers.params->get_handle(), 0, VK_WHOLE_SIZE);
+    vk::DescriptorBufferInfo params_buffer_descriptor(uniform_buffers.params->get_handle(), 0, VK_WHOLE_SIZE);
 
-	std::array<vk::WriteDescriptorSet, 3> write_descriptor_sets = {
-	    {{descriptor_set, 0, 0, vk::DescriptorType::eUniformBuffer, {}, matrix_buffer_descriptor},
-	     {descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, environment_image_descriptor},
-	     {descriptor_set, 2, 0, vk::DescriptorType::eUniformBuffer, {}, params_buffer_descriptor}}};
+    std::array<vk::WriteDescriptorSet, 3> write_descriptor_sets = {
+        {{descriptor_set, 0, 0, vk::DescriptorType::eUniformBuffer, {}, matrix_buffer_descriptor},
+         {descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, environment_image_descriptor},
+         {descriptor_set, 2, 0, vk::DescriptorType::eUniformBuffer, {}, params_buffer_descriptor}}};
 
-	get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
+    get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
 }
 
 void HPPHDR::update_params()
 {
-	uniform_buffers.params->convert_and_update(ubo_params);
+    uniform_buffers.params->convert_and_update(ubo_params);
 }
 
 void HPPHDR::update_uniform_buffers()
 {
-	ubo_matrices.projection       = camera.matrices.perspective;
-	ubo_matrices.modelview        = camera.matrices.view * models.transforms[models.object_index];
-	ubo_matrices.skybox_modelview = camera.matrices.view;
-	uniform_buffers.matrices->convert_and_update(ubo_matrices);
+    ubo_matrices.projection       = camera.matrices.perspective;
+    ubo_matrices.modelview        = camera.matrices.view * models.transforms[models.object_index];
+    ubo_matrices.skybox_modelview = camera.matrices.view;
+    uniform_buffers.matrices->convert_and_update(ubo_matrices);
 }
 
 std::unique_ptr<vkb::Application> create_hpp_hdr()
 {
-	return std::make_unique<HPPHDR>();
+    return std::make_unique<HPPHDR>();
 }

--- a/samples/api/hpp_hdr/hpp_hdr.cpp
+++ b/samples/api/hpp_hdr/hpp_hdr.cpp
@@ -23,722 +23,722 @@
 
 HPPHDR::HPPHDR()
 {
-    title = "HPP High dynamic range rendering";
+	title = "HPP High dynamic range rendering";
 }
 
 HPPHDR::~HPPHDR()
 {
-    if (get_device() && get_device()->get_handle())
-    {
-        vk::Device device = get_device()->get_handle();
+	if (get_device() && get_device()->get_handle())
+	{
+		vk::Device device = get_device()->get_handle();
 
-        bloom.destroy(device, descriptor_pool);
-        composition.destroy(device, descriptor_pool);
-        filter_pass.destroy(device);
-        models.destroy(device, descriptor_pool);
-        offscreen.destroy(device);
-        textures.destroy(device);
-    }
+		bloom.destroy(device, descriptor_pool);
+		composition.destroy(device, descriptor_pool);
+		filter_pass.destroy(device);
+		models.destroy(device, descriptor_pool);
+		offscreen.destroy(device);
+		textures.destroy(device);
+	}
 }
 
 bool HPPHDR::prepare(vkb::platform::HPPPlatform &platform)
 {
-    if (!HPPApiVulkanSample::prepare(platform))
-    {
-        return false;
-    }
+	if (!HPPApiVulkanSample::prepare(platform))
+	{
+		return false;
+	}
 
-    prepare_camera();
-    load_assets();
-    prepare_uniform_buffers();
-    prepare_offscreen_buffer();
+	prepare_camera();
+	load_assets();
+	prepare_uniform_buffers();
+	prepare_offscreen_buffer();
 
-    std::vector<vk::DescriptorPoolSize> pool_sizes = {{vk::DescriptorType::eUniformBuffer, 4}, {vk::DescriptorType::eCombinedImageSampler, 6}};
-    descriptor_pool                                = vkb::common::create_descriptor_pool(get_device()->get_handle(), 4, pool_sizes);
+	std::vector<vk::DescriptorPoolSize> pool_sizes = {{vk::DescriptorType::eUniformBuffer, 4}, {vk::DescriptorType::eCombinedImageSampler, 6}};
+	descriptor_pool                                = vkb::common::create_descriptor_pool(get_device()->get_handle(), 4, pool_sizes);
 
-    setup_bloom();
-    setup_composition();
-    setup_models();
-    build_command_buffers();
-    prepared = true;
-    return true;
+	setup_bloom();
+	setup_composition();
+	setup_models();
+	build_command_buffers();
+	prepared = true;
+	return true;
 }
 
 bool HPPHDR::resize(const uint32_t width, const uint32_t height)
 {
-    HPPApiVulkanSample::resize(width, height);
-    update_uniform_buffers();
-    return true;
+	HPPApiVulkanSample::resize(width, height);
+	update_uniform_buffers();
+	return true;
 }
 
 void HPPHDR::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 {
-    // Enable anisotropic filtering if supported
-    if (gpu.get_features().samplerAnisotropy)
-    {
-        gpu.get_mutable_requested_features().samplerAnisotropy = true;
-    }
+	// Enable anisotropic filtering if supported
+	if (gpu.get_features().samplerAnisotropy)
+	{
+		gpu.get_mutable_requested_features().samplerAnisotropy = true;
+	}
 }
 
 void HPPHDR::build_command_buffers()
 {
-    vk::CommandBufferBeginInfo command_buffer_begin_info;
+	vk::CommandBufferBeginInfo command_buffer_begin_info;
 
-    for (int32_t i = 0; i < draw_cmd_buffers.size(); ++i)
-    {
-        vk::CommandBuffer command_buffer = draw_cmd_buffers[i];
-        command_buffer.begin(command_buffer_begin_info);
+	for (int32_t i = 0; i < draw_cmd_buffers.size(); ++i)
+	{
+		vk::CommandBuffer command_buffer = draw_cmd_buffers[i];
+		command_buffer.begin(command_buffer_begin_info);
 
-        {
-            /*
-                First pass: Render scene to offscreen framebuffer
-            */
-            std::array<vk::ClearValue, 3> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
-                                                           vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
-                                                           vk::ClearDepthStencilValue(0.0f, 0)}};
-            vk::RenderPassBeginInfo       render_pass_begin_info(offscreen.render_pass, offscreen.framebuffer, {{0, 0}, offscreen.extent}, clear_values);
-            command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+		{
+			/*
+			    First pass: Render scene to offscreen framebuffer
+			*/
+			std::array<vk::ClearValue, 3> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
+			                                               vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
+			                                               vk::ClearDepthStencilValue(0.0f, 0)}};
+			vk::RenderPassBeginInfo       render_pass_begin_info(offscreen.render_pass, offscreen.framebuffer, {{0, 0}, offscreen.extent}, clear_values);
+			command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
 
-            vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(offscreen.extent.width), static_cast<float>(offscreen.extent.height), 0.0f, 1.0f);
-            command_buffer.setViewport(0, viewport);
+			vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(offscreen.extent.width), static_cast<float>(offscreen.extent.height), 0.0f, 1.0f);
+			command_buffer.setViewport(0, viewport);
 
-            vk::Rect2D scissor({0, 0}, offscreen.extent);
-            command_buffer.setScissor(0, scissor);
+			vk::Rect2D scissor({0, 0}, offscreen.extent);
+			command_buffer.setScissor(0, scissor);
 
-            // Skybox
-            if (display_skybox)
-            {
-                command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.skybox.pipeline);
-                command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.skybox.descriptor_set, {});
-                draw_model(models.skybox.meshes[0], command_buffer);
-            }
+			// Skybox
+			if (display_skybox)
+			{
+				command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.skybox.pipeline);
+				command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.skybox.descriptor_set, {});
+				draw_model(models.skybox.meshes[0], command_buffer);
+			}
 
-            // 3D object
-            command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.objects.pipeline);
-            command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.objects.descriptor_set, {});
-            draw_model(models.objects.meshes[models.object_index], command_buffer);
+			// 3D object
+			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.objects.pipeline);
+			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.objects.descriptor_set, {});
+			draw_model(models.objects.meshes[models.object_index], command_buffer);
 
-            command_buffer.endRenderPass();
-        }
+			command_buffer.endRenderPass();
+		}
 
-        /*
-            Second render pass: First bloom pass
-        */
-        if (bloom.enabled)
-        {
-            // Bloom filter
-            vk::ClearValue          clear_value(vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})));
-            vk::RenderPassBeginInfo render_pass_begin_info(filter_pass.render_pass, filter_pass.framebuffer, {{0, 0}, filter_pass.extent}, clear_value);
-            command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+		/*
+		    Second render pass: First bloom pass
+		*/
+		if (bloom.enabled)
+		{
+			// Bloom filter
+			vk::ClearValue          clear_value(vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})));
+			vk::RenderPassBeginInfo render_pass_begin_info(filter_pass.render_pass, filter_pass.framebuffer, {{0, 0}, filter_pass.extent}, clear_value);
+			command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
 
-            vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(filter_pass.extent.width), static_cast<float>(filter_pass.extent.height), 0.0f, 1.0f);
-            command_buffer.setViewport(0, viewport);
+			vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(filter_pass.extent.width), static_cast<float>(filter_pass.extent.height), 0.0f, 1.0f);
+			command_buffer.setViewport(0, viewport);
 
-            vk::Rect2D scissor({0, 0}, filter_pass.extent);
-            command_buffer.setScissor(0, scissor);
+			vk::Rect2D scissor({0, 0}, filter_pass.extent);
+			command_buffer.setScissor(0, scissor);
 
-            command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, bloom.pipeline_layout, 0, bloom.descriptor_set, {});
-            command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[1]);
-            command_buffer.draw(3, 1, 0, 0);
+			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, bloom.pipeline_layout, 0, bloom.descriptor_set, {});
+			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[1]);
+			command_buffer.draw(3, 1, 0, 0);
 
-            command_buffer.endRenderPass();
-        }
+			command_buffer.endRenderPass();
+		}
 
-        /*
-            Note: Explicit synchronization is not required between the render pass, as this is done implicit via sub pass dependencies
-        */
+		/*
+		    Note: Explicit synchronization is not required between the render pass, as this is done implicit via sub pass dependencies
+		*/
 
-        /*
-            Third render pass: Scene rendering with applied second bloom pass (when enabled)
-        */
-        {
-            // Final composition
-            std::array<vk::ClearValue, 2> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
-                                                           vk::ClearDepthStencilValue(0.0f, 0)}};
-            vk::RenderPassBeginInfo       render_pass_begin_info(render_pass, framebuffers[i], {{0, 0}, extent}, clear_values);
-            command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+		/*
+		    Third render pass: Scene rendering with applied second bloom pass (when enabled)
+		*/
+		{
+			// Final composition
+			std::array<vk::ClearValue, 2> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
+			                                               vk::ClearDepthStencilValue(0.0f, 0)}};
+			vk::RenderPassBeginInfo       render_pass_begin_info(render_pass, framebuffers[i], {{0, 0}, extent}, clear_values);
+			command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
 
-            vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f);
-            command_buffer.setViewport(0, viewport);
+			vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f);
+			command_buffer.setViewport(0, viewport);
 
-            vk::Rect2D scissor({0, 0}, extent);
-            command_buffer.setScissor(0, scissor);
+			vk::Rect2D scissor({0, 0}, extent);
+			command_buffer.setScissor(0, scissor);
 
-            command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, composition.pipeline_layout, 0, composition.descriptor_set, {});
+			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, composition.pipeline_layout, 0, composition.descriptor_set, {});
 
-            // Scene
-            command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, composition.pipeline);
-            command_buffer.draw(3, 1, 0, 0);
+			// Scene
+			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, composition.pipeline);
+			command_buffer.draw(3, 1, 0, 0);
 
-            // Bloom
-            if (bloom.enabled)
-            {
-                command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[0]);
-                command_buffer.draw(3, 1, 0, 0);
-            }
+			// Bloom
+			if (bloom.enabled)
+			{
+				command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[0]);
+				command_buffer.draw(3, 1, 0, 0);
+			}
 
-            draw_ui(command_buffer);
+			draw_ui(command_buffer);
 
-            command_buffer.endRenderPass();
-        }
+			command_buffer.endRenderPass();
+		}
 
-        command_buffer.end();
-    }
+		command_buffer.end();
+	}
 }
 
 void HPPHDR::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 {
-    if (drawer.header("Settings"))
-    {
-        if (drawer.combo_box("Object type", &models.object_index, object_names))
-        {
-            update_uniform_buffers();
-            build_command_buffers();
-        }
-        if (drawer.input_float("Exposure", &ubo_params.exposure, 0.025f, 3))
-        {
-            update_params();
-        }
-        if (drawer.checkbox("Bloom", &bloom.enabled))
-        {
-            build_command_buffers();
-        }
-        if (drawer.checkbox("Skybox", &display_skybox))
-        {
-            build_command_buffers();
-        }
-    }
+	if (drawer.header("Settings"))
+	{
+		if (drawer.combo_box("Object type", &models.object_index, object_names))
+		{
+			update_uniform_buffers();
+			build_command_buffers();
+		}
+		if (drawer.input_float("Exposure", &ubo_params.exposure, 0.025f, 3))
+		{
+			update_params();
+		}
+		if (drawer.checkbox("Bloom", &bloom.enabled))
+		{
+			build_command_buffers();
+		}
+		if (drawer.checkbox("Skybox", &display_skybox))
+		{
+			build_command_buffers();
+		}
+	}
 }
 
 void HPPHDR::render(float delta_time)
 {
-    if (!prepared)
-    {
-        return;
-    }
-    draw();
-    if (camera.updated)
-    {
-        update_uniform_buffers();
-    }
+	if (!prepared)
+	{
+		return;
+	}
+	draw();
+	if (camera.updated)
+	{
+		update_uniform_buffers();
+	}
 }
 
 vk::DeviceMemory HPPHDR::allocate_memory(vk::Image image)
 {
-    vk::MemoryRequirements memory_requirements = get_device()->get_handle().getImageMemoryRequirements(image);
+	vk::MemoryRequirements memory_requirements = get_device()->get_handle().getImageMemoryRequirements(image);
 
-    vk::MemoryAllocateInfo memory_allocate_info(memory_requirements.size,
-                                                get_device()->get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
+	vk::MemoryAllocateInfo memory_allocate_info(memory_requirements.size,
+	                                            get_device()->get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
 
-    return get_device()->get_handle().allocateMemory(memory_allocate_info);
+	return get_device()->get_handle().allocateMemory(memory_allocate_info);
 }
 
 HPPHDR::FrameBufferAttachment HPPHDR::create_attachment(vk::Format format, vk::ImageUsageFlagBits usage)
 {
-    vk::Image        image  = create_image(format, usage);
-    vk::DeviceMemory memory = allocate_memory(image);
-    get_device()->get_handle().bindImageMemory(image, memory, 0);
-    vk::ImageView view = create_image_view(format, usage, image);
+	vk::Image        image  = create_image(format, usage);
+	vk::DeviceMemory memory = allocate_memory(image);
+	get_device()->get_handle().bindImageMemory(image, memory, 0);
+	vk::ImageView view = create_image_view(format, usage, image);
 
-    return {format, image, memory, view};
+	return {format, image, memory, view};
 }
 
 void HPPHDR::create_bloom_pipelines()
 {
-    std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
-        load_shader("hdr/bloom.vert", vk::ShaderStageFlagBits::eVertex),
-        load_shader("hdr/bloom.frag", vk::ShaderStageFlagBits::eFragment)};
+	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
+	    load_shader("hdr/bloom.vert", vk::ShaderStageFlagBits::eVertex),
+	    load_shader("hdr/bloom.frag", vk::ShaderStageFlagBits::eFragment)};
 
-    // Set constant parameters via specialization constants
-    vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
+	// Set constant parameters via specialization constants
+	vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
 
-    uint32_t               dir = 1;
-    vk::SpecializationInfo specialization_info(1, &specialization_map_entry, sizeof(uint32_t), &dir);
-    shader_stages[1].pSpecializationInfo = &specialization_info;
+	uint32_t               dir = 1;
+	vk::SpecializationInfo specialization_info(1, &specialization_map_entry, sizeof(uint32_t), &dir);
+	shader_stages[1].pSpecializationInfo = &specialization_info;
 
-    vk::PipelineColorBlendAttachmentState blend_attachment_state;
-    blend_attachment_state.blendEnable         = true;
-    blend_attachment_state.colorBlendOp        = vk::BlendOp::eAdd;
-    blend_attachment_state.srcColorBlendFactor = vk::BlendFactor::eOne;
-    blend_attachment_state.dstColorBlendFactor = vk::BlendFactor::eOne;
-    blend_attachment_state.alphaBlendOp        = vk::BlendOp::eAdd;
-    blend_attachment_state.srcAlphaBlendFactor = vk::BlendFactor::eSrcAlpha;
-    blend_attachment_state.dstAlphaBlendFactor = vk::BlendFactor::eDstAlpha;
-    blend_attachment_state.colorWriteMask =
-        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+	vk::PipelineColorBlendAttachmentState blend_attachment_state;
+	blend_attachment_state.blendEnable         = true;
+	blend_attachment_state.colorBlendOp        = vk::BlendOp::eAdd;
+	blend_attachment_state.srcColorBlendFactor = vk::BlendFactor::eOne;
+	blend_attachment_state.dstColorBlendFactor = vk::BlendFactor::eOne;
+	blend_attachment_state.alphaBlendOp        = vk::BlendOp::eAdd;
+	blend_attachment_state.srcAlphaBlendFactor = vk::BlendFactor::eSrcAlpha;
+	blend_attachment_state.dstAlphaBlendFactor = vk::BlendFactor::eDstAlpha;
+	blend_attachment_state.colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
 
-    // Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
-    vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
-    depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
-    depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
-    depth_stencil_state.front          = depth_stencil_state.back;
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+	depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
+	depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
+	depth_stencil_state.front          = depth_stencil_state.back;
 
-    // Empty vertex input state, full screen triangles are generated by the vertex shader
-    bloom.pipelines[0] = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-                                                               pipeline_cache,
-                                                               shader_stages,
-                                                               {},
-                                                               vk::PrimitiveTopology::eTriangleList,
-                                                               vk::CullModeFlagBits::eFront,
-                                                               {blend_attachment_state},
-                                                               depth_stencil_state,
-                                                               bloom.pipeline_layout,
-                                                               render_pass);
+	// Empty vertex input state, full screen triangles are generated by the vertex shader
+	bloom.pipelines[0] = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+	                                                           pipeline_cache,
+	                                                           shader_stages,
+	                                                           {},
+	                                                           vk::PrimitiveTopology::eTriangleList,
+	                                                           vk::CullModeFlagBits::eFront,
+	                                                           {blend_attachment_state},
+	                                                           depth_stencil_state,
+	                                                           bloom.pipeline_layout,
+	                                                           render_pass);
 
-    dir                = 0;
-    bloom.pipelines[1] = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-                                                               pipeline_cache,
-                                                               shader_stages,
-                                                               {},
-                                                               vk::PrimitiveTopology::eTriangleList,
-                                                               vk::CullModeFlagBits::eFront,
-                                                               {blend_attachment_state},
-                                                               depth_stencil_state,
-                                                               bloom.pipeline_layout,
-                                                               filter_pass.render_pass);
+	dir                = 0;
+	bloom.pipelines[1] = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+	                                                           pipeline_cache,
+	                                                           shader_stages,
+	                                                           {},
+	                                                           vk::PrimitiveTopology::eTriangleList,
+	                                                           vk::CullModeFlagBits::eFront,
+	                                                           {blend_attachment_state},
+	                                                           depth_stencil_state,
+	                                                           bloom.pipeline_layout,
+	                                                           filter_pass.render_pass);
 }
 
 void HPPHDR::create_composition_pipeline()
 {
-    std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{load_shader("hdr/composition.vert", vk::ShaderStageFlagBits::eVertex),
-                                                                   load_shader("hdr/composition.frag", vk::ShaderStageFlagBits::eFragment)};
+	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{load_shader("hdr/composition.vert", vk::ShaderStageFlagBits::eVertex),
+	                                                               load_shader("hdr/composition.frag", vk::ShaderStageFlagBits::eFragment)};
 
-    vk::PipelineColorBlendAttachmentState blend_attachment_state;
-    blend_attachment_state.colorWriteMask =
-        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+	vk::PipelineColorBlendAttachmentState blend_attachment_state;
+	blend_attachment_state.colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
 
-    // Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
-    vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
-    depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
-    depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
-    depth_stencil_state.front          = depth_stencil_state.back;
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+	depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
+	depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
+	depth_stencil_state.front          = depth_stencil_state.back;
 
-    // Empty vertex input state, full screen triangles are generated by the vertex shader
-    composition.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-                                                                 pipeline_cache,
-                                                                 shader_stages,
-                                                                 {},
-                                                                 vk::PrimitiveTopology::eTriangleList,
-                                                                 vk::CullModeFlagBits::eFront,
-                                                                 {blend_attachment_state},
-                                                                 depth_stencil_state,
-                                                                 composition.pipeline_layout,
-                                                                 render_pass);
+	// Empty vertex input state, full screen triangles are generated by the vertex shader
+	composition.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+	                                                             pipeline_cache,
+	                                                             shader_stages,
+	                                                             {},
+	                                                             vk::PrimitiveTopology::eTriangleList,
+	                                                             vk::CullModeFlagBits::eFront,
+	                                                             {blend_attachment_state},
+	                                                             depth_stencil_state,
+	                                                             composition.pipeline_layout,
+	                                                             render_pass);
 }
 
 vk::Framebuffer HPPHDR::create_framebuffer(vk::RenderPass render_pass, std::vector<vk::ImageView> const &attachments, vk::Extent2D const &extent)
 {
-    vk::FramebufferCreateInfo framebuffer_create_info({}, render_pass, attachments, extent.width, extent.height, 1);
+	vk::FramebufferCreateInfo framebuffer_create_info({}, render_pass, attachments, extent.width, extent.height, 1);
 
-    return get_device()->get_handle().createFramebuffer(framebuffer_create_info);
+	return get_device()->get_handle().createFramebuffer(framebuffer_create_info);
 }
 
 vk::Image HPPHDR::create_image(vk::Format format, vk::ImageUsageFlagBits usage)
 {
-    vk::ImageCreateInfo image_create_info;
-    image_create_info.imageType   = vk::ImageType::e2D;
-    image_create_info.format      = format;
-    image_create_info.extent      = vk::Extent3D(offscreen.extent, 1);
-    image_create_info.mipLevels   = 1;
-    image_create_info.arrayLayers = 1;
-    image_create_info.samples     = vk::SampleCountFlagBits::e1;
-    image_create_info.tiling      = vk::ImageTiling::eOptimal;
-    image_create_info.usage       = usage | vk::ImageUsageFlagBits::eSampled;
+	vk::ImageCreateInfo image_create_info;
+	image_create_info.imageType   = vk::ImageType::e2D;
+	image_create_info.format      = format;
+	image_create_info.extent      = vk::Extent3D(offscreen.extent, 1);
+	image_create_info.mipLevels   = 1;
+	image_create_info.arrayLayers = 1;
+	image_create_info.samples     = vk::SampleCountFlagBits::e1;
+	image_create_info.tiling      = vk::ImageTiling::eOptimal;
+	image_create_info.usage       = usage | vk::ImageUsageFlagBits::eSampled;
 
-    return get_device()->get_handle().createImage(image_create_info);
+	return get_device()->get_handle().createImage(image_create_info);
 }
 
 vk::ImageView HPPHDR::create_image_view(vk::Format format, vk::ImageUsageFlagBits usage, vk::Image image)
 {
-    vk::ImageAspectFlags aspect_mask = vkb::common::get_image_aspect_flags(usage, format);
+	vk::ImageAspectFlags aspect_mask = vkb::common::get_image_aspect_flags(usage, format);
 
-    vk::ImageViewCreateInfo image_view_create_info({}, image, vk::ImageViewType::e2D, format, {}, {aspect_mask, 0, 1, 0, 1});
+	vk::ImageViewCreateInfo image_view_create_info({}, image, vk::ImageViewType::e2D, format, {}, {aspect_mask, 0, 1, 0, 1});
 
-    return get_device()->get_handle().createImageView(image_view_create_info);
+	return get_device()->get_handle().createImageView(image_view_create_info);
 }
 
 void HPPHDR::create_models_pipelines()
 {
-    std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
-        load_shader("hdr/gbuffer.vert", vk::ShaderStageFlagBits::eVertex),
-        load_shader("hdr/gbuffer.frag", vk::ShaderStageFlagBits::eFragment)};
+	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages{
+	    load_shader("hdr/gbuffer.vert", vk::ShaderStageFlagBits::eVertex),
+	    load_shader("hdr/gbuffer.frag", vk::ShaderStageFlagBits::eFragment)};
 
-    // Set constant parameters via specialization constants
-    vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
+	// Set constant parameters via specialization constants
+	vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
 
-    // Set constant parameters via specialization constants
-    uint32_t               shadertype          = 0;
-    vk::SpecializationInfo specialization_info = vk::SpecializationInfo(1, &specialization_map_entry, sizeof(uint32_t), &shadertype);
-    shader_stages[0].pSpecializationInfo       = &specialization_info;
-    shader_stages[1].pSpecializationInfo       = &specialization_info;
+	// Set constant parameters via specialization constants
+	uint32_t               shadertype          = 0;
+	vk::SpecializationInfo specialization_info = vk::SpecializationInfo(1, &specialization_map_entry, sizeof(uint32_t), &shadertype);
+	shader_stages[0].pSpecializationInfo       = &specialization_info;
+	shader_stages[1].pSpecializationInfo       = &specialization_info;
 
-    // Vertex bindings an attributes for model rendering
-    // Binding description
-    vk::VertexInputBindingDescription vertex_input_binding(0, sizeof(HPPVertex), vk::VertexInputRate::eVertex);
+	// Vertex bindings an attributes for model rendering
+	// Binding description
+	vk::VertexInputBindingDescription vertex_input_binding(0, sizeof(HPPVertex), vk::VertexInputRate::eVertex);
 
-    // Attribute descriptions
-    std::vector<vk::VertexInputAttributeDescription> vertex_input_attributes = {{0, 0, vk::Format::eR32G32B32Sfloat, 0},
-                                                                                {1, 0, vk::Format::eR32G32B32Sfloat, 3 * sizeof(float)}};
+	// Attribute descriptions
+	std::vector<vk::VertexInputAttributeDescription> vertex_input_attributes = {{0, 0, vk::Format::eR32G32B32Sfloat, 0},
+	                                                                            {1, 0, vk::Format::eR32G32B32Sfloat, 3 * sizeof(float)}};
 
-    vk::PipelineVertexInputStateCreateInfo vertex_input_state({}, vertex_input_binding, vertex_input_attributes);
+	vk::PipelineVertexInputStateCreateInfo vertex_input_state({}, vertex_input_binding, vertex_input_attributes);
 
-    std::vector<vk::PipelineColorBlendAttachmentState> blend_attachment_states(2);
-    blend_attachment_states[0].colorWriteMask =
-        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
-    blend_attachment_states[1].colorWriteMask = blend_attachment_states[0].colorWriteMask;
+	std::vector<vk::PipelineColorBlendAttachmentState> blend_attachment_states(2);
+	blend_attachment_states[0].colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+	blend_attachment_states[1].colorWriteMask = blend_attachment_states[0].colorWriteMask;
 
-    // Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
-    vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
-    depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
-    depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
-    depth_stencil_state.front          = depth_stencil_state.back;
+	// Note: Using Reversed depth-buffer for increased precision, so Greater depth values are kept
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+	depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
+	depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
+	depth_stencil_state.front          = depth_stencil_state.back;
 
-    models.skybox.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-                                                                   pipeline_cache,
-                                                                   shader_stages,
-                                                                   vertex_input_state,
-                                                                   vk::PrimitiveTopology::eTriangleList,
-                                                                   vk::CullModeFlagBits::eBack,
-                                                                   blend_attachment_states,
-                                                                   depth_stencil_state,
-                                                                   models.pipeline_layout,
-                                                                   offscreen.render_pass);
+	models.skybox.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+	                                                               pipeline_cache,
+	                                                               shader_stages,
+	                                                               vertex_input_state,
+	                                                               vk::PrimitiveTopology::eTriangleList,
+	                                                               vk::CullModeFlagBits::eBack,
+	                                                               blend_attachment_states,
+	                                                               depth_stencil_state,
+	                                                               models.pipeline_layout,
+	                                                               offscreen.render_pass);
 
-    // Object rendering pipeline
-    shadertype = 1;
+	// Object rendering pipeline
+	shadertype = 1;
 
-    // Enable depth test and write
-    depth_stencil_state.depthWriteEnable = true;
-    depth_stencil_state.depthTestEnable  = true;
+	// Enable depth test and write
+	depth_stencil_state.depthWriteEnable = true;
+	depth_stencil_state.depthTestEnable  = true;
 
-    // Flip cull mode
-    models.objects.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
-                                                                    pipeline_cache,
-                                                                    shader_stages,
-                                                                    vertex_input_state,
-                                                                    vk::PrimitiveTopology::eTriangleList,
-                                                                    vk::CullModeFlagBits::eFront,
-                                                                    blend_attachment_states,
-                                                                    depth_stencil_state,
-                                                                    models.pipeline_layout,
-                                                                    offscreen.render_pass);
+	// Flip cull mode
+	models.objects.pipeline = vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+	                                                                pipeline_cache,
+	                                                                shader_stages,
+	                                                                vertex_input_state,
+	                                                                vk::PrimitiveTopology::eTriangleList,
+	                                                                vk::CullModeFlagBits::eFront,
+	                                                                blend_attachment_states,
+	                                                                depth_stencil_state,
+	                                                                models.pipeline_layout,
+	                                                                offscreen.render_pass);
 }
 
 vk::RenderPass HPPHDR::create_render_pass(std::vector<vk::AttachmentDescription> const &attachment_descriptions, vk::SubpassDescription const &subpass_description)
 {
-    // Use subpass dependencies for attachment layput transitions
-    std::array<vk::SubpassDependency, 2> subpass_dependencies;
+	// Use subpass dependencies for attachment layput transitions
+	std::array<vk::SubpassDependency, 2> subpass_dependencies;
 
-    subpass_dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-    subpass_dependencies[0].dstSubpass = 0;
-    // End of previous commands
-    subpass_dependencies[0].srcStageMask  = vk::PipelineStageFlagBits::eBottomOfPipe;
-    subpass_dependencies[0].srcAccessMask = vk::AccessFlagBits::eNoneKHR;
-    // Read/write from/to depth
-    subpass_dependencies[0].dstStageMask  = vk::PipelineStageFlagBits::eEarlyFragmentTests;
-    subpass_dependencies[0].dstAccessMask = vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
-    // Write to attachment
-    subpass_dependencies[0].dstStageMask |= vk::PipelineStageFlagBits::eColorAttachmentOutput;
-    subpass_dependencies[0].dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
+	subpass_dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+	subpass_dependencies[0].dstSubpass = 0;
+	// End of previous commands
+	subpass_dependencies[0].srcStageMask  = vk::PipelineStageFlagBits::eBottomOfPipe;
+	subpass_dependencies[0].srcAccessMask = vk::AccessFlagBits::eNoneKHR;
+	// Read/write from/to depth
+	subpass_dependencies[0].dstStageMask  = vk::PipelineStageFlagBits::eEarlyFragmentTests;
+	subpass_dependencies[0].dstAccessMask = vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
+	// Write to attachment
+	subpass_dependencies[0].dstStageMask |= vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	subpass_dependencies[0].dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
 
-    subpass_dependencies[1].srcSubpass = 0;
-    subpass_dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
-    // End of write to attachment
-    subpass_dependencies[1].srcStageMask  = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-    subpass_dependencies[1].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
-    // Attachment later read using sampler in 'bloom[0]' pipeline
-    subpass_dependencies[1].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
-    subpass_dependencies[1].dstAccessMask = vk::AccessFlagBits::eShaderRead;
+	subpass_dependencies[1].srcSubpass = 0;
+	subpass_dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+	// End of write to attachment
+	subpass_dependencies[1].srcStageMask  = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	subpass_dependencies[1].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
+	// Attachment later read using sampler in 'bloom[0]' pipeline
+	subpass_dependencies[1].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
+	subpass_dependencies[1].dstAccessMask = vk::AccessFlagBits::eShaderRead;
 
-    vk::RenderPassCreateInfo render_pass_create_info({}, attachment_descriptions, subpass_description, subpass_dependencies);
+	vk::RenderPassCreateInfo render_pass_create_info({}, attachment_descriptions, subpass_description, subpass_dependencies);
 
-    return get_device()->get_handle().createRenderPass(render_pass_create_info);
+	return get_device()->get_handle().createRenderPass(render_pass_create_info);
 }
 
 vk::Sampler HPPHDR::create_sampler()
 {
-    vk::SamplerCreateInfo sampler_create_info;
-    sampler_create_info.magFilter     = vk::Filter::eNearest;
-    sampler_create_info.minFilter     = vk::Filter::eNearest;
-    sampler_create_info.mipmapMode    = vk::SamplerMipmapMode::eLinear;
-    sampler_create_info.addressModeU  = vk::SamplerAddressMode::eClampToEdge;
-    sampler_create_info.addressModeV  = sampler_create_info.addressModeU;
-    sampler_create_info.addressModeW  = sampler_create_info.addressModeU;
-    sampler_create_info.mipLodBias    = 0.0f;
-    sampler_create_info.maxAnisotropy = 1.0f;
-    sampler_create_info.minLod        = 0.0f;
-    sampler_create_info.maxLod        = 1.0f;
-    sampler_create_info.borderColor   = vk::BorderColor::eFloatOpaqueWhite;
+	vk::SamplerCreateInfo sampler_create_info;
+	sampler_create_info.magFilter     = vk::Filter::eNearest;
+	sampler_create_info.minFilter     = vk::Filter::eNearest;
+	sampler_create_info.mipmapMode    = vk::SamplerMipmapMode::eLinear;
+	sampler_create_info.addressModeU  = vk::SamplerAddressMode::eClampToEdge;
+	sampler_create_info.addressModeV  = sampler_create_info.addressModeU;
+	sampler_create_info.addressModeW  = sampler_create_info.addressModeU;
+	sampler_create_info.mipLodBias    = 0.0f;
+	sampler_create_info.maxAnisotropy = 1.0f;
+	sampler_create_info.minLod        = 0.0f;
+	sampler_create_info.maxLod        = 1.0f;
+	sampler_create_info.borderColor   = vk::BorderColor::eFloatOpaqueWhite;
 
-    return get_device()->get_handle().createSampler(sampler_create_info);
+	return get_device()->get_handle().createSampler(sampler_create_info);
 }
 
 void HPPHDR::draw()
 {
-    HPPApiVulkanSample::prepare_frame();
+	HPPApiVulkanSample::prepare_frame();
 
-    submit_info.setCommandBuffers(draw_cmd_buffers[current_buffer]);
-    queue.submit(submit_info);
+	submit_info.setCommandBuffers(draw_cmd_buffers[current_buffer]);
+	queue.submit(submit_info);
 
-    HPPApiVulkanSample::submit_frame();
+	HPPApiVulkanSample::submit_frame();
 }
 
 void HPPHDR::load_assets()
 {
-    // Models
-    models.skybox.meshes.emplace_back(load_model("scenes/cube.gltf"));
-    std::vector<std::string> filenames = {"geosphere.gltf", "teapot.gltf", "torusknot.gltf"};
-    object_names                       = {"Sphere", "Teapot", "Torusknot"};
-    for (auto file : filenames)
-    {
-        models.objects.meshes.emplace_back(load_model("scenes/" + file));
-    }
+	// Models
+	models.skybox.meshes.emplace_back(load_model("scenes/cube.gltf"));
+	std::vector<std::string> filenames = {"geosphere.gltf", "teapot.gltf", "torusknot.gltf"};
+	object_names                       = {"Sphere", "Teapot", "Torusknot"};
+	for (auto file : filenames)
+	{
+		models.objects.meshes.emplace_back(load_model("scenes/" + file));
+	}
 
-    // Transforms
-    auto geosphere_matrix = glm::mat4(1.0f);
-    models.transforms.push_back(geosphere_matrix);
+	// Transforms
+	auto geosphere_matrix = glm::mat4(1.0f);
+	models.transforms.push_back(geosphere_matrix);
 
-    auto teapot_matrix = glm::mat4(1.0f);
-    teapot_matrix      = glm::scale(teapot_matrix, glm::vec3(10.0f, 10.0f, 10.0f));
-    teapot_matrix      = glm::rotate(teapot_matrix, glm::radians(180.0f), glm::vec3(1.0f, 0.0f, 0.0f));
-    models.transforms.push_back(teapot_matrix);
+	auto teapot_matrix = glm::mat4(1.0f);
+	teapot_matrix      = glm::scale(teapot_matrix, glm::vec3(10.0f, 10.0f, 10.0f));
+	teapot_matrix      = glm::rotate(teapot_matrix, glm::radians(180.0f), glm::vec3(1.0f, 0.0f, 0.0f));
+	models.transforms.push_back(teapot_matrix);
 
-    auto torus_matrix = glm::mat4(1.0f);
-    models.transforms.push_back(torus_matrix);
+	auto torus_matrix = glm::mat4(1.0f);
+	models.transforms.push_back(torus_matrix);
 
-    // Load HDR cube map
-    textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::sg::Image::Color);
+	// Load HDR cube map
+	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::sg::Image::Color);
 }
 
 void HPPHDR::prepare_camera()
 {
-    camera.type = vkb::CameraType::LookAt;
-    camera.set_position(glm::vec3(0.0f, 0.0f, -4.0f));
-    camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
+	camera.type = vkb::CameraType::LookAt;
+	camera.set_position(glm::vec3(0.0f, 0.0f, -4.0f));
+	camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
 
-    // Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
-    camera.set_perspective(60.0f, static_cast<float>(extent.width) / static_cast<float>(extent.height), 256.0f, 0.1f);
+	// Note: Using Revsered depth-buffer for increased precision, so Znear and Zfar are flipped
+	camera.set_perspective(60.0f, static_cast<float>(extent.width) / static_cast<float>(extent.height), 256.0f, 0.1f);
 }
 
 // Prepare a new framebuffer and attachments for offscreen rendering (G-Buffer)
 void HPPHDR::prepare_offscreen_buffer()
 {
-    // We need to select a format that supports the color attachment blending flag, so we iterate over multiple formats to find one that supports this flag
-    const std::vector<vk::Format> float_format_priority_list = {vk::Format::eR32G32B32A32Sfloat, vk::Format::eR16G16B16A16Sfloat};
+	// We need to select a format that supports the color attachment blending flag, so we iterate over multiple formats to find one that supports this flag
+	const std::vector<vk::Format> float_format_priority_list = {vk::Format::eR32G32B32A32Sfloat, vk::Format::eR16G16B16A16Sfloat};
 
-    auto formatIt = std::find_if(float_format_priority_list.begin(),
-                                 float_format_priority_list.end(),
-                                 [this](vk::Format format) {
-                                     const vk::FormatProperties properties = get_device()->get_gpu().get_handle().getFormatProperties(format);
-                                     return properties.optimalTilingFeatures & vk::FormatFeatureFlagBits::eColorAttachmentBlend;
-                                 });
-    if (formatIt == float_format_priority_list.end())
-    {
-        throw std::runtime_error("No suitable float format could be determined");
-    }
+	auto formatIt = std::find_if(float_format_priority_list.begin(),
+	                             float_format_priority_list.end(),
+	                             [this](vk::Format format) {
+		                             const vk::FormatProperties properties = get_device()->get_gpu().get_handle().getFormatProperties(format);
+		                             return properties.optimalTilingFeatures & vk::FormatFeatureFlagBits::eColorAttachmentBlend;
+	                             });
+	if (formatIt == float_format_priority_list.end())
+	{
+		throw std::runtime_error("No suitable float format could be determined");
+	}
 
-    vk::Format color_format = *formatIt;
+	vk::Format color_format = *formatIt;
 
-    {
-        offscreen.extent = extent;
+	{
+		offscreen.extent = extent;
 
-        // Color attachments
+		// Color attachments
 
-        // We are using two 128-Bit RGBA floating point color buffers for this sample
-        // In a performance or bandwith-limited scenario you should consider using a format with lower precision
-        offscreen.color[0] = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
-        offscreen.color[1] = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
-        // Depth attachment
-        offscreen.depth = create_attachment(depth_format, vk::ImageUsageFlagBits::eDepthStencilAttachment);
+		// We are using two 128-Bit RGBA floating point color buffers for this sample
+		// In a performance or bandwith-limited scenario you should consider using a format with lower precision
+		offscreen.color[0] = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
+		offscreen.color[1] = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
+		// Depth attachment
+		offscreen.depth = create_attachment(depth_format, vk::ImageUsageFlagBits::eDepthStencilAttachment);
 
-        // Set up separate renderpass with references to the colorand depth attachments
-        std::vector<vk::AttachmentDescription> attachment_descriptions(3);
+		// Set up separate renderpass with references to the colorand depth attachments
+		std::vector<vk::AttachmentDescription> attachment_descriptions(3);
 
-        // Init attachment properties
-        for (uint32_t i = 0; i < 3; ++i)
-        {
-            attachment_descriptions[i].samples        = vk::SampleCountFlagBits::e1;
-            attachment_descriptions[i].loadOp         = vk::AttachmentLoadOp::eClear;
-            attachment_descriptions[i].storeOp        = vk::AttachmentStoreOp::eStore;
-            attachment_descriptions[i].stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
-            attachment_descriptions[i].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
-            attachment_descriptions[i].initialLayout  = vk::ImageLayout::eUndefined;
-            attachment_descriptions[i].finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
-        }
-        attachment_descriptions[2].finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
+		// Init attachment properties
+		for (uint32_t i = 0; i < 3; ++i)
+		{
+			attachment_descriptions[i].samples        = vk::SampleCountFlagBits::e1;
+			attachment_descriptions[i].loadOp         = vk::AttachmentLoadOp::eClear;
+			attachment_descriptions[i].storeOp        = vk::AttachmentStoreOp::eStore;
+			attachment_descriptions[i].stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
+			attachment_descriptions[i].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+			attachment_descriptions[i].initialLayout  = vk::ImageLayout::eUndefined;
+			attachment_descriptions[i].finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
+		}
+		attachment_descriptions[2].finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
 
-        // Formats
-        attachment_descriptions[0].format = offscreen.color[0].format;
-        attachment_descriptions[1].format = offscreen.color[1].format;
-        attachment_descriptions[2].format = offscreen.depth.format;
+		// Formats
+		attachment_descriptions[0].format = offscreen.color[0].format;
+		attachment_descriptions[1].format = offscreen.color[1].format;
+		attachment_descriptions[2].format = offscreen.depth.format;
 
-        std::array<vk::AttachmentReference, 2> color_references{{{0, vk::ImageLayout::eColorAttachmentOptimal},
-                                                                 {1, vk::ImageLayout::eColorAttachmentOptimal}}};
+		std::array<vk::AttachmentReference, 2> color_references{{{0, vk::ImageLayout::eColorAttachmentOptimal},
+		                                                         {1, vk::ImageLayout::eColorAttachmentOptimal}}};
 
-        vk::AttachmentReference depth_reference(2, vk::ImageLayout::eDepthStencilAttachmentOptimal);
+		vk::AttachmentReference depth_reference(2, vk::ImageLayout::eDepthStencilAttachmentOptimal);
 
-        vk::SubpassDescription subpass({}, vk::PipelineBindPoint::eGraphics, nullptr, color_references, nullptr, &depth_reference);
+		vk::SubpassDescription subpass({}, vk::PipelineBindPoint::eGraphics, nullptr, color_references, nullptr, &depth_reference);
 
-        offscreen.render_pass = create_render_pass(attachment_descriptions, subpass);
+		offscreen.render_pass = create_render_pass(attachment_descriptions, subpass);
 
-        std::vector<vk::ImageView> attachments = {offscreen.color[0].view, offscreen.color[1].view, offscreen.depth.view};
-        offscreen.framebuffer                  = create_framebuffer(offscreen.render_pass, attachments, offscreen.extent);
+		std::vector<vk::ImageView> attachments = {offscreen.color[0].view, offscreen.color[1].view, offscreen.depth.view};
+		offscreen.framebuffer                  = create_framebuffer(offscreen.render_pass, attachments, offscreen.extent);
 
-        // Create sampler to sample from the color attachments
-        offscreen.sampler = create_sampler();
-    }
+		// Create sampler to sample from the color attachments
+		offscreen.sampler = create_sampler();
+	}
 
-    // Bloom separable filter pass
-    {
-        filter_pass.extent = extent;
+	// Bloom separable filter pass
+	{
+		filter_pass.extent = extent;
 
-        // Color attachments
+		// Color attachments
 
-        // Floating point color attachment
-        filter_pass.color = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
+		// Floating point color attachment
+		filter_pass.color = create_attachment(color_format, vk::ImageUsageFlagBits::eColorAttachment);
 
-        // Set up separate renderpass with references to the color and depth attachments
-        vk::AttachmentDescription attachment_description;
-        attachment_description.samples        = vk::SampleCountFlagBits::e1;
-        attachment_description.loadOp         = vk::AttachmentLoadOp::eClear;
-        attachment_description.storeOp        = vk::AttachmentStoreOp::eStore;
-        attachment_description.stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
-        attachment_description.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
-        attachment_description.initialLayout  = vk::ImageLayout::eUndefined;
-        attachment_description.finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
-        attachment_description.format         = filter_pass.color.format;
+		// Set up separate renderpass with references to the color and depth attachments
+		vk::AttachmentDescription attachment_description;
+		attachment_description.samples        = vk::SampleCountFlagBits::e1;
+		attachment_description.loadOp         = vk::AttachmentLoadOp::eClear;
+		attachment_description.storeOp        = vk::AttachmentStoreOp::eStore;
+		attachment_description.stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
+		attachment_description.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+		attachment_description.initialLayout  = vk::ImageLayout::eUndefined;
+		attachment_description.finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
+		attachment_description.format         = filter_pass.color.format;
 
-        vk::AttachmentReference color_reference(0, vk::ImageLayout::eColorAttachmentOptimal);
-        vk::SubpassDescription  subpass({}, vk::PipelineBindPoint::eGraphics, {}, color_reference);
+		vk::AttachmentReference color_reference(0, vk::ImageLayout::eColorAttachmentOptimal);
+		vk::SubpassDescription  subpass({}, vk::PipelineBindPoint::eGraphics, {}, color_reference);
 
-        filter_pass.render_pass = create_render_pass({attachment_description}, subpass);
-        filter_pass.framebuffer = create_framebuffer(filter_pass.render_pass, {filter_pass.color.view}, filter_pass.extent);
-        filter_pass.sampler     = create_sampler();
-    }
+		filter_pass.render_pass = create_render_pass({attachment_description}, subpass);
+		filter_pass.framebuffer = create_framebuffer(filter_pass.render_pass, {filter_pass.color.view}, filter_pass.extent);
+		filter_pass.sampler     = create_sampler();
+	}
 }
 
 // Prepare and initialize uniform buffer containing shader uniforms
 void HPPHDR::prepare_uniform_buffers()
 {
-    // Matrices vertex shader uniform buffer
-    uniform_buffers.matrices = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
-                                                                      sizeof(ubo_matrices),
-                                                                      vk::BufferUsageFlagBits::eUniformBuffer,
-                                                                      VMA_MEMORY_USAGE_CPU_TO_GPU);
+	// Matrices vertex shader uniform buffer
+	uniform_buffers.matrices = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
+	                                                                  sizeof(ubo_matrices),
+	                                                                  vk::BufferUsageFlagBits::eUniformBuffer,
+	                                                                  VMA_MEMORY_USAGE_CPU_TO_GPU);
 
-    // Params
-    uniform_buffers.params = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
-                                                                    sizeof(ubo_params),
-                                                                    vk::BufferUsageFlagBits::eUniformBuffer,
-                                                                    VMA_MEMORY_USAGE_CPU_TO_GPU);
+	// Params
+	uniform_buffers.params = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
+	                                                                sizeof(ubo_params),
+	                                                                vk::BufferUsageFlagBits::eUniformBuffer,
+	                                                                VMA_MEMORY_USAGE_CPU_TO_GPU);
 
-    update_uniform_buffers();
-    update_params();
+	update_uniform_buffers();
+	update_params();
 }
 
 void HPPHDR::setup_bloom()
 {
-    std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-                                                            {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}};
+	std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	                                                        {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}};
 
-    vk::Device device           = get_device()->get_handle();
-    bloom.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
-    bloom.pipeline_layout       = vkb::common::create_pipeline_layout(device, bloom.descriptor_set_layout);
-    create_bloom_pipelines();
-    bloom.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, bloom.descriptor_set_layout);
-    update_bloom_descriptor_set();
+	vk::Device device           = get_device()->get_handle();
+	bloom.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
+	bloom.pipeline_layout       = vkb::common::create_pipeline_layout(device, bloom.descriptor_set_layout);
+	create_bloom_pipelines();
+	bloom.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, bloom.descriptor_set_layout);
+	update_bloom_descriptor_set();
 }
 
 void HPPHDR::setup_composition()
 {
-    std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-                                                            {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}};
+	std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	                                                        {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}};
 
-    vk::Device device                 = get_device()->get_handle();
-    composition.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
-    composition.pipeline_layout       = vkb::common::create_pipeline_layout(device, composition.descriptor_set_layout);
-    create_composition_pipeline();
-    composition.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, composition.descriptor_set_layout);
-    update_composition_descriptor_set();
+	vk::Device device                 = get_device()->get_handle();
+	composition.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
+	composition.pipeline_layout       = vkb::common::create_pipeline_layout(device, composition.descriptor_set_layout);
+	create_composition_pipeline();
+	composition.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, composition.descriptor_set_layout);
+	update_composition_descriptor_set();
 }
 
 void HPPHDR::setup_models()
 {
-    std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex},
-                                                            {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-                                                            {2, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment}};
+	std::vector<vk::DescriptorSetLayoutBinding> bindings = {{0, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex},
+	                                                        {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	                                                        {2, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment}};
 
-    vk::Device device            = get_device()->get_handle();
-    models.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
-    models.pipeline_layout       = vkb::common::create_pipeline_layout(device, models.descriptor_set_layout);
-    create_models_pipelines();
+	vk::Device device            = get_device()->get_handle();
+	models.descriptor_set_layout = vkb::common::create_descriptor_set_layout(device, bindings);
+	models.pipeline_layout       = vkb::common::create_pipeline_layout(device, models.descriptor_set_layout);
+	create_models_pipelines();
 
-    // Objects descriptor set
-    models.objects.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
-    update_model_descriptor_set(models.objects.descriptor_set);
+	// Objects descriptor set
+	models.objects.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
+	update_model_descriptor_set(models.objects.descriptor_set);
 
-    // Sky box descriptor set
-    models.skybox.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
-    update_model_descriptor_set(models.skybox.descriptor_set);
+	// Sky box descriptor set
+	models.skybox.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
+	update_model_descriptor_set(models.skybox.descriptor_set);
 }
 
 void HPPHDR::update_composition_descriptor_set()
 {
-    std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
-                                                                 {offscreen.sampler, filter_pass.color.view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
+	std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
+	                                                             {offscreen.sampler, filter_pass.color.view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
 
-    std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
-        {{composition.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
-         {composition.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
+	std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
+	    {{composition.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
+	     {composition.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
 
-    get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
+	get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
 }
 
 void HPPHDR::update_bloom_descriptor_set()
 {
-    std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
-                                                                 {offscreen.sampler, offscreen.color[1].view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
+	std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
+	                                                             {offscreen.sampler, offscreen.color[1].view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
 
-    std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
-        {{bloom.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
-         {bloom.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
+	std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
+	    {{bloom.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
+	     {bloom.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
 
-    get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
+	get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
 }
 
 void HPPHDR::update_model_descriptor_set(vk::DescriptorSet descriptor_set)
 {
-    vk::DescriptorBufferInfo matrix_buffer_descriptor(uniform_buffers.matrices->get_handle(), 0, VK_WHOLE_SIZE);
+	vk::DescriptorBufferInfo matrix_buffer_descriptor(uniform_buffers.matrices->get_handle(), 0, VK_WHOLE_SIZE);
 
-    vk::DescriptorImageInfo environment_image_descriptor(
-        textures.envmap.sampler,
-        textures.envmap.image->get_vk_image_view().get_handle(),
-        descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.envmap.image->get_vk_image_view().get_format()));
+	vk::DescriptorImageInfo environment_image_descriptor(
+	    textures.envmap.sampler,
+	    textures.envmap.image->get_vk_image_view().get_handle(),
+	    descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.envmap.image->get_vk_image_view().get_format()));
 
-    vk::DescriptorBufferInfo params_buffer_descriptor(uniform_buffers.params->get_handle(), 0, VK_WHOLE_SIZE);
+	vk::DescriptorBufferInfo params_buffer_descriptor(uniform_buffers.params->get_handle(), 0, VK_WHOLE_SIZE);
 
-    std::array<vk::WriteDescriptorSet, 3> write_descriptor_sets = {
-        {{descriptor_set, 0, 0, vk::DescriptorType::eUniformBuffer, {}, matrix_buffer_descriptor},
-         {descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, environment_image_descriptor},
-         {descriptor_set, 2, 0, vk::DescriptorType::eUniformBuffer, {}, params_buffer_descriptor}}};
+	std::array<vk::WriteDescriptorSet, 3> write_descriptor_sets = {
+	    {{descriptor_set, 0, 0, vk::DescriptorType::eUniformBuffer, {}, matrix_buffer_descriptor},
+	     {descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, environment_image_descriptor},
+	     {descriptor_set, 2, 0, vk::DescriptorType::eUniformBuffer, {}, params_buffer_descriptor}}};
 
-    get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
+	get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
 }
 
 void HPPHDR::update_params()
 {
-    uniform_buffers.params->convert_and_update(ubo_params);
+	uniform_buffers.params->convert_and_update(ubo_params);
 }
 
 void HPPHDR::update_uniform_buffers()
 {
-    ubo_matrices.projection       = camera.matrices.perspective;
-    ubo_matrices.modelview        = camera.matrices.view * models.transforms[models.object_index];
-    ubo_matrices.skybox_modelview = camera.matrices.view;
-    uniform_buffers.matrices->convert_and_update(ubo_matrices);
+	ubo_matrices.projection       = camera.matrices.perspective;
+	ubo_matrices.modelview        = camera.matrices.view * models.transforms[models.object_index];
+	ubo_matrices.skybox_modelview = camera.matrices.view;
+	uniform_buffers.matrices->convert_and_update(ubo_matrices);
 }
 
 std::unique_ptr<vkb::Application> create_hpp_hdr()
 {
-    return std::make_unique<HPPHDR>();
+	return std::make_unique<HPPHDR>();
 }

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -570,7 +570,7 @@ void HPPTimestampQueries::prepare_offscreen_buffer()
 		// Color attachments
 
 		// We are using two 128-Bit RGBA floating point color buffers for this sample
-		// In a performance or bandwith-limited scenario you should consider using a format with lower precision
+		// In a performance or bandwidth-limited scenario you should consider using a format with lower precision
 		create_attachment(vk::Format::eR32G32B32A32Sfloat, vk::ImageUsageFlagBits::eColorAttachment, &offscreen.color[0]);
 		create_attachment(vk::Format::eR32G32B32A32Sfloat, vk::ImageUsageFlagBits::eColorAttachment, &offscreen.color[1]);
 		// Depth attachment

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -613,21 +613,31 @@ void HPPTimestampQueries::prepare_offscreen_buffer()
 
 		vk::SubpassDescription subpass({}, vk::PipelineBindPoint::eGraphics, {}, color_references, {}, &depth_reference);
 
-		// Use subpass dependencies for attachment layput transitions
-		std::array<vk::SubpassDependency, 2> dependencies = {{{VK_SUBPASS_EXTERNAL,
-		                                                       0,
-		                                                       vk::PipelineStageFlagBits::eBottomOfPipe,
-		                                                       vk::PipelineStageFlagBits::eColorAttachmentOutput,
-		                                                       vk::AccessFlagBits::eMemoryRead,
-		                                                       vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite,
-		                                                       vk::DependencyFlagBits::eByRegion},
-		                                                      {0,
-		                                                       VK_SUBPASS_EXTERNAL,
-		                                                       vk::PipelineStageFlagBits::eColorAttachmentOutput,
-		                                                       vk::PipelineStageFlagBits::eBottomOfPipe,
-		                                                       vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite,
-		                                                       vk::AccessFlagBits::eMemoryRead,
-		                                                       vk::DependencyFlagBits::eByRegion}}};
+		// Use subpass dependencies for attachment layout transitions
+		std::array<vk::SubpassDependency, 2> dependencies;
+
+		dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
+		dependencies[0].dstSubpass      = 0;
+		dependencies[0].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+		// End of previous commands
+		dependencies[0].srcStageMask  = vk::PipelineStageFlagBits::eBottomOfPipe;
+		dependencies[0].srcAccessMask = vk::AccessFlagBits::eNoneKHR;
+		// Read/write from/to depth
+		dependencies[0].dstStageMask  = vk::PipelineStageFlagBits::eEarlyFragmentTests;
+		dependencies[0].dstAccessMask = vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
+		// Write to attachment
+		dependencies[0].dstStageMask |= vk::PipelineStageFlagBits::eColorAttachmentOutput;
+		dependencies[0].dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
+
+		dependencies[1].srcSubpass      = 0;
+		dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
+		dependencies[1].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+		// End of write to attachment
+		dependencies[1].srcStageMask  = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+		dependencies[1].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
+		// Attachment later read using sampler in 'composition' pipeline
+		dependencies[1].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
+		dependencies[1].dstAccessMask = vk::AccessFlagBits::eShaderRead;
 
 		vk::RenderPassCreateInfo render_pass_create_info({}, attachment_descriptions, subpass, dependencies);
 
@@ -684,21 +694,31 @@ void HPPTimestampQueries::prepare_offscreen_buffer()
 
 		vk::SubpassDescription subpass({}, vk::PipelineBindPoint::eGraphics, {}, color_reference);
 
-		// Use subpass dependencies for attachment layput transitions
-		std::array<vk::SubpassDependency, 2> dependencies = {{{VK_SUBPASS_EXTERNAL,
-		                                                       0,
-		                                                       vk::PipelineStageFlagBits::eBottomOfPipe,
-		                                                       vk::PipelineStageFlagBits::eColorAttachmentOutput,
-		                                                       vk::AccessFlagBits::eMemoryRead,
-		                                                       vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite,
-		                                                       vk::DependencyFlagBits::eByRegion},
-		                                                      {0,
-		                                                       VK_SUBPASS_EXTERNAL,
-		                                                       vk::PipelineStageFlagBits::eColorAttachmentOutput,
-		                                                       vk::PipelineStageFlagBits::eBottomOfPipe,
-		                                                       vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite,
-		                                                       vk::AccessFlagBits::eMemoryRead,
-		                                                       vk::DependencyFlagBits::eByRegion}}};
+		// Use subpass dependencies for attachment layout transitions
+		std::array<vk::SubpassDependency, 2> dependencies;
+
+		dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
+		dependencies[0].dstSubpass      = 0;
+		dependencies[0].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+		// End of previous commands
+		dependencies[0].srcStageMask  = vk::PipelineStageFlagBits::eBottomOfPipe;
+		dependencies[0].srcAccessMask = vk::AccessFlagBits::eNoneKHR;
+		// Read from image in fragment shader
+		dependencies[0].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
+		dependencies[0].dstAccessMask = vk::AccessFlagBits::eShaderRead;
+		// Write to attachment
+		dependencies[0].dstStageMask |= vk::PipelineStageFlagBits::eColorAttachmentOutput;
+		dependencies[0].dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
+
+		dependencies[1].srcSubpass      = 0;
+		dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
+		dependencies[1].dependencyFlags = vk::DependencyFlagBits::eByRegion;
+		// End of write to attachment
+		dependencies[1].srcStageMask  = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+		dependencies[1].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
+		// Attachment later read using sampler in 'bloom[0]' pipeline
+		dependencies[1].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
+		dependencies[1].dstAccessMask = vk::AccessFlagBits::eShaderRead;
 
 		vk::RenderPassCreateInfo render_pass_create_info({}, attachment_description, subpass, dependencies);
 

--- a/samples/api/timestamp_queries/timestamp_queries.cpp
+++ b/samples/api/timestamp_queries/timestamp_queries.cpp
@@ -318,13 +318,13 @@ void TimestampQueries::prepare_offscreen_buffer()
 		// Color attachments
 
 		// We are using two 128-Bit RGBA floating point color buffers for this sample
-		// In a performance or bandwith-limited scenario you should consider using a format with lower precision
+		// In a performance or bandwidth-limited scenario you should consider using a format with lower precision
 		create_attachment(VK_FORMAT_R32G32B32A32_SFLOAT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &offscreen.color[0]);
 		create_attachment(VK_FORMAT_R32G32B32A32_SFLOAT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &offscreen.color[1]);
 		// Depth attachment
 		create_attachment(depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, &offscreen.depth);
 
-		// Set up separate renderpass with references to the colorand depth attachments
+		// Set up separate renderpass with references to the color and depth attachments
 		std::array<VkAttachmentDescription, 3> attachment_descriptions = {};
 
 		// Init attachment properties
@@ -366,24 +366,31 @@ void TimestampQueries::prepare_offscreen_buffer()
 		subpass.colorAttachmentCount    = 2;
 		subpass.pDepthStencilAttachment = &depth_reference;
 
-		// Use subpass dependencies for attachment layput transitions
+		// Use subpass dependencies for attachment layout transitions
 		std::array<VkSubpassDependency, 2> dependencies;
 
 		dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
 		dependencies[0].dstSubpass      = 0;
-		dependencies[0].srcStageMask    = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		dependencies[0].dstStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[0].srcAccessMask   = VK_ACCESS_MEMORY_READ_BIT;
-		dependencies[0].dstAccessMask   = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 		dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+		// End of previous commands
+		dependencies[0].srcStageMask  = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		dependencies[0].srcAccessMask = 0;
+		// Read/write from/to depth
+		dependencies[0].dstStageMask  = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+		dependencies[0].dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+		// Write to attachment
+		dependencies[0].dstStageMask |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[0].dstAccessMask |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 
 		dependencies[1].srcSubpass      = 0;
 		dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
-		dependencies[1].srcStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[1].dstStageMask    = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		dependencies[1].srcAccessMask   = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-		dependencies[1].dstAccessMask   = VK_ACCESS_MEMORY_READ_BIT;
 		dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+		// End of write to attachment
+		dependencies[1].srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		// Attachment later read using sampler in 'composition' pipeline
+		dependencies[1].dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+		dependencies[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
 		VkRenderPassCreateInfo render_pass_create_info = {};
 		render_pass_create_info.sType                  = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -438,7 +445,7 @@ void TimestampQueries::prepare_offscreen_buffer()
 		// Two floating point color buffers
 		create_attachment(VK_FORMAT_R32G32B32A32_SFLOAT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, &filter_pass.color[0]);
 
-		// Set up separate renderpass with references to the colorand depth attachments
+		// Set up separate renderpass with references to the color and depth attachments
 		std::array<VkAttachmentDescription, 1> attachment_descriptions = {};
 
 		// Init attachment properties
@@ -459,24 +466,31 @@ void TimestampQueries::prepare_offscreen_buffer()
 		subpass.pColorAttachments    = color_references.data();
 		subpass.colorAttachmentCount = 1;
 
-		// Use subpass dependencies for attachment layput transitions
+		// Use subpass dependencies for attachment layout transitions
 		std::array<VkSubpassDependency, 2> dependencies;
 
 		dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
 		dependencies[0].dstSubpass      = 0;
-		dependencies[0].srcStageMask    = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		dependencies[0].dstStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[0].srcAccessMask   = VK_ACCESS_MEMORY_READ_BIT;
-		dependencies[0].dstAccessMask   = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 		dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+		// End of previous commands
+		dependencies[0].srcStageMask  = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		dependencies[0].srcAccessMask = 0;
+		// Read from image in fragment shader
+		dependencies[0].dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+		dependencies[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		// Write to attachment
+		dependencies[0].dstStageMask |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[0].dstAccessMask |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 
 		dependencies[1].srcSubpass      = 0;
 		dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
-		dependencies[1].srcStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[1].dstStageMask    = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		dependencies[1].srcAccessMask   = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-		dependencies[1].dstAccessMask   = VK_ACCESS_MEMORY_READ_BIT;
 		dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+		// End of write to attachment
+		dependencies[1].srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		// Attachment later read using sampler in 'bloom[0]' pipeline
+		dependencies[1].dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+		dependencies[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
 		VkRenderPassCreateInfo render_pass_create_info = {};
 		render_pass_create_info.sType                  = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;


### PR DESCRIPTION
## Description

This PR fixes synchronization errors produced by validation layers in 'timestamp_queries' and 'hdr' samples.
Fixes for both samples are the same as this samples contain similar code.
With this fixes there are no more validation errors.

## Notes:

Tested on:
VulkanSDK: 1.3.239.0
Driver Version: 528.49.0.0
Windows 10
Nvidia Quadro P600
Intel i7-8750H
32 GB RAM

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on **Windows**, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)

