### PR TITLE
Fix sample build selection for hpp_hello_triangle

### DIFF
--- a/samples/api/hpp_hello_triangle/CMakeLists.txt
+++ b/samples/api/hpp_hello_triangle/CMakeLists.txt
@@ -29,4 +29,6 @@ add_sample(
         "triangle.vert"
         "triangle.frag")
 
-target_compile_definitions(${FOLDER_NAME} PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+if(${VKB_${FOLDER_NAME}})
+    target_compile_definitions(${FOLDER_NAME} PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+endif()


### PR DESCRIPTION
## Description

We have a CMake option to toggle builds for every sample. This way you can e.g. only select a set of samples to be build, which is helpful when doing framework related changes as it decreased build times.

But deselecting the hpp_hello_triangle samples made CMake throw an error:

```
CMake Error at samples/api/hpp_hello_triangle/CMakeLists.txt:32 (target_compile_definitions):
  Cannot specify compile definitions for target "hpp_hello_triangle" which is
  not built by this project.
```

This PR checks if that sample is actually selected for building and only sets the above target_compile_definition if that's the case. 

So with this change it's now also possible to untick the hpp_hello_triangle sample at CMake level.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
