### PR TITLE
Cleanup on [HPP]CommandBuffer

### DIFF
--- a/framework/core/command_buffer.h
+++ b/framework/core/command_buffer.h
@@ -57,14 +57,6 @@ class CommandBuffer : public core::VulkanResource<VkCommandBuffer, VK_OBJECT_TYP
 		AlwaysAllocate,
 	};
 
-	enum class State
-	{
-		Invalid,
-		Initial,
-		Recording,
-		Executable,
-	};
-
 	/**
 	 * @brief Helper structure used to track render pass state
 	 */
@@ -86,8 +78,6 @@ class CommandBuffer : public core::VulkanResource<VkCommandBuffer, VK_OBJECT_TYP
 	CommandBuffer &operator=(const CommandBuffer &) = delete;
 
 	CommandBuffer &operator=(CommandBuffer &&) = delete;
-
-	bool is_recording() const;
 
 	/**
 	 * @brief Flushes the command buffer, pushing the new changes
@@ -230,8 +220,6 @@ class CommandBuffer : public core::VulkanResource<VkCommandBuffer, VK_OBJECT_TYP
 
 	void buffer_memory_barrier(const core::Buffer &buffer, VkDeviceSize offset, VkDeviceSize size, const BufferMemoryBarrier &memory_barrier);
 
-	const State get_state() const;
-
 	void set_update_after_bind(bool update_after_bind_);
 
 	void reset_query_pool(const QueryPool &query_pool, uint32_t first_query, uint32_t query_count);
@@ -253,8 +241,6 @@ class CommandBuffer : public core::VulkanResource<VkCommandBuffer, VK_OBJECT_TYP
 	const VkCommandBufferLevel level;
 
   private:
-	State state{State::Initial};
-
 	CommandPool &command_pool;
 
 	RenderPassBinding current_render_pass;

--- a/framework/core/hpp_command_buffer.h
+++ b/framework/core/hpp_command_buffer.h
@@ -52,14 +52,6 @@ class HPPCommandBuffer : public core::HPPVulkanResource<vk::CommandBuffer>
 		AlwaysAllocate,
 	};
 
-	enum class State
-	{
-		Invalid,
-		Initial,
-		Recording,
-		Executable,
-	};
-
   public:
 	HPPCommandBuffer(vkb::core::HPPCommandPool &command_pool, vk::CommandBufferLevel level);
 	HPPCommandBuffer(HPPCommandBuffer &&other);
@@ -217,8 +209,6 @@ class HPPCommandBuffer : public core::HPPVulkanResource<vk::CommandBuffer>
 
 	const RenderPassBinding &get_current_render_pass() const;
 	const uint32_t           get_current_subpass_index() const;
-	const State              get_state() const;
-	bool                     is_recording() const;
 
 	/**
 	 * @brief Check that the render area is an optimal size by comparing to the render area granularity
@@ -227,7 +217,6 @@ class HPPCommandBuffer : public core::HPPVulkanResource<vk::CommandBuffer>
 
   private:
 	const vk::CommandBufferLevel     level = {};
-	State                            state = State::Initial;
 	vkb::core::HPPCommandPool       &command_pool;
 	RenderPassBinding                current_render_pass     = {};
 	vkb::rendering::HPPPipelineState pipeline_state          = {};


### PR DESCRIPTION
## Description

The move constructor of `vkb::CommandBuffer` now initializes/moves all members.
State logging is removed from both, `vkb::CommandBuffer` and `vkb::core::HPPCommandBuffer`, as this functionality is better done by the validation layer, and as it was only partially supported by `vkb::CommandBuffer`.

Compiled and tested on Win10, using NVIDIA GPU.

Fixes #631

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
