### PR TITLE
Improve CI Concurrency By Cancelling Outdated Jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build ${{ matrix.platform }} in ${{ matrix.build_type }}"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,10 @@ on:
 env:
   TARGET_BRANCH: main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changed-files:
     container: ghcr.io/khronosgroupactions/clang-tools:15.0.0

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   external_project:
     name: Build as external project

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build ${{ matrix.platform }} in ${{ matrix.build_type }}"


### PR DESCRIPTION
Cancels inflight jobs if a PR is updated and the jobs are not complete. I noticed this became an issue after iterating quickly on PRs that I was currently working on. There would be a backlog of jobs waiting to complete