### PR TITLE
Introduce helper functions vkb::[common::]select_surface_format

### DIFF
--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -95,6 +95,26 @@ inline vk::ShaderModule load_shader(const std::string &filename, vk::Device devi
 	return static_cast<vk::ShaderModule>(vkb::load_shader(filename, device, static_cast<VkShaderStageFlagBits>(stage)));
 }
 
+inline vk::SurfaceFormatKHR select_surface_format(vk::PhysicalDevice             gpu,
+                                                  vk::SurfaceKHR                 surface,
+                                                  std::vector<vk::Format> const &preferred_formats = {
+                                                      vk::Format::eR8G8B8A8Srgb, vk::Format::eB8G8R8A8Srgb, vk::Format::eA8B8G8R8SrgbPack32})
+{
+	std::vector<vk::SurfaceFormatKHR> supported_surface_formats = gpu.getSurfaceFormatsKHR(surface);
+	assert(!supported_surface_formats.empty());
+
+	auto it = std::find_if(supported_surface_formats.begin(),
+	                       supported_surface_formats.end(),
+	                       [&preferred_formats](vk::SurfaceFormatKHR surface_format) {
+		                       return std::any_of(preferred_formats.begin(),
+		                                          preferred_formats.end(),
+		                                          [&surface_format](vk::Format format) { return format == surface_format.format; });
+	                       });
+
+	// We use the first supported format as a fallback in case none of the preferred formats is available
+	return it != supported_surface_formats.end() ? *it : supported_surface_formats[0];
+}
+
 inline void set_image_layout(vk::CommandBuffer         command_buffer,
                              vk::Image                 image,
                              vk::ImageLayout           old_layout,

--- a/framework/common/vk_common.cpp
+++ b/framework/common/vk_common.cpp
@@ -388,6 +388,26 @@ VkShaderModule load_shader(const std::string &filename, VkDevice device, VkShade
 	return shader_module;
 }
 
+VkSurfaceFormatKHR select_surface_format(VkPhysicalDevice gpu, VkSurfaceKHR surface, std::vector<VkFormat> const &preferred_formats)
+{
+	uint32_t surface_format_count;
+	vkGetPhysicalDeviceSurfaceFormatsKHR(gpu, surface, &surface_format_count, nullptr);
+	assert(0 < surface_format_count);
+	std::vector<VkSurfaceFormatKHR> supported_surface_formats(surface_format_count);
+	vkGetPhysicalDeviceSurfaceFormatsKHR(gpu, surface, &surface_format_count, supported_surface_formats.data());
+
+	auto it = std::find_if(supported_surface_formats.begin(),
+	                       supported_surface_formats.end(),
+	                       [&preferred_formats](VkSurfaceFormatKHR surface_format) {
+		                       return std::any_of(preferred_formats.begin(),
+		                                          preferred_formats.end(),
+		                                          [&surface_format](VkFormat format) { return format == surface_format.format; });
+	                       });
+
+	// We use the first supported format as a fallback in case none of the preferred formats is available
+	return it != supported_surface_formats.end() ? *it : supported_surface_formats[0];
+}
+
 // Create an image memory barrier for changing the layout of
 // an image and put it into an active command buffer
 // See chapter 11.4 "Image Layout" for details

--- a/framework/common/vk_common.h
+++ b/framework/common/vk_common.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2021, Arm Limited and Contributors
- * Copyright (c) 2019-2021, Sascha Willems
+/* Copyright (c) 2018-2023, Arm Limited and Contributors
+ * Copyright (c) 2019-2023, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -100,6 +100,18 @@ int32_t get_bits_per_pixel(VkFormat format);
 VkShaderModule load_shader(const std::string &filename, VkDevice device, VkShaderStageFlagBits stage);
 
 /**
+ * @brief Helper function to select a VkSurfaceFormatKHR
+ * @param gpu The VkPhysicalDevice to select a format for.
+ * @param surface The VkSurfaceKHR to select a format for.
+ * @param preferred_formats List of preferred VkFormats to use.
+ * @return The preferred VkSurfaceFormatKHR.
+ */
+VkSurfaceFormatKHR select_surface_format(VkPhysicalDevice             gpu,
+                                         VkSurfaceKHR                 surface,
+                                         std::vector<VkFormat> const &preferred_formats = {
+                                             VK_FORMAT_R8G8B8A8_SRGB, VK_FORMAT_B8G8R8A8_SRGB, VK_FORMAT_A8B8G8R8_SRGB_PACK32});
+
+/**
  * @brief Image memory barrier structure used to define
  *        memory access for an image view during command recording.
  */
@@ -123,9 +135,9 @@ struct ImageMemoryBarrier
 };
 
 /**
-* @brief Buffer memory barrier structure used to define
-*        memory access for a buffer during command recording.
-*/
+ * @brief Buffer memory barrier structure used to define
+ *        memory access for a buffer during command recording.
+ */
 struct BufferMemoryBarrier
 {
 	VkPipelineStageFlags src_stage_mask{VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT};
@@ -138,8 +150,8 @@ struct BufferMemoryBarrier
 };
 
 /**
-* @brief Put an image memory barrier for setting an image layout on the sub resource into the given command buffer
-*/
+ * @brief Put an image memory barrier for setting an image layout on the sub resource into the given command buffer
+ */
 void set_image_layout(
     VkCommandBuffer         command_buffer,
     VkImage                 image,
@@ -150,8 +162,8 @@ void set_image_layout(
     VkPipelineStageFlags    dst_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
 /**
-* @brief Uses a fixed sub resource layout with first mip level and layer
-*/
+ * @brief Uses a fixed sub resource layout with first mip level and layer
+ */
 void set_image_layout(
     VkCommandBuffer      command_buffer,
     VkImage              image,
@@ -162,8 +174,8 @@ void set_image_layout(
     VkPipelineStageFlags dst_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
 /**
-* @brief Insert an image memory barrier into the command buffer
-*/
+ * @brief Insert an image memory barrier into the command buffer
+ */
 void insert_image_memory_barrier(
     VkCommandBuffer         command_buffer,
     VkImage                 image,
@@ -188,23 +200,23 @@ struct LoadStoreInfo
 namespace gbuffer
 {
 /**
-  * @return Load store info to load all and store only the swapchain
-  */
+ * @return Load store info to load all and store only the swapchain
+ */
 std::vector<LoadStoreInfo> get_load_all_store_swapchain();
 
 /**
-  * @return Load store info to clear all and store only the swapchain
-  */
+ * @return Load store info to clear all and store only the swapchain
+ */
 std::vector<LoadStoreInfo> get_clear_all_store_swapchain();
 
 /**
-  * @return Load store info to clear and store all images
-  */
+ * @return Load store info to clear and store all images
+ */
 std::vector<LoadStoreInfo> get_clear_store_all();
 
 /**
-  * @return Default clear values for the G-buffer
-  */
+ * @return Default clear values for the G-buffer
+ */
 std::vector<VkClearValue> get_clear_value();
 }        // namespace gbuffer
 

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -435,24 +435,7 @@ void HelloTriangle::init_swapchain(Context &context)
 	VkSurfaceCapabilitiesKHR surface_properties;
 	VK_CHECK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(context.gpu, context.surface, &surface_properties));
 
-	uint32_t surface_format_count;
-	vkGetPhysicalDeviceSurfaceFormatsKHR(context.gpu, context.surface, &surface_format_count, nullptr);
-	std::vector<VkSurfaceFormatKHR> supported_surface_formats(surface_format_count);
-	vkGetPhysicalDeviceSurfaceFormatsKHR(context.gpu, context.surface, &surface_format_count, supported_surface_formats.data());
-
-	// We want to get an SRGB image format that matches our list of preferred format candidates
-	// We initialize to the first supported format, which will be the fallback in case none of the preferred formats is available
-	VkSurfaceFormatKHR format                = supported_surface_formats[0];
-	auto               preferred_format_list = std::vector<VkFormat>{VK_FORMAT_R8G8B8A8_SRGB, VK_FORMAT_B8G8R8A8_SRGB, VK_FORMAT_A8B8G8R8_SRGB_PACK32};
-
-	for (auto &candidate : supported_surface_formats)
-	{
-		if (std::find(preferred_format_list.begin(), preferred_format_list.end(), candidate.format) != preferred_format_list.end())
-		{
-			format = candidate;
-			break;
-		}
-	}
+	VkSurfaceFormatKHR format = vkb::select_surface_format(context.gpu, context.surface);
 
 	VkExtent2D swapchain_size;
 	if (surface_properties.currentExtent.width == 0xFFFFFFFF)

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -723,20 +723,7 @@ void HPPHelloTriangle::init_swapchain()
 
 	vk::Extent2D swapchain_extent = (surface_properties.currentExtent.width == 0xFFFFFFFF) ? swapchain_data.extent : surface_properties.currentExtent;
 
-	std::vector<vk::SurfaceFormatKHR> supported_surface_formats = gpu.getSurfaceFormatsKHR(surface);
-	assert(!supported_surface_formats.empty());
-
-	// We want to get an SRGB image format that matches our list of preferred format candidates
-	auto preferred_format_list = std::vector<vk::Format>{vk::Format::eR8G8B8A8Srgb, vk::Format::eB8G8R8A8Srgb, vk::Format::eA8B8G8R8SrgbPack32};
-
-	// Look for the first supported format in our list of preferred formats
-	auto formatIt =
-	    std::find_if(supported_surface_formats.begin(),
-	                 supported_surface_formats.end(),
-	                 [&preferred_format_list](vk::SurfaceFormatKHR const &candidate) { return std::find(preferred_format_list.begin(), preferred_format_list.end(), candidate.format) != preferred_format_list.end(); });
-
-	// We use the first supported format as a fallback in case none of the preferred formats is available
-	vk::SurfaceFormatKHR surface_format = (formatIt == supported_surface_formats.end()) ? supported_surface_formats[0] : formatIt->format;
+	vk::SurfaceFormatKHR surface_format = vkb::common::select_surface_format(gpu, surface);
 
 	vk::SwapchainKHR old_swapchain = swapchain_data.swapchain;
 

--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -42,24 +42,7 @@ void SwapchainRecreation::get_queue()
 
 void SwapchainRecreation::query_surface_format()
 {
-	uint32_t surface_format_count;
-	vkGetPhysicalDeviceSurfaceFormatsKHR(get_gpu_handle(), get_surface(), &surface_format_count, nullptr);
-	std::vector<VkSurfaceFormatKHR> supported_surface_formats(surface_format_count);
-	vkGetPhysicalDeviceSurfaceFormatsKHR(get_gpu_handle(), get_surface(), &surface_format_count, supported_surface_formats.data());
-
-	// We want to get an SRGB image format that matches our list of preferred format candiates
-	// We initialize to the first supported format, which will be the fallback in case none of the preferred formats is available
-	surface_format             = supported_surface_formats[0];
-	auto preferred_format_list = std::vector<VkFormat>{VK_FORMAT_R8G8B8A8_SRGB, VK_FORMAT_B8G8R8A8_SRGB, VK_FORMAT_A8B8G8R8_SRGB_PACK32};
-
-	for (auto &candidate : supported_surface_formats)
-	{
-		if (std::find(preferred_format_list.begin(), preferred_format_list.end(), candidate.format) != preferred_format_list.end())
-		{
-			surface_format = candidate;
-			break;
-		}
-	}
+	surface_format = vkb::select_surface_format(get_gpu_handle(), get_surface());
 }
 
 void SwapchainRecreation::query_present_modes()

--- a/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
+++ b/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
@@ -369,27 +369,9 @@ void FullScreenExclusive::init_swapchain()
 	VkSurfaceCapabilitiesKHR surface_properties;
 	VK_CHECK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(context.gpu, context.surface, &surface_properties));
 
-	uint32_t surface_format_count;
-	vkGetPhysicalDeviceSurfaceFormatsKHR(context.gpu, context.surface, &surface_format_count, nullptr);
-	std::vector<VkSurfaceFormatKHR> supported_surface_formats(surface_format_count);
-	vkGetPhysicalDeviceSurfaceFormatsKHR(context.gpu, context.surface, &surface_format_count, supported_surface_formats.data());
-
-	// We want to get an SRGB image format that matches our list of preferred format candidates
-	// We initialize to the first supported format, which will be the fallback in case none of the preferred formats is available
-	VkSurfaceFormatKHR format                = supported_surface_formats[0];
-	auto               preferred_format_list = std::vector<VkFormat>{VK_FORMAT_R8G8B8A8_SRGB, VK_FORMAT_B8G8R8A8_SRGB, VK_FORMAT_A8B8G8R8_SRGB_PACK32};
-
-	for (auto &candidate : supported_surface_formats)
-	{
-		if (std::find(preferred_format_list.begin(), preferred_format_list.end(), candidate.format) != preferred_format_list.end())
-		{
-			format = candidate;
-			break;
-		}
-	}
+	VkSurfaceFormatKHR format = vkb::select_surface_format(context.gpu, context.surface);
 
 	VkExtent2D swapchain_size;
-
 	if (is_full_screen_exclusive)
 	{
 		swapchain_size = surface_properties.maxImageExtent;


### PR DESCRIPTION
## Description

It turned out, the surface format selection boilerplate was just used three times over all the samples. And the framework does it slightly differently.
But here are the helper functions to select a surface format (both for Vulkan and Vulkan-Hpp) and their usage in the samples.

Compiled and tested on Win10, using NVIDIA GPU.

Fixes #647

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
