### PR TITLE
Rework UI toggle

### DIFF
--- a/app/plugins/user_interface_options/user_interface_options.cpp
+++ b/app/plugins/user_interface_options/user_interface_options.cpp
@@ -1,0 +1,47 @@
+/* Copyright (c) 2023, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "user_interface_options.h"
+
+#include <algorithm>
+
+#include "gui.h"
+#include "hpp_gui.h"
+
+namespace plugins
+{
+UserInterfaceOptions::UserInterfaceOptions() :
+    UserInterfaceOptionsTags("User interface options",
+                             "A collection of flags to configure the user interface",
+                             {}, {&user_interface_options_group})
+{
+}
+
+bool UserInterfaceOptions::is_active(const vkb::CommandParser &parser)
+{
+	return true;
+}
+
+void UserInterfaceOptions::init(const vkb::CommandParser &parser)
+{
+	if (parser.contains(&hide_ui_flag))
+	{
+		vkb::Gui::visible    = false;
+		vkb::HPPGui::visible = false;
+	}
+}
+}        // namespace plugins

--- a/app/plugins/user_interface_options/user_interface_options.h
+++ b/app/plugins/user_interface_options/user_interface_options.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2023, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "platform/plugins/plugin_base.h"
+
+namespace plugins
+{
+class UserInterfaceOptions;
+
+using UserInterfaceOptionsTags = vkb::PluginBase<UserInterfaceOptions, vkb::tags::Passive>;
+
+/**
+ * @brief User interface Options
+ *
+ * Configure the default user interface
+ *
+ */
+class UserInterfaceOptions : public UserInterfaceOptionsTags
+{
+  public:
+	UserInterfaceOptions();
+
+	virtual ~UserInterfaceOptions() = default;
+
+	virtual bool is_active(const vkb::CommandParser &parser) override;
+
+	virtual void init(const vkb::CommandParser &options) override;
+
+	vkb::FlagCommand hide_ui_flag = {vkb::FlagType::FlagOnly, "hideui", "", "If flag is set, hides the user interface at startup"};
+
+	vkb::CommandGroup user_interface_options_group = {"User interface Options", {&hide_ui_flag}};
+};
+}        // namespace plugins

--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -312,6 +312,11 @@ void ApiVulkanSample::input_event(const vkb::InputEvent &input_event)
 					case vkb::KeyCode::P:
 						paused = !paused;
 						break;
+					case vkb::KeyCode::F1:
+						if (gui)
+						{
+							gui->visible = !gui->visible;
+						}
 					default:
 						break;
 				}

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -75,6 +75,8 @@ inline void reset_graph_max_value(StatGraphData &graph_data)
 }
 }        // namespace
 
+bool Gui::visible = true;
+
 const double Gui::press_time_ms = 200.0f;
 
 const float Gui::overlay_alpha = 0.3f;
@@ -1077,7 +1079,7 @@ bool Gui::input_event(const InputEvent &input_event)
 		}
 	}
 
