### PR TITLE
Change vkb::HPPResourceCache from a facade over vkb::ResourceCache to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -46,6 +46,8 @@ set(FRAMEWORK_FILES
     hpp_gui.h
     hpp_resource_binding_state.h
     hpp_resource_cache.h
+    hpp_resource_record.h
+    hpp_resource_replay.h
     hpp_vulkan_sample.h
     # Source Files
     gui.cpp
@@ -67,6 +69,7 @@ set(FRAMEWORK_FILES
     camera.cpp
     hpp_gui.cpp
     hpp_api_vulkan_sample.cpp
+    hpp_resource_cache.cpp
 	hpp_vulkan_sample.cpp)
 
 set(COMMON_FILES
@@ -82,6 +85,7 @@ set(COMMON_FILES
     common/strings.h
     common/tags.h
     common/hpp_error.h
+    common/hpp_resource_caching.h
     common/hpp_strings.h
     common/hpp_utils.h
     common/hpp_vk_common.h
@@ -249,6 +253,8 @@ set(CORE_FILES
     core/hpp_command_buffer.h
     core/hpp_command_pool.h
     core/hpp_debug.h
+    core/hpp_descriptor_pool.h
+    core/hpp_descriptor_set.h
     core/hpp_descriptor_set_layout.h
     core/hpp_device.h
     core/hpp_framebuffer.h

--- a/framework/common/hpp_resource_caching.h
+++ b/framework/common/hpp_resource_caching.h
@@ -1,0 +1,408 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "resource_caching.h"
+#include <core/hpp_device.h>
+#include <vulkan/vulkan_hash.hpp>
+
+namespace std
+{
+template <typename Key, typename Value>
+struct hash<std::map<Key, Value>>
+{
+	size_t operator()(std::map<Key, Value> const &bindings) const
+	{
+		size_t result = 0;
+		vkb::hash_combine(result, bindings.size());
+		for (auto &binding : bindings)
+		{
+			vkb::hash_combine(result, binding.first);
+			vkb::hash_combine(result, binding.second);
+		}
+		return result;
+	}
+};
+
+template <typename T>
+struct hash<std::vector<T>>
+{
+	size_t operator()(std::vector<T> const &values) const
+	{
+		size_t result = 0;
+		vkb::hash_combine(result, values.size());
+		for (auto const &value : values)
+		{
+			vkb::hash_combine(result, value);
+		}
+		return result;
+	}
+};
+
+template <>
+struct hash<vkb::common::HPPLoadStoreInfo>
+{
+	size_t operator()(vkb::common::HPPLoadStoreInfo const &lsi) const
+	{
+		size_t result = 0;
+		vkb::hash_combine(result, lsi.load_op);
+		vkb::hash_combine(result, lsi.store_op);
+		return result;
+	}
+};
+
+template <typename T>
+struct hash<vkb::core::HPPVulkanResource<T>>
+{
+	size_t operator()(const vkb::core::HPPVulkanResource<T> &vulkan_resource) const
+	{
+		return std::hash<T>()(vulkan_resource.get_handle());
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPDescriptorPool>
+{
+	size_t operator()(const vkb::core::HPPDescriptorPool &descriptor_pool) const
+	{
+		return std::hash<vkb::DescriptorPool>()(reinterpret_cast<vkb::DescriptorPool const &>(descriptor_pool));
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPDescriptorSet>
+{
+	size_t operator()(vkb::core::HPPDescriptorSet &descriptor_set) const
+	{
+		size_t result = 0;
+		vkb::hash_combine(result, descriptor_set.get_layout());
+		// descriptor_pool ?
+		vkb::hash_combine(result, descriptor_set.get_buffer_infos());
+		vkb::hash_combine(result, descriptor_set.get_image_infos());
+		vkb::hash_combine(result, descriptor_set.get_handle());
+		// write_descriptor_sets ?
+
+		return result;
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPDescriptorSetLayout>
+{
+	size_t operator()(const vkb::core::HPPDescriptorSetLayout &descriptor_set_layout) const
+	{
+		return std::hash<vkb::DescriptorSetLayout>()(reinterpret_cast<vkb::DescriptorSetLayout const &>(descriptor_set_layout));
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPImage>
+{
+	size_t operator()(const vkb::core::HPPImage &image) const
+	{
+		size_t result = 0;
+		vkb::hash_combine(result, image.get_memory());
+		vkb::hash_combine(result, image.get_type());
+		vkb::hash_combine(result, image.get_extent());
+		vkb::hash_combine(result, image.get_format());
+		vkb::hash_combine(result, image.get_usage());
+		vkb::hash_combine(result, image.get_sample_count());
+		vkb::hash_combine(result, image.get_tiling());
+		vkb::hash_combine(result, image.get_subresource());
+		vkb::hash_combine(result, image.get_array_layer_count());
+		return result;
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPImageView>
+{
+	size_t operator()(const vkb::core::HPPImageView &image_view) const
+	{
+		size_t result = std::hash<vkb::core::HPPVulkanResource<vk::ImageView>>()(image_view);
+		vkb::hash_combine(result, image_view.get_image());
+		vkb::hash_combine(result, image_view.get_format());
+		vkb::hash_combine(result, image_view.get_subresource_range());
+		return result;
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPRenderPass>
+{
+	size_t operator()(const vkb::core::HPPRenderPass &render_pass) const
+	{
+		return std::hash<vkb::RenderPass>()(reinterpret_cast<vkb::RenderPass const &>(render_pass));
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPShaderModule>
+{
+	size_t operator()(const vkb::core::HPPShaderModule &shader_module) const
+	{
+		return std::hash<vkb::ShaderModule>()(reinterpret_cast<vkb::ShaderModule const &>(shader_module));
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPShaderResource>
+{
+	size_t operator()(vkb::core::HPPShaderResource const &shader_resource) const
+	{
+		size_t result = 0;
+		vkb::hash_combine(result, shader_resource.stages);
+		vkb::hash_combine(result, shader_resource.type);
+		vkb::hash_combine(result, shader_resource.mode);
+		vkb::hash_combine(result, shader_resource.set);
+		vkb::hash_combine(result, shader_resource.binding);
+		vkb::hash_combine(result, shader_resource.location);
+		vkb::hash_combine(result, shader_resource.input_attachment_index);
+		vkb::hash_combine(result, shader_resource.vec_size);
+		vkb::hash_combine(result, shader_resource.columns);
+		vkb::hash_combine(result, shader_resource.array_size);
+		vkb::hash_combine(result, shader_resource.offset);
+		vkb::hash_combine(result, shader_resource.size);
+		vkb::hash_combine(result, shader_resource.constant_id);
+		vkb::hash_combine(result, shader_resource.qualifiers);
+		vkb::hash_combine(result, shader_resource.name);
+		return result;
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPShaderSource>
+{
+	size_t operator()(const vkb::core::HPPShaderSource &shader_source) const
+	{
+		return std::hash<vkb::ShaderSource>()(reinterpret_cast<vkb::ShaderSource const &>(shader_source));
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPShaderVariant>
+{
+	size_t operator()(const vkb::core::HPPShaderVariant &shader_variant) const
+	{
+		return std::hash<vkb::ShaderVariant>()(reinterpret_cast<vkb::ShaderVariant const &>(shader_variant));
+	}
+};
+
+template <>
+struct hash<vkb::core::HPPSubpassInfo>
+{
+	size_t operator()(vkb::core::HPPSubpassInfo const &subpass_info) const
+	{
+		size_t result = 0;
+		vkb::hash_combine(result, subpass_info.input_attachments);
+		vkb::hash_combine(result, subpass_info.output_attachments);
+		vkb::hash_combine(result, subpass_info.color_resolve_attachments);
+		vkb::hash_combine(result, subpass_info.disable_depth_stencil_attachment);
+		vkb::hash_combine(result, subpass_info.depth_stencil_resolve_attachment);
+		vkb::hash_combine(result, subpass_info.depth_stencil_resolve_mode);
+		vkb::hash_combine(result, subpass_info.debug_name);
+		return result;
+	}
+};
+
+template <>
+struct hash<vkb::rendering::HPPAttachment>
+{
+	size_t operator()(const vkb::rendering::HPPAttachment &attachment) const
+	{
+		size_t result = 0;
+		vkb::hash_combine(result, attachment.format);
+		vkb::hash_combine(result, attachment.samples);
+		vkb::hash_combine(result, attachment.usage);
+		vkb::hash_combine(result, attachment.initial_layout);
+		return result;
+	}
+};
+
+template <>
+struct hash<vkb::rendering::HPPPipelineState>
+{
+	size_t operator()(const vkb::rendering::HPPPipelineState &pipeline_state) const
+	{
+		return std::hash<vkb::PipelineState>()(reinterpret_cast<vkb::PipelineState const &>(pipeline_state));
+	}
+};
+
+template <>
+struct hash<vkb::rendering::HPPRenderTarget>
+{
+	size_t operator()(const vkb::rendering::HPPRenderTarget &render_target) const
+	{
+		size_t result = 0;
+		vkb::hash_combine(result, render_target.get_extent());
+		for (auto const &view : render_target.get_views())
+		{
+			vkb::hash_combine(result, view);
+		}
+		for (auto const &attachment : render_target.get_attachments())
+		{
+			vkb::hash_combine(result, attachment);
+		}
+		for (auto const &input : render_target.get_input_attachments())
+		{
+			vkb::hash_combine(result, input);
+		}
+		for (auto const &output : render_target.get_output_attachments())
+		{
+			vkb::hash_combine(result, output);
+		}
+		return result;
+	}
+};
+
+}        // namespace std
+
+namespace vkb
+{
+/**
+ * @brief facade helper functions and structs around the functions and structs in common/resource_caching, providing a vulkan.hpp-based interface
+ */
+
+namespace
+{
+template <class T, class... A>
+struct HPPRecordHelper
+{
+	size_t record(HPPResourceRecord & /*recorder*/, A &.../*args*/)
+	{
+		assert(false);
+		return 0;
+	}
+
+	void index(HPPResourceRecord & /*recorder*/, size_t /*index*/, T & /*resource*/)
+	{
+		assert(false);
+	}
+};
+
+template <class... A>
+struct HPPRecordHelper<vkb::core::HPPShaderModule, A...>
+{
+	size_t record(HPPResourceRecord &recorder, A &...args)
+	{
+		return recorder.register_shader_module(args...);
+	}
+
+	void index(HPPResourceRecord &recorder, size_t index, vkb::core::HPPShaderModule &shader_module)
+	{
+		recorder.set_shader_module(index, shader_module);
+	}
+};
+
+template <class... A>
+struct HPPRecordHelper<vkb::core::HPPPipelineLayout, A...>
+{
+	size_t record(HPPResourceRecord &recorder, A &...args)
+	{
+		return recorder.register_pipeline_layout(args...);
+	}
+
+	void index(HPPResourceRecord &recorder, size_t index, vkb::core::HPPPipelineLayout &pipeline_layout)
+	{
+		recorder.set_pipeline_layout(index, pipeline_layout);
+	}
+};
+
+template <class... A>
+struct HPPRecordHelper<vkb::core::HPPRenderPass, A...>
+{
+	size_t record(HPPResourceRecord &recorder, A &...args)
+	{
+		return recorder.register_render_pass(args...);
+	}
+
+	void index(HPPResourceRecord &recorder, size_t index, vkb::core::HPPRenderPass &render_pass)
+	{
+		recorder.set_render_pass(index, render_pass);
+	}
+};
+
+template <class... A>
+struct HPPRecordHelper<vkb::core::HPPGraphicsPipeline, A...>
+{
+	size_t record(HPPResourceRecord &recorder, A &...args)
+	{
+		return recorder.register_graphics_pipeline(args...);
+	}
+
+	void index(HPPResourceRecord &recorder, size_t index, vkb::core::HPPGraphicsPipeline &graphics_pipeline)
+	{
+		recorder.set_graphics_pipeline(index, graphics_pipeline);
+	}
+};
+}        // namespace
+
+template <class T, class... A>
+T &request_resource(vkb::core::HPPDevice &device, vkb::HPPResourceRecord *recorder, std::unordered_map<size_t, T> &resources, A &...args)
+{
+	HPPRecordHelper<T, A...> record_helper;
+
+	size_t hash{0U};
+	hash_param(hash, args...);
+
+	auto res_it = resources.find(hash);
+
+	if (res_it != resources.end())
+	{
+		return res_it->second;
+	}
+
+	// If we do not have it already, create and cache it
+	const char *res_type = typeid(T).name();
+	size_t      res_id   = resources.size();
+
+	LOGD("Building #{} cache object ({})", res_id, res_type);
+
+// Only error handle in release
+#ifndef DEBUG
+	try
+	{
+#endif
+		T resource(device, args...);
+
+		auto res_ins_it = resources.emplace(hash, std::move(resource));
+
+		if (!res_ins_it.second)
+		{
+			throw std::runtime_error{std::string{"Insertion error for #"} + std::to_string(res_id) + "cache object (" + res_type + ")"};
+		}
+
+		res_it = res_ins_it.first;
+
+		if (recorder)
+		{
+			size_t index = record_helper.record(*recorder, args...);
+			record_helper.index(*recorder, index, res_it->second);
+		}
+#ifndef DEBUG
+	}
+	catch (const std::exception &e)
+	{
+		LOGE("Creation error for #{} cache object ({})", res_id, res_type);
+		throw e;
+	}
+#endif
+
+	return res_it->second;
+}
+}        // namespace vkb

--- a/framework/core/hpp_command_buffer.h
+++ b/framework/core/hpp_command_buffer.h
@@ -30,6 +30,7 @@ namespace vkb
 namespace core
 {
 class HPPCommandPool;
+class HPPDescriptorSetLayout;
 
 /**
  * @brief Helper class to manage and record a command buffer, building and

--- a/framework/core/hpp_descriptor_pool.h
+++ b/framework/core/hpp_descriptor_pool.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "descriptor_pool.h"
+#include <core/hpp_descriptor_set_layout.h>
+
+namespace vkb
+{
+namespace core
+{
+class HPPDevice;
+
+/**
+ * @brief facade class around vkb::DescriptorPool, providing a vulkan.hpp-based interface
+ *
+ * See vkb::DescriptorPool for documentation
+ */
+class HPPDescriptorPool : private vkb::DescriptorPool
+{
+  public:
+	HPPDescriptorPool(vkb::core::HPPDevice &device, const vkb::core::HPPDescriptorSetLayout &descriptor_set_layout, uint32_t pool_size = MAX_SETS_PER_POOL) :
+	    vkb::DescriptorPool(reinterpret_cast<vkb::Device &>(device), reinterpret_cast<vkb::DescriptorSetLayout const &>(descriptor_set_layout), pool_size)
+	{}
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_descriptor_set.h
+++ b/framework/core/hpp_descriptor_set.h
@@ -1,0 +1,69 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "descriptor_set.h"
+#include <core/hpp_descriptor_pool.h>
+#include <core/hpp_descriptor_set_layout.h>
+
+namespace vkb
+{
+namespace core
+{
+/**
+ * @brief facade class around vkb::DescriptorSet, providing a vulkan.hpp-based interface
+ *
+ * See vkb::DescriptorSet for documentation
+ */
+class HPPDescriptorSet : private vkb::DescriptorSet
+{
+  public:
+	HPPDescriptorSet(vkb::core::HPPDevice                       &device,
+	                 const vkb::core::HPPDescriptorSetLayout    &descriptor_set_layout,
+	                 vkb::core::HPPDescriptorPool               &descriptor_pool,
+	                 const BindingMap<vk::DescriptorBufferInfo> &buffer_infos = {},
+	                 const BindingMap<vk::DescriptorImageInfo>  &image_infos  = {}) :
+	    vkb::DescriptorSet(reinterpret_cast<vkb::Device &>(device),
+	                       reinterpret_cast<vkb::DescriptorSetLayout const &>(descriptor_set_layout),
+	                       reinterpret_cast<vkb::DescriptorPool &>(descriptor_pool),
+	                       reinterpret_cast<BindingMap<VkDescriptorBufferInfo> const &>(buffer_infos),
+	                       reinterpret_cast<BindingMap<VkDescriptorImageInfo> const &>(image_infos))
+	{}
+
+	BindingMap<vk::DescriptorBufferInfo> &get_buffer_infos()
+	{
+		return reinterpret_cast<BindingMap<vk::DescriptorBufferInfo> &>(vkb::DescriptorSet::get_buffer_infos());
+	}
+
+	vk::DescriptorSet get_handle() const
+	{
+		return static_cast<vk::DescriptorSet>(vkb::DescriptorSet::get_handle());
+	}
+
+	BindingMap<vk::DescriptorImageInfo> &get_image_infos()
+	{
+		return reinterpret_cast<BindingMap<vk::DescriptorImageInfo> &>(vkb::DescriptorSet::get_image_infos());
+	}
+
+	const vkb::core::HPPDescriptorSetLayout &get_layout() const
+	{
+		return reinterpret_cast<vkb::core::HPPDescriptorSetLayout const &>(vkb::DescriptorSet::get_layout());
+	}
+};
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_descriptor_set_layout.h
+++ b/framework/core/hpp_descriptor_set_layout.h
@@ -24,6 +24,10 @@ namespace vkb
 {
 namespace core
 {
+class HPPDevice;
+class HPPShaderModule;
+struct HPPShaderResource;
+
 /**
  * @brief facade class around vkb::DescriptorSetLayout, providing a vulkan.hpp-based interface
  *
@@ -32,6 +36,16 @@ namespace core
 class HPPDescriptorSetLayout : private vkb::DescriptorSetLayout
 {
   public:
+	HPPDescriptorSetLayout(vkb::core::HPPDevice                            &device,
+	                       const uint32_t                                   set_index,
+	                       const std::vector<vkb::core::HPPShaderModule *> &shader_modules,
+	                       const std::vector<vkb::core::HPPShaderResource> &resource_set) :
+	    vkb::DescriptorSetLayout(reinterpret_cast<vkb::Device &>(device),
+	                             set_index,
+	                             reinterpret_cast<std::vector<vkb::ShaderModule *> const &>(shader_modules),
+	                             reinterpret_cast<std::vector<vkb::ShaderResource> const &>(resource_set))
+	{}
+
 	vk::DescriptorSetLayout get_handle() const
 	{
 		return static_cast<vk::DescriptorSetLayout>(vkb::DescriptorSetLayout::get_handle());

--- a/framework/core/hpp_framebuffer.h
+++ b/framework/core/hpp_framebuffer.h
@@ -22,8 +22,16 @@
 
 namespace vkb
 {
+namespace rendering
+{
+class HPPRenderTarget;
+}
+
 namespace core
 {
+class HPPDevice;
+class HPPRenderPass;
+
 /**
  * @brief facade class around vkb::Framebuffer, providing a vulkan.hpp-based interface
  *
@@ -32,6 +40,12 @@ namespace core
 class HPPFramebuffer : private vkb::Framebuffer
 {
   public:
+	HPPFramebuffer(vkb::core::HPPDevice &device, const vkb::rendering::HPPRenderTarget &render_target, const vkb::core::HPPRenderPass &render_pass) :
+	    vkb::Framebuffer(reinterpret_cast<vkb::Device &>(device),
+	                     reinterpret_cast<vkb::RenderTarget const &>(render_target),
+	                     reinterpret_cast<vkb::RenderPass const &>(render_pass))
+	{}
+
 	const vk::Extent2D &get_extent() const
 	{
 		return reinterpret_cast<vk::Extent2D const &>(vkb::Framebuffer::get_extent());

--- a/framework/core/hpp_pipeline.h
+++ b/framework/core/hpp_pipeline.h
@@ -21,6 +21,11 @@
 
 namespace vkb
 {
+namespace rendering
+{
+class HPPPipelineState;
+}
+
 namespace core
 {
 /**
@@ -37,12 +42,32 @@ class HPPPipeline : private vkb::Pipeline
 	}
 };
 
-class HPPComputePipeline : public HPPPipeline
+class HPPComputePipeline : private vkb::ComputePipeline
 {
+  public:
+	HPPComputePipeline(vkb::core::HPPDevice &device, vk::PipelineCache pipeline_cache, vkb::rendering::HPPPipelineState &pipeline_state) :
+	    vkb::ComputePipeline(
+	        reinterpret_cast<vkb::Device &>(device), static_cast<VkPipelineCache>(pipeline_cache), reinterpret_cast<vkb::PipelineState &>(pipeline_state))
+	{}
+
+	vk::Pipeline get_handle() const
+	{
+		return static_cast<vk::Pipeline>(vkb::ComputePipeline::get_handle());
+	}
 };
 
-class HPPGraphicsPipeline : public HPPPipeline
+class HPPGraphicsPipeline : private vkb::GraphicsPipeline
 {
+  public:
+	HPPGraphicsPipeline(vkb::core::HPPDevice &device, vk::PipelineCache pipeline_cache, vkb::rendering::HPPPipelineState &pipeline_state) :
+	    vkb::GraphicsPipeline(
+	        reinterpret_cast<vkb::Device &>(device), static_cast<VkPipelineCache>(pipeline_cache), reinterpret_cast<vkb::PipelineState &>(pipeline_state))
+	{}
+
+	vk::Pipeline get_handle() const
+	{
+		return static_cast<vk::Pipeline>(vkb::GraphicsPipeline::get_handle());
+	}
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_pipeline_layout.h
+++ b/framework/core/hpp_pipeline_layout.h
@@ -36,6 +36,10 @@ class HPPPipelineLayout : private vkb::PipelineLayout
 	using vkb::PipelineLayout::has_descriptor_set_layout;
 
   public:
+	HPPPipelineLayout(vkb::core::HPPDevice &device, const std::vector<vkb::core::HPPShaderModule *> &shader_modules) :
+	    vkb::PipelineLayout(reinterpret_cast<vkb::Device &>(device), reinterpret_cast<std::vector<vkb::ShaderModule *> const &>(shader_modules))
+	{}
+
 	vkb::core::HPPDescriptorSetLayout &get_descriptor_set_layout(const uint32_t set_index) const
 	{
 		return reinterpret_cast<vkb::core::HPPDescriptorSetLayout &>(vkb::PipelineLayout::get_descriptor_set_layout(set_index));

--- a/framework/core/hpp_render_pass.h
+++ b/framework/core/hpp_render_pass.h
@@ -22,6 +22,16 @@
 
 namespace vkb
 {
+namespace common
+{
+struct HPPLoadStoreInfo;
+
+}
+namespace rendering
+{
+struct HPPAttachment;
+}
+
 namespace core
 {
 /**
@@ -47,6 +57,16 @@ class HPPRenderPass : private vkb::RenderPass
 	using vkb::RenderPass::get_color_output_count;
 
   public:
+	HPPRenderPass(vkb::core::HPPDevice                             &device,
+	              const std::vector<vkb::rendering::HPPAttachment> &attachments,
+	              const std::vector<vkb::common::HPPLoadStoreInfo> &load_store_infos,
+	              const std::vector<vkb::core::HPPSubpassInfo>     &subpasses) :
+	    vkb::RenderPass(reinterpret_cast<vkb::Device &>(device),
+	                    reinterpret_cast<std::vector<vkb::Attachment> const &>(attachments),
+	                    reinterpret_cast<std::vector<vkb::LoadStoreInfo> const &>(load_store_infos),
+	                    reinterpret_cast<std::vector<vkb::SubpassInfo> const &>(subpasses))
+	{}
+
 	vk::RenderPass get_handle() const
 	{
 		return static_cast<vk::RenderPass>(vkb::RenderPass::get_handle());

--- a/framework/core/hpp_shader_module.h
+++ b/framework/core/hpp_shader_module.h
@@ -30,6 +30,36 @@ namespace core
  * See vkb::ShaderModule for documentation
  */
 
+class HPPShaderSource : private vkb::ShaderSource
+{
+  public:
+	HPPShaderSource(const std::string &filename) :
+	    vkb::ShaderSource(filename)
+	{}
+};
+
+class HPPShaderVariant : private vkb::ShaderVariant
+{};
+
+class HPPShaderModule : private vkb::ShaderModule
+{
+  public:
+	using vkb::ShaderModule::get_id;
+
+  public:
+	HPPShaderModule(vkb::core::HPPDevice              &device,
+	                vk::ShaderStageFlagBits            stage,
+	                const vkb::core::HPPShaderSource  &glsl_source,
+	                const std::string                 &entry_point,
+	                const vkb::core::HPPShaderVariant &shader_variant) :
+	    vkb::ShaderModule(reinterpret_cast<vkb::Device &>(device),
+	                      static_cast<VkShaderStageFlagBits>(stage),
+	                      reinterpret_cast<vkb::ShaderSource const &>(glsl_source),
+	                      entry_point,
+	                      reinterpret_cast<vkb::ShaderVariant const &>(shader_variant))
+	{}
+};
+
 /// This determines the type and method of how descriptor set should be created and bound
 enum class HPPShaderResourceMode
 {

--- a/framework/hpp_gui.cpp
+++ b/framework/hpp_gui.cpp
@@ -198,8 +198,8 @@ HPPGui::HPPGui(HPPVulkanSample &sample_, const vkb::platform::HPPWindow &window,
 		device.get_command_pool().reset_pool();
 	}
 
-	vkb::ShaderSource vert_shader("imgui.vert");
-	vkb::ShaderSource frag_shader("imgui.frag");
+	vkb::core::HPPShaderSource vert_shader("imgui.vert");
+	vkb::core::HPPShaderSource frag_shader("imgui.frag");
 
 	std::vector<vkb::core::HPPShaderModule *> shader_modules;
 	shader_modules.push_back(&device.get_resource_cache().request_shader_module(vk::ShaderStageFlagBits::eVertex, vert_shader, {}));

--- a/framework/hpp_resource_cache.cpp
+++ b/framework/hpp_resource_cache.cpp
@@ -1,0 +1,212 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hpp_resource_cache.h"
+#include <common/hpp_resource_caching.h>
+#include <core/hpp_descriptor_set.h>
+#include <core/hpp_device.h>
+#include <core/hpp_image_view.h>
+#include <core/hpp_pipeline_layout.h>
+
+namespace vkb
+{
+namespace
+{
+template <class T, class... A>
+T &request_resource(
+    vkb::core::HPPDevice &device, vkb::HPPResourceRecord &recorder, std::mutex &resource_mutex, std::unordered_map<std::size_t, T> &resources, A &...args)
+{
+	std::lock_guard<std::mutex> guard(resource_mutex);
+
+	auto &res = request_resource(device, &recorder, resources, args...);
+
+	return res;
+}
+}        // namespace
+
+HPPResourceCache::HPPResourceCache(vkb::core::HPPDevice &device) :
+    device{device}
+{}
+
+void HPPResourceCache::clear()
+{
+	state.shader_modules.clear();
+	state.pipeline_layouts.clear();
+	state.descriptor_sets.clear();
+	state.descriptor_set_layouts.clear();
+	state.render_passes.clear();
+	clear_pipelines();
+	clear_framebuffers();
+}
+
+void HPPResourceCache::clear_framebuffers()
+{
+	state.framebuffers.clear();
+}
+
+void HPPResourceCache::clear_pipelines()
+{
+	state.graphics_pipelines.clear();
+	state.compute_pipelines.clear();
+}
+
+const HPPResourceCacheState &HPPResourceCache::get_internal_state() const
+{
+	return state;
+}
+
+vkb::core::HPPComputePipeline &HPPResourceCache::request_compute_pipeline(vkb::rendering::HPPPipelineState &pipeline_state)
+{
+	return request_resource(device, recorder, compute_pipeline_mutex, state.compute_pipelines, pipeline_cache, pipeline_state);
+}
+
+vkb::core::HPPDescriptorSet &HPPResourceCache::request_descriptor_set(vkb::core::HPPDescriptorSetLayout          &descriptor_set_layout,
+                                                                      const BindingMap<vk::DescriptorBufferInfo> &buffer_infos,
+                                                                      const BindingMap<vk::DescriptorImageInfo>  &image_infos)
+{
+	auto &descriptor_pool = request_resource(device, recorder, descriptor_set_mutex, state.descriptor_pools, descriptor_set_layout);
+	return request_resource(device, recorder, descriptor_set_mutex, state.descriptor_sets, descriptor_set_layout, descriptor_pool, buffer_infos, image_infos);
+}
+
+vkb::core::HPPDescriptorSetLayout &HPPResourceCache::request_descriptor_set_layout(const uint32_t                                   set_index,
+                                                                                   const std::vector<vkb::core::HPPShaderModule *> &shader_modules,
+                                                                                   const std::vector<vkb::core::HPPShaderResource> &set_resources)
+{
+	return request_resource(device, recorder, descriptor_set_layout_mutex, state.descriptor_set_layouts, set_index, shader_modules, set_resources);
+}
+
+vkb::core::HPPFramebuffer &HPPResourceCache::request_framebuffer(const vkb::rendering::HPPRenderTarget &render_target,
+                                                                 const vkb::core::HPPRenderPass        &render_pass)
+{
+	return request_resource(device, recorder, framebuffer_mutex, state.framebuffers, render_target, render_pass);
+}
+
+vkb::core::HPPGraphicsPipeline &HPPResourceCache::request_graphics_pipeline(vkb::rendering::HPPPipelineState &pipeline_state)
+{
+	return request_resource(device, recorder, graphics_pipeline_mutex, state.graphics_pipelines, pipeline_cache, pipeline_state);
+}
+
+vkb::core::HPPPipelineLayout &HPPResourceCache::request_pipeline_layout(const std::vector<vkb::core::HPPShaderModule *> &shader_modules)
+{
+	return request_resource(device, recorder, pipeline_layout_mutex, state.pipeline_layouts, shader_modules);
+}
+
+vkb::core::HPPRenderPass &HPPResourceCache::request_render_pass(const std::vector<vkb::rendering::HPPAttachment> &attachments,
+                                                                const std::vector<vkb::common::HPPLoadStoreInfo> &load_store_infos,
+                                                                const std::vector<vkb::core::HPPSubpassInfo>     &subpasses)
+{
+	return request_resource(device, recorder, render_pass_mutex, state.render_passes, attachments, load_store_infos, subpasses);
+}
+
+vkb::core::HPPShaderModule &HPPResourceCache::request_shader_module(vk::ShaderStageFlagBits            stage,
+                                                                    const vkb::core::HPPShaderSource  &glsl_source,
+                                                                    const vkb::core::HPPShaderVariant &shader_variant)
+{
+	std::string entry_point{"main"};
+	return request_resource(device, recorder, shader_module_mutex, state.shader_modules, stage, glsl_source, entry_point, shader_variant);
+}
+
+std::vector<uint8_t> HPPResourceCache::serialize()
+{
+	return recorder.get_data();
+}
+
+void HPPResourceCache::set_pipeline_cache(vk::PipelineCache new_pipeline_cache)
+{
+	pipeline_cache = new_pipeline_cache;
+}
+
+void HPPResourceCache::update_descriptor_sets(const std::vector<vkb::core::HPPImageView> &old_views, const std::vector<vkb::core::HPPImageView> &new_views)
+{
+	// Find descriptor sets referring to the old image view
+	std::vector<vk::WriteDescriptorSet> set_updates;
+	std::set<size_t>                    matches;
+
+	for (size_t i = 0; i < old_views.size(); ++i)
+	{
+		auto &old_view = old_views[i];
+		auto &new_view = new_views[i];
+
+		for (auto &kd_pair : state.descriptor_sets)
+		{
+			auto &key            = kd_pair.first;
+			auto &descriptor_set = kd_pair.second;
+
+			auto &image_infos = descriptor_set.get_image_infos();
+
+			for (auto &ba_pair : image_infos)
+			{
+				auto &binding = ba_pair.first;
+				auto &array   = ba_pair.second;
+
+				for (auto &ai_pair : array)
+				{
+					auto &array_element = ai_pair.first;
+					auto &image_info    = ai_pair.second;
+
+					if (image_info.imageView == old_view.get_handle())
+					{
+						// Save key to remove old descriptor set
+						matches.insert(key);
+
+						// Update image info with new view
+						image_info.imageView = new_view.get_handle();
+
+						// Save struct for writing the update later
+						if (auto binding_info = descriptor_set.get_layout().get_layout_binding(binding))
+						{
+							vk::WriteDescriptorSet write_descriptor_set(descriptor_set.get_handle(), binding, array_element, binding_info->descriptorType, image_info);
+							set_updates.push_back(write_descriptor_set);
+						}
+						else
+						{
+							LOGE("Shader layout set does not use image binding at #{}", binding);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if (!set_updates.empty())
+	{
+		device.get_handle().updateDescriptorSets(set_updates, {});
+	}
+
+	// Delete old entries (moved out descriptor sets)
+	for (auto &match : matches)
+	{
+		// Move out of the map
+		auto it             = state.descriptor_sets.find(match);
+		auto descriptor_set = std::move(it->second);
+		state.descriptor_sets.erase(match);
+
+		// Generate new key
+		size_t new_key = std::hash<vkb::core::HPPDescriptorSet>()(descriptor_set);
+
+		// Add (key, resource) to the cache
+		state.descriptor_sets.emplace(new_key, std::move(descriptor_set));
+	}
+}
+
+void HPPResourceCache::warmup(const std::vector<uint8_t> &data)
+{
+	recorder.set_data(data);
+
+	replayer.play(*this, recorder);
+}
+}        // namespace vkb

--- a/framework/hpp_resource_cache.h
+++ b/framework/hpp_resource_cache.h
@@ -17,86 +17,102 @@
 
 #pragma once
 
-#include <resource_cache.h>
+#include <core/hpp_descriptor_set.h>
+#include <core/hpp_framebuffer.h>
+#include <core/hpp_pipeline_layout.h>
+#include <core/hpp_render_pass.h>
+#include <hpp_resource_record.h>
+#include <hpp_resource_replay.h>
+#include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
 namespace core
 {
-class HPPComputePipeline;
-class HPPDevice;
-class HPPGraphicsPipeline;
-class HPPPipelineLayout;
-class HPPShaderModule;
+class HPPDescriptorPool;
+class HPPDescriptorSetLayout;
+class HPPImageView;
 }        // namespace core
 
 namespace rendering
 {
-struct HPPAttachment;
+class HPPRenderTarget;
 }
 
 /**
- * @brief facade class around vkb::ResourceCache, providing a vulkan.hpp-based interface
+ * @brief Struct to hold the internal state of the Resource Cache
+ *
+ */
+struct HPPResourceCacheState
+{
+	std::unordered_map<std::size_t, vkb::core::HPPShaderModule>        shader_modules;
+	std::unordered_map<std::size_t, vkb::core::HPPPipelineLayout>      pipeline_layouts;
+	std::unordered_map<std::size_t, vkb::core::HPPDescriptorSetLayout> descriptor_set_layouts;
+	std::unordered_map<std::size_t, vkb::core::HPPDescriptorPool>      descriptor_pools;
+	std::unordered_map<std::size_t, vkb::core::HPPRenderPass>          render_passes;
+	std::unordered_map<std::size_t, vkb::core::HPPGraphicsPipeline>    graphics_pipelines;
+	std::unordered_map<std::size_t, vkb::core::HPPComputePipeline>     compute_pipelines;
+	std::unordered_map<std::size_t, vkb::core::HPPDescriptorSet>       descriptor_sets;
+	std::unordered_map<std::size_t, vkb::core::HPPFramebuffer>         framebuffers;
+};
+
+/**
+ * @brief vulkan.hpp version of the vkb::ResourceCache class
  *
  * See vkb::ResourceCache for documentation
  */
-class HPPResourceCache : private vkb::ResourceCache
+class HPPResourceCache
 {
   public:
-	using vkb::ResourceCache::clear;
-	using vkb::ResourceCache::clear_framebuffers;
-	using vkb::ResourceCache::clear_pipelines;
-	using vkb::ResourceCache::serialize;
-	using vkb::ResourceCache::warmup;
+	HPPResourceCache(vkb::core::HPPDevice &device);
 
-	HPPResourceCache(vkb::core::HPPDevice &device) :
-	    vkb::ResourceCache(reinterpret_cast<vkb::Device &>(device))
-	{}
+	HPPResourceCache(const HPPResourceCache &)            = delete;
+	HPPResourceCache(HPPResourceCache &&)                 = delete;
+	HPPResourceCache &operator=(const HPPResourceCache &) = delete;
+	HPPResourceCache &operator=(HPPResourceCache &&)      = delete;
 
-	vkb::core::HPPComputePipeline &request_compute_pipeline(vkb::rendering::HPPPipelineState &pipeline_state)
-	{
-		return reinterpret_cast<vkb::core::HPPComputePipeline &>(
-		    vkb::ResourceCache::request_compute_pipeline(reinterpret_cast<vkb::PipelineState &>(pipeline_state)));
-	}
+	void                               clear();
+	void                               clear_framebuffers();
+	void                               clear_pipelines();
+	const HPPResourceCacheState       &get_internal_state() const;
+	vkb::core::HPPComputePipeline     &request_compute_pipeline(vkb::rendering::HPPPipelineState &pipeline_state);
+	vkb::core::HPPDescriptorSet       &request_descriptor_set(vkb::core::HPPDescriptorSetLayout          &descriptor_set_layout,
+	                                                          const BindingMap<vk::DescriptorBufferInfo> &buffer_infos,
+	                                                          const BindingMap<vk::DescriptorImageInfo>  &image_infos);
+	vkb::core::HPPDescriptorSetLayout &request_descriptor_set_layout(const uint32_t                                   set_index,
+	                                                                 const std::vector<vkb::core::HPPShaderModule *> &shader_modules,
+	                                                                 const std::vector<vkb::core::HPPShaderResource> &set_resources);
+	vkb::core::HPPFramebuffer         &request_framebuffer(const vkb::rendering::HPPRenderTarget &render_target, const vkb::core::HPPRenderPass &render_pass);
+	vkb::core::HPPGraphicsPipeline    &request_graphics_pipeline(vkb::rendering::HPPPipelineState &pipeline_state);
+	vkb::core::HPPPipelineLayout      &request_pipeline_layout(const std::vector<vkb::core::HPPShaderModule *> &shader_modules);
+	vkb::core::HPPRenderPass          &request_render_pass(const std::vector<vkb::rendering::HPPAttachment> &attachments,
+	                                                       const std::vector<vkb::common::HPPLoadStoreInfo> &load_store_infos,
+	                                                       const std::vector<vkb::core::HPPSubpassInfo>     &subpasses);
+	vkb::core::HPPShaderModule        &request_shader_module(
+	           vk::ShaderStageFlagBits stage, const vkb::core::HPPShaderSource &glsl_source, const vkb::core::HPPShaderVariant &shader_variant = {});
+	std::vector<uint8_t> serialize();
+	void                 set_pipeline_cache(vk::PipelineCache pipeline_cache);
 
-	vkb::core::HPPFramebuffer &request_framebuffer(const vkb::rendering::HPPRenderTarget &render_target, const vkb::core::HPPRenderPass &render_pass)
-	{
-		return reinterpret_cast<vkb::core::HPPFramebuffer &>(vkb::ResourceCache::request_framebuffer(reinterpret_cast<vkb::RenderTarget const &>(render_target),
-		                                                                                             reinterpret_cast<vkb::RenderPass const &>(render_pass)));
-	}
+	/// @brief Update those descriptor sets referring to old views
+	/// @param old_views Old image views referred by descriptor sets
+	/// @param new_views New image views to be referred
+	void update_descriptor_sets(const std::vector<vkb::core::HPPImageView> &old_views, const std::vector<vkb::core::HPPImageView> &new_views);
 
-	vkb::core::HPPGraphicsPipeline &request_graphics_pipeline(vkb::rendering::HPPPipelineState &pipeline_state)
-	{
-		return reinterpret_cast<vkb::core::HPPGraphicsPipeline &>(
-		    vkb::ResourceCache::request_graphics_pipeline(reinterpret_cast<vkb::PipelineState &>(pipeline_state)));
-	}
+	void warmup(const std::vector<uint8_t> &data);
 
-	vkb::core::HPPPipelineLayout &request_pipeline_layout(const std::vector<vkb::core::HPPShaderModule *> &shader_modules)
-	{
-		return reinterpret_cast<vkb::core::HPPPipelineLayout &>(
-		    vkb::ResourceCache::request_pipeline_layout(reinterpret_cast<std::vector<vkb::ShaderModule *> const &>(shader_modules)));
-	}
-
-	vkb::core::HPPRenderPass &request_render_pass(const std::vector<vkb::rendering::HPPAttachment> &attachments,
-	                                              const std::vector<vkb::common::HPPLoadStoreInfo> &load_store_infos,
-	                                              const std::vector<vkb::core::HPPSubpassInfo>     &subpasses)
-	{
-		return reinterpret_cast<vkb::core::HPPRenderPass &>(
-		    vkb::ResourceCache::request_render_pass(reinterpret_cast<std::vector<vkb::Attachment> const &>(attachments),
-		                                            reinterpret_cast<std::vector<vkb::LoadStoreInfo> const &>(load_store_infos),
-		                                            reinterpret_cast<std::vector<vkb::SubpassInfo> const &>(subpasses)));
-	}
-
-	vkb::core::HPPShaderModule &request_shader_module(vk::ShaderStageFlagBits stage, const ShaderSource &glsl_source, const ShaderVariant &shader_variant = {})
-	{
-		return reinterpret_cast<vkb::core::HPPShaderModule &>(
-		    vkb::ResourceCache::request_shader_module(static_cast<VkShaderStageFlagBits>(stage), glsl_source, shader_variant));
-	}
-
-	void set_pipeline_cache(vk::PipelineCache pipeline_cache)
-	{
-		vkb::ResourceCache::set_pipeline_cache(static_cast<VkPipelineCache>(pipeline_cache));
-	}
+  private:
+	vkb::core::HPPDevice  &device;
+	vkb::HPPResourceRecord recorder                    = {};
+	vkb::HPPResourceReplay replayer                    = {};
+	vk::PipelineCache      pipeline_cache              = nullptr;
+	HPPResourceCacheState  state                       = {};
+	std::mutex             descriptor_set_mutex        = {};
+	std::mutex             pipeline_layout_mutex       = {};
+	std::mutex             shader_module_mutex         = {};
+	std::mutex             descriptor_set_layout_mutex = {};
+	std::mutex             graphics_pipeline_mutex     = {};
+	std::mutex             render_pass_mutex           = {};
+	std::mutex             compute_pipeline_mutex      = {};
+	std::mutex             framebuffer_mutex           = {};
 };
-
 }        // namespace vkb

--- a/framework/hpp_resource_record.h
+++ b/framework/hpp_resource_record.h
@@ -1,0 +1,107 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "resource_record.h"
+#include <core/hpp_pipeline.h>
+
+namespace vkb
+{
+namespace common
+{
+struct HPPLoadStoreInfo;
+}
+
+namespace rendering
+{
+struct HPPAttachment;
+}
+
+namespace core
+{
+class HPPPipelineLayout;
+class HPPRenderPass;
+class HPPShaderModule;
+class HPPShaderSource;
+class HPPShaderVariant;
+struct HPPSubpassInfo;
+}        // namespace core
+
+/**
+ * @brief facade class around vkb::ResourceRecord, providing a vulkan.hpp-based interface
+ *
+ * See vkb::ResourceRecord for documentation
+ */
+class HPPResourceRecord : private vkb::ResourceRecord
+{
+  public:
+	using vkb::ResourceRecord::get_data;
+	using vkb::ResourceRecord::set_data;
+
+	size_t register_graphics_pipeline(vk::PipelineCache pipeline_cache, vkb::rendering::HPPPipelineState &pipeline_state)
+	{
+		return vkb::ResourceRecord::register_graphics_pipeline(static_cast<VkPipelineCache>(pipeline_cache),
+		                                                       reinterpret_cast<vkb::PipelineState &>(pipeline_state));
+	}
+
+	size_t register_pipeline_layout(const std::vector<vkb::core::HPPShaderModule *> &shader_modules)
+	{
+		return vkb::ResourceRecord::register_pipeline_layout(reinterpret_cast<std::vector<vkb::ShaderModule *> const &>(shader_modules));
+	}
+
+	size_t register_render_pass(const std::vector<vkb::rendering::HPPAttachment> &attachments,
+	                            const std::vector<vkb::common::HPPLoadStoreInfo> &load_store_infos,
+	                            const std::vector<vkb::core::HPPSubpassInfo>     &subpasses)
+	{
+		return vkb::ResourceRecord::register_render_pass(reinterpret_cast<std::vector<vkb::Attachment> const &>(attachments),
+		                                                 reinterpret_cast<std::vector<vkb::LoadStoreInfo> const &>(load_store_infos),
+		                                                 reinterpret_cast<std::vector<vkb::SubpassInfo> const &>(subpasses));
+	}
+
+	size_t register_shader_module(vk::ShaderStageFlagBits            stage,
+	                              const vkb::core::HPPShaderSource  &glsl_source,
+	                              const std::string                 &entry_point,
+	                              const vkb::core::HPPShaderVariant &shader_variant)
+	{
+		return vkb::ResourceRecord::register_shader_module(static_cast<VkShaderStageFlagBits>(stage),
+		                                                   reinterpret_cast<vkb::ShaderSource const &>(glsl_source),
+		                                                   entry_point,
+		                                                   reinterpret_cast<vkb::ShaderVariant const &>(shader_variant));
+	}
+
+	void set_graphics_pipeline(size_t index, const vkb::core::HPPGraphicsPipeline &graphics_pipeline)
+	{
+		vkb::ResourceRecord::set_graphics_pipeline(index, reinterpret_cast<vkb::GraphicsPipeline const &>(graphics_pipeline));
+	}
+
+	void set_pipeline_layout(size_t index, const vkb::core::HPPPipelineLayout &pipeline_layout)
+	{
+		vkb::ResourceRecord::set_pipeline_layout(index, reinterpret_cast<vkb::PipelineLayout const &>(pipeline_layout));
+	}
+
+	void set_render_pass(size_t index, const vkb::core::HPPRenderPass &render_pass)
+	{
+		vkb::ResourceRecord::set_render_pass(index, reinterpret_cast<vkb::RenderPass const &>(render_pass));
+	}
+
+	void set_shader_module(size_t index, const vkb::core::HPPShaderModule &shader_module)
+	{
+		vkb::ResourceRecord::set_shader_module(index, reinterpret_cast<vkb::ShaderModule const &>(shader_module));
+	}
+};
+}        // namespace vkb

--- a/framework/hpp_resource_replay.h
+++ b/framework/hpp_resource_replay.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "resource_replay.h"
+
+namespace vkb
+{
+class HPPResourceCache;
+class HPPResourceRecord;
+
+/**
+ * @brief facade class around vkb::ResourceReplay, providing a vulkan.hpp-based interface
+ *
+ * See vkb::ResourceReplay for documentation
+ */
+class HPPResourceReplay : private vkb::ResourceReplay
+{
+  public:
+	void play(vkb::HPPResourceCache &resource_cache, vkb::HPPResourceRecord &recorder)
+	{
+		vkb::ResourceReplay::play(reinterpret_cast<vkb::ResourceCache &>(resource_cache), reinterpret_cast<vkb::ResourceRecord &>(recorder));
+	}
+};
+}        // namespace vkb

--- a/framework/rendering/hpp_pipeline_state.h
+++ b/framework/rendering/hpp_pipeline_state.h
@@ -18,12 +18,15 @@
 #pragma once
 
 #include "pipeline_state.h"
-#include <core/hpp_pipeline_layout.h>
-#include <core/hpp_render_pass.h>
 #include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
+namespace core
+{
+class HPPPipelineLayout;
+}
+
 namespace rendering
 {
 struct HPPColorBlendAttachmentState
@@ -82,6 +85,9 @@ struct HPPRasterizationState
 	vk::Bool32        depth_bias_enable         = false;
 };
 
+class HPPSpecializationConstantState : private vkb::SpecializationConstantState
+{};
+
 struct HPPStencilOpState
 {
 	vk::StencilOp fail_op       = vk::StencilOp::eReplace;
@@ -121,6 +127,16 @@ class HPPPipelineState : private vkb::PipelineState
 	const vkb::core::HPPPipelineLayout &get_pipeline_layout() const
 	{
 		return reinterpret_cast<vkb::core::HPPPipelineLayout const &>(vkb::PipelineState::get_pipeline_layout());
+	}
+
+	const vkb::core::HPPRenderPass *get_render_pass() const
+	{
+		return reinterpret_cast<vkb::core::HPPRenderPass const *>(vkb::PipelineState::get_render_pass());
+	}
+
+	const vkb::rendering::HPPSpecializationConstantState &get_specialization_constant_state() const
+	{
+		return reinterpret_cast<vkb::rendering::HPPSpecializationConstantState const &>(vkb::PipelineState::get_specialization_constant_state());
 	}
 
 	void set_color_blend_state(const vkb::rendering::HPPColorBlendState &color_blend_state)


### PR DESCRIPTION
## Description

Transcoding of vkb::ResourceCache using Vulkan-Hpp, tested on Win10 and nvidia HW.
This change also include

- some adjustments of the class `vkb::HPPGUI`
- some extensions of the facade classes `vkb::core::HPPDescriptorSetLayout`, `vkb::core::HPPFramebuffer`, `vkb::core::HPPComputePipeline`, `vkb::core::HPPGraphicsPipeline`, `vkb::core::HPPPipelineLayout`, `vkb::core::HPPRenderPass`, and `vkb::rendering::HPPPipelineState`
- introduction of helper functions and structs in `hpp_resource_caching.h`, partly as facade to functions and structs in resource_caching.h
- introduction of new facade classes `vkb::core::HPPDescriptorPool`, `vkb::core::HPDescriptorSet`, `vkb::core::HPPShaderSource`, `vkb::core::HPPShaderVariant`, `vkb::core::HPPShaderModule`, `vkb::HPPResourceRecord`, `vkb::HPPResourceReplay`, and `vkb::rendering::HPPSpecializationConstantState`
 
## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
