### PR TITLE
Resolve some Vulkan-Hpp-related issues on Win32.

### DIFF
--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -92,7 +92,7 @@ inline bool is_dynamic_buffer_descriptor_type(vk::DescriptorType descriptor_type
 
 inline vk::ShaderModule load_shader(const std::string &filename, vk::Device device, vk::ShaderStageFlagBits stage)
 {
-	return vkb::load_shader(filename, device, static_cast<VkShaderStageFlagBits>(stage));
+	return static_cast<vk::ShaderModule>(vkb::load_shader(filename, device, static_cast<VkShaderStageFlagBits>(stage)));
 }
 
 inline void set_image_layout(vk::CommandBuffer         command_buffer,
@@ -104,7 +104,7 @@ inline void set_image_layout(vk::CommandBuffer         command_buffer,
                              vk::PipelineStageFlags    dst_mask = vk::PipelineStageFlagBits::eAllCommands)
 {
 	vkb::set_image_layout(command_buffer,
-	                      image,
+	                      static_cast<VkImage>(image),
 	                      static_cast<VkImageLayout>(old_layout),
 	                      static_cast<VkImageLayout>(new_layout),
 	                      static_cast<VkImageSubresourceRange>(subresource_range),

--- a/framework/core/hpp_buffer.cpp
+++ b/framework/core/hpp_buffer.cpp
@@ -84,7 +84,7 @@ HPPBuffer::~HPPBuffer()
 	if (get_handle() && (allocation != VK_NULL_HANDLE))
 	{
 		unmap();
-		vmaDestroyBuffer(get_device().get_memory_allocator(), get_handle(), allocation);
+		vmaDestroyBuffer(get_device().get_memory_allocator(), static_cast<VkBuffer>(get_handle()), allocation);
 	}
 }
 
@@ -93,7 +93,7 @@ VmaAllocation HPPBuffer::get_allocation() const
 	return allocation;
 }
 
-VkDeviceMemory HPPBuffer::get_memory() const
+vk::DeviceMemory HPPBuffer::get_memory() const
 {
 	return memory;
 }

--- a/framework/core/hpp_buffer.h
+++ b/framework/core/hpp_buffer.h
@@ -55,7 +55,7 @@ class HPPBuffer : public vkb::core::HPPVulkanResource<vk::Buffer>
 
 	VmaAllocation  get_allocation() const;
 	const uint8_t *get_data() const;
-	VkDeviceMemory get_memory() const;
+	vk::DeviceMemory get_memory() const;
 
 	/**
 	 * @return Return the buffer's device address (note: requires that the buffer has been created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT usage fla)

--- a/framework/core/hpp_image.cpp
+++ b/framework/core/hpp_image.cpp
@@ -138,7 +138,7 @@ HPPImage::~HPPImage()
 	if (get_handle() && memory)
 	{
 		unmap();
-		vmaDestroyImage(get_device().get_memory_allocator(), get_handle(), memory);
+		vmaDestroyImage(get_device().get_memory_allocator(), static_cast<VkImage>(get_handle()), memory);
 	}
 }
 

--- a/samples/api/hpp_texture_loading/hpp_texture_loading.cpp
+++ b/samples/api/hpp_texture_loading/hpp_texture_loading.cpp
@@ -170,7 +170,7 @@ void HPPTextureLoading::load_texture()
 		memory_allocate_info  = {memory_requirements.size,
 		                         get_device()->get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal)};
 		texture.device_memory = get_device()->get_handle().allocateMemory(memory_allocate_info);
-		VK_CHECK(vkBindImageMemory(get_device()->get_handle(), texture.image, texture.device_memory, 0));
+		get_device()->get_handle().bindImageMemory(texture.image, texture.device_memory, 0);
 
 		vk::CommandBuffer copy_command = get_device()->create_command_buffer(vk::CommandBufferLevel::ePrimary, true);
 


### PR DESCRIPTION
## Description

Resolve some Vulkan-Hpp-related issues on Win32.

See #682

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