-	// Toggle GUI elements when tap or clicking outside the GUI windows
+	// Toggle debug UI view when tap or clicking outside the GUI windows
 	if (!io.WantCaptureMouse)
 	{
 		bool press_down = (input_event.get_source() == EventSource::Mouse && static_cast<const MouseButtonInputEvent &>(input_event).get_action() == MouseAction::Down) || (input_event.get_source() == EventSource::Touchscreen && static_cast<const TouchInputEvent &>(input_event).get_action() == TouchAction::Down);
@@ -1103,11 +1105,7 @@ bool Gui::input_event(const InputEvent &input_event)
 				if (input_event.get_source() == EventSource::Mouse)
 				{
 					const auto &mouse_button = static_cast<const MouseButtonInputEvent &>(input_event);
-					if (mouse_button.get_button() == MouseButton::Left)
-					{
-						visible = !visible;
-					}
-					else if (mouse_button.get_button() == MouseButton::Right)
+					if (mouse_button.get_button() == MouseButton::Right)
 					{
 						debug_view.active = !debug_view.active;
 					}
@@ -1115,11 +1113,7 @@ bool Gui::input_event(const InputEvent &input_event)
 				else if (input_event.get_source() == EventSource::Touchscreen)
 				{
 					const auto &touch_event = static_cast<const TouchInputEvent &>(input_event);
-					if (!two_finger_tap && touch_event.get_touch_points() == 1)
-					{
-						visible = !visible;
-					}
-					else if (two_finger_tap && touch_event.get_touch_points() == 2)
+					if (two_finger_tap && touch_event.get_touch_points() == 2)
 					{
 						debug_view.active = !debug_view.active;
 					}

--- a/framework/gui.h
+++ b/framework/gui.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2021, Arm Limited and Contributors
- * Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2018-2023, Arm Limited and Contributors
+ * Copyright (c) 2019-2023, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -83,12 +83,12 @@ class Drawer
   public:
 	Drawer() = default;
 
-	/** 
+	/**
 	 * @brief Clears the dirty bit set
 	 */
 	void clear();
 
-	/** 
+	/**
 	 * @brief Returns true if the drawer has been updated
 	 */
 	bool is_dirty();
@@ -238,6 +238,9 @@ class Gui
 		glm::vec2 scale;
 		glm::vec2 translate;
 	} push_const_block;
+
+	/// Used to show/hide the GUI
+	static bool visible;
 
 	/**
 	 * @brief Initializes the Gui
@@ -411,9 +414,6 @@ class Gui
 
 	/// Used to measure duration of input events
 	Timer timer;
-
-	/// Used to show/hide the GUI
-	bool visible{true};
 
 	bool prev_visible{true};
 

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -299,6 +299,11 @@ void HPPApiVulkanSample::input_event(const vkb::InputEvent &input_event)
 					case vkb::KeyCode::P:
 						paused = !paused;
 						break;
+					case vkb::KeyCode::F1:
+						if (gui)
+						{
+							gui->visible = !gui->visible;
+						}
 					default:
 						break;
 				}

--- a/framework/hpp_gui.cpp
+++ b/framework/hpp_gui.cpp
@@ -52,6 +52,7 @@ void reset_graph_max_value(StatGraphData &graph_data)
 }
 }        // namespace
 
+bool                   HPPGui::visible       = true;
 const double           HPPGui::press_time_ms = 200.0f;
 const float            HPPGui::overlay_alpha = 0.3f;
 const std::string      HPPGui::default_font  = "Roboto-Regular";
@@ -1037,11 +1038,7 @@ bool HPPGui::input_event(const InputEvent &input_event)
 				if (input_event.get_source() == EventSource::Mouse)
 				{
 					const auto &mouse_button = static_cast<const MouseButtonInputEvent &>(input_event);
-					if (mouse_button.get_button() == MouseButton::Left)
-					{
-						visible = !visible;
-					}
-					else if (mouse_button.get_button() == MouseButton::Right)
+					if (mouse_button.get_button() == MouseButton::Right)
 					{
 						debug_view.active = !debug_view.active;
 					}
@@ -1049,11 +1046,7 @@ bool HPPGui::input_event(const InputEvent &input_event)
 				else if (input_event.get_source() == EventSource::Touchscreen)
 				{
 					const auto &touch_event = static_cast<const TouchInputEvent &>(input_event);
-					if (!two_finger_tap && touch_event.get_touch_points() == 1)
-					{
-						visible = !visible;
-					}
-					else if (two_finger_tap && touch_event.get_touch_points() == 2)
+					if (two_finger_tap && touch_event.get_touch_points() == 2)
 					{
 						debug_view.active = !debug_view.active;
 					}

--- a/framework/hpp_gui.h
+++ b/framework/hpp_gui.h
@@ -205,6 +205,8 @@ class HPPGui
   public:
 	// The name of the default font file to use
 	static const std::string default_font;
+	// Used to show/hide the GUI
+	static bool visible;
 
   public:
 	/**
@@ -376,8 +378,7 @@ class HPPGui
 	vk::DescriptorSetLayout                  descriptor_set_layout = nullptr;
 	vk::DescriptorSet                        descriptor_set        = nullptr;
 	vk::Pipeline                             pipeline              = nullptr;
-	Timer                                    timer;                                // Used to measure duration of input events
-	bool                                     visible                = true;        // Used to show/hide the GUI
+	Timer                                    timer;        // Used to measure duration of input events
 	bool                                     prev_visible           = true;
 	bool                                     two_finger_tap         = false;        // Whether or not the GUI has detected a multi touch gesture
 	bool                                     show_graph_file_output = false;


### PR DESCRIPTION
## Description

This PR changes how the GUI is toggled.

- It removes the simple left-click or single point touch to hide/show the GUI, which often led to accidentally hiding the GUI when trying to rotate the camera
- Visibility of the GUI can be toggled at runtime with the F1 key
- The GUI can be hidden by default using the "hideui" argument

This affects the api samples (also including the HPP ones).

The "other" UI that's used by the non-api samples is not touched.

Fixes #651

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making