### PR TITLE
Change the CommandPools to _not_ use VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT.

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -147,11 +147,7 @@ bool ApiVulkanSample::resize(const uint32_t _width, const uint32_t _height)
 		}
 	}
 
-	// Command buffers need to be recreated as they may store
-	// references to the recreated frame buffer
-	destroy_command_buffers();
-	create_command_buffers();
-	build_command_buffers();
+	rebuild_command_buffers();
 
 	device->wait_idle();
 
@@ -456,7 +452,7 @@ void ApiVulkanSample::update_overlay(float delta_time)
 
 		if (gui->update_buffers() || gui->get_drawer().is_dirty())
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 			gui->get_drawer().clear();
 		}
 	}
@@ -601,6 +597,12 @@ void ApiVulkanSample::view_changed()
 void ApiVulkanSample::build_command_buffers()
 {}
 
+void ApiVulkanSample::rebuild_command_buffers()
+{
+	vkResetCommandPool(device->get_handle(), cmd_pool, 0);
+	build_command_buffers();
+}
+
 void ApiVulkanSample::create_synchronization_primitives()
 {
 	// Wait fences to sync command buffer access
@@ -617,7 +619,6 @@ void ApiVulkanSample::create_command_pool()
 	VkCommandPoolCreateInfo command_pool_info = {};
 	command_pool_info.sType                   = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
 	command_pool_info.queueFamilyIndex        = device->get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT, 0).get_family_index();
-	command_pool_info.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 	VK_CHECK(vkCreateCommandPool(device->get_handle(), &command_pool_info, nullptr, &cmd_pool));
 }
 

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -274,6 +274,11 @@ class ApiVulkanSample : public vkb::VulkanSample
 	virtual void build_command_buffers() = 0;
 
 	/**
+	 * @brief Rebuild the command buffers by first resetting the corresponding command pool and then building the command buffers.
+	 */
+	void rebuild_command_buffers();
+
+	/**
 	 * @brief Creates the fences for rendering
 	 */
 	void create_synchronization_primitives();

--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -60,9 +60,9 @@ class Device : public core::VulkanResource<VkDevice, VK_OBJECT_TYPE_DEVICE>
 	 * @param debug_utils The debug utils to be associated to this device
 	 * @param requested_extensions (Optional) List of required device extensions and whether support is optional or not
 	 */
