### PR TITLE
Do not require access to external storage

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-- Copyright (c) 2019-2021, Arm Limited and Contributors
+- Copyright (c) 2019-2023, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -23,15 +23,9 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
-	                 tools:ignore="ScopedStorage" />
-
 	<application android:label="@string/app_name"
 		android:allowBackup="false"
 		android:debuggable="true"
-		android:requestLegacyExternalStorage="true"
 		android:icon="@mipmap/ic_launcher"
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:theme="@style/AppTheme"

--- a/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
+++ b/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,14 +21,10 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
-import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
-import android.os.Environment;
-import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -74,10 +70,6 @@ public class SampleLauncherActivity extends AppCompatActivity {
             File external_files_dir = getExternalFilesDir("");
             File temp_files_dir = getCacheDir();
             if (external_files_dir != null && temp_files_dir != null) {
-                // User no longer has permissions to access applications' storage, save files in
-                // top level (shared) external storage directory
-                String shared_storage = external_files_dir.getPath().split(Pattern.quote("Android"))[0];
-                external_files_dir = new File(shared_storage, getPackageName());
                 initFilePath(external_files_dir.toString(), temp_files_dir.toString());
             }
 
@@ -87,8 +79,6 @@ public class SampleLauncherActivity extends AppCompatActivity {
 
         // Required Permissions
         permissions = new ArrayList<>();
-        permissions.add(new Permission(Manifest.permission.WRITE_EXTERNAL_STORAGE, 1));
-        permissions.add(new Permission(Manifest.permission.READ_EXTERNAL_STORAGE, 2));
 
         if (checkPermissions()) {
             // Permissions previously granted skip requesting them
@@ -97,18 +87,6 @@ public class SampleLauncherActivity extends AppCompatActivity {
         } else {
             // Chain request permissions
             requestNextPermission();
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            if (!Environment.isExternalStorageManager())
-            {
-                // Prompt the user to "Allow access to all files"
-                Intent intent = new Intent();
-                                    intent.setAction(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
-                                    Uri uri = Uri.fromParts("package", this.getPackageName(), null);
-                                    intent.setData(uri);
-                startActivity(intent);
-            }
         }
     }
 

--- a/app/android/res/values/strings.xml
+++ b/app/android/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-- Copyright (c) 2019-2020, Arm Limited and Contributors
+- Copyright (c) 2019-2023, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -22,7 +22,7 @@
 	<string name="channel_name">vkb_channel</string>
 	<string name="channel_desc">vkb_channel is a channel for the vulkan best practice application notifications</string>
 	<string name="native_lib_name">vulkan_samples</string>
-	<string name="permissions_text">Permission to access files is required to load assets</string>
+	<string name="permissions_text">Some permissions were not granted</string>
 	<string name="permissions_button">Grant Permissions</string>
 	<string name="menu_run_samples_title">Run All Samples</string>
 	<string name="open_file_with">Open File With</string>

--- a/bldsys/cmake/android_package.cmake
+++ b/bldsys/cmake/android_package.cmake
@@ -1,5 +1,5 @@
 #[[
- Copyright (c) 2019-2021, Arm Limited and Contributors
+ Copyright (c) 2019-2023, Arm Limited and Contributors
 
  SPDX-License-Identifier: Apache-2.0
 
@@ -113,7 +113,7 @@ function(android_sync_folder)
     set(SYNC_COMMAND ${CMAKE_COMMAND}
             -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
             -DFOLDER_DIR=${TARGET_PATH}/.
-            -DDEVICE_DIR=/sdcard/com.khronos.${PROJECT_NAME}/${FOLDER_NAME}/
+            -DDEVICE_DIR=/sdcard/Android/data/com.khronos.${PROJECT_NAME}/files/${FOLDER_NAME}/
             -P "${SCRIPT_DIR}/android_sync_folder.cmake")
 
     add_custom_target(

--- a/bldsys/cmake/android_sync_folder.cmake
+++ b/bldsys/cmake/android_sync_folder.cmake
@@ -79,7 +79,7 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 if(NOT "${ret_var}" STREQUAL "0")
- message(FATAL_ERROR "Could not copy ${FOLDER_DIR} to final dir:\n${ret_msg}")
+ message(WARNING "Could not copy ${FOLDER_DIR} to final dir:\n${ret_msg}")
 else()
  message(STATUS "Copied ${TEMP_DIR} to ${DIR_PATH}:\n${ret_msg}")
 endif()

--- a/bldsys/cmake/android_sync_folder.cmake
+++ b/bldsys/cmake/android_sync_folder.cmake
@@ -17,9 +17,9 @@
 
  ]]
 
- set(CMAKE_MODULE_PATH
- ${CMAKE_MODULE_PATH}
- ${CMAKE_MODULE_PATH}/module)
+set(CMAKE_MODULE_PATH
+  ${CMAKE_MODULE_PATH}
+  ${CMAKE_MODULE_PATH}/module)
 set(FOLDER_DIR ${FOLDER_DIR})
 set(DEVICE_DIR ${DEVICE_DIR})
 
@@ -79,7 +79,7 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 if(NOT "${ret_var}" STREQUAL "0")
- message(WARNING "Could not copy ${FOLDER_DIR} to final dir:\n${ret_msg}")
+ message(FATAL_ERROR "Could not copy ${FOLDER_DIR} to final dir:\n${ret_msg}")
 else()
  message(STATUS "Copied ${TEMP_DIR} to ${DIR_PATH}:\n${ret_msg}")
 endif()

--- a/bldsys/cmake/android_sync_folder.cmake
+++ b/bldsys/cmake/android_sync_folder.cmake
@@ -1,5 +1,5 @@
 #[[
- Copyright (c) 2019, Arm Limited and Contributors
+ Copyright (c) 2019-2023, Arm Limited and Contributors
 
  SPDX-License-Identifier: Apache-2.0
 
@@ -17,37 +17,81 @@
 
  ]]
 
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    ${CMAKE_MODULE_PATH}/module)
+ set(CMAKE_MODULE_PATH
+ ${CMAKE_MODULE_PATH}
+ ${CMAKE_MODULE_PATH}/module)
 set(FOLDER_DIR ${FOLDER_DIR})
 set(DEVICE_DIR ${DEVICE_DIR})
 
 find_package(Adb 1.0.39 REQUIRED)
 
