### PR TITLE
Change vkb::core::HPPPipelineLayout from a facade over vkb::PipelineLayout to a self-contained class using vulkan.hpp

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -309,6 +309,7 @@ set(CORE_FILES
     core/hpp_image_view.cpp
     core/hpp_instance.cpp
     core/hpp_physical_device.cpp
+    core/hpp_pipeline_layout.cpp
     core/hpp_queue.cpp
     core/hpp_swapchain.cpp
     core/hpp_vulkan_resource.cpp

--- a/framework/common/hpp_resource_caching.h
+++ b/framework/common/hpp_resource_caching.h
@@ -285,14 +285,11 @@ struct HPPRecordHelper
 {
 	size_t record(HPPResourceRecord & /*recorder*/, A &.../*args*/)
 	{
-		assert(false);
 		return 0;
 	}
 
 	void index(HPPResourceRecord & /*recorder*/, size_t /*index*/, T & /*resource*/)
-	{
-		assert(false);
-	}
+	{}
 };
 
 template <class... A>

--- a/framework/core/hpp_command_buffer.h
+++ b/framework/core/hpp_command_buffer.h
@@ -241,7 +241,7 @@ class HPPCommandBuffer : public core::HPPVulkanResource<vk::CommandBuffer>
 	// that contain update after bind, as they wont be implicitly updated
 	bool update_after_bind = false;
 
-	std::unordered_map<uint32_t, vkb::core::HPPDescriptorSetLayout *> descriptor_set_layout_binding_state;
+	std::unordered_map<uint32_t, vkb::core::HPPDescriptorSetLayout const *> descriptor_set_layout_binding_state;
 };
 
 template <class T>