-	Device(PhysicalDevice &                       gpu,
+	Device(PhysicalDevice                        &gpu,
 	       VkSurfaceKHR                           surface,
-	       std::unique_ptr<DebugUtils> &&         debug_utils,
+	       std::unique_ptr<DebugUtils>          &&debug_utils,
 	       std::unordered_map<const char *, bool> requested_extensions = {});
 
 	/**
@@ -72,7 +72,7 @@ class Device : public core::VulkanResource<VkDevice, VK_OBJECT_TYPE_DEVICE>
 	 * @param surface The surface
 	 */
 	Device(PhysicalDevice &gpu,
-	       VkDevice &      vulkan_device,
+	       VkDevice       &vulkan_device,
 	       VkSurfaceKHR    surface);
 
 	Device(const Device &) = delete;
@@ -148,23 +148,23 @@ class Device : public core::VulkanResource<VkDevice, VK_OBJECT_TYPE_DEVICE>
 	uint32_t get_memory_type(uint32_t bits, VkMemoryPropertyFlags properties, VkBool32 *memory_type_found = nullptr) const;
 
 	/**
-	* @brief Creates a vulkan buffer
-	* @param usage The buffer usage
-	* @param properties The memory properties
-	* @param size The size of the buffer
-	* @param memory The pointer to the buffer memory
-	* @param data The data to place inside the buffer
-	* @returns A valid VkBuffer
-	*/
+	 * @brief Creates a vulkan buffer
+	 * @param usage The buffer usage
+	 * @param properties The memory properties
+	 * @param size The size of the buffer
+	 * @param memory The pointer to the buffer memory
+	 * @param data The data to place inside the buffer
+	 * @returns A valid VkBuffer
+	 */
 	VkBuffer create_buffer(VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, VkDeviceSize size, VkDeviceMemory *memory, void *data = nullptr);
 
 	/**
-	* @brief Copies a buffer from one to another
-	* @param src The buffer to copy from
-	* @param dst The buffer to copy to
-	* @param queue The queue to submit the copy command to
-	* @param copy_region The amount to copy, if null copies the entire buffer
-	*/
+	 * @brief Copies a buffer from one to another
+	 * @param src The buffer to copy from
+	 * @param dst The buffer to copy to
+	 * @param queue The queue to submit the copy command to
+	 * @param copy_region The amount to copy, if null copies the entire buffer
+	 */
 	void copy_buffer(vkb::core::Buffer &src, vkb::core::Buffer &dst, VkQueue queue, VkBufferCopy *copy_region = nullptr);
 
 	/**
@@ -173,7 +173,7 @@ class Device : public core::VulkanResource<VkDevice, VK_OBJECT_TYPE_DEVICE>
 	 * @param flags The command pool flags
 	 * @returns A valid VkCommandPool
 	 */
-	VkCommandPool create_command_pool(uint32_t queue_index, VkCommandPoolCreateFlags flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+	VkCommandPool create_command_pool(uint32_t queue_index, VkCommandPoolCreateFlags flags = 0);
 
 	/**
 	 * @brief Requests a command buffer from the device's command pool

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -139,11 +139,7 @@ bool HPPApiVulkanSample::resize(const uint32_t, const uint32_t)
 		gui->resize(extent.width, extent.height);
 	}
 
-	// Command buffers need to be recreated as they may store
-	// references to the recreated frame buffer
-	destroy_command_buffers();
-	create_command_buffers();
-	build_command_buffers();
+	rebuild_command_buffers();
 
 	get_device()->get_handle().waitIdle();
 
@@ -429,7 +425,7 @@ void HPPApiVulkanSample::update_overlay(float delta_time)
 
 		if (gui->update_buffers() || gui->get_drawer().is_dirty())
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 			gui->get_drawer().clear();
 		}
 	}
@@ -571,6 +567,12 @@ void HPPApiVulkanSample::view_changed()
 void HPPApiVulkanSample::build_command_buffers()
 {}
 
+void HPPApiVulkanSample::rebuild_command_buffers()
+{
+	get_device()->get_handle().resetCommandPool(cmd_pool);
+	build_command_buffers();
+}
+
 void HPPApiVulkanSample::create_synchronization_primitives()
 {
 	// Wait fences to sync command buffer access
@@ -585,7 +587,7 @@ void HPPApiVulkanSample::create_synchronization_primitives()
 void HPPApiVulkanSample::create_command_pool()
 {
 	uint32_t                  queue_family_index = get_device()->get_queue_by_flags(vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute, 0).get_family_index();
-	vk::CommandPoolCreateInfo command_pool_info(vk::CommandPoolCreateFlagBits::eResetCommandBuffer, queue_family_index);
+	vk::CommandPoolCreateInfo command_pool_info({}, queue_family_index);
 	cmd_pool = get_device()->get_handle().createCommandPool(command_pool_info);
 }
 

--- a/framework/hpp_api_vulkan_sample.h
+++ b/framework/hpp_api_vulkan_sample.h
@@ -224,6 +224,11 @@ class HPPApiVulkanSample : public vkb::HPPVulkanSample
 	virtual void build_command_buffers() = 0;
 
 	/**
+	 * @brief Rebuild the command buffers by first resetting the corresponding command pool and then building the command buffers.
+	 */
+	void rebuild_command_buffers();
+
+	/**
 	 * @brief Creates the fences for rendering
 	 */
 	void create_synchronization_primitives();

--- a/samples/api/compute_nbody/compute_nbody.cpp
+++ b/samples/api/compute_nbody/compute_nbody.cpp
@@ -78,13 +78,6 @@ void ComputeNBody::load_assets()
 
 void ComputeNBody::build_command_buffers()
 {
-	// Destroy command buffers if already present
-	if (!check_command_buffers())
-	{
-		destroy_command_buffers();
-		create_command_buffers();
-	}
-
 	VkCommandBufferBeginInfo command_buffer_begin_info = vkb::initializers::command_buffer_begin_info();
 
 	VkClearValue clear_values[2];
@@ -657,7 +650,6 @@ void ComputeNBody::prepare_compute()
 	VkCommandPoolCreateInfo command_pool_create_info = {};
 	command_pool_create_info.sType                   = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
 	command_pool_create_info.queueFamilyIndex        = get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT);
-	command_pool_create_info.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 	VK_CHECK(vkCreateCommandPool(get_device().get_handle(), &command_pool_create_info, nullptr, &compute.command_pool));
 
 	// Create a command buffer for compute operations

--- a/samples/api/hdr/hdr.cpp
+++ b/samples/api/hdr/hdr.cpp
@@ -934,7 +934,7 @@ void HDR::on_update_ui_overlay(vkb::Drawer &drawer)
 		if (drawer.combo_box("Object type", &models.object_index, object_names))
 		{
 			update_uniform_buffers();
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.input_float("Exposure", &ubo_params.exposure, 0.025f, 3))
 		{
@@ -942,11 +942,11 @@ void HDR::on_update_ui_overlay(vkb::Drawer &drawer)
 		}
 		if (drawer.checkbox("Bloom", &bloom))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Skybox", &display_skybox))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 }

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
@@ -78,13 +78,6 @@ void HPPComputeNBody::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 
 void HPPComputeNBody::build_command_buffers()
 {
-	// Destroy command buffers if already present
-	if (!check_command_buffers())
-	{
-		destroy_command_buffers();
-		create_command_buffers();
-	}
-
 	std::array<vk::ClearValue, 2> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 1.0f}})),
 	                                               vk::ClearDepthStencilValue(0.0f, 0)}};
 