+# Sync files to temporary directory
+get_filename_component(DIR_PATH "${FOLDER_DIR}" DIRECTORY)
+get_filename_component(DIR_NAME "${DIR_PATH}" NAME)
+set(TEMP_DIR "/data/local/tmp/${DIR_NAME}")
+
 # Ensure that directory exists in the target
 
-set(ADB_COMMAND ${ADB_EXECUTABLE} shell mkdir -p ${DEVICE_DIR})
+set(ADB_COMMAND ${ADB_EXECUTABLE} shell mkdir -p ${TEMP_DIR})
 
 execute_process(
-     COMMAND
-     ${ADB_COMMAND})
+  COMMAND
+  ${ADB_COMMAND})
 
-# Sync files
-
-set(ADB_COMMAND ${ADB_EXECUTABLE} push --sync ${FOLDER_DIR} ${DEVICE_DIR})
+set(ADB_COMMAND ${ADB_EXECUTABLE} push --sync ${FOLDER_DIR} ${TEMP_DIR})
 
 execute_process(
-     COMMAND
-     ${ADB_COMMAND}
-     RESULT_VARIABLE
-     ret_var
-     OUTPUT_VARIABLE
-     ret_msg
-     OUTPUT_STRIP_TRAILING_WHITESPACE)
+  COMMAND
+  ${ADB_COMMAND}
+  RESULT_VARIABLE
+  ret_var
+  OUTPUT_VARIABLE
+  ret_msg
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 if(NOT "${ret_var}" STREQUAL "0")
-    message(WARNING "Could not sync ${FOLDER_DIR} to device:\n${ret_msg}")
+ message(WARNING "Could not sync ${FOLDER_DIR} to temp dir:\n${ret_msg}")
 else()
-    message(STATUS "Updating ${FOLDER_DIR}:\n${ret_msg}")
+ message(STATUS "Updated ${FOLDER_DIR} to ${TEMP_DIR}:\n${ret_msg}")
 endif()
+
+# Copy to final device destination
+
+get_filename_component(DIR_PATH "${DEVICE_DIR}" DIRECTORY)
+
+# Ensure that directory exists in the target
+
+set(ADB_COMMAND ${ADB_EXECUTABLE} shell mkdir -p ${DIR_PATH})
+
+execute_process(
+  COMMAND
+  ${ADB_COMMAND})
+
+set(ADB_COMMAND ${ADB_EXECUTABLE} shell cp -r ${TEMP_DIR} ${DIR_PATH})
+
+execute_process(
+  COMMAND
+  ${ADB_COMMAND}
+  RESULT_VARIABLE
+  ret_var
+  OUTPUT_VARIABLE
+  ret_msg
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(NOT "${ret_var}" STREQUAL "0")
+ message(WARNING "Could not copy ${FOLDER_DIR} to final dir:\n${ret_msg}")
+else()
+ message(STATUS "Copied ${TEMP_DIR} to ${DIR_PATH}:\n${ret_msg}")
+endif()
+
+execute_process(
+  COMMAND
+  ${ADB_COMMAND})
+
+# Ensure file permissions
+
+set(ADB_COMMAND ${ADB_EXECUTABLE} shell chmod 777 -R ${DIR_PATH})
+
+execute_process(
+  COMMAND
+  ${ADB_COMMAND})


### PR DESCRIPTION
## Description

Yet another option to fix the issue with permissions in the latest Android versions, see #678 and #692

Rather than directly running `adb push --sync` to the application's storage, which can cause permission issues, sync shaders and assets to temporary storage, then use `adb shell` to copy them to the application's location. This is all possible without requesting special external storage permissions, so the changes from #370 were reverted.

Fixes #646

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [n/a] I have used existing framework/helper functions where possible
- [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

