### PR TITLE
Windows CLI Fix

### DIFF
--- a/components/core/include/core/platform/entrypoint.hpp
+++ b/components/core/include/core/platform/entrypoint.hpp
@@ -60,6 +60,7 @@ extern std::unique_ptr<vkb::PlatformContext> create_platform_context(int argc, c
 		int platform_main(const vkb::PlatformContext &context_name)
 
 #else
+#	include <stdexcept>
 #	define CUSTOM_MAIN(context_name)                           \
 		int main(int argc, char *argv[])                        \
 		{                                                       \

--- a/components/windows/src/context.cpp
+++ b/components/windows/src/context.cpp
@@ -87,16 +87,19 @@ WindowsPlatformContext::WindowsPlatformContext(HINSTANCE hInstance, HINSTANCE hP
 	_temp_directory             = get_temp_path_from_environment();
 	_arguments                  = get_args();
 
-	// allocate a console for this app
-	// TODO: do we really need to do this?
-	// if (!AllocConsole())
-	// {
-	// 	throw std::runtime_error{"AllocConsole error"};
-	// }
+	// Attempt to attach to the parent process console if it exists
+	if (!AttachConsole(ATTACH_PARENT_PROCESS))
+	{
+		// No parent console, allocate a new one for this process
+		if (!AllocConsole())
+		{
+			throw std::runtime_error{"AllocConsole error"};
+		}
+	}
 
-	// FILE *fp;
-	// freopen_s(&fp, "conin$", "r", stdin);
-	// freopen_s(&fp, "conout$", "w", stdout);
-	// freopen_s(&fp, "conout$", "w", stderr);
+	FILE *fp;
+	freopen_s(&fp, "conin$", "r", stdin);
+	freopen_s(&fp, "conout$", "w", stdout);
+	freopen_s(&fp, "conout$", "w", stderr);
 }
 }        // namespace vkb


### PR DESCRIPTION
## Description

Fixes Windows CLI issues

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