--- a/framework/core/hpp_descriptor_set_layout.h
+++ b/framework/core/hpp_descriptor_set_layout.h
@@ -36,6 +36,9 @@ struct HPPShaderResource;
 class HPPDescriptorSetLayout : private vkb::DescriptorSetLayout
 {
   public:
+	using vkb::DescriptorSetLayout::get_index;
+
+  public:
 	HPPDescriptorSetLayout(vkb::core::HPPDevice                            &device,
 	                       const uint32_t                                   set_index,
 	                       const std::vector<vkb::core::HPPShaderModule *> &shader_modules,

--- a/framework/core/hpp_pipeline_layout.cpp
+++ b/framework/core/hpp_pipeline_layout.cpp
@@ -1,0 +1,195 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hpp_pipeline_layout.h"
+
+#include <core/hpp_device.h>
+#include <core/hpp_shader_module.h>
+
+namespace vkb
+{
+namespace core
+{
+HPPPipelineLayout::HPPPipelineLayout(vkb::core::HPPDevice &device, const std::vector<vkb::core::HPPShaderModule *> &shader_modules) :
+    device{device},
+    shader_modules{shader_modules}
+{
+	// Collect and combine all the shader resources from each of the shader modules
+	// Collate them all into a map that is indexed by the name of the resource
+	for (auto *shader_module : shader_modules)
+	{
+		for (const auto &shader_resource : shader_module->get_resources())
+		{
+			std::string key = shader_resource.name;
+
+			// Since 'Input' and 'Output' resources can have the same name, we modify the key string
+			if (shader_resource.type == vkb::core::HPPShaderResourceType::Input || shader_resource.type == vkb::core::HPPShaderResourceType::Output)
+			{
+				key = std::to_string(static_cast<uint32_t>(shader_resource.stages)) + "_" + key;
+			}
+
+			auto it = shader_resources.find(key);
+
+			if (it != shader_resources.end())
+			{
+				// Append stage flags if resource already exists
+				it->second.stages |= shader_resource.stages;
+			}
+			else
+			{
+				// Create a new entry in the map
+				shader_resources.emplace(key, shader_resource);
+			}
+		}
+	}
+
+	// Sift through the map of name indexed shader resources
+	// Separate them into their respective sets
+	for (auto &it : shader_resources)
+	{
+		auto &shader_resource = it.second;
+
+		// Find binding by set index in the map.
+		auto it2 = shader_sets.find(shader_resource.set);
+
+		if (it2 != shader_sets.end())
+		{
+			// Add resource to the found set index
+			it2->second.push_back(shader_resource);
+		}
+		else
+		{
+			// Create a new set index and with the first resource
+			shader_sets.emplace(shader_resource.set, std::vector<vkb::core::HPPShaderResource>{shader_resource});
+		}
+	}
+
+	// Create a descriptor set layout for each shader set in the shader modules
+	for (auto &shader_set_it : shader_sets)
+	{
+		descriptor_set_layouts.emplace_back(
+		    &device.get_resource_cache().request_descriptor_set_layout(shader_set_it.first, shader_modules, shader_set_it.second));
+	}
+
+	// Collect all the descriptor set layout handles, maintaining set order
+	std::vector<vk::DescriptorSetLayout> descriptor_set_layout_handles;
+	for (auto descriptor_set_layout : descriptor_set_layouts)
+	{
+		descriptor_set_layout_handles.push_back(descriptor_set_layout ? descriptor_set_layout->get_handle() : nullptr);
+	}
+
+	// Collect all the push constant shader resources
+	std::vector<vk::PushConstantRange> push_constant_ranges;
+	for (auto &push_constant_resource : get_resources(vkb::core::HPPShaderResourceType::PushConstant))
+	{
+		push_constant_ranges.push_back({push_constant_resource.stages, push_constant_resource.offset, push_constant_resource.size});
+	}
+
+	vk::PipelineLayoutCreateInfo create_info({}, descriptor_set_layout_handles, push_constant_ranges);
+
+	// Create the Vulkan pipeline layout handle
+	handle = device.get_handle().createPipelineLayout(create_info);
+}
+
+HPPPipelineLayout::HPPPipelineLayout(HPPPipelineLayout &&other) :
+    device{other.device},
+    handle{other.handle},
+    shader_modules{std::move(other.shader_modules)},
+    shader_resources{std::move(other.shader_resources)},
+    shader_sets{std::move(other.shader_sets)},
+    descriptor_set_layouts{std::move(other.descriptor_set_layouts)}
+{
+	other.handle = nullptr;
+}
+
+HPPPipelineLayout::~HPPPipelineLayout()
+{
+	// Destroy pipeline layout
+	if (handle)
+	{
+		device.get_handle().destroyPipelineLayout(handle);
+	}
+}
+
+vkb::core::HPPDescriptorSetLayout const &HPPPipelineLayout::get_descriptor_set_layout(const uint32_t set_index) const
+{
+	auto it = std::find_if(descriptor_set_layouts.begin(),
+	                       descriptor_set_layouts.end(),
+	                       [&set_index](auto const *descriptor_set_layout) { return descriptor_set_layout->get_index() == set_index; });
+	if (it == descriptor_set_layouts.end())
+	{
+		throw std::runtime_error("Couldn't find descriptor set layout at set index " + to_string(set_index));
+	}
+	return **it;
+}
+
+vk::PipelineLayout HPPPipelineLayout::get_handle() const
+{
+	return handle;
+}
+
+vk::ShaderStageFlags HPPPipelineLayout::get_push_constant_range_stage(uint32_t size, uint32_t offset) const
+{
+	vk::ShaderStageFlags stages;
+
+	for (auto &push_constant_resource : get_resources(vkb::core::HPPShaderResourceType::PushConstant))
+	{
+		if (push_constant_resource.offset <= offset && offset + size <= push_constant_resource.offset + push_constant_resource.size)
+		{
+			stages |= push_constant_resource.stages;
+		}
+	}
+	return stages;
+}
+
+std::vector<vkb::core::HPPShaderResource> HPPPipelineLayout::get_resources(const vkb::core::HPPShaderResourceType &type, vk::ShaderStageFlagBits stage) const
+{
+	std::vector<vkb::core::HPPShaderResource> found_resources;
+
+	for (auto &it : shader_resources)
+	{
+		auto &shader_resource = it.second;
+
+		if (shader_resource.type == type || type == vkb::core::HPPShaderResourceType::All)
+		{
+			if (shader_resource.stages == stage || stage == vk::ShaderStageFlagBits::eAll)
+			{
+				found_resources.push_back(shader_resource);
+			}
+		}
+	}
+
+	return found_resources;
+}
+
+const std::vector<vkb::core::HPPShaderModule *> &HPPPipelineLayout::get_shader_modules() const
+{
+	return shader_modules;
+}
+
+const std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> &HPPPipelineLayout::get_shader_sets() const
+{
+	return shader_sets;
+}
+
+bool HPPPipelineLayout::has_descriptor_set_layout(const uint32_t set_index) const
+{
+	return set_index < descriptor_set_layouts.size();
+}
+
+}        // namespace core
+}        // namespace vkb

--- a/framework/core/hpp_pipeline_layout.h
+++ b/framework/core/hpp_pipeline_layout.h
@@ -17,48 +17,48 @@
 
 #pragma once
 
-#include "core/pipeline_layout.h"
-#include <core/hpp_descriptor_set_layout.h>
 #include <core/hpp_shader_module.h>
+#include <vector>
+#include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
 namespace core
 {
+class HPPDevice;
+class HPPDescriptorSetLayout;
+
 /**
- * @brief facade class around vkb::core::PipelineLayout, providing a vulkan.hpp-based interface
+ * @brief A wrapper class for vk::HPPPipelineLayout
  *
- * See vkb::core::PipelineLayout for documentation
  */
-class HPPPipelineLayout : private vkb::PipelineLayout
+class HPPPipelineLayout
 {
   public:
-	using vkb::PipelineLayout::has_descriptor_set_layout;
+	HPPPipelineLayout(vkb::core::HPPDevice &device, const std::vector<vkb::core::HPPShaderModule *> &shader_modules);
+	HPPPipelineLayout(const HPPPipelineLayout &) = delete;
+	HPPPipelineLayout(HPPPipelineLayout &&other);
+	~HPPPipelineLayout();
 
-  public:
-	HPPPipelineLayout(vkb::core::HPPDevice &device, const std::vector<vkb::core::HPPShaderModule *> &shader_modules) :
-	    vkb::PipelineLayout(reinterpret_cast<vkb::Device &>(device), reinterpret_cast<std::vector<vkb::ShaderModule *> const &>(shader_modules))
-	{}
+	HPPPipelineLayout &operator=(const HPPPipelineLayout &) = delete;
+	HPPPipelineLayout &operator=(HPPPipelineLayout &&)      = delete;
 
-	vkb::core::HPPDescriptorSetLayout &get_descriptor_set_layout(const uint32_t set_index) const
-	{
-		return reinterpret_cast<vkb::core::HPPDescriptorSetLayout &>(vkb::PipelineLayout::get_descriptor_set_layout(set_index));
-	}
+	vkb::core::HPPDescriptorSetLayout const                                       &get_descriptor_set_layout(const uint32_t set_index) const;
+	vk::PipelineLayout                                                             get_handle() const;
+	vk::ShaderStageFlags                                                           get_push_constant_range_stage(uint32_t size, uint32_t offset = 0) const;
+	std::vector<vkb::core::HPPShaderResource>                                      get_resources(const vkb::core::HPPShaderResourceType &type  = vkb::core::HPPShaderResourceType::All,
+	                                                                                             vk::ShaderStageFlagBits                 stage = vk::ShaderStageFlagBits::eAll) const;
+	const std::vector<vkb::core::HPPShaderModule *>                               &get_shader_modules() const;
+	const std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> &get_shader_sets() const;
+	bool                                                                           has_descriptor_set_layout(const uint32_t set_index) const;
 
-	vk::PipelineLayout get_handle() const
-	{
-		return static_cast<vk::PipelineLayout>(vkb::PipelineLayout::get_handle());
-	}
-
-	vk::ShaderStageFlags get_push_constant_range_stage(uint32_t size, uint32_t offset = 0) const
-	{
-		return static_cast<vk::ShaderStageFlags>(vkb::PipelineLayout::get_push_constant_range_stage(size, offset));
-	}
-
-	const std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> &get_shader_sets() const
-	{
-		return reinterpret_cast<std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> const &>(vkb::PipelineLayout::get_shader_sets());
-	}
+  private:
+	vkb::core::HPPDevice                                                   &device;
+	vk::PipelineLayout                                                      handle;
+	std::vector<vkb::core::HPPShaderModule *>                               shader_modules;                // The shader modules that this pipeline layout uses
+	std::unordered_map<std::string, vkb::core::HPPShaderResource>           shader_resources;              // The shader resources that this pipeline layout uses, indexed by their name
+	std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> shader_sets;                   // A map of each set and the resources it owns used by the pipeline layout
+	std::vector<vkb::core::HPPDescriptorSetLayout *>                        descriptor_set_layouts;        // The different descriptor set layouts for this pipeline layout
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_shader_module.h
+++ b/framework/core/hpp_shader_module.h
@@ -24,11 +24,58 @@ namespace vkb
 {
 namespace core
 {
+class HPPDevice;
 /**
  * @brief facade class around vkb::ShaderModule, providing a vulkan.hpp-based interface
  *
  * See vkb::ShaderModule for documentation
  */
+
+/// Types of shader resources
+enum class HPPShaderResourceType
+{
+	Input,
+	InputAttachment,
+	Output,
+	Image,
+	ImageSampler,
+	ImageStorage,
+	Sampler,
+	BufferUniform,
+	BufferStorage,
+	PushConstant,
+	SpecializationConstant,
+	All
+};
+
+/// This determines the type and method of how descriptor set should be created and bound
+enum class HPPShaderResourceMode
+{
+	Static,
+	Dynamic,
+	UpdateAfterBind
+};
+
+/// Store shader resource data.
+/// Used by the shader module.
+struct HPPShaderResource
+{
+	vk::ShaderStageFlags  stages;
+	HPPShaderResourceType type;
+	HPPShaderResourceMode mode;
+	uint32_t              set;
+	uint32_t              binding;
+	uint32_t              location;
+	uint32_t              input_attachment_index;
+	uint32_t              vec_size;
+	uint32_t              columns;
+	uint32_t              array_size;
+	uint32_t              offset;
+	uint32_t              size;
+	uint32_t              constant_id;
+	uint32_t              qualifiers;
+	std::string           name;
+};
 
 class HPPShaderSource : private vkb::ShaderSource
 {
@@ -58,52 +105,11 @@ class HPPShaderModule : private vkb::ShaderModule
 	                      entry_point,
 	                      reinterpret_cast<vkb::ShaderVariant const &>(shader_variant))
 	{}
-};
 
-/// This determines the type and method of how descriptor set should be created and bound
-enum class HPPShaderResourceMode
-{
-	Static,
-	Dynamic,
-	UpdateAfterBind
-};
-
-/// Types of shader resources
-enum class HPPShaderResourceType
-{
-	Input,
-	InputAttachment,
-	Output,
-	Image,
-	ImageSampler,
-	ImageStorage,
-	Sampler,
-	BufferUniform,
-	BufferStorage,
-	PushConstant,
-	SpecializationConstant,
-	All
-};
-
-/// Store shader resource data.
-/// Used by the shader module.
-struct HPPShaderResource
-{
-	vk::ShaderStageFlags  stages;
-	HPPShaderResourceType type;
-	HPPShaderResourceMode mode;
-	uint32_t              set;
-	uint32_t              binding;
-	uint32_t              location;
-	uint32_t              input_attachment_index;
-	uint32_t              vec_size;
-	uint32_t              columns;
-	uint32_t              array_size;
-	uint32_t              offset;
-	uint32_t              size;
-	uint32_t              constant_id;
-	uint32_t              qualifiers;
-	std::string           name;
+	const std::vector<vkb::core::HPPShaderResource> &get_resources() const
+	{
+		return reinterpret_cast<std::vector<vkb::core::HPPShaderResource> const &>(vkb::ShaderModule::get_resources());
+	}
 };
 
 }        // namespace core


### PR DESCRIPTION
## Description

Transcoding of vkb::PipelineLayout using Vulkan-Hpp, tested on Win10 and nvidia HW.
This change also include

- some adjustments in `common/hpp_resource_caching.h`, `vkb::core::HPPCommandBuffer`
- some extensions of the facade classes vkb::core::HPPDescriptorSetLayout and vkb::core::HPPShaderModule

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
