### PR TITLE
Add "samples-oneline" command line option

### DIFF
--- a/app/plugins/start_sample/start_sample.cpp
+++ b/app/plugins/start_sample/start_sample.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Arm Limited and Contributors
+/* Copyright (c) 2020-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,13 +24,15 @@ namespace plugins
 StartSample::StartSample() :
     StartSampleTags("Apps",
                     "A collection of flags to samples and apps.",
-                    {}, {&sample_subcmd, &samples_subcmd})
+                    {}, {&sample_subcmd, &samples_subcmd, &samples_oneline_subcmd})
 {
 }
 
 bool StartSample::is_active(const vkb::CommandParser &parser)
 {
-	return parser.contains(&sample_cmd) || parser.contains(&samples_subcmd);
+	return parser.contains(&sample_cmd) ||
+	       parser.contains(&samples_subcmd) ||
+	       parser.contains(&samples_oneline_subcmd);
 }
 
 void StartSample::init(const vkb::CommandParser &parser)
@@ -48,7 +50,7 @@ void StartSample::init(const vkb::CommandParser &parser)
 			platform->request_application(sample);
 		}
 	}
-	else if (parser.contains(&samples_subcmd))
+	else if (parser.contains(&samples_subcmd) || parser.contains(&samples_oneline_subcmd))
 	{
 		// List samples
 
@@ -61,10 +63,17 @@ void StartSample::init(const vkb::CommandParser &parser)
 		for (auto *app : samples)
 		{
 			auto sample = reinterpret_cast<apps::SampleInfo *>(app);
-			LOGI("{}", sample->name.c_str());
-			LOGI("\tid: {}", sample->id.c_str());
-			LOGI("\tdescription: {}", sample->description.c_str());
-			LOGI("");
+			if (parser.contains(&samples_subcmd))
+			{
+				LOGI("{}", sample->name.c_str());
+				LOGI("\tid: {}", sample->id.c_str());
+				LOGI("\tdescription: {}", sample->description.c_str());
+				LOGI("");
+			}
+			else
+			{
+				LOGI("{}", sample->id.c_str());
+			}
 		}
 
 		platform->close();

--- a/app/plugins/start_sample/start_sample.h
+++ b/app/plugins/start_sample/start_sample.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Arm Limited and Contributors
+/* Copyright (c) 2020-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -43,8 +43,9 @@ class StartSample : public StartSampleTags
 
 	virtual void init(const vkb::CommandParser &parser) override;
 
-	vkb::PositionalCommand sample_cmd     = {"sample_id", "ID of the sample to run"};
-	vkb::SubCommand        sample_subcmd  = {"sample", "Run a specific sample", {&sample_cmd}};
-	vkb::SubCommand        samples_subcmd = {"samples", "List available samples", {}};
+	vkb::PositionalCommand sample_cmd             = {"sample_id", "ID of the sample to run"};
+	vkb::SubCommand        sample_subcmd          = {"sample", "Run a specific sample", {&sample_cmd}};
+	vkb::SubCommand        samples_subcmd         = {"samples", "List available samples with descriptions", {}};
+	vkb::SubCommand        samples_oneline_subcmd = {"samples-oneline", "List available samples, one per line", {}};
 };
 }        // namespace plugins


### PR DESCRIPTION
## Description

Adds a new command line option "samples-oneline" that displays a minimal list of sample ids, which is much shorter than the full set of descriptions printed with the "samples" option. It's much easier to find the sample id you're looking for in the short-form list.

Compare these with just five samples for example:
```
--> ./vulkan_samples samples-oneline
[info] Available Samples
[info] 
[info] compute_nbody
[info] dynamic_uniform_buffers
[info] hdr
[info] hello_triangle
[info] hlsl_shaders
```
```
--> ./vulkan_samples samples
[info] Available Samples
[info] 
[info] Compute N-Body simulation
[info]  id: compute_nbody
[info]  description: Multi-pass compute dispatch N-Body particle simulation
[info] 
[info] Dynamic uniform buffers
[info]  id: dynamic_uniform_buffers
[info]  description: Demonstrates the use of dynamic offsets into one single uniform buffers for rendering multiple objects
[info] 
[info] HDR
[info]  id: hdr
[info]  description: High-dynamic-range rendering
[info] 
[info] Hello Triangle
[info]  id: hello_triangle
[info]  description: An introduction into Vulkan and its respective objects.
[info] 
[info] Using HLSL shaders in Vulkan with glslang
[info]  id: hlsl_shaders
[info]  description: Shows how to generate SPIR-V from HLSL shaders that can be used in Vulkan
```

Fixes #752

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  