@@ -462,7 +455,7 @@ void HPPComputeNBody::prepare_compute()
 	}
 
 	// Separate command pool as queue family for compute may be different than graphics
-	compute.command_pool = device.createCommandPool({vk::CommandPoolCreateFlagBits::eResetCommandBuffer, compute.queue_family_index});
+	compute.command_pool = device.createCommandPool({{}, compute.queue_family_index});
 
 	// Create a command buffer for compute operations
 	compute.command_buffer = vkb::common::allocate_command_buffer(device, compute.command_pool);

--- a/samples/api/hpp_hdr/hpp_hdr.cpp
+++ b/samples/api/hpp_hdr/hpp_hdr.cpp
@@ -191,7 +191,7 @@ void HPPHDR::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 		if (drawer.combo_box("Object type", &models.object_index, object_names))
 		{
 			update_uniform_buffers();
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.input_float("Exposure", &ubo_params.exposure, 0.025f, 3))
 		{
@@ -199,11 +199,11 @@ void HPPHDR::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 		}
 		if (drawer.checkbox("Bloom", &bloom.enabled))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Skybox", &display_skybox))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 }

--- a/samples/api/hpp_instancing/hpp_instancing.cpp
+++ b/samples/api/hpp_instancing/hpp_instancing.cpp
@@ -83,7 +83,7 @@ bool HPPInstancing::prepare(const vkb::ApplicationOptions &options)
 bool HPPInstancing::resize(const uint32_t width, const uint32_t height)
 {
 	HPPApiVulkanSample::resize(width, height);
-	build_command_buffers();
+	rebuild_command_buffers();
 	return true;
 }
 

--- a/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
+++ b/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
@@ -191,7 +191,7 @@ void HPPTerrainTessellation::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 		{
 			if (drawer.checkbox("Wireframe", &wireframe))
 			{
-				build_command_buffers();
+				rebuild_command_buffers();
 			}
 		}
 	}

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -271,7 +271,7 @@ void HPPTimestampQueries::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 		if (drawer.combo_box("Object type", &models.object_index, object_names))
 		{
 			update_uniform_buffers();
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.input_float("Exposure", &ubo_params.exposure, 0.025f, 3))
 		{
@@ -279,11 +279,11 @@ void HPPTimestampQueries::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 		}
 		if (drawer.checkbox("Bloom", &bloom))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Skybox", &display_skybox))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 	if (drawer.header("timing"))

--- a/samples/api/instancing/instancing.cpp
+++ b/samples/api/instancing/instancing.cpp
@@ -533,7 +533,7 @@ void Instancing::on_update_ui_overlay(vkb::Drawer &drawer)
 bool Instancing::resize(const uint32_t width, const uint32_t height)
 {
 	ApiVulkanSample::resize(width, height);
-	build_command_buffers();
+	rebuild_command_buffers();
 	return true;
 }
 

--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -318,7 +318,7 @@ void SwapchainRecreation::setup_frame()
 		// Reset/recycle resources, they are no longer in use.
 		recycle_fence(frame.submit_fence);
 		recycle_semaphore(frame.acquire_semaphore);
