### PR TITLE
Fix missing ktx lib

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -163,7 +163,7 @@ set(KTX_INCLUDE_DIRS
     ${KTX_DIR}/other_include
 )
 
-add_library(ktx SHARED ${KTX_SOURCES})
+add_library(ktx STATIC ${KTX_SOURCES})
 
 target_compile_definitions(ktx PUBLIC LIBKTX)
 if (WIN32)


### PR DESCRIPTION
## Description

After updating the build system to build and compile much quicker we also set KTX to be a shared library by default. Due to how the build system propagates libraries across folders the runtime linker can not find KTX. There are two ways to fix this.

1. Use a static library instead (easy - compiled into the executable)
2. Package the ktx library next to the executable (hard - must support all platforms)

I chose the easy option :)

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making