### PR TITLE
Add a color picker UI element

### DIFF
--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -1245,25 +1245,45 @@ void Drawer::text(const char *formatstr, ...)
 	va_end(args);
 }
 
-bool Drawer::color_picker(const char *caption, const char channel_count, float *color, uint16_t width, ImGuiColorEditFlags flags)
+bool Drawer::color_picker(const char *caption, std::array<float, 3> &color, float width, ImGuiColorEditFlags flags)
 {
-	assert((channel_count == 3 || channel_count == 4) && "Channel count value must be 3 or 4");
 	bool res;
-	if (width)
-		ImGui::PushItemWidth(width);
-	switch (channel_count)
-	{
-		case 3:
-			res = ImGui::ColorPicker3(caption, color, flags);
-			break;
-		case 4:
-			res = ImGui::ColorPicker4(caption, color, flags);
-			break;
-	}
+	ImGui::PushItemWidth(width);
+	res = ImGui::ColorPicker3(caption, color.data(), flags);
+	ImGui::PopItemWidth();
 	if (res)
-	{
 		dirty = true;
-	};
+	return res;
+}
+
+bool Drawer::color_picker(const char *caption, std::array<float, 4> &color, float width, ImGuiColorEditFlags flags)
+{
+	bool res;
+	ImGui::PushItemWidth(width);
+	res = ImGui::ColorPicker4(caption, color.data(), flags);
+	ImGui::PopItemWidth();
+	if (res)
+		dirty = true;
+	return res;
+}
+
+bool Drawer::color_edit(const char *caption, std::array<float, 3> &color, float width, ImGuiColorEditFlags flags)
+{
+	bool res;
+	ImGui::PushItemWidth(width);
+	res = ImGui::ColorEdit3(caption, color.data(), flags);
+	ImGui::PopItemWidth();
+	if (res)
+		dirty = true;
+	return res;
+}
+
+bool Drawer::color_edit(const char *caption, std::array<float, 4> &color, float width, ImGuiColorEditFlags flags)
+{
+	bool res;
+	res = ImGui::ColorEdit4(caption, color.data(), flags);
+	if (res)
+		dirty = true;
 	return res;
 }
 

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -1245,4 +1245,26 @@ void Drawer::text(const char *formatstr, ...)
 	va_end(args);
 }
 
+bool Drawer::color_picker(const char *caption, const char channel_count, float *color, uint16_t width, ImGuiColorEditFlags flags)
+{
+	assert((channel_count == 3 || channel_count == 4) && "Channel count value must be 3 or 4");
+	bool res;
+	if (width)
+		ImGui::PushItemWidth(width);
+	switch (channel_count)
+	{
+		case 3:
+			res = ImGui::ColorPicker3(caption, color, flags);
+			break;
+		case 4:
+			res = ImGui::ColorPicker4(caption, color, flags);
+			break;
+	}
+	if (res)
+	{
+		dirty = true;
+	};
+	return res;
+}
+
 }        // namespace vkb

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -1245,46 +1245,28 @@ void Drawer::text(const char *formatstr, ...)
 	va_end(args);
 }
 
-bool Drawer::color_picker(const char *caption, std::array<float, 3> &color, float width, ImGuiColorEditFlags flags)
+template <>
+bool Drawer::color_op_impl<Drawer::ColorOp::Edit, 3>(const char *caption, float *colors, ImGuiColorEditFlags flags)
 {
-	bool res;
-	ImGui::PushItemWidth(width);
-	res = ImGui::ColorPicker3(caption, color.data(), flags);
-	ImGui::PopItemWidth();
-	if (res)
-		dirty = true;
-	return res;
+	return ImGui::ColorEdit3(caption, colors, flags);
 }
 
-bool Drawer::color_picker(const char *caption, std::array<float, 4> &color, float width, ImGuiColorEditFlags flags)
+template <>
+bool Drawer::color_op_impl<Drawer::ColorOp::Edit, 4>(const char *caption, float *colors, ImGuiColorEditFlags flags)
 {
-	bool res;
-	ImGui::PushItemWidth(width);
-	res = ImGui::ColorPicker4(caption, color.data(), flags);
-	ImGui::PopItemWidth();
-	if (res)
-		dirty = true;
-	return res;
+	return ImGui::ColorEdit4(caption, colors, flags);
 }
 