-		vkResetCommandBuffer(frame.command_buffer, 0);
+		vkResetCommandPool(get_device_handle(), frame.command_pool, 0);
 
 		// Destroy any garbage that's associated with this submission.
 		for (SwapchainObjects &garbage : frame.swapchain_garbage)
@@ -345,7 +345,7 @@ void SwapchainRecreation::setup_frame()
 	if (frame.command_pool == VK_NULL_HANDLE)
 	{
 		VkCommandPoolCreateInfo cmd_pool_info{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
-		cmd_pool_info.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+		cmd_pool_info.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
 		cmd_pool_info.queueFamilyIndex = queue->get_family_index();
 		VK_CHECK(vkCreateCommandPool(get_device_handle(), &cmd_pool_info, nullptr, &frame.command_pool));
 

--- a/samples/api/terrain_tessellation/terrain_tessellation.cpp
+++ b/samples/api/terrain_tessellation/terrain_tessellation.cpp
@@ -786,7 +786,7 @@ void TerrainTessellation::on_update_ui_overlay(vkb::Drawer &drawer)
 		{
 			if (drawer.checkbox("Wireframe", &wireframe))
 			{
-				build_command_buffers();
+				rebuild_command_buffers();
 			}
 		}
 	}

--- a/samples/api/texture_loading/texture_loading.cpp
+++ b/samples/api/texture_loading/texture_loading.cpp
@@ -259,8 +259,8 @@ void TextureLoading::load_texture()
 		device->flush_command_buffer(copy_command, queue, true);
 
 		// Clean up staging resources
-		vkFreeMemory(get_device().get_handle(), staging_memory, nullptr);
 		vkDestroyBuffer(get_device().get_handle(), staging_buffer, nullptr);
+		vkFreeMemory(get_device().get_handle(), staging_memory, nullptr);
 	}
 	else
 	{

--- a/samples/api/texture_mipmap_generation/texture_mipmap_generation.cpp
+++ b/samples/api/texture_mipmap_generation/texture_mipmap_generation.cpp
@@ -179,8 +179,8 @@ void TextureMipMapGeneration::load_texture_generate_mipmaps(std::string file_nam
 	device->flush_command_buffer(copy_command, queue, true);
 
 	// Clean up staging resources
-	vkFreeMemory(device->get_handle(), staging_memory, nullptr);
 	vkDestroyBuffer(device->get_handle(), staging_buffer, nullptr);
+	vkFreeMemory(device->get_handle(), staging_memory, nullptr);
 
 	// Generate the mip chain
 	// ---------------------------------------------------------------

--- a/samples/api/timestamp_queries/timestamp_queries.cpp
+++ b/samples/api/timestamp_queries/timestamp_queries.cpp
@@ -995,7 +995,7 @@ void TimestampQueries::on_update_ui_overlay(vkb::Drawer &drawer)
 		if (drawer.combo_box("Object type", &models.object_index, object_names))
 		{
 			update_uniform_buffers();
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.input_float("Exposure", &ubo_params.exposure, 0.025f, 3))
 		{
@@ -1003,11 +1003,11 @@ void TimestampQueries::on_update_ui_overlay(vkb::Drawer &drawer)
 		}
 		if (drawer.checkbox("Bloom", &bloom))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Skybox", &display_skybox))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 	if (drawer.header("timing"))

--- a/samples/extensions/calibrated_timestamps/calibrated_timestamps.cpp
+++ b/samples/extensions/calibrated_timestamps/calibrated_timestamps.cpp
@@ -895,15 +895,15 @@ void CalibratedTimestamps::on_update_ui_overlay(vkb::Drawer &drawer)
 		if (drawer.combo_box("Object type", &models.object_index, object_names))
 		{
 			update_uniform_buffers();
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Bloom", &bloom))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Skybox", &display_skybox))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 

--- a/samples/extensions/color_write_enable/color_write_enable.cpp
+++ b/samples/extensions/color_write_enable/color_write_enable.cpp
@@ -545,7 +545,7 @@ void ColorWriteEnable::on_update_ui_overlay(vkb::Drawer &drawer)
 		                                                    ImGuiColorEditFlags_Float |
 		                                                    ImGuiColorEditFlags_RGB))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 
@@ -553,15 +553,15 @@ void ColorWriteEnable::on_update_ui_overlay(vkb::Drawer &drawer)
 	{
 		if (drawer.checkbox("Red bit", &r_bit_enabled))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Green bit", &g_bit_enabled))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Blue bit", &b_bit_enabled))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 }

