### PR TITLE
Fix surface format priority list for HPP samples

### DIFF
--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -160,7 +160,7 @@ void HPPApiVulkanSample::create_render_context(vkb::platform::HPPPlatform const 
 {
 	// We always want an sRGB surface to match the display.
 	// If we used a UNORM surface, we'd have to do the conversion to sRGB ourselves at the end of our fragment shaders.
-	auto surface_priority_list = std::vector<vk::SurfaceFormatKHR>{{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
+	auto surface_priority_list = std::vector<vk::SurfaceFormatKHR>{{vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
 	                                                               {vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}};
 
 	render_context = platform.create_render_context(*device, surface, surface_priority_list);


### PR DESCRIPTION
## Description

While doing some framework stuff I noticed that the HPP samples looked considerably darker on my setup than the non-HPP samples.

E.g. the terrain tessellation one:

HPP:

![image](https://user-images.githubusercontent.com/10283127/233634393-f1feebf4-9eec-4368-a3c1-b738f915327b.png)

non-HPP:

![image](https://user-images.githubusercontent.com/10283127/233634380-df031d95-a9d5-4cd1-9e2d-93e4c2df6cf7.png)

This was caused by a small typo in the HPP swapchain's format priority list. Instead of BGRA, RGBA like the non-HPP swapchain, the HPP had the RGBA one twice.

This PR fixes the HPP priority list to match the non-HPP, fixing the color differences.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