-bool Drawer::color_edit(const char *caption, std::array<float, 3> &color, float width, ImGuiColorEditFlags flags)
+template <>
+bool Drawer::color_op_impl<Drawer::ColorOp::Pick, 3>(const char *caption, float *colors, ImGuiColorEditFlags flags)
 {
-	bool res;
-	ImGui::PushItemWidth(width);
-	res = ImGui::ColorEdit3(caption, color.data(), flags);
-	ImGui::PopItemWidth();
-	if (res)
-		dirty = true;
-	return res;
+	return ImGui::ColorPicker3(caption, colors, flags);
 }
 
-bool Drawer::color_edit(const char *caption, std::array<float, 4> &color, float width, ImGuiColorEditFlags flags)
+template <>
+bool Drawer::color_op_impl<Drawer::ColorOp::Pick, 4>(const char *caption, float *colors, ImGuiColorEditFlags flags)
 {
-	bool res;
-	res = ImGui::ColorEdit4(caption, color.data(), flags);
-	if (res)
-		dirty = true;
-	return res;
+	return ImGui::ColorPicker4(caption, colors, flags);
 }
 
 }        // namespace vkb

--- a/framework/gui.h
+++ b/framework/gui.h
@@ -81,6 +81,12 @@ struct Font
 class Drawer
 {
   public:
+	enum class ColorOp
+	{
+		Edit,
+		Pick
+	};
+
 	Drawer() = default;
 
 	/**
@@ -202,16 +208,48 @@ class Drawer
 
 	/**
 	 * @brief Adds a color edit to the gui
+	 * @tparam OP Mode of the color element.
+	 * @tparam N Color channel count. Must be 3 or 4.
 	 * @param caption The text to display
 	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
 	 * @param width Element width. Zero is a special value for the default element width.
 	 * @param flags Flags to modify the appearance and behavior of the element.
 	 */
-	bool color_edit(const char *caption, std::array<float, 4> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+	template <ColorOp OP, size_t N>
+	bool color_op(const std::string &caption, std::array<float, N> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0)
+	{
+		static_assert((N == 3) || (N == 4), "The channel count must be 3 or 4.");
+
+		ImGui::PushItemWidth(width);
+		bool res = color_op_impl<OP, N>(caption.c_str(), color.data(), flags);
+		ImGui::PopItemWidth();
+		if (res)
+			dirty = true;
+		return res;
+	}
 
   private:
+	template <ColorOp OP, size_t N>
+	inline bool color_op_impl(const char *caption, float *colors, ImGuiColorEditFlags flags)
+	{
+		assert(false);
+		return false;
+	}
+
 	bool dirty{false};
 };
+
+template <>
+bool Drawer::color_op_impl<Drawer::ColorOp::Edit, 3>(const char *caption, float *colors, ImGuiColorEditFlags flags);
+
+template <>
+bool Drawer::color_op_impl<Drawer::ColorOp::Edit, 4>(const char *caption, float *colors, ImGuiColorEditFlags flags);
+
+template <>
+bool Drawer::color_op_impl<Drawer::ColorOp::Pick, 3>(const char *caption, float *colors, ImGuiColorEditFlags flags);
+
+template <>
+bool Drawer::color_op_impl<Drawer::ColorOp::Pick, 4>(const char *caption, float *colors, ImGuiColorEditFlags flags);
 
 class VulkanSample;
 

--- a/framework/gui.h
+++ b/framework/gui.h
@@ -173,6 +173,16 @@ class Drawer
 	 */
 	void text(const char *formatstr, ...);
 
+	/**
+	 * @brief Adds a color picker to the gui
+	 * @param caption The text to display
+	 * @param channel_count Number of channels. Must be 3 or 4.
+	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
+	 * @param width Element width.
+	 * @param flags Flags to modify the appearance and behavior of the element.
+	 */
+	bool color_picker(const char *caption, const char channel_count, float *color, uint16_t width = 0, ImGuiColorEditFlags flags = 0);
+
   private:
 	bool dirty{false};
 };

