### PR TITLE
Cleanup on classes vkb::Swapchain and vkb::core::HPPSwapchain

### DIFF
--- a/framework/core/hpp_swapchain.h
+++ b/framework/core/hpp_swapchain.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -69,16 +69,16 @@ class HPPSwapchain
 	/**
 	 * @brief Constructor to create a swapchain.
 	 */
-	HPPSwapchain(HPPDevice &                              device,
+	HPPSwapchain(HPPDevice                               &device,
 	             vk::SurfaceKHR                           surface,
-	             const vk::Extent2D &                     extent                       = {},
-	             const uint32_t                           image_count                  = 3,
-	             const vk::SurfaceTransformFlagBitsKHR    transform                    = vk::SurfaceTransformFlagBitsKHR::eIdentity,
-	             const vk::PresentModeKHR                 present_mode                 = vk::PresentModeKHR::eFifo,
-	             const std::set<vk::ImageUsageFlagBits> & image_usage_flags            = {vk::ImageUsageFlagBits::eColorAttachment, vk::ImageUsageFlagBits::eTransferSrc},
-	             const std::vector<vk::PresentModeKHR> &  present_mode_priority_list   = {vk::PresentModeKHR::eFifo, vk::PresentModeKHR::eMailbox},
+	             const vk::PresentModeKHR                 present_mode,
+	             const std::vector<vk::PresentModeKHR>   &present_mode_priority_list   = {vk::PresentModeKHR::eFifo, vk::PresentModeKHR::eMailbox},
 	             const std::vector<vk::SurfaceFormatKHR> &surface_format_priority_list = {{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
 	                                                                                      {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}},
+	             const vk::Extent2D                      &extent                       = {},
+	             const uint32_t                           image_count                  = 3,
+	             const vk::SurfaceTransformFlagBitsKHR    transform                    = vk::SurfaceTransformFlagBitsKHR::eIdentity,
+	             const std::set<vk::ImageUsageFlagBits>  &image_usage_flags            = {vk::ImageUsageFlagBits::eColorAttachment, vk::ImageUsageFlagBits::eTransferSrc},
 	             vk::SwapchainKHR                         old_swapchain                = nullptr);
 
 	HPPSwapchain(const HPPSwapchain &) = delete;
@@ -91,8 +91,6 @@ class HPPSwapchain
 
 	HPPSwapchain &operator=(HPPSwapchain &&) = delete;
 
-	void create();
-
 	bool is_valid() const;
 
 	HPPDevice const &get_device() const;
@@ -104,7 +102,6 @@ class HPPSwapchain
 	const vk::Extent2D &get_extent() const;
 
 	vk::Format get_format() const;
-	void       set_format(vk::Format);
 
 	const std::vector<vk::Image> &get_images() const;
 
@@ -115,17 +112,6 @@ class HPPSwapchain
 	vk::ImageUsageFlags get_usage() const;
 
 	vk::PresentModeKHR get_present_mode() const;
-	void               set_present_mode(vk::PresentModeKHR present_mode);
-
-	/**
-	 * @brief Sets the order in which the swapchain prioritizes selecting its present mode
-	 */
-	void set_present_mode_priority(const std::vector<vk::PresentModeKHR> &present_mode_priority_list);
-
-	/**
-	 * @brief Sets the order in which the swapchain prioritizes selecting its surface format
-	 */
-	void set_surface_format_priority(const std::vector<vk::SurfaceFormatKHR> &surface_format_priority_list);
 
   private:
 	HPPDevice &device;

--- a/framework/core/swapchain.cpp
+++ b/framework/core/swapchain.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -277,63 +277,85 @@ inline VkImageUsageFlags composite_image_flags(std::set<VkImageUsageFlagBits> &i
 }        // namespace
 
 Swapchain::Swapchain(Swapchain &old_swapchain, const VkExtent2D &extent) :
-    Swapchain{old_swapchain, old_swapchain.device, old_swapchain.surface, extent, old_swapchain.properties.image_count, old_swapchain.properties.pre_transform, old_swapchain.properties.present_mode, old_swapchain.image_usage_flags}
-{
-	present_mode_priority_list   = old_swapchain.present_mode_priority_list;
-	surface_format_priority_list = old_swapchain.surface_format_priority_list;
-	create();
-}
+    Swapchain{old_swapchain,
+              old_swapchain.device,
+              old_swapchain.surface,
+              old_swapchain.properties.present_mode,
+              old_swapchain.present_mode_priority_list,
+              old_swapchain.surface_format_priority_list,
+              extent,
+              old_swapchain.properties.image_count,
+              old_swapchain.properties.pre_transform,
+              old_swapchain.image_usage_flags}
+{}
 
 Swapchain::Swapchain(Swapchain &old_swapchain, const uint32_t image_count) :
-    Swapchain{old_swapchain, old_swapchain.device, old_swapchain.surface, old_swapchain.properties.extent, image_count, old_swapchain.properties.pre_transform, old_swapchain.properties.present_mode, old_swapchain.image_usage_flags}
-{
-	present_mode_priority_list   = old_swapchain.present_mode_priority_list;
-	surface_format_priority_list = old_swapchain.surface_format_priority_list;
-	create();
-}
+    Swapchain{old_swapchain,
+              old_swapchain.device,
+              old_swapchain.surface,
+              old_swapchain.properties.present_mode,
+              old_swapchain.present_mode_priority_list,
+              old_swapchain.surface_format_priority_list,
+              old_swapchain.properties.extent,
+              image_count,
+              old_swapchain.properties.pre_transform,
+              old_swapchain.image_usage_flags}
+{}
 
 Swapchain::Swapchain(Swapchain &old_swapchain, const std::set<VkImageUsageFlagBits> &image_usage_flags) :
-    Swapchain{old_swapchain, old_swapchain.device, old_swapchain.surface, old_swapchain.properties.extent, old_swapchain.properties.image_count, old_swapchain.properties.pre_transform, old_swapchain.properties.present_mode, image_usage_flags}
-{
-	present_mode_priority_list   = old_swapchain.present_mode_priority_list;
-	surface_format_priority_list = old_swapchain.surface_format_priority_list;
-	create();
-}
+    Swapchain{old_swapchain,
+              old_swapchain.device,
+              old_swapchain.surface,
+              old_swapchain.properties.present_mode,
+              old_swapchain.present_mode_priority_list,
+              old_swapchain.surface_format_priority_list,
+              old_swapchain.properties.extent,
+              old_swapchain.properties.image_count,
+              old_swapchain.properties.pre_transform,
+              image_usage_flags}
+{}
 
 Swapchain::Swapchain(Swapchain &old_swapchain, const VkExtent2D &extent, const VkSurfaceTransformFlagBitsKHR transform) :
+    Swapchain{old_swapchain,
+              old_swapchain.device,
+              old_swapchain.surface,
+              old_swapchain.properties.present_mode,
+              old_swapchain.present_mode_priority_list,
+              old_swapchain.surface_format_priority_list,
+              extent,
+              old_swapchain.properties.image_count,
+              transform,
+              old_swapchain.image_usage_flags}
+{}
 
-    Swapchain{old_swapchain, old_swapchain.device, old_swapchain.surface, extent, old_swapchain.properties.image_count, transform, old_swapchain.properties.present_mode, old_swapchain.image_usage_flags}
-
+Swapchain::Swapchain(Device                                &device,
+                     VkSurfaceKHR                           surface,
+                     const VkPresentModeKHR                 present_mode,
+                     std::vector<VkPresentModeKHR> const   &present_mode_priority_list,
+                     const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list,
+                     const VkExtent2D                      &extent,
+                     const uint32_t                         image_count,
+                     const VkSurfaceTransformFlagBitsKHR    transform,
+                     const std::set<VkImageUsageFlagBits>  &image_usage_flags) :
+    Swapchain{*this, device, surface, present_mode, present_mode_priority_list, surface_format_priority_list, extent, image_count, transform, image_usage_flags}
 {
-	present_mode_priority_list   = old_swapchain.present_mode_priority_list;
-	surface_format_priority_list = old_swapchain.surface_format_priority_list;
-	create();
 }
 
-Swapchain::Swapchain(Device &                              device,
-                     VkSurfaceKHR                          surface,
-                     const VkExtent2D &                    extent,
-                     const uint32_t                        image_count,
-                     const VkSurfaceTransformFlagBitsKHR   transform,
-                     const VkPresentModeKHR                present_mode,
-                     const std::set<VkImageUsageFlagBits> &image_usage_flags) :
-    Swapchain{*this, device, surface, extent, image_count, transform, present_mode, image_usage_flags}
-{
-}
-
-Swapchain::Swapchain(Swapchain &                           old_swapchain,
-                     Device &                              device,
-                     VkSurfaceKHR                          surface,
-                     const VkExtent2D &                    extent,
-                     const uint32_t                        image_count,
-                     const VkSurfaceTransformFlagBitsKHR   transform,
-                     const VkPresentModeKHR                present_mode,
-                     const std::set<VkImageUsageFlagBits> &image_usage_flags) :
+Swapchain::Swapchain(Swapchain                             &old_swapchain,
+                     Device                                &device,
+                     VkSurfaceKHR                           surface,
+                     const VkPresentModeKHR                 present_mode,
+                     std::vector<VkPresentModeKHR> const   &present_mode_priority_list,
+                     const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list,
+                     const VkExtent2D                      &extent,
+                     const uint32_t                         image_count,
+                     const VkSurfaceTransformFlagBitsKHR    transform,
+                     const std::set<VkImageUsageFlagBits>  &image_usage_flags) :
     device{device},
     surface{surface}
 {
-	present_mode_priority_list   = old_swapchain.present_mode_priority_list;
-	surface_format_priority_list = old_swapchain.surface_format_priority_list;
+	this->present_mode_priority_list   = present_mode_priority_list;
+	this->surface_format_priority_list = surface_format_priority_list;
 
 	VkSurfaceCapabilitiesKHR surface_capabilities{};
 	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(this->device.get_gpu().get_handle(), surface, &surface_capabilities);
@@ -375,31 +397,7 @@ Swapchain::Swapchain(Swapchain &                           old_swapchain,
 	// Pass through defaults to the create function
 	properties.old_swapchain = old_swapchain.get_handle();
 	properties.present_mode  = present_mode;
-}
 
-Swapchain::~Swapchain()
-{
-	if (handle != VK_NULL_HANDLE)
-	{
-		vkDestroySwapchainKHR(device.get_handle(), handle, nullptr);
-	}
-}
-
-Swapchain::Swapchain(Swapchain &&other) :
-    device{other.device},
-    surface{other.surface},
-    handle{other.handle},
-    image_usage_flags{std::move(other.image_usage_flags)},
-    images{std::move(other.images)},
-    properties{std::move(other.properties)}
-{
-	other.handle  = VK_NULL_HANDLE;
-	other.surface = VK_NULL_HANDLE;
-}
-
-void Swapchain::create()
-{
-	// Revalidate the present mode and surface format
 	properties.present_mode   = choose_present_mode(properties.present_mode, present_modes, present_mode_priority_list);
 	properties.surface_format = choose_surface_format(properties.surface_format, surface_formats, surface_format_priority_list);
 
@@ -429,7 +427,29 @@ void Swapchain::create()
 	images.resize(image_available);
 
 	VK_CHECK(vkGetSwapchainImagesKHR(device.get_handle(), handle, &image_available, images.data()));
-}        // namespace vkb
+}
+
+Swapchain::~Swapchain()
+{
+	if (handle != VK_NULL_HANDLE)
+	{
+		vkDestroySwapchainKHR(device.get_handle(), handle, nullptr);
+	}
+}
+
+Swapchain::Swapchain(Swapchain &&other) :
+    device{other.device},
+    surface{std::exchange(other.surface, VK_NULL_HANDLE)},
+    handle{std::exchange(other.handle, VK_NULL_HANDLE)},
+    images{std::exchange(other.images, {})},
+    surface_formats{std::exchange(other.surface_formats, {})},
+    present_modes{std::exchange(other.present_modes, {})},
+    properties{std::exchange(other.properties, {})},
+    present_mode_priority_list{std::exchange(other.present_mode_priority_list, {})},
+    surface_format_priority_list{std::exchange(other.surface_format_priority_list, {})},
+    image_usage_flags{std::move(other.image_usage_flags)}
+{
+}
 
 bool Swapchain::is_valid() const
 {
@@ -444,11 +464,6 @@ Device &Swapchain::get_device()
 VkSwapchainKHR Swapchain::get_handle() const
 {
 	return handle;
-}
-
-SwapchainProperties &Swapchain::get_properties()
-{
-	return properties;
 }
 
 VkResult Swapchain::acquire_next_image(uint32_t &image_index, VkSemaphore image_acquired_semaphore, VkFence fence) const
@@ -486,17 +501,6 @@ VkImageUsageFlags Swapchain::get_usage() const
 	return properties.image_usage;
 }
 
-void Swapchain::set_present_mode_priority(const std::vector<VkPresentModeKHR> &new_present_mode_priority_list)
-{
-	assert(!new_present_mode_priority_list.empty() && "Priority list must not be empty");
-	present_mode_priority_list = new_present_mode_priority_list;
-}
-
-void Swapchain::set_surface_format_priority(const std::vector<VkSurfaceFormatKHR> &new_surface_format_priority_list)
-{
-	assert(!new_surface_format_priority_list.empty() && "Priority list must not be empty");
-	surface_format_priority_list = new_surface_format_priority_list;
-}
 VkPresentModeKHR Swapchain::get_present_mode() const
 {
 	return properties.present_mode;

--- a/framework/core/swapchain.h
+++ b/framework/core/swapchain.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2022, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -73,26 +73,33 @@ class Swapchain
 	/**
 	 * @brief Constructor to create a swapchain.
 	 */
-	Swapchain(Device &                              device,
-	          VkSurfaceKHR                          surface,
-	          const VkExtent2D &                    extent            = {},
-	          const uint32_t                        image_count       = 3,
-	          const VkSurfaceTransformFlagBitsKHR   transform         = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-	          const VkPresentModeKHR                present_mode      = VK_PRESENT_MODE_FIFO_KHR,
-	          const std::set<VkImageUsageFlagBits> &image_usage_flags = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_SRC_BIT});
+	Swapchain(Device                                &device,
+	          VkSurfaceKHR                           surface,
+	          const VkPresentModeKHR                 present_mode,
+	          const std::vector<VkPresentModeKHR>   &present_mode_priority_list   = {VK_PRESENT_MODE_FIFO_KHR,
+	                                                                                 VK_PRESENT_MODE_MAILBOX_KHR},
+	          const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list = {{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	                                                                                 {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}},
+	          const VkExtent2D                      &extent                       = {},
+	          const uint32_t                         image_count                  = 3,
+	          const VkSurfaceTransformFlagBitsKHR    transform                    = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
+	          const std::set<VkImageUsageFlagBits>  &image_usage_flags            = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_SRC_BIT});
 
 	/**
 	 * @brief Constructor to create a swapchain from the old swapchain
 	 *        by configuring all parameters.
 	 */
-	Swapchain(Swapchain &                           old_swapchain,
-	          Device &                              device,
-	          VkSurfaceKHR                          surface,
-	          const VkExtent2D &                    extent            = {},
-	          const uint32_t                        image_count       = 3,
-	          const VkSurfaceTransformFlagBitsKHR   transform         = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-	          const VkPresentModeKHR                present_mode      = VK_PRESENT_MODE_FIFO_KHR,
-	          const std::set<VkImageUsageFlagBits> &image_usage_flags = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_SRC_BIT});
+	Swapchain(Swapchain                             &old_swapchain,
+	          Device                                &device,
+	          VkSurfaceKHR                           surface,
+	          const VkPresentModeKHR                 present_mode,
+	          const std::vector<VkPresentModeKHR>   &present_mode_priority_list   = {VK_PRESENT_MODE_FIFO_KHR, VK_PRESENT_MODE_MAILBOX_KHR},
+	          const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list = {{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	                                                                                 {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}},
+	          const VkExtent2D                      &extent                       = {},
+	          const uint32_t                         image_count                  = 3,
+	          const VkSurfaceTransformFlagBitsKHR    transform                    = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
+	          const std::set<VkImageUsageFlagBits>  &image_usage_flags            = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_SRC_BIT});
 
 	Swapchain(const Swapchain &) = delete;
 
@@ -104,15 +111,11 @@ class Swapchain
 
 	Swapchain &operator=(Swapchain &&) = delete;
 
-	void create();
-
 	bool is_valid() const;
 
 	Device &get_device();
 
 	VkSwapchainKHR get_handle() const;
-
-	SwapchainProperties &get_properties();
 
 	VkResult acquire_next_image(uint32_t &image_index, VkSemaphore image_acquired_semaphore, VkFence fence = VK_NULL_HANDLE) const;
 
@@ -129,16 +132,6 @@ class Swapchain
 	VkImageUsageFlags get_usage() const;
 
 	VkPresentModeKHR get_present_mode() const;
-
-	/**
-	 * @brief Sets the order in which the swapchain prioritizes selecting its present mode
-	 */
-	void set_present_mode_priority(const std::vector<VkPresentModeKHR> &present_mode_priority_list);
-
-	/**
-	 * @brief Sets the order in which the swapchain prioritizes selecting its surface format
-	 */
-	void set_surface_format_priority(const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list);
 
   private:
 	Device &device;

--- a/framework/platform/android/android_platform.cpp
+++ b/framework/platform/android/android_platform.cpp
@@ -89,7 +89,7 @@ extern "C"
 
 		for (int i = 0; i < env->GetArrayLength(arg_strings); i++)
 		{
-			jstring arg_string = (jstring)(env->GetObjectArrayElement(arg_strings, i));
+			jstring arg_string = (jstring) (env->GetObjectArrayElement(arg_strings, i));
 
 			const char *arg = env->GetStringUTFChars(arg_string, 0);
 
@@ -316,24 +316,28 @@ void on_app_cmd(android_app *app, int32_t cmd)
 
 	switch (cmd)
 	{
-		case APP_CMD_INIT_WINDOW: {
+		case APP_CMD_INIT_WINDOW:
+		{
 			platform->resize(ANativeWindow_getWidth(app->window),
 			                 ANativeWindow_getHeight(app->window));
 			platform->set_surface_ready();
 			break;
 		}
-		case APP_CMD_CONTENT_RECT_CHANGED: {
+		case APP_CMD_CONTENT_RECT_CHANGED:
+		{
 			// Get the new size
 			auto width  = app->contentRect.right - app->contentRect.left;
 			auto height = app->contentRect.bottom - app->contentRect.top;
 			platform->resize(width, height);
 			break;
 		}
-		case APP_CMD_GAINED_FOCUS: {
+		case APP_CMD_GAINED_FOCUS:
+		{
 			platform->set_focus(true);
 			break;
 		}
-		case APP_CMD_LOST_FOCUS: {
+		case APP_CMD_LOST_FOCUS:
+		{
 			platform->set_focus(false);
 			break;
 		}
@@ -527,24 +531,14 @@ android_app *AndroidPlatform::get_android_app()
 
 std::unique_ptr<RenderContext> AndroidPlatform::create_render_context(Device &device, VkSurfaceKHR surface, const std::vector<VkSurfaceFormatKHR> &surface_format_priority) const
 {
-	auto context = Platform::create_render_context(device, surface, surface_format_priority);
+	assert(!surface_format_priority.empty() && "Surface format priority list must contain at least one preferred surface format");
 
-	context->set_present_mode_priority({VK_PRESENT_MODE_FIFO_KHR,
-	                                    VK_PRESENT_MODE_MAILBOX_KHR,
-	                                    VK_PRESENT_MODE_IMMEDIATE_KHR});
+	VkPresentModeKHR              present_mode = (window_properties.vsync == Window::Vsync::OFF) ? VK_PRESENT_MODE_MAILBOX_KHR : VK_PRESENT_MODE_FIFO_KHR;
+	std::vector<VkPresentModeKHR> present_mode_priority_list{VK_PRESENT_MODE_FIFO_KHR,
+	                                                         VK_PRESENT_MODE_MAILBOX_KHR,
+	                                                         VK_PRESENT_MODE_IMMEDIATE_KHR};
 
-	switch (window_properties.vsync)
-	{
-		case Window::Vsync::OFF:
-			context->request_present_mode(VK_PRESENT_MODE_MAILBOX_KHR);
-			break;
-		case Window::Vsync::ON:
-		default:
-			context->request_present_mode(VK_PRESENT_MODE_FIFO_KHR);
-			break;
-	}
-
-	return std::move(context);
+	return std::make_unique<RenderContext>(device, surface, *window, present_mode, present_mode_priority_list, surface_format_priority);
 }
 
 std::vector<spdlog::sink_ptr> AndroidPlatform::get_platform_sinks()

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2022, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -186,30 +186,14 @@ std::unique_ptr<RenderContext> Platform::create_render_context(Device &device, V
 {
 	assert(!surface_format_priority.empty() && "Surface format priority list must contain at least one preferred surface format");
 
-	auto context = std::make_unique<RenderContext>(device, surface, *window);
-
-	context->set_surface_format_priority(surface_format_priority);
-
-	context->request_image_format(surface_format_priority[0].format);
-
-	context->set_present_mode_priority({
+	VkPresentModeKHR              present_mode = (window_properties.vsync == Window::Vsync::ON) ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_MAILBOX_KHR;
+	std::vector<VkPresentModeKHR> present_mode_priority_list{
 	    VK_PRESENT_MODE_MAILBOX_KHR,
 	    VK_PRESENT_MODE_FIFO_KHR,
 	    VK_PRESENT_MODE_IMMEDIATE_KHR,
-	});
+	};
 
-	switch (window_properties.vsync)
-	{
-		case Window::Vsync::ON:
-			context->request_present_mode(VK_PRESENT_MODE_FIFO_KHR);
-			break;
-		case Window::Vsync::OFF:
-		default:
-			context->request_present_mode(VK_PRESENT_MODE_MAILBOX_KHR);
-			break;
-	}
-
-	return std::move(context);
+	return std::make_unique<RenderContext>(device, surface, *window, present_mode, present_mode_priority_list, surface_format_priority);
 }
 
 void Platform::terminate(ExitCode code)

--- a/framework/rendering/hpp_render_context.h
+++ b/framework/rendering/hpp_render_context.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -42,8 +42,17 @@ class HPPRenderContext
 	 * @param device A valid device
 	 * @param surface A surface, nullptr if in headless mode
 	 * @param window The window where the surface was created
+	 * @param present_mode Requests to set the present mode of the swapchain
+	 * @param present_mode_priority_list The order in which the swapchain prioritizes selecting its present mode
+	 * @param surface_format_priority_list The order in which the swapchain prioritizes selecting its surface format
 	 */
-	HPPRenderContext(vkb::core::HPPDevice &device, vk::SurfaceKHR surface, const vkb::platform::HPPWindow &window);
+	HPPRenderContext(vkb::core::HPPDevice                    &device,
+	                 vk::SurfaceKHR                           surface,
+	                 const vkb::platform::HPPWindow          &window,
+	                 vk::PresentModeKHR                       present_mode                 = vk::PresentModeKHR::eFifo,
+	                 std::vector<vk::PresentModeKHR> const   &present_mode_priority_list   = {vk::PresentModeKHR::eFifo, vk::PresentModeKHR::eMailbox},
+	                 std::vector<vk::SurfaceFormatKHR> const &surface_format_priority_list = {
+	                     {vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}, {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}});
 
 	HPPRenderContext(const HPPRenderContext &) = delete;
 
@@ -54,26 +63,6 @@ class HPPRenderContext
 	HPPRenderContext &operator=(const HPPRenderContext &) = delete;
 
 	HPPRenderContext &operator=(HPPRenderContext &&) = delete;
-
-	/**
-	 * @brief Requests to set the present mode of the swapchain, must be called before prepare
-	 */
-	void request_present_mode(const vk::PresentModeKHR present_mode);
-
-	/**
-	 * @brief Requests to set a specific image format for the swapchain
-	 */
-	void request_image_format(const vk::Format format);
-
-	/**
-	 * @brief Sets the order in which the swapchain prioritizes selecting its present mode
-	 */
-	void set_present_mode_priority(const std::vector<vk::PresentModeKHR> &present_mode_priority_list);
-
-	/**
-	 * @brief Sets the order in which the swapchain prioritizes selecting its surface format
-	 */
-	void set_surface_format_priority(const std::vector<vk::SurfaceFormatKHR> &surface_format_priority_list);
 
 	/**
 	 * @brief Prepares the RenderFrames for rendering
@@ -229,13 +218,6 @@ class HPPRenderContext
 	std::unique_ptr<vkb::core::HPPSwapchain> swapchain;
 
 	vkb::core::HPPSwapchainProperties swapchain_properties;
-
-	// A list of present modes in order of priority (vector[0] has high priority, vector[size-1] has low priority)
-	std::vector<vk::PresentModeKHR> present_mode_priority_list = {vk::PresentModeKHR::eFifo, vk::PresentModeKHR::eMailbox};
-
-	// A list of surface formats in order of priority (vector[0] has high priority, vector[size-1] has low priority)
-	std::vector<vk::SurfaceFormatKHR> surface_format_priority_list = {{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
-	                                                                  {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}};
 
 	std::vector<std::unique_ptr<HPPRenderFrame>> frames;
 

--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -23,11 +23,13 @@ namespace vkb
 {
 VkFormat RenderContext::DEFAULT_VK_FORMAT = VK_FORMAT_R8G8B8A8_SRGB;
 
-RenderContext::RenderContext(Device &device, VkSurfaceKHR surface, const Window &window) :
-    device{device},
-    window{window},
-    queue{device.get_suitable_graphics_queue()},
-    surface_extent{window.get_extent().width, window.get_extent().height}
+RenderContext::RenderContext(Device                                &device,
+                             VkSurfaceKHR                           surface,
+                             const Window                          &window,
+                             VkPresentModeKHR                       present_mode,
+                             const std::vector<VkPresentModeKHR>   &present_mode_priority_list,
+                             const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list) :
+    device{device}, window{window}, queue{device.get_suitable_graphics_queue()}, surface_extent{window.get_extent().width, window.get_extent().height}
 {
 	if (surface != VK_NULL_HANDLE)
 	{
@@ -38,30 +40,12 @@ RenderContext::RenderContext(Device &device, VkSurfaceKHR surface, const Window 
 
 		if (surface_properties.currentExtent.width == 0xFFFFFFFF)
 		{
-			swapchain = std::make_unique<Swapchain>(device, surface, surface_extent);
+			swapchain = std::make_unique<Swapchain>(device, surface, present_mode, present_mode_priority_list, surface_format_priority_list, surface_extent);
 		}
 		else
 		{
-			swapchain = std::make_unique<Swapchain>(device, surface);
+			swapchain = std::make_unique<Swapchain>(device, surface, present_mode, present_mode_priority_list, surface_format_priority_list);
 		}
-	}
-}
-
-void RenderContext::request_present_mode(const VkPresentModeKHR present_mode)
-{
-	if (swapchain)
-	{
-		auto &properties        = swapchain->get_properties();
-		properties.present_mode = present_mode;
-	}
-}
-
-void RenderContext::request_image_format(const VkFormat format)
-{
-	if (swapchain)
-	{
-		auto &properties                 = swapchain->get_properties();
-		properties.surface_format.format = format;
 	}
 }
 
@@ -71,10 +55,6 @@ void RenderContext::prepare(size_t thread_count, RenderTarget::CreateFunc create
 
 	if (swapchain)
 	{
-		swapchain->set_present_mode_priority(present_mode_priority_list);
-		swapchain->set_surface_format_priority(surface_format_priority_list);
-		swapchain->create();
-
 		surface_extent = swapchain->get_extent();
 
 		VkExtent3D extent{surface_extent.width, surface_extent.height, 1};
@@ -108,18 +88,6 @@ void RenderContext::prepare(size_t thread_count, RenderTarget::CreateFunc create
 	this->create_render_target_func = create_render_target_func;
 	this->thread_count              = thread_count;
 	this->prepared                  = true;
-}
-
-void RenderContext::set_present_mode_priority(const std::vector<VkPresentModeKHR> &new_present_mode_priority_list)
-{
-	assert(!new_present_mode_priority_list.empty() && "Priority list must not be empty");
-	present_mode_priority_list = new_present_mode_priority_list;
-}
-
-void RenderContext::set_surface_format_priority(const std::vector<VkSurfaceFormatKHR> &new_surface_format_priority_list)
-{
-	assert(!new_surface_format_priority_list.empty() && "Priority list must not be empty");
-	surface_format_priority_list = new_surface_format_priority_list;
 }
 
 VkFormat RenderContext::get_format() const

--- a/framework/rendering/render_context.h
+++ b/framework/rendering/render_context.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2022, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -65,8 +65,18 @@ class RenderContext
 	 * @param device A valid device
 	 * @param surface A surface, VK_NULL_HANDLE if in headless mode
 	 * @param window The window where the surface was created
+	 * @param present_mode Requests to set the present mode of the swapchain
+	 * @param present_mode_priority_list The order in which the swapchain prioritizes selecting its present mode
+	 * @param surface_format_priority_list The order in which the swapchain prioritizes selecting its surface format
 	 */
-	RenderContext(Device &device, VkSurfaceKHR surface, const Window &window);
+	RenderContext(Device                                &device,
+	              VkSurfaceKHR                           surface,
+	              const Window                          &window,
+	              VkPresentModeKHR                       present_mode                 = VK_PRESENT_MODE_FIFO_KHR,
+	              const std::vector<VkPresentModeKHR>   &present_mode_priority_list   = {VK_PRESENT_MODE_FIFO_KHR, VK_PRESENT_MODE_MAILBOX_KHR},
+	              const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list = {
+	                  {VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	                  {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}});
 
 	RenderContext(const RenderContext &) = delete;
 
@@ -77,26 +87,6 @@ class RenderContext
 	RenderContext &operator=(const RenderContext &) = delete;
 
 	RenderContext &operator=(RenderContext &&) = delete;
-
-	/**
-	 * @brief Requests to set the present mode of the swapchain, must be called before prepare
-	 */
-	void request_present_mode(const VkPresentModeKHR present_mode);
-
-	/**
-	 * @brief Requests to set a specific image format for the swapchain
-	 */
-	void request_image_format(const VkFormat format);
-
-	/**
-	 * @brief Sets the order in which the swapchain prioritizes selecting its present mode
-	 */
-	void set_present_mode_priority(const std::vector<VkPresentModeKHR> &present_mode_priority_list);
-
-	/**
-	 * @brief Sets the order in which the swapchain prioritizes selecting its surface format
-	 */
-	void set_surface_format_priority(const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list);
 
 	/**
 	 * @brief Prepares the RenderFrames for rendering
@@ -249,16 +239,6 @@ class RenderContext
 	std::unique_ptr<Swapchain> swapchain;
 
 	SwapchainProperties swapchain_properties;
-
-	// A list of present modes in order of priority (vector[0] has high priority, vector[size-1] has low priority)
-	std::vector<VkPresentModeKHR> present_mode_priority_list = {
-	    VK_PRESENT_MODE_FIFO_KHR,
-	    VK_PRESENT_MODE_MAILBOX_KHR};
-
-	// A list of surface formats in order of priority (vector[0] has high priority, vector[size-1] has low priority)
-	std::vector<VkSurfaceFormatKHR> surface_format_priority_list = {
-	    {VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	    {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}};
 
 	std::vector<std::unique_ptr<RenderFrame>> frames;
 


### PR DESCRIPTION
## Description

Each constructor of those classes now creates a swapchain.
Required some adjustments in vkb::RenderContext, vkb::Platform, vkb::rendering::HPPRenderContext, and vkb::platform::HPPPlatform

Builds on Win10 using VS2022, runs on Win10 with NVidia GPU.

Resolves #534.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