--- a/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
+++ b/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
@@ -618,7 +618,7 @@ void ConservativeRasterization::on_update_ui_overlay(vkb::Drawer &drawer)
 	{
 		if (drawer.checkbox("Conservative rasterization", &conservative_raster_enabled))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 	if (drawer.header("Device properties"))

--- a/samples/extensions/debug_utils/debug_utils.cpp
+++ b/samples/extensions/debug_utils/debug_utils.cpp
@@ -1113,11 +1113,11 @@ void DebugUtils::on_update_ui_overlay(vkb::Drawer &drawer)
 	{
 		if (drawer.checkbox("Bloom", &bloom))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("skysphere", &display_skysphere))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 }

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -1141,7 +1141,7 @@ void ExtendedDynamicState2::cube_animation(float delta_time)
 		/* Write new position to object */
 		transform.set_translation(translation);
 		gui_settings.time_tick = true;
-		build_command_buffers();
+		rebuild_command_buffers();
 	}
 }
 

--- a/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.cpp
+++ b/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.cpp
@@ -377,7 +377,7 @@ void FragmentShaderBarycentric::on_update_ui_overlay(vkb::Drawer &drawer)
 	{
 		if (drawer.combo_box("Effects", &gui_settings.selected_effect, gui_settings.effect_names))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 }

--- a/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
+++ b/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
@@ -736,7 +736,7 @@ void FragmentShadingRate::on_update_ui_overlay(vkb::Drawer &drawer)
 	{
 		if (drawer.checkbox("Enable attachment shading rate", &enable_attachment_shading_rate))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Color shading rates", &color_shading_rate))
 		{
@@ -744,7 +744,7 @@ void FragmentShadingRate::on_update_ui_overlay(vkb::Drawer &drawer)
 		}
 		if (drawer.checkbox("skysphere", &display_skysphere))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 }
@@ -757,7 +757,7 @@ bool FragmentShadingRate::resize(const uint32_t width, const uint32_t height)
 		setup_framebuffer();
 	}
 	update_uniform_buffers();
-	build_command_buffers();
+	rebuild_command_buffers();
 	return true;
 }
 

--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -603,6 +603,9 @@ void FragmentShadingRateDynamic::build_command_buffers()
 		VK_CHECK(vkEndCommandBuffer(render_target._command_buffer));
 	};
 
