### PR TITLE
Port of #665 and #659 to hpp-based samples.

### DIFF
--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -450,17 +450,14 @@ void HPPApiVulkanSample::prepare_frame()
 		{
 			std::tie(result, current_buffer) = get_render_context().get_swapchain().acquire_next_image(semaphores.acquired_image_ready);
 		}
+		// Recreate the swapchain if it's no longer compatible with the surface (eErrorOutOfDateKHR)
+		// Don't catch other failures here, they are propagated up the calling hierarchy
 		catch (vk::OutOfDateKHRError & /*err*/)
-		{
-			result = vk::Result::eErrorOutOfDateKHR;
-		}
-
-		// Recreate the swapchain if it's no longer compatible with the surface (eErrorOutOfDateKHR) or no longer optimal for
-		// presentation (eSuboptimalKHR)
-		if ((result == vk::Result::eErrorOutOfDateKHR) || (result == vk::Result::eSuboptimalKHR))
 		{
 			resize(extent.width, extent.height);
 		}
+		// VK_SUBOPTIMAL_KHR is a success code and means that acquire was successful and semaphore is signaled but image is suboptimal
+		// allow rendering frame to suboptimal swapchain as otherwise we would have to manually unsignal semaphore and acquire image again
 	}
 }
 

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -298,6 +298,7 @@ void HPPTimestampQueries::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 		if (bloom)
 		{
 			drawer.text("Pass 3: Second bloom pass %.3f ms", float(time_stamps[5] - time_stamps[4]) * timestampFrequency / 1000000.0f);
+			drawer.set_dirty(true);
 		}
 	}
 }


### PR DESCRIPTION
## Description

Port of #665 and #659 to hpp-based samples.

Builds on Win10 with VS2022, tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
