### PR TITLE
added shaders to ray tracing extended example IDE project

### DIFF
--- a/samples/extensions/ray_tracing_extended/CMakeLists.txt
+++ b/samples/extensions/ray_tracing_extended/CMakeLists.txt
@@ -24,4 +24,8 @@ add_sample_with_tags(
     CATEGORY ${CATEGORY_NAME}
     AUTHOR "Holochip Corporation"
     NAME "Ray tracing extended"
-    DESCRIPTION "Extended example of Ray Tracing highlighting the Bottom and Top Level Acceleration Structure rebuild and AO.")
+    DESCRIPTION "Extended example of Ray Tracing highlighting the Bottom and Top Level Acceleration Structure rebuild and AO."
+    SHADER_FILES_GLSL
+        "khr_ray_tracing_extended/raygen.rgen"
+        "khr_ray_tracing_extended/miss.rmiss"
+        "khr_ray_tracing_extended/closesthit.rchit")


### PR DESCRIPTION
## Description

Added the shaders of ray tracing extended to the IDE project, the same way they are in other projects.
This allows for easy finding and opening of said shader files within the IDE.