### PR TITLE
Add github repository links for Antora documentation

### DIFF
--- a/bldsys/cmake/template/README.adoc.in
+++ b/bldsys/cmake/template/README.adoc.in
@@ -49,6 +49,17 @@ Ideally it also contains an image of how the sample is supposed to look.
 For an example you can take a look at the readme's of existing samples, e.g. https://raw.githubusercontent.com/KhronosGroup/Vulkan-Samples/main/samples/extensions/descriptor_indexing/README.adoc
 ////
 
+= Sample name
+
+////
+The following block adds linkage to this repo in the Vulkan docs site project. It's only visible if the file is viewed via the Antora framework.
+////
+
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/PUT_SAMPLE_PATH_HERE[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 ////

--- a/samples/api/README.adoc
+++ b/samples/api/README.adoc
@@ -18,6 +18,11 @@
 ////
 = API samples
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api[Khronos Vulkan samples github repository].
+endif::[]
+
+
 The goal of these samples is to demonstrate how to use a given Vulkan feature at the API level with as little abstraction as possible.
 
 A list of all API samples can be found link:../README.adoc#api-samples[here].

--- a/samples/api/README.adoc
+++ b/samples/api/README.adoc
@@ -18,11 +18,6 @@
 ////
 = API samples
 
-ifdef::site-gen-antora[]
-TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api[Khronos Vulkan samples github repository].
-endif::[]
-
-
 The goal of these samples is to demonstrate how to use a given Vulkan feature at the API level with as little abstraction as possible.
 
 A list of all API samples can be found link:../README.adoc#api-samples[here].

--- a/samples/api/compute_nbody/README.adoc
+++ b/samples/api/compute_nbody/README.adoc
@@ -19,4 +19,9 @@
 
 === Compute shader N-Body simulation
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/compute_nbody[Khronos Vulkan samples github repository].
+endif::[]
+
+
 Compute shader example that uses two passes and shared compute shader memory for simulating a N-Body particle system.

--- a/samples/api/dynamic_uniform_buffers/README.adoc
+++ b/samples/api/dynamic_uniform_buffers/README.adoc
@@ -19,4 +19,9 @@
 
 === Dynamic Uniform buffers
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/dynamic_uniform_buffers[Khronos Vulkan samples github repository].
+endif::[]
+
+
 Dynamic uniform buffers are used for rendering multiple objects with separate matrices stored in a single uniform buffer object, that are addressed dynamically.

--- a/samples/api/hdr/README.adoc
+++ b/samples/api/hdr/README.adoc
@@ -19,4 +19,9 @@
 
 === High dynamic range
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hdr[Khronos Vulkan samples github repository].
+endif::[]
+
+
 Implements a high dynamic range rendering pipeline using 16/32 bit floating point precision for all calculations.

--- a/samples/api/hello_triangle/README.adoc
+++ b/samples/api/hello_triangle/README.adoc
@@ -19,4 +19,9 @@
 
 === Hello Triangle
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hello_triangle[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A self-contained (minimal use of framework) sample that illustrates the rendering of a triangle.

--- a/samples/api/hlsl_shaders/README.adoc
+++ b/samples/api/hlsl_shaders/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Using HLSL shaders in Vulkan
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hlsl_shaders[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This tutorial, along with the accompanying example code, shows how to use shaders written in the High Level Shading Language (HLSL) in Vulkan at runtime.
 
 Vulkan does not directly consume shaders in a human-readable text format, but instead uses SPIR-V as an intermediate representation.

--- a/samples/api/hpp_compute_nbody/README.adoc
+++ b/samples/api/hpp_compute_nbody/README.adoc
@@ -20,4 +20,9 @@
 
 === HPP Compute shader N-Body simulation
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_compute_nbody[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/compute_nbody[Compute N-Body] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_dynamic_uniform_buffers/README.adoc
+++ b/samples/api/hpp_dynamic_uniform_buffers/README.adoc
@@ -20,4 +20,9 @@
 
 === HPP Dynamic Uniform Buffers
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_dynamic_uniform_buffers[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/dynamic_uniform_buffers[Dynamic Uniform buffers] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_hdr/README.adoc
+++ b/samples/api/hpp_hdr/README.adoc
@@ -20,4 +20,9 @@
 
 === HPP High dynamic range
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_hdr[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/hdr[High dynamic range] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_hello_triangle/README.adoc
+++ b/samples/api/hpp_hello_triangle/README.adoc
@@ -20,4 +20,9 @@
 
 === HPP Hello Triangle
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_hello_triangle[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/hello_triangle[Hello Triangle] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_hlsl_shaders/README.adoc
+++ b/samples/api/hpp_hlsl_shaders/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Using HLSL shaders in Vulkan with Vulkan-Hpp
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_hlsl_shaders[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This tutorial, along with the accompanying example code, shows how to use shaders written in the High Level Shading Language (HLSL) in Vulkan at runtime, using Vulkan-Hpp.
 
 Vulkan does not directly consume shaders in a human-readable text format, but instead uses SPIR-V as an intermediate representation.

--- a/samples/api/hpp_instancing/README.adoc
+++ b/samples/api/hpp_instancing/README.adoc
@@ -20,4 +20,9 @@
 
 === HPP Instancing
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_instancing[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/instancing[Instancing] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_separate_image_sampler/README.adoc
+++ b/samples/api/hpp_separate_image_sampler/README.adoc
@@ -21,6 +21,11 @@
 
 === HPP Separate image sampler
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_separate_image_sampler[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/separate_image_sampler[Separate image sampler] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 = Separating samplers and images

--- a/samples/api/hpp_terrain_tessellation/README.adoc
+++ b/samples/api/hpp_terrain_tessellation/README.adoc
@@ -20,4 +20,9 @@
 
 === HPP Terrain Tessellation
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_terrain_tessellation[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/terrain_tessellation[Terrain Tessellation] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_texture_loading/README.adoc
+++ b/samples/api/hpp_texture_loading/README.adoc
@@ -20,4 +20,9 @@
 
 === HPP Texture Loading
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_texture_loading[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/texture_loading[Texture loading] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_texture_mipmap_generation/README.adoc
+++ b/samples/api/hpp_texture_mipmap_generation/README.adoc
@@ -21,6 +21,11 @@
 
 === HPP Texture mipmap generation
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_texture_mipmap_generation[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/texture_mipmap_generation[Texture mipmap generation] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 = Run-time mip-map generation
@@ -230,3 +235,4 @@ vk::ImageViewCreateInfo image_view_create_info({},
                                                {vk::ImageAspectFlagBits::eColor, 0, texture.mip_levels, 0, 1});
 texture.view = get_device()->get_handle().createImageView(image_view_create_info);
 ----
+

--- a/samples/api/hpp_timestamp_queries/README.adoc
+++ b/samples/api/hpp_timestamp_queries/README.adoc
@@ -21,6 +21,11 @@
 
 === HPP timestamp queries
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_timestamp_queries[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/timestamp_queries[Timestamp queries] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 = Timestamp queries
@@ -280,3 +285,4 @@ This is pretty much the same as the `vk::CommandBuffer::writeTimestamp` function
 == Verdict
 
 Even though timestamp queries are limited due to how a GPU works, they can still be useful for profiling and finding performance GPU bottlenecks.
+ul for profiling and finding performance GPU bottlenecks.

--- a/samples/api/instancing/README.adoc
+++ b/samples/api/instancing/README.adoc
@@ -19,4 +19,9 @@
 
 === Instancing
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/instancing[Khronos Vulkan samples github repository].
+endif::[]
+
+
 Uses the instancing feature for rendering many instances of the same mesh from a single vertex buffer with variable parameters and textures.

--- a/samples/api/separate_image_sampler/README.adoc
+++ b/samples/api/separate_image_sampler/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Separating samplers and images
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/separate_image_sampler[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This tutorial, along with the accompanying example code, shows how to separate samplers and images in a Vulkan application.
 Opposite to combined image and samplers, this allows the application to freely mix an arbitrary set of samplers and images in the shader.
 

--- a/samples/api/swapchain_recreation/README.adoc
+++ b/samples/api/swapchain_recreation/README.adoc
@@ -19,6 +19,11 @@
 
 === Swapchain Recreation +
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/swapchain_recreation[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A sample that implements best practices in handling present resources and swapchain recreation, for example due to window resizing or present mode changes.
 
 Before VK_EXT_swapchain_maintenance1, there is no straightforward way to tell when a semaphore associated with a present operation can be recycled, or when a retired swapchain can be destroyed.

--- a/samples/api/terrain_tessellation/README.adoc
+++ b/samples/api/terrain_tessellation/README.adoc
@@ -19,4 +19,9 @@
 
 === Terrain Tessellation
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/terrain_tessellation[Khronos Vulkan samples github repository].
+endif::[]
+
+
 Uses a tessellation shader for rendering a terrain with dynamic level-of-detail and frustum culling.

--- a/samples/api/texture_loading/README.adoc
+++ b/samples/api/texture_loading/README.adoc
@@ -19,4 +19,9 @@
 
 === Texture loading
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/texture_loading[Khronos Vulkan samples github repository].
+endif::[]
+
+
 Loading and rendering of a 2D texture map from a file.

--- a/samples/api/texture_mipmap_generation/README.adoc
+++ b/samples/api/texture_mipmap_generation/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Run-time mip-map generation
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/texture_mipmap_generation[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Generates a complete texture mip-chain at runtime from a base image using image blits and proper image barriers.
@@ -258,4 +263,6 @@ This is specified in the `VkImageViewCreateInfo.subresourceRange.levelCount` fie
 	view.subresourceRange.layerCount     = 1;
 	view.subresourceRange.levelCount     = texture.mip_levels;
 	VK_CHECK(vkCreateImageView(device->get_handle(), &view, nullptr, &texture.view));
+----
+ nullptr, &texture.view));
 ----

--- a/samples/api/timestamp_queries/README.adoc
+++ b/samples/api/timestamp_queries/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Timestamp queries
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/timestamp_queries[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This tutorial, along with the accompanying example code, shows how to use timestamp queries to measure timings on the GPU.
 
 The sample, based on the HDR one, does multiple render passes and will use timestamp queries to get GPU timings for the different render passes.
@@ -276,3 +281,4 @@ This is pretty much the same as the `vkCmdWriteTimestamp` function used in this 
 == Verdict
 
 Even though timestamp queries are limited due to how a GPU works, they can still be useful for profiling and finding performance GPU bottlenecks.
+ul for profiling and finding performance GPU bottlenecks.

--- a/samples/extensions/README.adoc
+++ b/samples/extensions/README.adoc
@@ -18,11 +18,6 @@
 ////
 = Extension samples
 
-ifdef::site-gen-antora[]
-TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions[Khronos Vulkan samples github repository].
-endif::[]
-
-
 The goal of these samples is to demonstrate how to use a particular Vulkan extension at the API level with as little abstraction as possible.
 
 A list of all extension samples can be found link:../README.adoc#extension-samples[here].

--- a/samples/extensions/README.adoc
+++ b/samples/extensions/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Extension samples
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions[Khronos Vulkan samples github repository].
+endif::[]
+
+
 The goal of these samples is to demonstrate how to use a particular Vulkan extension at the API level with as little abstraction as possible.
 
 A list of all extension samples can be found link:../README.adoc#extension-samples[here].

--- a/samples/extensions/buffer_device_address/README.adoc
+++ b/samples/extensions/buffer_device_address/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Buffer device address
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/buffer_device_address[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Buffer device address is a very powerful and unique feature to Vulkan which is not present in any other modern graphics API.
@@ -294,3 +299,4 @@ If the `bufferDeviceAddressCaptureReplay` is not present however, tools like Ren
 == Conclusion
 
 Buffer device address is an extremely powerful feature which enables various use cases which were either impossible or very impractical before.
+e cases which were either impossible or very impractical before.

--- a/samples/extensions/calibrated_timestamps/README.adoc
+++ b/samples/extensions/calibrated_timestamps/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Calibrated Timestamps
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/calibrated_timestamps[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This sample demonstrates the extension `VK_EXT_calibrated_timestamps`.
 The calibrated timestamps profiles any given portion of code, unlike timestamp queries, which only profiles an entire graphic queue.
 

--- a/samples/extensions/color_write_enable/README.adoc
+++ b/samples/extensions/color_write_enable/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Color write enable
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/color_write_enable[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 This sample demonstrates how to use the `VK_EXT_color_write_enable` extension.

--- a/samples/extensions/conditional_rendering/README.adoc
+++ b/samples/extensions/conditional_rendering/README.adoc
@@ -17,6 +17,11 @@
 -
 ////
 = Conditional rendering
+
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering[Khronos Vulkan samples github repository].
+endif::[]
+
 :pp: {plus}{plus}
 
 image::./images/sample.png[Sample]

--- a/samples/extensions/conservative_rasterization/README.adoc
+++ b/samples/extensions/conservative_rasterization/README.adoc
@@ -19,6 +19,11 @@
 
 === Conservative Rasterization
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conservative_rasterization[Khronos Vulkan samples github repository].
+endif::[]
+
+
 *Extension*: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_EXT_conservative_rasterization[`VK_EXT_conservative_rasterization`]
 
 Uses conservative rasterization to change the way fragments are generated.

--- a/samples/extensions/debug_utils/README.adoc
+++ b/samples/extensions/debug_utils/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Vulkan Debug Utilities Extension
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/debug_utils[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 This tutorial, along with the accompanying example code, demonstrates the use of the https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_EXT_debug_utils[VK_EXT_debug_utils] extension to setup a validation layer messenger callback and pass additional debugging information to debuggers like https://renderdoc.org/[RenderDoc].
@@ -285,5 +290,8 @@ After setting these up press (4) to start the application from within RenderDoc.
 Once the sample application is running, press F12 do capture the current frame, close the application and then select the capture in RenderDoc.
 
 Once loaded you should be able to see a trace of a whole frame from that sample application along with labels and named Vulkan objects:
+
+image:./images/renderdoc_final.jpg[]
+s and named Vulkan objects:
 
 image:./images/renderdoc_final.jpg[]

--- a/samples/extensions/descriptor_buffer_basic/README.adoc
+++ b/samples/extensions/descriptor_buffer_basic/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Descriptor buffers
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/descriptor_buffer_basic[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Binding and managing descriptors in Vulkan can become pretty complex, both for the application and the driver.
@@ -253,3 +258,4 @@ vkCmdSetDescriptorBufferOffsetsEXT(draw_cmd_buffers[i], VK_PIPELINE_BIND_POINT_G
 
 With descriptor set and pipeline layouts, Vulkan decouples the shader interfaces from the application.
 And since we don't change these but only the way how we provide descriptors to the GPU, *no changes to the shaders are required*.
+haders are required*.

--- a/samples/extensions/descriptor_indexing/README.adoc
+++ b/samples/extensions/descriptor_indexing/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Descriptor indexing
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/descriptor_indexing[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Descriptor indexing is an extension which adds a *lot* of flexibility to how resources are accessed.
@@ -436,6 +441,11 @@ We end up with:
 ----
 
 Adding debug symbols to the SPIR-V helps here, but that's another topic.
+
+== Conclusion
+
+Descriptor indexing is a highly potent extension, but with great power comes great responsibility to use all debug tools available to you.
+s to the SPIR-V helps here, but that's another topic.
 
 == Conclusion
 

--- a/samples/extensions/dynamic_line_rasterization/README.adoc
+++ b/samples/extensions/dynamic_line_rasterization/README.adoc
@@ -19,6 +19,11 @@
 
 = Dynamic line rasterization
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/dynamic_line_rasterization[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::screenshot.png[]
 
 == Overview

--- a/samples/extensions/dynamic_rendering/README.adoc
+++ b/samples/extensions/dynamic_rendering/README.adoc
@@ -17,6 +17,11 @@ limitations under the License.
 ////
 = Dynamic Rendering
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/dynamic_rendering[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 This sample demonstrates how to use the `VK_KHR_dynamic_rendering` extension, which eliminates the need to create render passes and improves flexibility while developing render pipelines.

--- a/samples/extensions/extended_dynamic_state2/README.adoc
+++ b/samples/extensions/extended_dynamic_state2/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Extended dynamic state 2
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/extended_dynamic_state2[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::./images/extended_dynamic_state2_screenshot.png[Sample]
 
 == Overview
@@ -268,3 +273,4 @@ add_device_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
 
 If the https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT.html[`VkPhysicalDeviceExtendedDynamicState2FeaturesEXT`] structure is included in the pNext chain of the `VkPhysicalDeviceFeatures2` structure passed to vkGetPhysicalDeviceFeatures2, it is filled in to indicate whether each corresponding feature is supported.
 `VkPhysicalDeviceExtendedDynamicState2FeaturesEXT` can also be used in the pNext chain of `VkDeviceCreateInfo` to selectively enable these features.
+o selectively enable these features.

--- a/samples/extensions/fragment_shader_barycentric/README.adoc
+++ b/samples/extensions/fragment_shader_barycentric/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Fragment shader barycentric
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/fragment_shader_barycentric[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::./images/fragment_shader_barycentric_screenshot.png[fragment_shader_barycentric]
 
 Fragment shader barycentric feature provides support for accessing the barycentric coordinates (linear and perspective) in the fragment shader and vertex attribute with the `pervertexEXT` decoration.

--- a/samples/extensions/fragment_shading_rate/README.adoc
+++ b/samples/extensions/fragment_shading_rate/README.adoc
@@ -19,6 +19,11 @@
 
 === Fragment shading rate
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/fragment_shading_rate[Khronos Vulkan samples github repository].
+endif::[]
+
+
 *Extension*: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_fragment_shading_rate.html[`VK_KHR_fragment_shading_rate`]
 
 Uses a special framebuffer attachment to control fragment shading rates for different framebuffer regions.

--- a/samples/extensions/fragment_shading_rate_dynamic/README.adoc
+++ b/samples/extensions/fragment_shading_rate_dynamic/README.adoc
@@ -19,6 +19,11 @@
 
 == Fragment Shading Rate
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/fragment_shading_rate_dynamic[Khronos Vulkan samples github repository].
+endif::[]
+
+
 The KHR fragment shading rate extension introduces the ability to selectively render at different sample rates within the same rendered image.
 This can be useful when rendering at very high resolutions or when the frequency content is not evenly spread through the rendered image.
 This tutorial demonstrates one way of controlling that sample rate by estimating the frequency content of each pixel of the rendered image.

--- a/samples/extensions/full_screen_exclusive/README.adoc
+++ b/samples/extensions/full_screen_exclusive/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Full Screen Exclusive
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/full_screen_exclusive[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 This code sample demonstrates how to incorporate the Vulkan extension `VK_EXT_full_screen_exclusive`.

--- a/samples/extensions/graphics_pipeline_library/README.adoc
+++ b/samples/extensions/graphics_pipeline_library/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Graphics pipeline libraries
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/graphics_pipeline_library[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 The https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_graphics_pipeline_library.html[`VK_EXT_graphics_pipeline_library`] extensions allows separate compilation of different parts of the graphics pipeline.

--- a/samples/extensions/gshader_to_mshader/README.adoc
+++ b/samples/extensions/gshader_to_mshader/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Geometry shader to mesh shader
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/gshader_to_mshader[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::./images/visualization_of_normals.png[Sample]
 
 == Overview

--- a/samples/extensions/logic_op_dynamic_state/README.adoc
+++ b/samples/extensions/logic_op_dynamic_state/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Logic operations dynamic state
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/logic_op_dynamic_state[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::./images/logic_op_dynamic_state_screenshot.png[Sample]
 
 == Overview

--- a/samples/extensions/memory_budget/README.adoc
+++ b/samples/extensions/memory_budget/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Memory Budget extended features
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/memory_budget[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This sample demonstrates how to incorporate the Vulkan memory budget extension.
 Memory budget extension helps users to sample the memory budget consumption on each heap from the `physical device`, and is able to tell the `property flag` for each heap.
 Which is a proper debug tool to visualize the memory consumption in run-time.

--- a/samples/extensions/mesh_shader_culling/README.adoc
+++ b/samples/extensions/mesh_shader_culling/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Mesh Shader Culling
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/mesh_shader_culling[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::./images/mesh_shader_culling.png[Mesh Shader Culling]
 
 == Overview

--- a/samples/extensions/mesh_shading/README.adoc
+++ b/samples/extensions/mesh_shading/README.adoc
@@ -19,6 +19,11 @@
 
 == Mesh shading
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/mesh_shading[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This code sample demonstrates how to create the absolute most basic mesh shading example.
 It creates a single  triangle in a mesh shader.
 There is no vertex shader, there is only a mesh shader and a fragment shader.

--- a/samples/extensions/open_cl_interop/README.adoc
+++ b/samples/extensions/open_cl_interop/README.adoc
@@ -18,6 +18,11 @@
 ////
 = OpenCL interoperability
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/open_cl_interop[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 In certain scenarios OpenCL is used for compute, while another API is used for graphics, and interoperability between two APIs becomes important in this case.

--- a/samples/extensions/open_gl_interop/README.adoc
+++ b/samples/extensions/open_gl_interop/README.adoc
@@ -19,6 +19,11 @@
 
 === OpenGL interoperability
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/open_gl_interop[Khronos Vulkan samples github repository].
+endif::[]
+
+
 *Extensions*: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_external_memory.html[`VK_KHR_external_memory`], https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_external_semaphore.html[`VK_KHR_external_semaphore`]
 
 Render a procedural image using OpenGL and incorporate that rendered content into a Vulkan scene.

--- a/samples/extensions/patch_control_points/README.adoc
+++ b/samples/extensions/patch_control_points/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Patch control point
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/patch_control_points[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::./images/patch_control_point_screenshot.png[Sample]
 
 == Overview

--- a/samples/extensions/portability/README.adoc
+++ b/samples/extensions/portability/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Vulkan Portability Extension
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/portability[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 This tutorial, along with the accompanying example code, demonstrates the use of the https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_portability_subset[VK_KHR_portability_subset] extension.

--- a/samples/extensions/push_descriptors/README.adoc
+++ b/samples/extensions/push_descriptors/README.adoc
@@ -19,6 +19,11 @@
 
 === Push Descriptors
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/push_descriptors[Khronos Vulkan samples github repository].
+endif::[]
+
+
 *Extension*: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_push_descriptor[`VK_KHR_push_descriptor`]
 
 Push descriptors apply the push constants concept to descriptor sets.

--- a/samples/extensions/ray_queries/README.adoc
+++ b/samples/extensions/ray_queries/README.adoc
@@ -19,6 +19,11 @@
 
 === Basic ray queries
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/ray_queries[Khronos Vulkan samples github repository].
+endif::[]
+
+
 *Extensions*: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_ray_query[`VK_KHR_ray_query`], https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_acceleration_structure[`VK_KHR_acceleration_structure`]
 
 Render a sponza scene using the ray query extension.

--- a/samples/extensions/ray_tracing_basic/README.adoc
+++ b/samples/extensions/ray_tracing_basic/README.adoc
@@ -19,6 +19,11 @@
 
 === Basic hardware accelerated ray tracing
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/ray_tracing_basic[Khronos Vulkan samples github repository].
+endif::[]
+
+
 *Extensions*: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_ray_tracing_pipeline[`VK_KHR_ray_tracing_pipeline`], https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_acceleration_structure[`VK_KHR_acceleration_structure`]
 
 Render a basic scene using the official cross-vendor ray tracing extension.

--- a/samples/extensions/ray_tracing_extended/README.adoc
+++ b/samples/extensions/ray_tracing_extended/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Ray-tracing: Extended features and dynamic objects
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/ray_tracing_extended[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This code sample demonstrates how to incorporate animations into a ray-traced scene, and shows how to incorporate different types of changing objects within the acceleration structures.
 
 == Acceleration structures

--- a/samples/extensions/ray_tracing_reflection/README.adoc
+++ b/samples/extensions/ray_tracing_reflection/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Ray tracing - reflection
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/ray_tracing_reflection[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::./img1.png[]
 
 == Overview

--- a/samples/extensions/raytracing_basic/README.adoc
+++ b/samples/extensions/raytracing_basic/README.adoc
@@ -19,6 +19,11 @@
 
 === Basic hardware accelerated ray tracing
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/raytracing_basic[Khronos Vulkan samples github repository].
+endif::[]
+
+
 *Extensions*: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_ray_tracing_pipeline[`VK_KHR_ray_tracing_pipeline`], https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_acceleration_structure[`VK_KHR_acceleration_structure`]
 
 Render a basic scene using the official cross-vendor ray tracing extension.

--- a/samples/extensions/raytracing_extended/README.adoc
+++ b/samples/extensions/raytracing_extended/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Ray-tracing: Extended features and dynamic objects
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/raytracing_extended[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This code sample demonstrates how to incorporate animations into a ray-traced scene, and shows how to incorporate different types of changing objects within the acceleration structures.
 
 == Acceleration structures

--- a/samples/extensions/shader_object/README.adoc
+++ b/samples/extensions/shader_object/README.adoc
@@ -15,6 +15,11 @@
 ////
 = Shader Object
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/shader_object[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::./images/shader_object_screenshot.png[Sample]
 
 == Overview
@@ -462,3 +467,4 @@ Because of this the layer's files will always need to be somewhere accessible to
 Shader objects can be an invaluable tool for simplifying shader and state management in highly dynamic application architectures which don't lend themselves to practical implementation using pipelines.
 
 With increasingly widespread driver support augmented by the emulation layer, applications best suited to this kind of architecture can be designed around shader objects instead of pipelines with high confidence that they will achieve a user experience as good or better than what a pipeline based implementation could realistically achieve.
+d to this kind of architecture can be designed around shader objects instead of pipelines with high confidence that they will achieve a user experience as good or better than what a pipeline based implementation could realistically achieve.

--- a/samples/extensions/synchronization_2/README.adoc
+++ b/samples/extensions/synchronization_2/README.adoc
@@ -19,6 +19,11 @@
 
 === Synchronization2
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/synchronization_2[Khronos Vulkan samples github repository].
+endif::[]
+
+
 *Extension* https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_KHR_synchronization2[`VK_KHR_synchronization2`]
 
 Demonstrates the use of the reworked synchronization api introduced with `VK_KHR_synchronization2`.

--- a/samples/extensions/timeline_semaphore/README.adoc
+++ b/samples/extensions/timeline_semaphore/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Timeline semaphore
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/timeline_semaphore[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 In Vulkan 1.0, we were introduced to `VkSemaphore` which is able to synchronize work between Vulkan queues.
@@ -359,6 +364,10 @@ ApiVulkanSample::submit_frame();
 
 Timeline semaphores grants a lot of flexibility to applications.
 With modern approaches of task graphs, many threads and free flowing synchronization, timeline semaphores simplify a lot of things and removes the need for emulating a similar concept with binary semaphores and fences.
+
+Be careful with out-of-order submissions.
+There are various pitfalls with this approach which have been outlined in this sample.
+s.
 
 Be careful with out-of-order submissions.
 There are various pitfalls with this approach which have been outlined in this sample.

--- a/samples/extensions/vertex_dynamic_state/README.adoc
+++ b/samples/extensions/vertex_dynamic_state/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Vertex input dynamic state
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/vertex_dynamic_state[Khronos Vulkan samples github repository].
+endif::[]
+
+
 image::./images/sample.png[Sample]
 
 == Overview

--- a/samples/performance/16bit_arithmetic/README.adoc
+++ b/samples/performance/16bit_arithmetic/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Using explicit 16-bit arithmetic in applications
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/16bit_arithmetic[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 In the world of mobile GPUs, `mediump` has long been used as a critical optimization for performance and bandwidth.

--- a/samples/performance/16bit_storage_input_output/README.adoc
+++ b/samples/performance/16bit_storage_input_output/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Using 16-bit storage InputOutput feature to reduce bandwidth on tile-based architectures
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/16bit_storage_input_output[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 On some tile-based deferred renderers (TBDR), such as Arm Mali GPUs, vertex shading and fragment shading is split into two distinct stages.

--- a/samples/performance/README.adoc
+++ b/samples/performance/README.adoc
@@ -18,11 +18,6 @@
 ////
 = Performance samples
 
-ifdef::site-gen-antora[]
-TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance[Khronos Vulkan samples github repository].
-endif::[]
-
-
 The goal of these samples is to demonstrate how to use certain features and functions to achieve optimal performance.
 To visualize this, they also include real-time profiling information.
 

--- a/samples/performance/README.adoc
+++ b/samples/performance/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Performance samples
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance[Khronos Vulkan samples github repository].
+endif::[]
+
+
 The goal of these samples is to demonstrate how to use certain features and functions to achieve optimal performance.
 To visualize this, they also include real-time profiling information.
 

--- a/samples/performance/afbc/README.adoc
+++ b/samples/performance/afbc/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Enabling AFBC in your Vulkan Application
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/afbc[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 AFBC (Arm Frame Buffer Compression) is a real-time lossless compression algorithm found in Arm Mali GPUs, designed to tackle the ever-growing demand for higher resolution graphics.

--- a/samples/performance/async_compute/README.adoc
+++ b/samples/performance/async_compute/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Using async compute to saturate GPU
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/async_compute[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Most Vulkan implementations expose multiple Vulkan queues which the application can make use of at any one time.

--- a/samples/performance/command_buffer_usage/README.adoc
+++ b/samples/performance/command_buffer_usage/README.adoc
@@ -17,6 +17,11 @@
 -
 ////
 = Command buffer usage and multi-threaded recording
+
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/command_buffer_usage[Khronos Vulkan samples github repository].
+endif::[]
+
 :pp: {plus}{plus}
 
 == Overview

--- a/samples/performance/constant_data/README.adoc
+++ b/samples/performance/constant_data/README.adoc
@@ -17,6 +17,11 @@
 -
 ////
 = *Constant data in Vulkan*
+
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/constant_data[Khronos Vulkan samples github repository].
+endif::[]
+
 :pp: {plus}{plus}
 
 == *Overview*
@@ -447,5 +452,8 @@ A few different stats are affected in the Mali GPU by using this, but the main t
 *Impact*
 
 * Failing to use the correct method of constant data will negatively impact performance, causing either reduced FPS and/or increased BW and load/store activity.
+* On Mali, register mapped uniforms are effectively free.
+Any spilling to buffers in memory will increase load/store cache accesses to the per thread uniform fetches.
+ reduced FPS and/or increased BW and load/store activity.
 * On Mali, register mapped uniforms are effectively free.
 Any spilling to buffers in memory will increase load/store cache accesses to the per thread uniform fetches.

--- a/samples/performance/descriptor_management/README.adoc
+++ b/samples/performance/descriptor_management/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Descriptor and buffer management
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/descriptor_management[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 An application using Vulkan will have to implement a system to manage descriptor pools and sets.

--- a/samples/performance/hpp_pipeline_cache/README.adoc
+++ b/samples/performance/hpp_pipeline_cache/README.adoc
@@ -17,6 +17,11 @@
 -
 ////
 = HPP Pipeline Management
+
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/hpp_pipeline_cache[Khronos Vulkan samples github repository].
+endif::[]
+
 :pp: {plus}{plus}
 
 A transcoded version of the performance sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/performance/pipeline_cache[Pipeline Cache] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.

--- a/samples/performance/hpp_swapchain_images/README.adoc
+++ b/samples/performance/hpp_swapchain_images/README.adoc
@@ -21,6 +21,11 @@
 
 === HPP Swapchain Images
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/hpp_swapchain_images[Khronos Vulkan samples github repository].
+endif::[]
+
+
 A transcoded version of the performance sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/performance/swapchain_images[Swapchain Images] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 = Choosing the right number of swapchain images

--- a/samples/performance/layout_transitions/README.adoc
+++ b/samples/performance/layout_transitions/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Layout transitions
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/layout_transitions[Khronos Vulkan samples github repository].
+endif::[]
+
+
 Vulkan requires the application to manage image layouts, so that all render pass attachments are in the correct layout when the render pass begins.
 This is usually done using pipeline barriers or the `initialLayout` and `finalLayout` parameters of the render pass.
 

--- a/samples/performance/msaa/README.adoc
+++ b/samples/performance/msaa/README.adoc
@@ -18,6 +18,11 @@
 ////
 = MSAA (Multisample anti-aliasing)
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/msaa[Khronos Vulkan samples github repository].
+endif::[]
+
+
 Aliasing is the result of under-sampling a signal.
 In graphics this means computing the color of a pixel at a resolution that results in artifacts, commonly jaggies at model edges.
 Multisample anti-aliasing (MSAA) is an efficient technique that reduces pixel sampling error.

--- a/samples/performance/multi_draw_indirect/README.adoc
+++ b/samples/performance/multi_draw_indirect/README.adoc
@@ -18,6 +18,11 @@
 ////
 = GPU Rendering and Multi-Draw Indirect
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/multi_draw_indirect[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This sample demonstrates how to reduce CPU usage by offloading draw call generation and frustum culling to the GPU.
 
 == Draw Call Generation

--- a/samples/performance/multithreading_render_passes/README.adoc
+++ b/samples/performance/multithreading_render_passes/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Multi-threaded recording with multiple render passes
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/multithreading_render_passes[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Ideally you render all stages of your frame in a single render pass.

--- a/samples/performance/pipeline_barriers/README.adoc
+++ b/samples/performance/pipeline_barriers/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Using pipeline barriers efficiently
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/pipeline_barriers[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Vulkan gives the application significant control over memory access for resources.

--- a/samples/performance/pipeline_cache/README.adoc
+++ b/samples/performance/pipeline_cache/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Pipeline Management
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/pipeline_cache[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Vulkan gives applications the ability to save internal representation of a pipeline (graphics or compute) to enable recreating the same pipeline later.

--- a/samples/performance/render_passes/README.adoc
+++ b/samples/performance/render_passes/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Appropriate use of render pass attachments
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/render_passes[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Vulkan render-passes use attachments to describe input and output render targets.

--- a/samples/performance/specialization_constants/README.adoc
+++ b/samples/performance/specialization_constants/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Utilizing Specialization Constants
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/specialization_constants[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Vulkan exposes a number of methods for setting values within shader code during run-time, this includes UBOs and Specialization Constants.

--- a/samples/performance/subpasses/README.adoc
+++ b/samples/performance/subpasses/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Subpasses
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/subpasses[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Vulkan introduces the concept of _subpasses_ to subdivide a single xref:../render_passes/README.adoc[render pass] into separate logical phases.

--- a/samples/performance/surface_rotation/README.adoc
+++ b/samples/performance/surface_rotation/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Appropriate use of surface rotation
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Mobile devices can be rotated, therefore the logical orientation of the application window and the physical orientation of the display may not match.
@@ -300,3 +305,4 @@ This may require use of the GPU or a dedicated 2D block on some systems which ca
 *Debugging*
 
 * You may use a system profiler such as Streamline to spot extra memory loads in the GPU counters, either as a direct effect (GPU composition) or as a side-effect (memory pressure).
+s a direct effect (GPU composition) or as a side-effect (memory pressure).

--- a/samples/performance/swapchain_images/README.adoc
+++ b/samples/performance/swapchain_images/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Choosing the right number of swapchain images
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/swapchain_images[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 Vulkan gives the application some significant control over the number of swapchain images to be created.

--- a/samples/performance/texture_compression_basisu/README.adoc
+++ b/samples/performance/texture_compression_basisu/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Using Basis Universal supercompressed GPU texture codec with Vulkan
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/texture_compression_basisu[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 This tutorial, along with the accompanying example code, demonstrates how to use Basis universal supercompressed GPU textures in a Vulkan application.
@@ -260,3 +265,4 @@ You can also zoom in and rotate the image to see the effect of different input a
 
 NOTE: Transcoding speed suffers a lot in debug builds.
 For best performance, running a release build is advised.
+elease build is advised.

--- a/samples/performance/texture_compression_comparison/README.adoc
+++ b/samples/performance/texture_compression_comparison/README.adoc
@@ -19,4 +19,9 @@
 
 == Texture compression comparison
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/texture_compression_comparison[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This sample demonstrates how to use different types of compressed GPU textures in a Vulkan application, and shows the timing benefits of each.

--- a/samples/performance/wait_idle/README.adoc
+++ b/samples/performance/wait_idle/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Synchronizing the CPU and GPU
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/wait_idle[Khronos Vulkan samples github repository].
+endif::[]
+
+
 == Overview
 
 This sample compares two methods for synchronizing between the CPU and GPU, `WaitIdle` and `Fences` demonstrating which one is the best option in order to avoid stalling.

--- a/samples/tooling/README.adoc
+++ b/samples/tooling/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Tooling samples
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/tooling[Khronos Vulkan samples github repository].
+endif::[]
+
+
 The goal of these samples is to demonstrate how to use tooling features that are not directly part of Vulkan, but e.g.
 provided by the LunarG Vulkan SDK.
 

--- a/samples/tooling/README.adoc
+++ b/samples/tooling/README.adoc
@@ -18,11 +18,6 @@
 ////
 = Tooling samples
 
-ifdef::site-gen-antora[]
-TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/tooling[Khronos Vulkan samples github repository].
-endif::[]
-
-
 The goal of these samples is to demonstrate how to use tooling features that are not directly part of Vulkan, but e.g.
 provided by the LunarG Vulkan SDK.
 

--- a/samples/tooling/profiles/README.adoc
+++ b/samples/tooling/profiles/README.adoc
@@ -18,6 +18,11 @@
 ////
 = Using Vulkan profiles
 
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/tooling/profiles[Khronos Vulkan samples github repository].
+endif::[]
+
+
 This sample demonstrates the usage of the https://github.com/KhronosGroup/Vulkan-Profiles[Vulkan Profiles Library].
 Profiles define a common requirement baseline of properties, features, extensions, etc.
 to make Vulkan applications more portable.


### PR DESCRIPTION
## Description

This PR adds a highlighted "tip" block to every sample readme that links to the github repository folder. This makes it easy to jump from the docs site right into the code:

![image](https://github.com/KhronosGroup/Vulkan-Samples/assets/10283127/81937a94-d545-4178-a1ab-f0fcc79d37d0)

These blocks use asciidocs define feature and are as such only visible when viewing the readme files in an Antora-generated site. They're not visible in the github preview. I also added that block to the template readme.

**This is a pure documentation PR that does not change any sample code.**

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
