### PR TITLE
Change external_files_dir logic and permission logic.

### DIFF
--- a/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
+++ b/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
+++ b/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
@@ -74,10 +74,6 @@ public class SampleLauncherActivity extends AppCompatActivity {
             File external_files_dir = getExternalFilesDir("");
             File temp_files_dir = getCacheDir();
             if (external_files_dir != null && temp_files_dir != null) {
-                // User no longer has permissions to access applications' storage, save files in
-                // top level (shared) external storage directory
-                String shared_storage = external_files_dir.getPath().split(Pattern.quote("Android"))[0];
-                external_files_dir = new File(shared_storage, getPackageName());
                 initFilePath(external_files_dir.toString(), temp_files_dir.toString());
             }
 
@@ -90,7 +86,7 @@ public class SampleLauncherActivity extends AppCompatActivity {
         permissions.add(new Permission(Manifest.permission.WRITE_EXTERNAL_STORAGE, 1));
         permissions.add(new Permission(Manifest.permission.READ_EXTERNAL_STORAGE, 2));
 
-        if (checkPermissions()) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT || checkPermissions()) {
             // Permissions previously granted skip requesting them
             parseArguments();
             showSamples();


### PR DESCRIPTION
## Description
Current implementation has problem, it doesn't show sample list well, I tested on Pixel 6 with Android 13.

I removed changing external_files_dir path. It changed directory path from '/storage/emulated/0/Android/data/com.khronos.vulkan_samples/files' to '/storage/emulated/0/com.khronos.vulkan_samples/'. But on the build.md file guide to copy resource to '/storage/emulated/0/Android/data/com.khronos.vulkan_samples/files'. And also it is better to use '/storage/emulated/0/Android/data/com.khronos.vulkan_samples', because it is deleted automatically when application is deleted.

And about the permission, current logic makes not showing sample list on the Android 13 device. it is happen because WRITE_EXTERNAL_STORAGE and READ_EXTERNAL_STORAGE has no effect after API level 33, current logic think application doesn't have permissions. However it can be used without permission request after API level 19. https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE
I add if API level is same or higher than 19(Kitkat), skip the checkPermissions() and assume it already have these permissions. It is also related with not working on S23 device on https://github.com/KhronosGroup/Vulkan-Samples/issues/646.

Fixes #646 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
