### PR TITLE
cleanup on image layout transition functions

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -1025,12 +1025,11 @@ Texture ApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::C
 
 	// Image barrier for optimal image (target)
 	// Optimal image will be used as destination for the copy
-	vkb::set_image_layout(
-	    command_buffer,
-	    texture.image->get_vk_image().get_handle(),
-	    VK_IMAGE_LAYOUT_UNDEFINED,
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    subresource_range);
+	vkb::image_layout_transition(command_buffer,
+	                             texture.image->get_vk_image().get_handle(),
+	                             VK_IMAGE_LAYOUT_UNDEFINED,
+	                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	                             subresource_range);
 
 	// Copy mip levels from staging buffer
 	vkCmdCopyBufferToImage(
@@ -1042,12 +1041,11 @@ Texture ApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::C
 	    bufferCopyRegions.data());
 
 	// Change texture image layout to shader read after all mip levels have been copied
-	vkb::set_image_layout(
-	    command_buffer,
-	    texture.image->get_vk_image().get_handle(),
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-	    subresource_range);
+	vkb::image_layout_transition(command_buffer,
+	                             texture.image->get_vk_image().get_handle(),
+	                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	                             subresource_range);
 
 	device->flush_command_buffer(command_buffer, queue.get_handle());
 
@@ -1129,12 +1127,11 @@ Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Im
 
 	// Image barrier for optimal image (target)
 	// Optimal image will be used as destination for the copy
-	vkb::set_image_layout(
-	    command_buffer,
-	    texture.image->get_vk_image().get_handle(),
-	    VK_IMAGE_LAYOUT_UNDEFINED,
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    subresource_range);
+	vkb::image_layout_transition(command_buffer,
+	                             texture.image->get_vk_image().get_handle(),
+	                             VK_IMAGE_LAYOUT_UNDEFINED,
+	                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	                             subresource_range);
 
 	// Copy mip levels from staging buffer
 	vkCmdCopyBufferToImage(
@@ -1146,12 +1143,11 @@ Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Im
 	    buffer_copy_regions.data());
 
 	// Change texture image layout to shader read after all mip levels have been copied
-	vkb::set_image_layout(
-	    command_buffer,
-	    texture.image->get_vk_image().get_handle(),
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-	    subresource_range);
+	vkb::image_layout_transition(command_buffer,
+	                             texture.image->get_vk_image().get_handle(),
+	                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	                             subresource_range);
 
 	device->flush_command_buffer(command_buffer, queue.get_handle());
 
@@ -1230,12 +1226,11 @@ Texture ApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::
 
 	// Image barrier for optimal image (target)
 	// Optimal image will be used as destination for the copy
-	vkb::set_image_layout(
-	    command_buffer,
-	    texture.image->get_vk_image().get_handle(),
-	    VK_IMAGE_LAYOUT_UNDEFINED,
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    subresource_range);
+	vkb::image_layout_transition(command_buffer,
+	                             texture.image->get_vk_image().get_handle(),
+	                             VK_IMAGE_LAYOUT_UNDEFINED,
+	                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	                             subresource_range);
 
 	// Copy mip levels from staging buffer
 	vkCmdCopyBufferToImage(
@@ -1247,12 +1242,11 @@ Texture ApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::
 	    buffer_copy_regions.data());
 
 	// Change texture image layout to shader read after all mip levels have been copied
-	vkb::set_image_layout(
-	    command_buffer,
-	    texture.image->get_vk_image().get_handle(),
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-	    subresource_range);
+	vkb::image_layout_transition(command_buffer,
+	                             texture.image->get_vk_image().get_handle(),
+	                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	                             subresource_range);
 
 	device->flush_command_buffer(command_buffer, queue.get_handle());
 

--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -107,6 +107,30 @@ inline vk::ShaderModule load_shader(const std::string &filename, vk::Device devi
 	return static_cast<vk::ShaderModule>(vkb::load_shader(filename, device, static_cast<VkShaderStageFlagBits>(stage)));
 }
 