+	// small_command_buffers are not controlled by ApiVulkanSample, that is we need to explicitly reset them here!
+	vkResetCommandPool(get_device().get_handle(), command_pool, 0);
+
 	for (int32_t i = 0; i < draw_cmd_buffers.size(); ++i)
 	{
 		assert(subpass_extent.width > 0 && subpass_extent.width <= width && subpass_extent.height > 0 &&
@@ -1153,10 +1156,7 @@ bool FragmentShadingRateDynamic::prepare(const vkb::ApplicationOptions &options)
 	// Note: Using Revered depth-buffer for increased precision, so Znear and Zfar are flipped
 	camera.set_perspective(60.0f, static_cast<float>(width) / static_cast<float>(height), 256.0f, 0.1f);
 
-	// VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
-	auto command_pool_create  = vkb::initializers::command_pool_create_info();
-	command_pool_create.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-	command_pool_create.pNext = VK_NULL_HANDLE;
+	auto command_pool_create = vkb::initializers::command_pool_create_info();
 	vkCreateCommandPool(get_device().get_handle(), &command_pool_create, VK_NULL_HANDLE, &command_pool);
 
 	load_assets();
@@ -1190,7 +1190,7 @@ void FragmentShadingRateDynamic::on_update_ui_overlay(vkb::Drawer &drawer)
 	{
 		if (drawer.checkbox("Enable attachment shading rate", &enable_attachment_shading_rate))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 
 		static const std::vector<std::string> frequency_decimation_rates = {"1", "2", "4", "8", "16"};
@@ -1212,7 +1212,7 @@ void FragmentShadingRateDynamic::on_update_ui_overlay(vkb::Drawer &drawer)
 
 		if (drawer.checkbox("sky-sphere", &display_sky_sphere))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 }
@@ -1228,7 +1228,7 @@ bool FragmentShadingRateDynamic::resize(const uint32_t new_width, const uint32_t
 	create_compute_pipeline();
 	setup_framebuffer();
 	setup_descriptor_sets();
-	build_command_buffers();
+	rebuild_command_buffers();
 	update_uniform_buffers();
 	return true;
 }

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
@@ -514,7 +514,7 @@ void GraphicsPipelineLibrary::render(float delta_time)
 	if (new_pipeline_created)
 	{
 		new_pipeline_created = false;
-		build_command_buffers();
+		rebuild_command_buffers();
 	}
 	draw();
 

--- a/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
+++ b/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
@@ -415,12 +415,12 @@ void GshaderToMshader::on_update_ui_overlay(vkb::Drawer &drawer)
 		if (drawer.checkbox("Display normals - gshader", &showNormalsGeo))
 		{
 			showNormalsMesh = false;
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("Display normals - mshader", &showNormalsMesh))
 		{
 			showNormalsGeo = false;
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 }

--- a/samples/extensions/memory_budget/memory_budget.cpp
+++ b/samples/extensions/memory_budget/memory_budget.cpp
@@ -629,7 +629,7 @@ void MemoryBudget::on_update_ui_overlay(vkb::Drawer &drawer)
 bool MemoryBudget::resize(uint32_t width, uint32_t height)
 {
 	bool resizeResults = ApiVulkanSample::resize(width, height);
-	build_command_buffers();
+	rebuild_command_buffers();
 	return resizeResults;
 }
 

--- a/samples/extensions/portability/portability.cpp
+++ b/samples/extensions/portability/portability.cpp
@@ -924,11 +924,11 @@ void Portability::on_update_ui_overlay(vkb::Drawer &drawer)
 	{
 		if (drawer.checkbox("Bloom", &bloom))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 		if (drawer.checkbox("skysphere", &display_skysphere))
 		{
-			build_command_buffers();
+			rebuild_command_buffers();
 		}
 	}
 }

--- a/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
+++ b/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
@@ -686,7 +686,6 @@ void RaytracingBasic::build_command_buffers()
 		image_descriptor.imageLayout            = VK_IMAGE_LAYOUT_GENERAL;
 		VkWriteDescriptorSet result_image_write = vkb::initializers::write_descriptor_set(descriptor_set, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, &image_descriptor);
 		vkUpdateDescriptorSets(get_device().get_handle(), 1, &result_image_write, 0, VK_NULL_HANDLE);
-		build_command_buffers();
 	}
 
 	VkCommandBufferBeginInfo command_buffer_begin_info = vkb::initializers::command_buffer_begin_info();

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -1226,7 +1226,6 @@ void RaytracingExtended::build_command_buffers()
 		image_descriptor.imageLayout            = VK_IMAGE_LAYOUT_GENERAL;
 		VkWriteDescriptorSet result_image_write = vkb::initializers::write_descriptor_set(descriptor_set, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, &image_descriptor);
 		vkUpdateDescriptorSets(get_device().get_handle(), 1, &result_image_write, 0, VK_NULL_HANDLE);
-		build_command_buffers();
 	}
 
 	VkCommandBufferBeginInfo command_buffer_begin_info = vkb::initializers::command_buffer_begin_info();

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
@@ -813,7 +813,6 @@ void RaytracingReflection::build_command_buffers()
 		image_descriptor.imageLayout            = VK_IMAGE_LAYOUT_GENERAL;
 		VkWriteDescriptorSet result_image_write = vkb::initializers::write_descriptor_set(descriptor_set, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, &image_descriptor);
 		vkUpdateDescriptorSets(get_device().get_handle(), 1, &result_image_write, 0, VK_NULL_HANDLE);
-		build_command_buffers();
 	}
 
 	VkCommandBufferBeginInfo command_buffer_begin_info{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -798,7 +798,7 @@ void MultiDrawIndirect::render(float delta_time)
 
 	if (m_requires_rebuild)
 	{
-		build_command_buffers();
+		rebuild_command_buffers();
 		m_requires_rebuild = false;
 	}
 


### PR DESCRIPTION
## Description

Resolves validation layer warning on usage of `VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT`.
Instead, the command buffers are explicitly reset by resetting the corresponding command pool.
Includes reordering of destructions in API samples `texture_loading` and `texture_mipmap_generation`.
Note that Extensions sample `ray_tracing_extended` now gets a different validation layer warning due to its different usage of the draw_cmd_buffers. Needs to be resolved!

Builds on Win10 with VS2022. Runs on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
