### PR TITLE
Change "press any key" to "press return"

### DIFF
--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -240,7 +240,7 @@ void Platform::terminate(ExitCode code)
 	if (code != ExitCode::Success && !using_plugin<::plugins::ForceClose>())
 	{
 #ifndef ANDROID
-		std::cout << "Press any key to continue";
+		std::cout << "Press return to continue";
 		std::cin.get();
 #endif
 	}


### PR DESCRIPTION
## Description

Pressing any key would be possible using getch(), but getch() is non-standard so probably best avoided.
The existing std::cin.get() uses buffered i/o so actually only completes when return is pressed.

This change simply updates the message to be more correct.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  