+inline void image_layout_transition(vk::CommandBuffer command_buffer,
+                                    vk::Image         image,
+                                    vk::ImageLayout   old_layout,
+                                    vk::ImageLayout   new_layout)
+{
+	vkb::image_layout_transition(command_buffer,
+	                             static_cast<VkImage>(image),
+	                             static_cast<VkImageLayout>(old_layout),
+	                             static_cast<VkImageLayout>(new_layout));
+}
+
+inline void image_layout_transition(vk::CommandBuffer         command_buffer,
+                                    vk::Image                 image,
+                                    vk::ImageLayout           old_layout,
+                                    vk::ImageLayout           new_layout,
+                                    vk::ImageSubresourceRange subresource_range)
+{
+	vkb::image_layout_transition(command_buffer,
+	                             static_cast<VkImage>(image),
+	                             static_cast<VkImageLayout>(old_layout),
+	                             static_cast<VkImageLayout>(new_layout),
+	                             static_cast<VkImageSubresourceRange>(subresource_range));
+}
+
 inline vk::SurfaceFormatKHR select_surface_format(vk::PhysicalDevice             gpu,
                                                   vk::SurfaceKHR                 surface,
                                                   std::vector<vk::Format> const &preferred_formats = {
@@ -125,23 +149,6 @@ inline vk::SurfaceFormatKHR select_surface_format(vk::PhysicalDevice            
 
 	// We use the first supported format as a fallback in case none of the preferred formats is available
 	return it != supported_surface_formats.end() ? *it : supported_surface_formats[0];
-}
-
-inline void set_image_layout(vk::CommandBuffer         command_buffer,
-                             vk::Image                 image,
-                             vk::ImageLayout           old_layout,
-                             vk::ImageLayout           new_layout,
-                             vk::ImageSubresourceRange subresource_range,
-                             vk::PipelineStageFlags    src_mask = vk::PipelineStageFlagBits::eAllCommands,
-                             vk::PipelineStageFlags    dst_mask = vk::PipelineStageFlagBits::eAllCommands)
-{
-	vkb::set_image_layout(command_buffer,
-	                      static_cast<VkImage>(image),
-	                      static_cast<VkImageLayout>(old_layout),
-	                      static_cast<VkImageLayout>(new_layout),
-	                      static_cast<VkImageSubresourceRange>(subresource_range),
-	                      static_cast<VkPipelineStageFlags>(src_mask),
-	                      static_cast<VkPipelineStageFlags>(dst_mask));
 }
 
 // helper functions not backed by vk_common.h

--- a/framework/common/vk_common.h
+++ b/framework/common/vk_common.h
@@ -157,42 +157,73 @@ struct BufferMemoryBarrier
 };
 
 /**
- * @brief Put an image memory barrier for setting an image layout on the sub resource into the given command buffer
+ * @brief Put an image memory barrier for a layout transition of an image, using explicitly give transition parameters.
+ * @param command_buffer The VkCommandBuffer to record the barrier.
+ * @param image The VkImage to transition.
+ * @param src_stage_mask The VkPipelineStageFlags to use as source.
+ * @param dst_stage_mask The VkPipelineStageFlags to use as destination.
+ * @param src_access_mask The VkAccessFlags to use as source.
+ * @param dst_access_mask The VkAccessFlags to use as destination.
+ * @param old_layout The VkImageLayout to transition from.
+ * @param new_layout The VkImageLayout to transition to.
+ * @param subresource_range The VkImageSubresourceRange to use with the transition.
  */
-void set_image_layout(
-    VkCommandBuffer         command_buffer,
-    VkImage                 image,
-    VkImageLayout           old_layout,
-    VkImageLayout           new_layout,
-    VkImageSubresourceRange subresource_range,
-    VkPipelineStageFlags    src_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-    VkPipelineStageFlags    dst_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+void image_layout_transition(VkCommandBuffer                command_buffer,
+                             VkImage                        image,
+                             VkPipelineStageFlags           src_stage_mask,
+                             VkPipelineStageFlags           dst_stage_mask,
+                             VkAccessFlags                  src_access_mask,
+                             VkAccessFlags                  dst_access_mask,
+                             VkImageLayout                  old_layout,
+                             VkImageLayout                  new_layout,
+                             VkImageSubresourceRange const &subresource_range);
 
 /**
- * @brief Uses a fixed sub resource layout with first mip level and layer
+ * @brief Put an image memory barrier for a layout transition of an image, on a given subresource range.
+ *
+ * The src_stage_mask, dst_stage_mask, src_access_mask, and dst_access_mask used are determined from old_layout and new_layout.
+ *
+ * @param command_buffer The VkCommandBuffer to record the barrier.
+ * @param image The VkImage to transition.
+ * @param old_layout The VkImageLayout to transition from.
+ * @param new_layout The VkImageLayout to transition to.
+ * @param subresource_range The VkImageSubresourceRange to use with the transition.
  */
-void set_image_layout(
-    VkCommandBuffer      command_buffer,
-    VkImage              image,
-    VkImageAspectFlags   aspect_mask,
-    VkImageLayout        old_layout,
-    VkImageLayout        new_layout,
-    VkPipelineStageFlags src_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-    VkPipelineStageFlags dst_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+void image_layout_transition(VkCommandBuffer                command_buffer,
+                             VkImage                        image,
+                             VkImageLayout                  old_layout,
+                             VkImageLayout                  new_layout,
+                             VkImageSubresourceRange const &subresource_range);
 
 /**
- * @brief Insert an image memory barrier into the command buffer
+ * @brief Put an image memory barrier for a layout transition of an image, on a fixed subresource with first mip level and layer.
+ *
+ * The src_stage_mask, dst_stage_mask, src_access_mask, and dst_access_mask used are determined from old_layout and new_layout.
+ *
+ * @param command_buffer The VkCommandBuffer to record the barrier.
+ * @param image The VkImage to transition.
+ * @param old_layout The VkImageLayout to transition from.
+ * @param new_layout The VkImageLayout to transition to.
  */
-void insert_image_memory_barrier(
-    VkCommandBuffer         command_buffer,
-    VkImage                 image,
-    VkAccessFlags           src_access_mask,
-    VkAccessFlags           dst_access_mask,
-    VkImageLayout           old_layout,
-    VkImageLayout           new_layout,
-    VkPipelineStageFlags    src_stage_mask,
-    VkPipelineStageFlags    dst_stage_mask,
-    VkImageSubresourceRange subresource_range);
+void image_layout_transition(VkCommandBuffer command_buffer,
+                             VkImage         image,
+                             VkImageLayout   old_layout,
+                             VkImageLayout   new_layout);
+
+/**
+ * @brief Put an image memory barrier for a layout transition of a vector of images, with a given subresource range per image.
+ *
+ * The src_stage_mask, dst_stage_mask, src_access_mask, and dst_access_mask used are determined from old_layout and new_layout.
+ *
+ * @param command_buffer The VkCommandBuffer to record the barrier.
+ * @param imagesAndRanges The images to transition, with accompanying subresource ranges.
+ * @param old_layout The VkImageLayout to transition from.
+ * @param new_layout The VkImageLayout to transition to.
+ */
+void image_layout_transition(VkCommandBuffer                                                 command_buffer,
+                             std::vector<std::pair<VkImage, VkImageSubresourceRange>> const &imagesAndRanges,
+                             VkImageLayout                                                   old_layout,
+                             VkImageLayout                                                   new_layout);
 
 /**
  * @brief Load and store info for a render pass attachment.

--- a/framework/core/command_buffer.cpp
+++ b/framework/core/command_buffer.cpp
@@ -451,28 +451,15 @@ void CommandBuffer::image_memory_barrier(const core::ImageView &image_view, cons
 		subresource_range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
 	}
 
-	VkImageMemoryBarrier image_memory_barrier{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-	image_memory_barrier.oldLayout           = memory_barrier.old_layout;
-	image_memory_barrier.newLayout           = memory_barrier.new_layout;
-	image_memory_barrier.image               = image_view.get_image().get_handle();
-	image_memory_barrier.subresourceRange    = subresource_range;
-	image_memory_barrier.srcAccessMask       = memory_barrier.src_access_mask;
-	image_memory_barrier.dstAccessMask       = memory_barrier.dst_access_mask;
-	image_memory_barrier.srcQueueFamilyIndex = memory_barrier.old_queue_family;
-	image_memory_barrier.dstQueueFamilyIndex = memory_barrier.new_queue_family;
-
-	VkPipelineStageFlags src_stage_mask = memory_barrier.src_stage_mask;
-	VkPipelineStageFlags dst_stage_mask = memory_barrier.dst_stage_mask;
-
-	vkCmdPipelineBarrier(
-	    get_handle(),
-	    src_stage_mask,
-	    dst_stage_mask,
-	    0,
-	    0, nullptr,
-	    0, nullptr,
-	    1,
-	    &image_memory_barrier);
+	vkb::image_layout_transition(get_handle(),
+	                             image_view.get_image().get_handle(),
+	                             memory_barrier.src_stage_mask,
+	                             memory_barrier.dst_stage_mask,
+	                             memory_barrier.src_access_mask,
+	                             memory_barrier.dst_access_mask,
+	                             memory_barrier.old_layout,
+	                             memory_barrier.new_layout,
+	                             subresource_range);
 }
 
 void CommandBuffer::buffer_memory_barrier(const core::Buffer &buffer, VkDeviceSize offset, VkDeviceSize size, const BufferMemoryBarrier &memory_barrier)

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -885,7 +885,7 @@ HPPTexture HPPApiVulkanSample::load_texture(const std::string &file, vkb::sg::Im
 
 	// Image barrier for optimal image (target)
 	// Optimal image will be used as destination for the copy
-	vkb::common::set_image_layout(
+	vkb::common::image_layout_transition(
 	    command_buffer, texture.image->get_vk_image().get_handle(), vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, subresource_range);
 
 	// Copy mip levels from staging buffer
@@ -893,11 +893,11 @@ HPPTexture HPPApiVulkanSample::load_texture(const std::string &file, vkb::sg::Im
 	    stage_buffer.get_handle(), texture.image->get_vk_image().get_handle(), vk::ImageLayout::eTransferDstOptimal, bufferCopyRegions);
 
 	// Change texture image layout to shader read after all mip levels have been copied
-	vkb::common::set_image_layout(command_buffer,
-	                              texture.image->get_vk_image().get_handle(),
-	                              vk::ImageLayout::eTransferDstOptimal,
-	                              vk::ImageLayout::eShaderReadOnlyOptimal,
-	                              subresource_range);
+	vkb::common::image_layout_transition(command_buffer,
+	                                     texture.image->get_vk_image().get_handle(),
+	                                     vk::ImageLayout::eTransferDstOptimal,
+	                                     vk::ImageLayout::eShaderReadOnlyOptimal,
+	                                     subresource_range);
 
 	get_device()->flush_command_buffer(command_buffer, queue.get_handle());
 
@@ -972,7 +972,7 @@ HPPTexture HPPApiVulkanSample::load_texture_array(const std::string &file, vkb::
 
 	// Image barrier for optimal image (target)
 	// Optimal image will be used as destination for the copy
-	vkb::common::set_image_layout(
+	vkb::common::image_layout_transition(
 	    command_buffer, texture.image->get_vk_image().get_handle(), vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, subresource_range);
 
 	// Copy mip levels from staging buffer
@@ -980,11 +980,11 @@ HPPTexture HPPApiVulkanSample::load_texture_array(const std::string &file, vkb::
 	    stage_buffer.get_handle(), texture.image->get_vk_image().get_handle(), vk::ImageLayout::eTransferDstOptimal, buffer_copy_regions);
 
 	// Change texture image layout to shader read after all mip levels have been copied
-	vkb::common::set_image_layout(command_buffer,
-	                              texture.image->get_vk_image().get_handle(),
-	                              vk::ImageLayout::eTransferDstOptimal,
-	                              vk::ImageLayout::eShaderReadOnlyOptimal,
-	                              subresource_range);
+	vkb::common::image_layout_transition(command_buffer,
+	                                     texture.image->get_vk_image().get_handle(),
+	                                     vk::ImageLayout::eTransferDstOptimal,
+	                                     vk::ImageLayout::eShaderReadOnlyOptimal,
+	                                     subresource_range);
 
 	get_device()->flush_command_buffer(command_buffer, queue.get_handle());
 
@@ -1056,7 +1056,7 @@ HPPTexture HPPApiVulkanSample::load_texture_cubemap(const std::string &file, vkb
 
 	// Image barrier for optimal image (target)
 	// Optimal image will be used as destination for the copy
-	vkb::common::set_image_layout(
+	vkb::common::image_layout_transition(
 	    command_buffer, texture.image->get_vk_image().get_handle(), vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, subresource_range);
 
 	// Copy mip levels from staging buffer
@@ -1064,11 +1064,11 @@ HPPTexture HPPApiVulkanSample::load_texture_cubemap(const std::string &file, vkb
 	    stage_buffer.get_handle(), texture.image->get_vk_image().get_handle(), vk::ImageLayout::eTransferDstOptimal, buffer_copy_regions);
 
 	// Change texture image layout to shader read after all mip levels have been copied
-	vkb::common::set_image_layout(command_buffer,
-	                              texture.image->get_vk_image().get_handle(),
-	                              vk::ImageLayout::eTransferDstOptimal,
-	                              vk::ImageLayout::eShaderReadOnlyOptimal,
-	                              subresource_range);
+	vkb::common::image_layout_transition(command_buffer,
+	                                     texture.image->get_vk_image().get_handle(),
+	                                     vk::ImageLayout::eTransferDstOptimal,
+	                                     vk::ImageLayout::eShaderReadOnlyOptimal,
+	                                     subresource_range);
 
 	get_device()->flush_command_buffer(command_buffer, queue.get_handle());
 

--- a/samples/api/texture_mipmap_generation/texture_mipmap_generation.cpp
+++ b/samples/api/texture_mipmap_generation/texture_mipmap_generation.cpp
@@ -142,16 +142,7 @@ void TextureMipMapGeneration::load_texture_generate_mipmaps(std::string file_nam
 	VkCommandBuffer copy_command = device->create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
 	// Optimal image will be used as destination for the copy, so we must transfer from our initial undefined image layout to the transfer destination layout
-	vkb::insert_image_memory_barrier(
-	    copy_command,
-	    texture.image,
-	    0,
-	    VK_ACCESS_TRANSFER_WRITE_BIT,
-	    VK_IMAGE_LAYOUT_UNDEFINED,
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    VK_PIPELINE_STAGE_TRANSFER_BIT,
-	    VK_PIPELINE_STAGE_TRANSFER_BIT,
-	    {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
+	vkb::image_layout_transition(copy_command, texture.image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
 	// Copy the first mip of the chain, remaining mips will be generated
 	VkBufferImageCopy buffer_copy_region               = {};
@@ -165,16 +156,7 @@ void TextureMipMapGeneration::load_texture_generate_mipmaps(std::string file_nam
 	vkCmdCopyBufferToImage(copy_command, staging_buffer, texture.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy_region);
 
 	// Transition first mip level to transfer source so we can blit(read) from it
-	vkb::insert_image_memory_barrier(
-	    copy_command,
-	    texture.image,
-	    VK_ACCESS_TRANSFER_WRITE_BIT,
-	    VK_ACCESS_TRANSFER_READ_BIT,
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-	    VK_PIPELINE_STAGE_TRANSFER_BIT,
-	    VK_PIPELINE_STAGE_TRANSFER_BIT,
-	    {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
+	vkb::image_layout_transition(copy_command, texture.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
 
 	device->flush_command_buffer(copy_command, queue, true);
 
@@ -210,16 +192,11 @@ void TextureMipMapGeneration::load_texture_generate_mipmaps(std::string file_nam
 		image_blit.dstOffsets[1].z           = 1;
 
 		// Prepare current mip level as image blit destination
-		vkb::insert_image_memory_barrier(
-		    blit_command,
-		    texture.image,
-		    0,
-		    VK_ACCESS_TRANSFER_WRITE_BIT,
-		    VK_IMAGE_LAYOUT_UNDEFINED,
-		    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-		    VK_PIPELINE_STAGE_TRANSFER_BIT,
-		    VK_PIPELINE_STAGE_TRANSFER_BIT,
-		    {VK_IMAGE_ASPECT_COLOR_BIT, i, 1, 0, 1});
+		vkb::image_layout_transition(blit_command,
+		                             texture.image,
+		                             VK_IMAGE_LAYOUT_UNDEFINED,
+		                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		                             {VK_IMAGE_ASPECT_COLOR_BIT, i, 1, 0, 1});
 
 		// Blit from previous level
 		vkCmdBlitImage(
@@ -233,29 +210,19 @@ void TextureMipMapGeneration::load_texture_generate_mipmaps(std::string file_nam
 		    VK_FILTER_LINEAR);
 
 		// Prepare current mip level as image blit source for next level
-		vkb::insert_image_memory_barrier(
-		    blit_command,
-		    texture.image,
-		    VK_ACCESS_TRANSFER_WRITE_BIT,
-		    VK_ACCESS_TRANSFER_READ_BIT,
-		    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-		    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-		    VK_PIPELINE_STAGE_TRANSFER_BIT,
-		    VK_PIPELINE_STAGE_TRANSFER_BIT,
-		    {VK_IMAGE_ASPECT_COLOR_BIT, i, 1, 0, 1});
+		vkb::image_layout_transition(blit_command,
+		                             texture.image,
+		                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+		                             {VK_IMAGE_ASPECT_COLOR_BIT, i, 1, 0, 1});
 	}
 
 	// After the loop, all mip layers are in TRANSFER_SRC layout, so transition all to SHADER_READ
-	vkb::insert_image_memory_barrier(
-	    blit_command,
-	    texture.image,
-	    VK_ACCESS_TRANSFER_READ_BIT,
-	    VK_ACCESS_SHADER_READ_BIT,
-	    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-	    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-	    VK_PIPELINE_STAGE_TRANSFER_BIT,
-	    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-	    {VK_IMAGE_ASPECT_COLOR_BIT, 0, texture.mip_levels, 0, 1});
+	vkb::image_layout_transition(blit_command,
+	                             texture.image,
+	                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+	                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	                             {VK_IMAGE_ASPECT_COLOR_BIT, 0, texture.mip_levels, 0, 1});
 
 	device->flush_command_buffer(blit_command, queue, true);
 	// ---------------------------------------------------------------

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -433,27 +433,14 @@ DescriptorIndexing::TestImage DescriptorIndexing::create_image(const float rgb[3
 	auto &cmd = get_device().request_command_buffer();
 	cmd.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
-	VkImageMemoryBarrier barrier = vkb::initializers::image_memory_barrier();
-	barrier.srcAccessMask        = 0;
-	barrier.dstAccessMask        = VK_ACCESS_TRANSFER_WRITE_BIT;
-	barrier.oldLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
-	barrier.newLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-	barrier.subresourceRange     = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-	barrier.image                = test_image.image;
-	vkCmdPipelineBarrier(cmd.get_handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
-	                     0, 0, nullptr, 0, nullptr, 1, &barrier);
+	vkb::image_layout_transition(cmd.get_handle(), test_image.image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
 	VkBufferImageCopy copy_info{};
 	copy_info.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
 	copy_info.imageExtent      = image_info.extent;
 	vkCmdCopyBufferToImage(cmd.get_handle(), staging_buffer->get_handle(), test_image.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_info);
 
-	barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-	barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-	barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-	barrier.newLayout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-	vkCmdPipelineBarrier(cmd.get_handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-	                     0, 0, nullptr, 0, nullptr, 1, &barrier);
+	vkb::image_layout_transition(cmd.get_handle(), test_image.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 	VK_CHECK(cmd.end());
 

--- a/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
+++ b/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
@@ -370,23 +370,17 @@ void DynamicRendering::build_command_buffers()
 
 		if (enable_dynamic)
 		{
-			vkb::insert_image_memory_barrier(draw_cmd_buffer,
-			                                 swapchain_buffers[i].image,
-			                                 0,
-			                                 VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-			                                 VK_IMAGE_LAYOUT_UNDEFINED,
-			                                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-			                                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-			                                 VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, range);
+			vkb::image_layout_transition(draw_cmd_buffer,
+			                             swapchain_buffers[i].image,
+			                             VK_IMAGE_LAYOUT_UNDEFINED,
+			                             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+			                             range);
 
-			vkb::insert_image_memory_barrier(draw_cmd_buffer,
-			                                 depth_stencil.image,
-			                                 0,
-			                                 VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
-			                                 VK_IMAGE_LAYOUT_UNDEFINED,
-			                                 VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
-			                                 VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
-			                                 VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT, depth_range);
+			vkb::image_layout_transition(draw_cmd_buffer,
+			                             depth_stencil.image,
+			                             VK_IMAGE_LAYOUT_UNDEFINED,
+			                             VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+			                             depth_range);
 
 			VkRenderingAttachmentInfoKHR color_attachment_info = vkb::initializers::rendering_attachment_info();
 			color_attachment_info.imageView                    = swapchain_buffers[i].view;        // color_attachment.image_view;
@@ -417,15 +411,11 @@ void DynamicRendering::build_command_buffers()
 			draw_scene();
 			vkCmdEndRenderingKHR(draw_cmd_buffer);
 
-			vkb::insert_image_memory_barrier(draw_cmd_buffer,
-			                                 swapchain_buffers[i].image,
-			                                 VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-			                                 0,
-			                                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-			                                 VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-			                                 VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-			                                 VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-			                                 range);
+			vkb::image_layout_transition(draw_cmd_buffer,
+			                             swapchain_buffers[i].image,
+			                             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+			                             VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+			                             range);
 		}
 		else
 		{

--- a/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
+++ b/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
@@ -186,20 +186,9 @@ void FragmentShadingRate::create_shading_rate_attachment()
 	delete[] shading_rate_pattern_data;
 
 	// Upload the buffer containing the shading rates to the image that'll be used as the shading rate attachment inside our renderpass
-	VkCommandBuffer         copy_cmd          = device->create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
-	VkImageSubresourceRange subresource_range = {};
-	subresource_range.aspectMask              = VK_IMAGE_ASPECT_COLOR_BIT;
-	subresource_range.levelCount              = 1;
-	subresource_range.layerCount              = 1;
+	VkCommandBuffer copy_cmd = device->create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-	VkImageMemoryBarrier image_memory_barrier = vkb::initializers::image_memory_barrier();
-	image_memory_barrier.oldLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
-	image_memory_barrier.newLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-	image_memory_barrier.srcAccessMask        = 0;
-	image_memory_barrier.dstAccessMask        = VK_ACCESS_TRANSFER_WRITE_BIT;
-	image_memory_barrier.image                = shading_rate_image.image;
-	image_memory_barrier.subresourceRange     = subresource_range;
-	vkCmdPipelineBarrier(copy_cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &image_memory_barrier);
+	vkb::image_layout_transition(copy_cmd, shading_rate_image.image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
 	VkBufferImageCopy buffer_copy_region           = {};
 	buffer_copy_region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -210,13 +199,8 @@ void FragmentShadingRate::create_shading_rate_attachment()
 	vkCmdCopyBufferToImage(copy_cmd, staging_buffer->get_handle(), shading_rate_image.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy_region);
 
 	// Transfer image layout to fragment shading rate attachment layout required to access this in the renderpass
-	image_memory_barrier.oldLayout        = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-	image_memory_barrier.newLayout        = VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR;
-	image_memory_barrier.srcAccessMask    = VK_ACCESS_TRANSFER_WRITE_BIT;
-	image_memory_barrier.dstAccessMask    = 0;
-	image_memory_barrier.image            = shading_rate_image.image;
-	image_memory_barrier.subresourceRange = subresource_range;
-	vkCmdPipelineBarrier(copy_cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 1, &image_memory_barrier);
+	vkb::image_layout_transition(
+	    copy_cmd, shading_rate_image.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR);
 
 	device->flush_command_buffer(copy_cmd, queue, true);
 

--- a/samples/extensions/open_gl_interop/open_gl_interop.cpp
+++ b/samples/extensions/open_gl_interop/open_gl_interop.cpp
@@ -260,28 +260,9 @@ void OpenGLInterop::prepare_shared_resources()
 		                                                          0, 1};
 		vkCreateImageView(deviceHandle, &viewCreateInfo, nullptr, &sharedTexture.view);
 
-		with_command_buffer([&](VkCommandBuffer image_command_buffer) {
-			VkImageMemoryBarrier image_memory_barrier  = vkb::initializers::image_memory_barrier();
-			image_memory_barrier.image                 = sharedTexture.image;
-			image_memory_barrier.srcAccessMask         = 0;
-			image_memory_barrier.dstAccessMask         = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-			image_memory_barrier.oldLayout             = VK_IMAGE_LAYOUT_UNDEFINED;
-			image_memory_barrier.newLayout             = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-			VkImageSubresourceRange &subresource_range = image_memory_barrier.subresourceRange;
-			subresource_range.aspectMask               = VK_IMAGE_ASPECT_COLOR_BIT;
-			subresource_range.levelCount               = 1;
-			subresource_range.layerCount               = 1;
-
-			vkCmdPipelineBarrier(
-			    image_command_buffer,
-			    VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-			    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-			    0,
-			    0, nullptr,
-			    0, nullptr,
-			    1, &image_memory_barrier);
-		},
-		                    sharedSemaphores.gl_ready);
+		with_command_buffer(
+		    [&](VkCommandBuffer image_command_buffer) { vkb::image_layout_transition(image_command_buffer, sharedTexture.image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL); },
+		    sharedSemaphores.gl_ready);
 	}
 }
 
@@ -700,24 +681,7 @@ void OpenGLInterop::build_command_buffers()
 
 		VK_CHECK(vkBeginCommandBuffer(draw_cmd_buffers[i], &command_buffer_begin_info));
 
-		{
-			VkImageMemoryBarrier image_memory_barrier = vkb::initializers::image_memory_barrier();
-			image_memory_barrier.image                = sharedTexture.image;
-			image_memory_barrier.srcAccessMask        = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-			image_memory_barrier.dstAccessMask        = VK_ACCESS_SHADER_READ_BIT;
-			image_memory_barrier.oldLayout            = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-			image_memory_barrier.newLayout            = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-			VkImageSubresourceRange &subresource_range = image_memory_barrier.subresourceRange;
-			subresource_range.aspectMask               = VK_IMAGE_ASPECT_COLOR_BIT;
-			subresource_range.levelCount               = 1;
-			subresource_range.layerCount               = 1;
-			vkCmdPipelineBarrier(
-			    draw_cmd_buffers[i],
-			    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-			    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
-			    0, nullptr, 0, nullptr, 1, &image_memory_barrier);
-		}
+		vkb::image_layout_transition(draw_cmd_buffers[i], sharedTexture.image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 		vkCmdBeginRenderPass(draw_cmd_buffers[i], &render_pass_begin_info,
 		                     VK_SUBPASS_CONTENTS_INLINE);
@@ -744,31 +708,8 @@ void OpenGLInterop::build_command_buffers()
 
 		vkCmdEndRenderPass(draw_cmd_buffers[i]);
 
-		{
-			VkImageMemoryBarrier image_memory_barrier = vkb::initializers::image_memory_barrier();
-			image_memory_barrier.image                = sharedTexture.image;
-			image_memory_barrier.srcAccessMask        = VK_ACCESS_SHADER_READ_BIT;
-			image_memory_barrier.dstAccessMask        = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-			image_memory_barrier.oldLayout            = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-			image_memory_barrier.newLayout            = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		vkb::image_layout_transition(draw_cmd_buffers[i], sharedTexture.image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
-			VkImageSubresourceRange &subresource_range = image_memory_barrier.subresourceRange;
-			subresource_range.aspectMask               = VK_IMAGE_ASPECT_COLOR_BIT;
-			subresource_range.levelCount               = 1;
-			subresource_range.layerCount               = 1;
-
-			// Insert a memory dependency at the proper pipeline stages that will execute the image layout transition
-			// Source pipeline stage is host write/read execution (VK_PIPELINE_STAGE_HOST_BIT)
-			// Destination pipeline stage is copy command execution (VK_PIPELINE_STAGE_TRANSFER_BIT)
-			vkCmdPipelineBarrier(
-			    draw_cmd_buffers[i],
-			    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-			    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-			    0,
-			    0, nullptr,
-			    0, nullptr,
-			    1, &image_memory_barrier);
-		}
 		VK_CHECK(vkEndCommandBuffer(draw_cmd_buffers[i]));
 	}
 }

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -197,10 +197,15 @@ void RaytracingExtended::create_storage_image()
 	VK_CHECK(vkCreateImageView(get_device().get_handle(), &color_image_view, nullptr, &storage_image.view));
 
 	VkCommandBuffer command_buffer = get_device().create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
-	vkb::set_image_layout(command_buffer, storage_image.image,
-	                      VK_IMAGE_LAYOUT_UNDEFINED,
-	                      VK_IMAGE_LAYOUT_GENERAL,
-	                      {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
+	vkb::image_layout_transition(command_buffer,
+	                             storage_image.image,
+	                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+	                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+	                             {},
+	                             {},
+	                             VK_IMAGE_LAYOUT_UNDEFINED,
+	                             VK_IMAGE_LAYOUT_GENERAL,
+	                             {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
 	get_device().flush_command_buffer(command_buffer, queue);
 }
 
@@ -1401,20 +1406,21 @@ void RaytracingExtended::draw()
 	    Copy ray tracing output to swap chain image
 	*/
 	// Prepare current swap chain image as transfer destination
-	vkb::set_image_layout(
-	    draw_cmd_buffers[i],
-	    get_render_context().get_swapchain().get_images()[i],
-	    VK_IMAGE_LAYOUT_UNDEFINED,
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    subresource_range);
+	vkb::image_layout_transition(draw_cmd_buffers[i],
+	                             get_render_context().get_swapchain().get_images()[i],
+	                             VK_IMAGE_LAYOUT_UNDEFINED,
+	                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
 	// Prepare ray tracing output image as transfer source
-	vkb::set_image_layout(
-	    draw_cmd_buffers[i],
-	    storage_image.image,
-	    VK_IMAGE_LAYOUT_GENERAL,
-	    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-	    subresource_range);
+	vkb::image_layout_transition(draw_cmd_buffers[i],
+	                             storage_image.image,
+	                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+	                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+	                             {},
+	                             VK_ACCESS_TRANSFER_READ_BIT,
+	                             VK_IMAGE_LAYOUT_GENERAL,
+	                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+	                             subresource_range);
 
 	VkImageCopy copy_region{};
 	copy_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -1426,20 +1432,21 @@ void RaytracingExtended::draw()
 	               get_render_context().get_swapchain().get_images()[i], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 
 	// Transition swap chain image back for presentation
-	vkb::set_image_layout(
-	    draw_cmd_buffers[i],
-	    get_render_context().get_swapchain().get_images()[i],
-	    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-	    subresource_range);
+	vkb::image_layout_transition(draw_cmd_buffers[i],
+	                             get_render_context().get_swapchain().get_images()[i],
+	                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	                             VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
 	// Transition ray tracing output image back to general layout
-	vkb::set_image_layout(
-	    draw_cmd_buffers[i],
-	    storage_image.image,
-	    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-	    VK_IMAGE_LAYOUT_GENERAL,
-	    subresource_range);
+	vkb::image_layout_transition(draw_cmd_buffers[i],
+	                             storage_image.image,
+	                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+	                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+	                             VK_ACCESS_TRANSFER_READ_BIT,
+	                             {},
+	                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+	                             VK_IMAGE_LAYOUT_GENERAL,
+	                             subresource_range);
 	VK_CHECK(vkEndCommandBuffer(draw_cmd_buffers[i]));
 
 	submit_info.commandBufferCount = 1;

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
@@ -187,10 +187,15 @@ void RaytracingReflection::create_storage_image()
 	VK_CHECK(vkCreateImageView(get_device().get_handle(), &color_image_view, nullptr, &storage_image.view));
 
 	VkCommandBuffer command_buffer = get_device().create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
-	vkb::set_image_layout(command_buffer, storage_image.image,
-	                      VK_IMAGE_LAYOUT_UNDEFINED,
-	                      VK_IMAGE_LAYOUT_GENERAL,
-	                      {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
+	vkb::image_layout_transition(command_buffer,
+	                             storage_image.image,
+	                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+	                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+	                             {},
+	                             {},
+	                             VK_IMAGE_LAYOUT_UNDEFINED,
+	                             VK_IMAGE_LAYOUT_GENERAL,
+	                             {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
 	get_device().flush_command_buffer(command_buffer, queue);
 }
 
@@ -868,20 +873,20 @@ void RaytracingReflection::build_command_buffers()
 		*/
 
 		// Prepare current swap chain image as transfer destination
-		vkb::set_image_layout(
-		    draw_cmd_buffers[i],
-		    get_render_context().get_swapchain().get_images()[i],
-		    VK_IMAGE_LAYOUT_UNDEFINED,
-		    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-		    subresource_range);
+		vkb::image_layout_transition(draw_cmd_buffers[i],
+		                             get_render_context().get_swapchain().get_images()[i],
+		                             VK_IMAGE_LAYOUT_UNDEFINED,
+		                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
 		// Prepare ray tracing output image as transfer source
-		vkb::set_image_layout(
-		    draw_cmd_buffers[i],
-		    storage_image.image,
-		    VK_IMAGE_LAYOUT_GENERAL,
-		    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-		    subresource_range);
+		vkb::image_layout_transition(draw_cmd_buffers[i],
+		                             storage_image.image,
+		                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+		                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+		                             {},
+		                             VK_ACCESS_TRANSFER_READ_BIT,
+		                             VK_IMAGE_LAYOUT_GENERAL,
+		                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, subresource_range);
 
 		VkImageCopy copy_region{};
 		copy_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -893,18 +898,21 @@ void RaytracingReflection::build_command_buffers()
 		               get_render_context().get_swapchain().get_images()[i], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 
 		// Transition swap chain image back for presentation
-		vkb::set_image_layout(draw_cmd_buffers[i],
-		                      get_render_context().get_swapchain().get_images()[i],
-		                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-		                      VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-		                      subresource_range);
+		vkb::image_layout_transition(draw_cmd_buffers[i],
+		                             get_render_context().get_swapchain().get_images()[i],
+		                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		                             VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
 		// Transition ray tracing output image back to general layout
-		vkb::set_image_layout(draw_cmd_buffers[i],
-		                      storage_image.image,
-		                      VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-		                      VK_IMAGE_LAYOUT_GENERAL,
-		                      subresource_range);
+		vkb::image_layout_transition(draw_cmd_buffers[i],
+		                             storage_image.image,
+		                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+		                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+		                             VK_ACCESS_TRANSFER_READ_BIT,
+		                             {},
+		                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+		                             VK_IMAGE_LAYOUT_GENERAL,
+		                             subresource_range);
 
 		/*
 		    Start a new render pass to draw the UI overlay on top of the ray traced image

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -343,15 +343,8 @@ void MultiDrawIndirect::load_scene()
 		subresource_range.baseMipLevel            = 0;
 		subresource_range.levelCount              = texture.n_mip_maps;
 
-		VkImageMemoryBarrier image_barrier = vkb::initializers::image_memory_barrier();
-		image_barrier.srcAccessMask        = 0;
-		image_barrier.dstAccessMask        = VK_ACCESS_TRANSFER_WRITE_BIT;
-		image_barrier.image                = texture.image->get_handle();
-		image_barrier.subresourceRange     = subresource_range;
-		image_barrier.oldLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
-		image_barrier.newLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-
-		vkCmdPipelineBarrier(texture_cmd.get_handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &image_barrier);
+		vkb::image_layout_transition(
+		    texture_cmd.get_handle(), texture.image->get_handle(), VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresource_range);
 
 		auto              offsets              = image->get_offsets();
 		VkBufferImageCopy region               = {};
@@ -420,27 +413,17 @@ void MultiDrawIndirect::load_scene()
 		}
 	}
 
+	std::vector<std::pair<VkImage, VkImageSubresourceRange>> imagesAndRanges;
+	imagesAndRanges.reserve(textures.size());
+	for (auto const &texture : textures)
+	{
+		imagesAndRanges.emplace_back(
+		    std::make_pair(texture.image->get_handle(), VkImageSubresourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, texture.n_mip_maps, 0, 1}));
+	}
+
 	auto &cmd = device->get_command_pool().request_command_buffer();
 	cmd.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_NULL_HANDLE);
-	std::vector<VkImageMemoryBarrier> image_barriers;
-	image_barriers.reserve(textures.size());
-	for (auto &&texture : textures)
-	{
-		VkImageSubresourceRange subresource_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-		subresource_range.baseMipLevel            = 0;
-		subresource_range.levelCount              = texture.n_mip_maps;
-
-		VkImageMemoryBarrier image_barrier = vkb::initializers::image_memory_barrier();
-		image_barrier.srcAccessMask        = VK_ACCESS_TRANSFER_WRITE_BIT;
-		image_barrier.dstAccessMask        = VK_ACCESS_SHADER_READ_BIT;
-		image_barrier.image                = texture.image->get_handle();
-		image_barrier.subresourceRange     = subresource_range;
-		image_barrier.oldLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-		image_barrier.newLayout            = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-		image_barriers.emplace_back(image_barrier);
-	}
-	vkCmdPipelineBarrier(cmd.get_handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, static_cast<uint32_t>(image_barriers.size()), image_barriers.data());
+	vkb::image_layout_transition(cmd.get_handle(), imagesAndRanges, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 	cmd.end();
 	auto &queue = device->get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0);
 	queue.submit(cmd, device->request_fence());

--- a/samples/performance/texture_compression_comparison/texture_compression_comparison.cpp
+++ b/samples/performance/texture_compression_comparison/texture_compression_comparison.cpp
@@ -327,27 +327,12 @@ std::unique_ptr<vkb::sg::Image> TextureCompressionComparison::create_image(ktxTe
 
 	VkCommandBuffer command_buffer = get_device().create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-	VkImageMemoryBarrier initial_image_memory_barrier = vkb::initializers::image_memory_barrier();
-	initial_image_memory_barrier.image                = image;
-	initial_image_memory_barrier.subresourceRange     = subresource_range;
-	initial_image_memory_barrier.srcAccessMask        = 0;
-	initial_image_memory_barrier.dstAccessMask        = VK_ACCESS_TRANSFER_WRITE_BIT;
-	initial_image_memory_barrier.oldLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
-	initial_image_memory_barrier.newLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-
-	vkCmdPipelineBarrier(command_buffer, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, VK_NULL_HANDLE, 0, VK_NULL_HANDLE, 1, &initial_image_memory_barrier);
+	vkb::image_layout_transition(command_buffer, image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresource_range);
 
 	vkCmdCopyBufferToImage(command_buffer, staging_buffer->get_handle(), image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, buffer_copies.size(), buffer_copies.data());
 
-	VkImageMemoryBarrier image_memory_barrier = vkb::initializers::image_memory_barrier();
-	image_memory_barrier.image                = image;
-	image_memory_barrier.subresourceRange     = subresource_range;
-	image_memory_barrier.srcAccessMask        = VK_ACCESS_TRANSFER_WRITE_BIT;
-	image_memory_barrier.dstAccessMask        = VK_ACCESS_SHADER_READ_BIT;
-	image_memory_barrier.oldLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-	image_memory_barrier.newLayout            = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+	vkb::image_layout_transition(command_buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, subresource_range);
 
-	vkCmdPipelineBarrier(command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, VK_NULL_HANDLE, 0, VK_NULL_HANDLE, 1, &image_memory_barrier);
 	device->flush_command_buffer(command_buffer, get_device().get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0).get_handle(), true);
 
 	return image_out;

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -22,6 +22,7 @@
 #include "profiles.h"
 
 #include "common/error.h"
+#include "common/vk_common.h"
 #include "core/command_pool.h"
 #include "core/queue.h"
 #include "fence_pool.h"
@@ -236,27 +237,14 @@ void Profiles::generate_textures()
 		auto &cmd = get_device().request_command_buffer();
 		cmd.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
-		VkImageMemoryBarrier barrier = vkb::initializers::image_memory_barrier();
-		barrier.srcAccessMask        = 0;
-		barrier.dstAccessMask        = VK_ACCESS_TRANSFER_WRITE_BIT;
-		barrier.oldLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
-		barrier.newLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-		barrier.subresourceRange     = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-		barrier.image                = textures[i].image;
-		vkCmdPipelineBarrier(cmd.get_handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
-		                     0, 0, nullptr, 0, nullptr, 1, &barrier);
+		vkb::image_layout_transition(cmd.get_handle(), textures[i].image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
 		VkBufferImageCopy copy_info{};
 		copy_info.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
 		copy_info.imageExtent      = image_info.extent;
 		vkCmdCopyBufferToImage(cmd.get_handle(), staging_buffer->get_handle(), textures[i].image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_info);
 
-		barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-		barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-		barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-		barrier.newLayout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		vkCmdPipelineBarrier(cmd.get_handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-		                     0, 0, nullptr, 0, nullptr, 1, &barrier);
+		vkb::image_layout_transition(cmd.get_handle(), textures[i].image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 		VK_CHECK(cmd.end());
 


### PR DESCRIPTION
## Description

Resolves validation layer warnings on using `VK_PIPELINE_STAGE_ALL_COMMANDS_BIT`, which was the default for the `set_image_layout` helper function. Which actually was never used with different stages! And there was a helper function `insert_image_memory_barrier`, which did the exact same stuff.

Thus, introduced a set of helper functions `image_layout_transition` to cover this:
- One version just taking the command buffer to record with, the image to transition its layout, and the old and new image layout. A default subresource range is used to call into the next overload of this function.
- One version additionally taking a subresource range. The other flags are derived from the old and new image layout to form some meaningful set of flags. Then the next overload of this function is called.
- One version additionally taking all the flags needed to form a valid transition.
- One version taking a vector of images and subresource ranges. As above, the other flags are derived from the old and new image layout.

With this PR, all calls to `set_image_layout` and `insert_image_memory_barrier` are replaced by a call to one of the `image_layout_transition` routines, and those functions are removed. In addition, explicit calls to `vkCmdPipelineBarrier` with an image memory barrier are replaced by a call to `image_layout_transition`.

Compiled and tested on Win10, using NVIDIA GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
