### PR TITLE
Refactored vkb::is_depth_only_format and vkb::is_depth_stencil_format.

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -964,6 +964,7 @@ VkDescriptorImageInfo ApiVulkanSample::create_descriptor(Texture &texture, VkDes
 			}
 			else
 			{
+				assert(!vkb::is_depth_format(texture.image->get_vk_image_view().get_format()));
 				descriptor.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 			}
 			break;

--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -21,6 +21,7 @@
 
 #include "common/logging.h"
 #include "vulkan/vulkan.hpp"
+#include "vulkan/vulkan_format_traits.hpp"
 
 namespace vkb
 {
@@ -77,12 +78,23 @@ inline bool is_buffer_descriptor_type(vk::DescriptorType descriptor_type)
 
 inline bool is_depth_only_format(vk::Format format)
 {
+	assert(vkb::is_depth_only_format(static_cast<VkFormat>(format)) ==
+	       ((vk::componentCount(format) == 1) && (std::string(vk::componentName(format, 0)) == "D")));
 	return vkb::is_depth_only_format(static_cast<VkFormat>(format));
 }
 
 inline bool is_depth_stencil_format(vk::Format format)
 {
+	assert(vkb::is_depth_stencil_format(static_cast<VkFormat>(format)) ==
+	       ((vk::componentCount(format) == 2) && (std::string(vk::componentName(format, 0)) == "D") &&
+	        (std::string(vk::componentName(format, 1)) == "S")));
 	return vkb::is_depth_stencil_format(static_cast<VkFormat>(format));
+}
+
+inline bool is_depth_format(vk::Format format)
+{
+	assert(vkb::is_depth_format(static_cast<VkFormat>(format)) == (std::string(vk::componentName(format, 0)) == "D"));
+	return vkb::is_depth_format(static_cast<VkFormat>(format));
 }
 
 inline bool is_dynamic_buffer_descriptor_type(vk::DescriptorType descriptor_type)
@@ -196,12 +208,14 @@ inline vk::ImageAspectFlags get_image_aspect_flags(vk::ImageUsageFlagBits usage,
 	switch (usage)
 	{
 		case vk::ImageUsageFlagBits::eColorAttachment:
+			assert(!vkb::common::is_depth_format(format));
 			image_aspect_flags = vk::ImageAspectFlagBits::eColor;
 			break;
 		case vk::ImageUsageFlagBits::eDepthStencilAttachment:
+			assert(vkb::common::is_depth_format(format));
 			image_aspect_flags = vk::ImageAspectFlagBits::eDepth;
 			// Stencil aspect should only be set on depth + stencil formats
-			if (vkb::common::is_depth_stencil_format(format) && !vkb::common::is_depth_only_format(format))
+			if (vkb::common::is_depth_stencil_format(format))
 			{
 				image_aspect_flags |= vk::ImageAspectFlagBits::eStencil;
 			}

--- a/framework/common/vk_common.cpp
+++ b/framework/common/vk_common.cpp
@@ -130,6 +130,7 @@ VkShaderStageFlagBits find_shader_stage(const std::string &ext)
 	throw std::runtime_error("File extension `" + ext + "` does not have a vulkan shader stage.");
 }
 }        // namespace
+
 bool is_depth_only_format(VkFormat format)
 {
 	return format == VK_FORMAT_D16_UNORM ||
@@ -140,8 +141,12 @@ bool is_depth_stencil_format(VkFormat format)
 {
 	return format == VK_FORMAT_D16_UNORM_S8_UINT ||
 	       format == VK_FORMAT_D24_UNORM_S8_UINT ||
-	       format == VK_FORMAT_D32_SFLOAT_S8_UINT ||
-	       is_depth_only_format(format);
+	       format == VK_FORMAT_D32_SFLOAT_S8_UINT;
+}
+
+bool is_depth_format(VkFormat format)
+{
+	return is_depth_only_format(format) || is_depth_stencil_format(format);
 }
 
 VkFormat get_suitable_depth_format(VkPhysicalDevice physical_device, bool depth_only, const std::vector<VkFormat> &depth_format_priority_list)

--- a/framework/common/vk_common.h
+++ b/framework/common/vk_common.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2021, Arm Limited and Contributors
- * Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2018-2023, Arm Limited and Contributors
+ * Copyright (c) 2019-2023, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -48,11 +48,18 @@ namespace vkb
 bool is_depth_only_format(VkFormat format);
 
 /**
- * @brief Helper function to determine if a Vulkan format is depth or stencil.
+ * @brief Helper function to determine if a Vulkan format is depth with stencil.
  * @param format Vulkan format to check.
- * @return True if format is a depth or stencil, false otherwise.
+ * @return True if format is a depth with stencil, false otherwise.
  */
 bool is_depth_stencil_format(VkFormat format);
+
+/**
+ * @brief Helper function to determine if a Vulkan format is depth.
+ * @param format Vulkan format to check.
+ * @return True if format is a depth, false otherwise.
+ */
+bool is_depth_format(VkFormat format);
 
 /**
  * @brief Helper function to determine a suitable supported depth format based on a priority list

--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -679,13 +679,12 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 										image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 										break;
 									case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-										if (is_depth_stencil_format(image_view->get_format()))
+										if (is_depth_format(image_view->get_format()))
 										{
 											image_info.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
 										}
 										else
 										{
-											assert(!vkb::is_depth_format(image_view->get_format()));
 											image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 										}
 										break;

--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2022, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -685,6 +685,7 @@ void CommandBuffer::flush_descriptor_state(VkPipelineBindPoint pipeline_bind_poi
 										}
 										else
 										{
+											assert(!vkb::is_depth_format(image_view->get_format()));
 											image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 										}
 										break;

--- a/framework/core/hpp_command_buffer.cpp
+++ b/framework/core/hpp_command_buffer.cpp
@@ -701,7 +701,9 @@ void HPPCommandBuffer::flush_descriptor_state(vk::PipelineBindPoint pipeline_bin
 										image_info.imageLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
 										break;
 									case vk::DescriptorType::eInputAttachment:
-										image_info.imageLayout = vkb::common::is_depth_stencil_format(image_view->get_format()) ? vk::ImageLayout::eDepthStencilReadOnlyOptimal : vk::ImageLayout::eShaderReadOnlyOptimal;
+										assert(!vkb::common::is_depth_stencil_format(image_view->get_format()) || !vkb::common::is_depth_format(image_view->get_format()));
+										image_info.imageLayout =
+										    vkb::common::is_depth_stencil_format(image_view->get_format()) ? vk::ImageLayout::eDepthStencilReadOnlyOptimal : vk::ImageLayout::eShaderReadOnlyOptimal;
 										break;
 									case vk::DescriptorType::eStorageImage:
 										image_info.imageLayout = vk::ImageLayout::eGeneral;

--- a/framework/core/hpp_command_buffer.cpp
+++ b/framework/core/hpp_command_buffer.cpp
@@ -701,9 +701,8 @@ void HPPCommandBuffer::flush_descriptor_state(vk::PipelineBindPoint pipeline_bin
 										image_info.imageLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
 										break;
 									case vk::DescriptorType::eInputAttachment:
-										assert(!vkb::common::is_depth_stencil_format(image_view->get_format()) || !vkb::common::is_depth_format(image_view->get_format()));
 										image_info.imageLayout =
-										    vkb::common::is_depth_stencil_format(image_view->get_format()) ? vk::ImageLayout::eDepthStencilReadOnlyOptimal : vk::ImageLayout::eShaderReadOnlyOptimal;
+										    vkb::common::is_depth_format(image_view->get_format()) ? vk::ImageLayout::eDepthStencilReadOnlyOptimal : vk::ImageLayout::eShaderReadOnlyOptimal;
 										break;
 									case vk::DescriptorType::eStorageImage:
 										image_info.imageLayout = vk::ImageLayout::eGeneral;

--- a/framework/core/image_view.cpp
+++ b/framework/core/image_view.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -41,7 +41,7 @@ ImageView::ImageView(Image &img, VkImageViewType view_type, VkFormat format,
 	subresource_range.levelCount     = n_mip_levels == 0 ? image->get_subresource().mipLevel : n_mip_levels;
 	subresource_range.layerCount     = n_array_layers == 0 ? image->get_subresource().arrayLayer : n_array_layers;
 
-	if (is_depth_stencil_format(format))
+	if (is_depth_format(format))
 	{
 		subresource_range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
 	}

--- a/framework/core/render_pass.cpp
+++ b/framework/core/render_pass.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -120,7 +120,9 @@ std::vector<T> get_attachment_descriptions(const std::vector<Attachment> &attach
 		attachment.format        = attachments[i].format;
 		attachment.samples       = attachments[i].samples;
 		attachment.initialLayout = attachments[i].initial_layout;
-		attachment.finalLayout   = is_depth_stencil_format(attachment.format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		assert(!vkb::is_depth_stencil_format(attachment.format) || !vkb::is_depth_format(attachment.format));
+		attachment.finalLayout =
+		    vkb::is_depth_stencil_format(attachment.format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
 		if (i < load_store_infos.size())
 		{
@@ -213,7 +215,9 @@ void set_attachment_layouts(std::vector<T_SubpassDescription> &subpass_descripti
 			attachment_descriptions[reference.attachment].finalLayout = reference.layout;
 
 			// Do not use depth attachment if used as input
-			if (is_depth_stencil_format(attachment_descriptions[reference.attachment].format))
+			assert(!vkb::is_depth_stencil_format(attachment_descriptions[reference.attachment].format) ||
+			       !vkb::is_depth_format(attachment_descriptions[reference.attachment].format));
+			if (vkb::is_depth_stencil_format(attachment_descriptions[reference.attachment].format))
 			{
 				subpass.pDepthStencilAttachment = nullptr;
 			}
@@ -311,7 +315,7 @@ void RenderPass::create_renderpass(const std::vector<Attachment> &attachments, c
 		{
 			auto  initial_layout = attachments[o_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : attachments[o_attachment].initial_layout;
 			auto &description    = attachment_descriptions[o_attachment];
-			if (!is_depth_stencil_format(description.format))
+			if (!is_depth_format(description.format))
 			{
 				color_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(o_attachment, initial_layout));
 			}
@@ -320,7 +324,9 @@ void RenderPass::create_renderpass(const std::vector<Attachment> &attachments, c
 		// Fill input attachments references
 		for (auto i_attachment : subpass.input_attachments)
 		{
-			auto default_layout = is_depth_stencil_format(attachment_descriptions[i_attachment].format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			assert(!vkb::is_depth_stencil_format(attachment_descriptions[i_attachment].format) ||
+			       !vkb::is_depth_format(attachment_descriptions[i_attachment].format));
+			auto default_layout = vkb::is_depth_stencil_format(attachment_descriptions[i_attachment].format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 			auto initial_layout = attachments[i_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? default_layout : attachments[i_attachment].initial_layout;
 			input_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(i_attachment, initial_layout));
 		}
@@ -334,7 +340,7 @@ void RenderPass::create_renderpass(const std::vector<Attachment> &attachments, c
 		if (!subpass.disable_depth_stencil_attachment)
 		{
 			// Assumption: depth stencil attachment appears in the list before any depth stencil resolve attachment
-			auto it = find_if(attachments.begin(), attachments.end(), [](const Attachment attachment) { return is_depth_stencil_format(attachment.format); });
+			auto it = find_if(attachments.begin(), attachments.end(), [](const Attachment attachment) { return is_depth_format(attachment.format); });
 			if (it != attachments.end())
 			{
 				auto i_depth_stencil = vkb::to_u32(std::distance(attachments.begin(), it));
@@ -405,7 +411,8 @@ void RenderPass::create_renderpass(const std::vector<Attachment> &attachments, c
 
 		for (uint32_t k = 0U; k < to_u32(attachment_descriptions.size()); ++k)
 		{
-			if (is_depth_stencil_format(attachments[k].format))
+			assert(!vkb::is_depth_stencil_format(attachments[k].format) || !vkb::is_depth_format(attachments[k].format));
+			if (vkb::is_depth_stencil_format(attachments[k].format))
 			{
 				if (default_depth_stencil_attachment == VK_ATTACHMENT_UNUSED)
 				{

--- a/framework/core/render_pass.cpp
+++ b/framework/core/render_pass.cpp
@@ -120,9 +120,8 @@ std::vector<T> get_attachment_descriptions(const std::vector<Attachment> &attach
 		attachment.format        = attachments[i].format;
 		attachment.samples       = attachments[i].samples;
 		attachment.initialLayout = attachments[i].initial_layout;
-		assert(!vkb::is_depth_stencil_format(attachment.format) || !vkb::is_depth_format(attachment.format));
 		attachment.finalLayout =
-		    vkb::is_depth_stencil_format(attachment.format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		    vkb::is_depth_format(attachment.format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
 		if (i < load_store_infos.size())
 		{
@@ -215,9 +214,7 @@ void set_attachment_layouts(std::vector<T_SubpassDescription> &subpass_descripti
 			attachment_descriptions[reference.attachment].finalLayout = reference.layout;
 
 			// Do not use depth attachment if used as input
-			assert(!vkb::is_depth_stencil_format(attachment_descriptions[reference.attachment].format) ||
-			       !vkb::is_depth_format(attachment_descriptions[reference.attachment].format));
-			if (vkb::is_depth_stencil_format(attachment_descriptions[reference.attachment].format))
+			if (vkb::is_depth_format(attachment_descriptions[reference.attachment].format))
 			{
 				subpass.pDepthStencilAttachment = nullptr;
 			}
@@ -324,9 +321,7 @@ void RenderPass::create_renderpass(const std::vector<Attachment> &attachments, c
 		// Fill input attachments references
 		for (auto i_attachment : subpass.input_attachments)
 		{
-			assert(!vkb::is_depth_stencil_format(attachment_descriptions[i_attachment].format) ||
-			       !vkb::is_depth_format(attachment_descriptions[i_attachment].format));
-			auto default_layout = vkb::is_depth_stencil_format(attachment_descriptions[i_attachment].format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			auto default_layout = vkb::is_depth_format(attachment_descriptions[i_attachment].format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 			auto initial_layout = attachments[i_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? default_layout : attachments[i_attachment].initial_layout;
 			input_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(i_attachment, initial_layout));
 		}
@@ -411,8 +406,7 @@ void RenderPass::create_renderpass(const std::vector<Attachment> &attachments, c
 
 		for (uint32_t k = 0U; k < to_u32(attachment_descriptions.size()); ++k)
 		{
-			assert(!vkb::is_depth_stencil_format(attachments[k].format) || !vkb::is_depth_format(attachments[k].format));
-			if (vkb::is_depth_stencil_format(attachments[k].format))
+			if (vkb::is_depth_format(attachments[k].format))
 			{
 				if (default_depth_stencil_attachment == VK_ATTACHMENT_UNUSED)
 				{

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -838,8 +838,7 @@ vk::ImageLayout HPPApiVulkanSample::descriptor_type_to_image_layout(vk::Descript
 	{
 		case vk::DescriptorType::eCombinedImageSampler:
 		case vk::DescriptorType::eInputAttachment:
-			assert(!vkb::common::is_depth_stencil_format(format) || !vkb::common::is_depth_format(format));
-			return vkb::common::is_depth_stencil_format(format) ? vk::ImageLayout::eDepthStencilReadOnlyOptimal : vk::ImageLayout::eShaderReadOnlyOptimal;
+			return vkb::common::is_depth_format(format) ? vk::ImageLayout::eDepthStencilReadOnlyOptimal : vk::ImageLayout::eShaderReadOnlyOptimal;
 		case vk::DescriptorType::eStorageImage:
 			return vk::ImageLayout::eGeneral;
 		default:

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -838,6 +838,7 @@ vk::ImageLayout HPPApiVulkanSample::descriptor_type_to_image_layout(vk::Descript
 	{
 		case vk::DescriptorType::eCombinedImageSampler:
 		case vk::DescriptorType::eInputAttachment:
+			assert(!vkb::common::is_depth_stencil_format(format) || !vkb::common::is_depth_format(format));
 			return vkb::common::is_depth_stencil_format(format) ? vk::ImageLayout::eDepthStencilReadOnlyOptimal : vk::ImageLayout::eShaderReadOnlyOptimal;
 		case vk::DescriptorType::eStorageImage:
 			return vk::ImageLayout::eGeneral;

--- a/framework/rendering/postprocessing_renderpass.cpp
+++ b/framework/rendering/postprocessing_renderpass.cpp
@@ -411,9 +411,10 @@ void PostProcessingRenderPass::transition_attachments(
 	for (uint32_t output : output_attachments)
 	{
 		assert(output < views.size());
-		const VkFormat      attachment_format = views[output].get_format();
-		const bool          is_depth_stencil  = vkb::is_depth_only_format(attachment_format) || vkb::is_depth_stencil_format(attachment_format);
-		const VkImageLayout output_layout     = is_depth_stencil ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		const VkFormat attachment_format = views[output].get_format();
+		assert(!vkb::is_depth_stencil_format(attachment_format) || !vkb::is_depth_format(attachment_format));
+		const bool          is_depth_stencil = vkb::is_depth_stencil_format(attachment_format);
+		const VkImageLayout output_layout    = is_depth_stencil ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 		if (render_target.get_layout(output) == output_layout)
 		{
 			// No-op

--- a/framework/rendering/postprocessing_renderpass.cpp
+++ b/framework/rendering/postprocessing_renderpass.cpp
@@ -411,10 +411,9 @@ void PostProcessingRenderPass::transition_attachments(
 	for (uint32_t output : output_attachments)
 	{
 		assert(output < views.size());
-		const VkFormat attachment_format = views[output].get_format();
-		assert(!vkb::is_depth_stencil_format(attachment_format) || !vkb::is_depth_format(attachment_format));
-		const bool          is_depth_stencil = vkb::is_depth_stencil_format(attachment_format);
-		const VkImageLayout output_layout    = is_depth_stencil ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		const VkFormat      attachment_format = views[output].get_format();
+		const bool          is_depth_stencil  = vkb::is_depth_format(attachment_format);
+		const VkImageLayout output_layout     = is_depth_stencil ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 		if (render_target.get_layout(output) == output_layout)
 		{
 			// No-op

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -319,12 +319,14 @@ void HPPTimestampQueries::create_attachment(vk::Format format, vk::ImageUsageFla
 	switch (usage)
 	{
 		case vk::ImageUsageFlagBits::eColorAttachment:
+			assert(!vkb::common::is_depth_format(format));
 			aspect_mask = vk::ImageAspectFlagBits::eColor;
 			break;
 		case vk::ImageUsageFlagBits::eDepthStencilAttachment:
+			assert(vkb::common::is_depth_format(format));
 			aspect_mask = vk::ImageAspectFlagBits::eDepth;
 			// Stencil aspect should only be set on depth + stencil formats
-			if (vkb::common::is_depth_stencil_format(format) && !vkb::common::is_depth_only_format(format))
+			if (vkb::common::is_depth_stencil_format(format))
 			{
 				aspect_mask |= vk::ImageAspectFlagBits::eStencil;
 			}


### PR DESCRIPTION
## Description

This PR changes the meaning of `vkb::is_depth_stencil_format` from "depth or depth-with-stencil" to just "depth-with-stencil". `vkb::depth_only_format` stays the same, and a new function `vkb::is_depth_format` is what formerly was `vkb::is_depth_stencil_format`.
All places where those functions have been used in the framework and the samples are adjusted accordingly, and where appropriate, I added some assertions.

Compiled and tested on Win10, using NVIDIA GPU.

Fixes #584

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
