### PR TITLE
Fix UI of the timestamp_queries sample

### DIFF
--- a/samples/api/timestamp_queries/timestamp_queries.cpp
+++ b/samples/api/timestamp_queries/timestamp_queries.cpp
@@ -1007,6 +1007,7 @@ void TimestampQueries::on_update_ui_overlay(vkb::Drawer &drawer)
 		if (bloom)
 		{
 			drawer.text("Pass 3: Second bloom pass %.3f ms", static_cast<float>(time_stamps[5] - time_stamps[4]) * timestampFrequency / 1000000.0f);
+			drawer.set_dirty(true);
 		}
 	}
 }


### PR DESCRIPTION
* re-enabling the bloom option in the timestamp_queries sample no longer crops the last line of the passes timing label.
