### PR TITLE
Batch mode improvements

### DIFF
--- a/app/plugins/batch_mode/batch_mode.cpp
+++ b/app/plugins/batch_mode/batch_mode.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Arm Limited and Contributors
+/* Copyright (c) 2020-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -50,7 +50,7 @@ void BatchMode::init(const vkb::CommandParser &parser)
 
 	if (parser.contains(&wrap_flag))
 	{
-		wrap_to_start = parser.as<bool>(&wrap_flag);
+		wrap_to_start = true;
 	}
 
 	std::vector<std::string> tags;
@@ -79,7 +79,7 @@ void BatchMode::init(const vkb::CommandParser &parser)
 	properties.resizable = false;
 	platform->set_window_properties(properties);
 	platform->disable_input_processing();
-	platform->request_application((*sample_iter));
+	request_app();
 }
 
 void BatchMode::on_update(float delta_time)
@@ -114,6 +114,15 @@ void BatchMode::on_app_error(const std::string &app_id)
 	load_next_app();
 }
 
+void BatchMode::request_app()
+{
+	LOGI("===========================================");
+	LOGI("Running {}", (*sample_iter)->id);
+	LOGI("===========================================");
+
+	platform->request_application((*sample_iter));
+}
+
 void BatchMode::load_next_app()
 {
 	// Wrap it around to the start
@@ -127,12 +136,11 @@ void BatchMode::load_next_app()
 		else
 		{
 			platform->close();
+			return;
 		}
 	}
-	else
-	{
-		// App will be started before the next update loop
-		platform->request_application((*sample_iter));
-	}
+
+	// App will be started before the next update loop
+	request_app();
 }
 }        // namespace plugins

--- a/app/plugins/batch_mode/batch_mode.h
+++ b/app/plugins/batch_mode/batch_mode.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Arm Limited and Contributors
+/* Copyright (c) 2020-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -77,6 +77,8 @@ class BatchMode : public BatchModeTags
 	float elapsed_time{0.0f};
 
 	bool wrap_to_start = false;
+
+	void request_app();
 
 	void load_next_app();
 };


### PR DESCRIPTION
## Description

Now logs the name of the sample being started.
This is very useful if a sample crashes in batch mode as you can easily see from the log which sample it was.

Fixed the wrap-to-start command argument. There is no `.as<bool>` on the parser, so it always returned false. The logic for the wrapping was also slightly wrong in that the first sample would be missed during the wrap.

Fixes #616

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