--- a/framework/gui.h
+++ b/framework/gui.h
@@ -176,12 +176,38 @@ class Drawer
 	/**
 	 * @brief Adds a color picker to the gui
 	 * @param caption The text to display
-	 * @param channel_count Number of channels. Must be 3 or 4.
 	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
-	 * @param width Element width.
+	 * @param width Element width. Zero is a special value for the default element width.
 	 * @param flags Flags to modify the appearance and behavior of the element.
 	 */
-	bool color_picker(const char *caption, const char channel_count, float *color, uint16_t width = 0, ImGuiColorEditFlags flags = 0);
+	bool color_picker(const char *caption, std::array<float, 3> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+
+	/**
+	 * @brief Adds a color picker to the gui
+	 * @param caption The text to display
+	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
+	 * @param width Element width. Zero is a special value for the default element width.
+	 * @param flags Flags to modify the appearance and behavior of the element.
+	 */
+	bool color_picker(const char *caption, std::array<float, 4> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+
+	/**
+	 * @brief Adds a color edit to the gui
+	 * @param caption The text to display
+	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
+	 * @param width Element width. Zero is a special value for the default element width.
+	 * @param flags Flags to modify the appearance and behavior of the element.
+	 */
+	bool color_edit(const char *caption, std::array<float, 3> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+
+	/**
+	 * @brief Adds a color edit to the gui
+	 * @param caption The text to display
+	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
+	 * @param width Element width. Zero is a special value for the default element width.
+	 * @param flags Flags to modify the appearance and behavior of the element.
+	 */
+	bool color_edit(const char *caption, std::array<float, 4> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
 
   private:
 	bool dirty{false};

--- a/framework/hpp_gui.cpp
+++ b/framework/hpp_gui.cpp
@@ -1173,46 +1173,28 @@ void HPPDrawer::text(const char *formatstr, ...)
 	va_end(args);
 }
 
-bool HPPDrawer::color_picker(const char *caption, std::array<float, 3> &color, float width, ImGuiColorEditFlags flags)
+template <>
+bool HPPDrawer::color_op_impl<HPPDrawer::ColorOp::Edit, 3>(const char *caption, float *colors, ImGuiColorEditFlags flags)
 {
-	bool res;
-	ImGui::PushItemWidth(width);
-	res = ImGui::ColorPicker3(caption, color.data(), flags);
-	ImGui::PopItemWidth();
-	if (res)
-		dirty = true;
-	return res;
+	return ImGui::ColorEdit3(caption, colors, flags);
 }
 
-bool HPPDrawer::color_picker(const char *caption, std::array<float, 4> &color, float width, ImGuiColorEditFlags flags)
+template <>
+bool HPPDrawer::color_op_impl<HPPDrawer::ColorOp::Edit, 4>(const char *caption, float *colors, ImGuiColorEditFlags flags)
 {
-	bool res;
-	ImGui::PushItemWidth(width);
-	res = ImGui::ColorPicker4(caption, color.data(), flags);
-	ImGui::PopItemWidth();
-	if (res)
-		dirty = true;
-	return res;
+	return ImGui::ColorEdit4(caption, colors, flags);
 }
 
-bool HPPDrawer::color_edit(const char *caption, std::array<float, 3> &color, float width, ImGuiColorEditFlags flags)
+template <>
+bool HPPDrawer::color_op_impl<HPPDrawer::ColorOp::Pick, 3>(const char *caption, float *colors, ImGuiColorEditFlags flags)
 {
-	bool res;
-	ImGui::PushItemWidth(width);
-	res = ImGui::ColorEdit3(caption, color.data(), flags);
-	ImGui::PopItemWidth();
-	if (res)
-		dirty = true;
-	return res;
+	return ImGui::ColorPicker3(caption, colors, flags);
 }
 
-bool HPPDrawer::color_edit(const char *caption, std::array<float, 4> &color, float width, ImGuiColorEditFlags flags)
+template <>
+bool HPPDrawer::color_op_impl<HPPDrawer::ColorOp::Pick, 4>(const char *caption, float *colors, ImGuiColorEditFlags flags)
 {
-	bool res;
-	res = ImGui::ColorEdit4(caption, color.data(), flags);
-	if (res)
-		dirty = true;
-	return res;
+	return ImGui::ColorPicker4(caption, colors, flags);
 }
 
 }        // namespace vkb

--- a/framework/hpp_gui.cpp
+++ b/framework/hpp_gui.cpp
@@ -1173,4 +1173,46 @@ void HPPDrawer::text(const char *formatstr, ...)
 	va_end(args);
 }
 
+bool HPPDrawer::color_picker(const char *caption, std::array<float, 3> &color, float width, ImGuiColorEditFlags flags)
+{
+	bool res;
+	ImGui::PushItemWidth(width);
+	res = ImGui::ColorPicker3(caption, color.data(), flags);
+	ImGui::PopItemWidth();
+	if (res)
+		dirty = true;
+	return res;
+}
+
+bool HPPDrawer::color_picker(const char *caption, std::array<float, 4> &color, float width, ImGuiColorEditFlags flags)
+{
+	bool res;
+	ImGui::PushItemWidth(width);
+	res = ImGui::ColorPicker4(caption, color.data(), flags);
+	ImGui::PopItemWidth();
+	if (res)
+		dirty = true;
+	return res;
+}
+
+bool HPPDrawer::color_edit(const char *caption, std::array<float, 3> &color, float width, ImGuiColorEditFlags flags)
+{
+	bool res;
+	ImGui::PushItemWidth(width);
+	res = ImGui::ColorEdit3(caption, color.data(), flags);
+	ImGui::PopItemWidth();
+	if (res)
+		dirty = true;
+	return res;
+}
+
+bool HPPDrawer::color_edit(const char *caption, std::array<float, 4> &color, float width, ImGuiColorEditFlags flags)
+{
+	bool res;
+	res = ImGui::ColorEdit4(caption, color.data(), flags);
+	if (res)
+		dirty = true;
+	return res;
+}
+
 }        // namespace vkb

