### PR TITLE
Add Readme template to sample create script

### DIFF
--- a/bldsys/cmake/create_sample_project.cmake
+++ b/bldsys/cmake/create_sample_project.cmake
@@ -29,6 +29,7 @@ set(OUTPUT_DIR "${ROOT_DIR}/samples" CACHE PATH "")
 set(CMAKE_FILE ${SCRIPT_DIR}/template/${TEMPLATE_NAME}/CMakeLists.txt.in)
 set(SAMPLE_SOURCE_FILE ${SCRIPT_DIR}/template/${TEMPLATE_NAME}/sample.cpp.in)
 set(SAMPLE_HEADER_FILE ${SCRIPT_DIR}/template/${TEMPLATE_NAME}/sample.h.in)
+set(SAMPLE_README_FILE ${SCRIPT_DIR}/template/README.md.in)
 
 # Only create a new sample if a name is given
 if(NOT SAMPLE_NAME)
@@ -46,3 +47,4 @@ string(TOLOWER ${result} SAMPLE_NAME_FILE)
 configure_file(${CMAKE_FILE} ${OUTPUT_DIR}/${SAMPLE_NAME_FILE}/CMakeLists.txt @ONLY)
 configure_file(${SAMPLE_SOURCE_FILE} ${OUTPUT_DIR}/${SAMPLE_NAME_FILE}/${SAMPLE_NAME_FILE}.cpp)
 configure_file(${SAMPLE_HEADER_FILE} ${OUTPUT_DIR}/${SAMPLE_NAME_FILE}/${SAMPLE_NAME_FILE}.h)
+configure_file(${SAMPLE_README_FILE} ${OUTPUT_DIR}/${SAMPLE_NAME_FILE}/README.md)

--- a/bldsys/cmake/template/README.MD.in
+++ b/bldsys/cmake/template/README.MD.in
@@ -1,0 +1,73 @@
+<!--
+- Copyright (c) 2019-2023, The Khronos Group
+-
+- SPDX-License-Identifier: Apache-2.0
+-
+- Licensed under the Apache License, Version 2.0 the "License";
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-
+-->
+
+<!-- NOTE: Remove the following comment block for the actual readme of your sample -->
+
+<!--
+This is a template for the sample's readme. Every new sample should come with a readme that contains at least a short tutorial that accompanies the code of the example.
+
+Readmes are written in Markdown (see https://en.wikipedia.org/wiki/Markdown).
+
+You can freely choose how to structure it, but it should always contain an overview and conclusion paragraph.
+
+The readme can (and most often should) show code from along with an explanation. Code in markdown can be rendered using three backticks and can be formatted using a language specifier, e.g.:
+
+```cpp
+void main() {
+    std::cout << "Hello World";
+}
+```
+
+or
+
+```glsl
+void main() {
+    gl_color = vec4(1.0f);
+}
+```
+
+Ideally it also contains an image of how the sample is supposed to look.
+
+For an example you can take a look at the readme's of existing samples, e.g. https://raw.githubusercontent.com/SaschaWillems/Vulkan-Samples/main/samples/extensions/descriptor_indexing/README.md
+-->
+
+# Overview
+
+<!-- 
+This chapter should contain an overview of what this sample is trying to achieve. If extensions are used, this chapter should also list those.
+-->
+
+<!-- 
+The following chapters get into the details on how the sample is working, what features are used, etc. 
+
+The chapter itself can be structured by using sub paragraphs, e.g.:
+
+# Feature description
+
+# Enabling extensions
+
+# etc.
+
+-->
+
+# Conclusion
+
+<!--
+The tutorial should end with a conclusion chapter that recaps the tutorial and (if applicable) talks about pros and cons of the features demonstrated in this sample
+>


### PR DESCRIPTION
## Description

This PR adds a markdown Readme template to the sample templates. So if you now generate a new sample with the provided scripts, you also get a Readme inside the new sample's directory. The Readme itself only has a (very) minimal structure but contains comments on how to write a proper Readme for samples.

Note: It's a pure documentation PR, no sample code was added or changed.

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible

- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  