--- a/framework/hpp_gui.h
+++ b/framework/hpp_gui.h
@@ -161,6 +161,42 @@ class HPPDrawer
 	 */
 	void text(const char *formatstr, ...);
 
+	/**
+	 * @brief Adds a color picker to the gui
+	 * @param caption The text to display
+	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
+	 * @param width Element width. Zero is a special value for the default element width.
+	 * @param flags Flags to modify the appearance and behavior of the element.
+	 */
+	bool color_picker(const char *caption, std::array<float, 3> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+
+	/**
+	 * @brief Adds a color picker to the gui
+	 * @param caption The text to display
+	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
+	 * @param width Element width. Zero is a special value for the default element width.
+	 * @param flags Flags to modify the appearance and behavior of the element.
+	 */
+	bool color_picker(const char *caption, std::array<float, 4> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+
+	/**
+	 * @brief Adds a color edit to the gui
+	 * @param caption The text to display
+	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
+	 * @param width Element width. Zero is a special value for the default element width.
+	 * @param flags Flags to modify the appearance and behavior of the element.
+	 */
+	bool color_edit(const char *caption, std::array<float, 3> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+
+	/**
+	 * @brief Adds a color edit to the gui
+	 * @param caption The text to display
+	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
+	 * @param width Element width. Zero is a special value for the default element width.
+	 * @param flags Flags to modify the appearance and behavior of the element.
+	 */
+	bool color_edit(const char *caption, std::array<float, 4> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+
   private:
 	bool dirty = false;
 };

--- a/framework/hpp_gui.h
+++ b/framework/hpp_gui.h
@@ -69,6 +69,12 @@ struct HPPFont
 class HPPDrawer
 {
   public:
+	enum class ColorOp
+	{
+		Edit,
+		Pick
+	};
+
 	HPPDrawer() = default;
 
 	/**
@@ -162,44 +168,49 @@ class HPPDrawer
 	void text(const char *formatstr, ...);
 
 	/**
-	 * @brief Adds a color picker to the gui
-	 * @param caption The text to display
-	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
-	 * @param width Element width. Zero is a special value for the default element width.
-	 * @param flags Flags to modify the appearance and behavior of the element.
-	 */
-	bool color_picker(const char *caption, std::array<float, 3> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
-
-	/**
-	 * @brief Adds a color picker to the gui
-	 * @param caption The text to display
-	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
-	 * @param width Element width. Zero is a special value for the default element width.
-	 * @param flags Flags to modify the appearance and behavior of the element.
-	 */
-	bool color_picker(const char *caption, std::array<float, 4> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
-
-	/**
 	 * @brief Adds a color edit to the gui
+	 * @tparam OP Mode of the color element.
+	 * @tparam N Color channel count. Must be 3 or 4.
 	 * @param caption The text to display
 	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
 	 * @param width Element width. Zero is a special value for the default element width.
 	 * @param flags Flags to modify the appearance and behavior of the element.
 	 */
-	bool color_edit(const char *caption, std::array<float, 3> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+	template <ColorOp OP, size_t N>
+	bool color_op(const std::string &caption, std::array<float, N> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0)
+	{
+		static_assert((N == 3) || (N == 4), "The channel count must be 3 or 4.");
 
-	/**
-	 * @brief Adds a color edit to the gui
-	 * @param caption The text to display
-	 * @param color Color channel array on which the picker works. It contains values ranging from 0 to 1.
-	 * @param width Element width. Zero is a special value for the default element width.
-	 * @param flags Flags to modify the appearance and behavior of the element.
-	 */
-	bool color_edit(const char *caption, std::array<float, 4> &color, float width = 0.0f, ImGuiColorEditFlags flags = 0);
+		ImGui::PushItemWidth(width);
+		bool res = color_op_impl<OP, N>(caption.c_str(), color.data(), flags);
+		ImGui::PopItemWidth();
+		if (res)
+			dirty = true;
+		return res;
+	}
 
   private:
+	template <ColorOp OP, size_t N>
+	inline bool color_op_impl(const char *caption, float *colors, ImGuiColorEditFlags flags)
+	{
+		assert(false);
+		return false;
+	}
+
 	bool dirty = false;
 };
+
+template <>
+bool HPPDrawer::color_op_impl<HPPDrawer::ColorOp::Edit, 3>(const char *caption, float *colors, ImGuiColorEditFlags flags);
+
+template <>
+bool HPPDrawer::color_op_impl<HPPDrawer::ColorOp::Edit, 4>(const char *caption, float *colors, ImGuiColorEditFlags flags);
+
+template <>
+bool HPPDrawer::color_op_impl<HPPDrawer::ColorOp::Pick, 3>(const char *caption, float *colors, ImGuiColorEditFlags flags);
+
+template <>
+bool HPPDrawer::color_op_impl<HPPDrawer::ColorOp::Pick, 4>(const char *caption, float *colors, ImGuiColorEditFlags flags);
 
 class HPPVulkanSample;
 

--- a/samples/extensions/color_write_enable/color_write_enable.cpp
+++ b/samples/extensions/color_write_enable/color_write_enable.cpp
@@ -469,9 +469,9 @@ void ColorWriteEnable::build_command_buffers()
 	// Clear color values.
 	std::array<VkClearValue, 4> clear_values = {};
 	clear_values[0].color                    = {0.0f, 0.0f, 0.0f, 0.0f};
-	clear_values[1].color                    = {background_r_value, 0.0f, 0.0f, 0.0f};
-	clear_values[2].color                    = {0.0f, background_g_value, 0.0f, 0.0f};
-	clear_values[3].color                    = {0.0f, 0.0f, background_b_value, 0.0f};
+	clear_values[1].color                    = {background_color[0], 0.0f, 0.0f, 0.0f};
+	clear_values[2].color                    = {0.0f, background_color[1], 0.0f, 0.0f};
+	clear_values[3].color                    = {0.0f, 0.0f, background_color[2], 0.0f};
 
 	// Begin the render pass.
 	VkRenderPassBeginInfo render_pass_begin_info    = vkb::initializers::render_pass_begin_info();
@@ -539,15 +539,11 @@ void ColorWriteEnable::on_update_ui_overlay(vkb::Drawer &drawer)
 {
 	if (drawer.header("Background color"))
 	{
-		if (drawer.slider_float("Red", &background_r_value, 0.0f, 1.0f))
-		{
-			build_command_buffers();
-		}
-		if (drawer.slider_float("Green", &background_g_value, 0.0f, 1.0f))
-		{
-			build_command_buffers();
-		}
-		if (drawer.slider_float("Blue", &background_b_value, 0.0f, 1.0f))
+		if (drawer.color_picker("", 3, background_color.data(), 200,
+		                        ImGuiColorEditFlags_NoSidePreview |
+		                            ImGuiColorEditFlags_NoSmallPreview |
+		                            ImGuiColorEditFlags_Float |
+		                            ImGuiColorEditFlags_RGB))
 		{
 			build_command_buffers();
 		}

--- a/samples/extensions/color_write_enable/color_write_enable.cpp
+++ b/samples/extensions/color_write_enable/color_write_enable.cpp
@@ -539,7 +539,7 @@ void ColorWriteEnable::on_update_ui_overlay(vkb::Drawer &drawer)
 {
 	if (drawer.header("Background color"))
 	{
-		if (drawer.color_picker("", 3, background_color.data(), 200,
+		if (drawer.color_picker("", background_color, 300,
 		                        ImGuiColorEditFlags_NoSidePreview |
 		                            ImGuiColorEditFlags_NoSmallPreview |
 		                            ImGuiColorEditFlags_Float |

--- a/samples/extensions/color_write_enable/color_write_enable.cpp
+++ b/samples/extensions/color_write_enable/color_write_enable.cpp
@@ -539,11 +539,11 @@ void ColorWriteEnable::on_update_ui_overlay(vkb::Drawer &drawer)
 {
 	if (drawer.header("Background color"))
 	{
-		if (drawer.color_picker("", background_color, 300,
-		                        ImGuiColorEditFlags_NoSidePreview |
-		                            ImGuiColorEditFlags_NoSmallPreview |
-		                            ImGuiColorEditFlags_Float |
-		                            ImGuiColorEditFlags_RGB))
+		if (drawer.color_op<vkb::Drawer::ColorOp::Pick>("", background_color, 0,
+		                                                ImGuiColorEditFlags_NoSidePreview |
+		                                                    ImGuiColorEditFlags_NoSmallPreview |
+		                                                    ImGuiColorEditFlags_Float |
+		                                                    ImGuiColorEditFlags_RGB))
 		{
 			build_command_buffers();
 		}

--- a/samples/extensions/color_write_enable/color_write_enable.h
+++ b/samples/extensions/color_write_enable/color_write_enable.h
@@ -94,12 +94,11 @@ class ColorWriteEnable : public ApiVulkanSample
 	void setup_descriptor_set_layout();
 	void setup_descriptor_set();
 
-	bool  r_bit_enabled      = true;
-	bool  g_bit_enabled      = true;
-	bool  b_bit_enabled      = true;
-	float background_r_value = 0.5f;
-	float background_g_value = 0.5f;
-	float background_b_value = 0.5f;
+	bool r_bit_enabled = true;
+	bool g_bit_enabled = true;
+	bool b_bit_enabled = true;
+
+	std::array<float, 3> background_color = {0.5f, 0.5f, 0.5f};
 };
 
 std::unique_ptr<vkb::Application> create_color_write_enable();


### PR DESCRIPTION
## Description

The color picker is available in ImGui, but not in the Drawer class, so I added it there. The color picker functionality is useful for the dynamic blending sample I'm working on now. I used the color write enable sample to show the color picker in action.

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible

- [X] My changes do not add any regressions
- [X] I have tested every sample to ensure everything runs correctly
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
![1](https://github.com/KhronosGroup/Vulkan-Samples/assets/127966594/11e7cef8-e023-449d-80d9-f50badeb8425)
![2](https://github.com/KhronosGroup/Vulkan-Samples/assets/127966594/9af363c5-1d9a-4401-826c-717dc8cc22a7)


