### PR TITLE
Documentation format fixes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,36 +19,23 @@
 = Vulkan Samples
 // omit in toc
 :pp: {plus}{plus}
+ifndef::site-gen-antora[]
+:toc:
+endif::[]
 
 image::banner.jpg[Vulkan Samples banner]
 
-== Contents
-// omit in toc
-
-* <<renaming-default-branch,Renaming Default Branch>>
-* <<introduction,Introduction>>
- ** <<goals,Goals>>
-* <<samples,Samples>>
-* <<general-information,General information>>
-* <<setup,Setup>>
-* <<build,Build>>
- ** <<supported-platforms,Supported Platforms>>
-* <<usage,Usage>>
-* <<tests,Tests>>
-* <<license,License>>
- ** <<trademarks,Trademarks>>
-* <<contributions,Contributions>>
-* <<related-resources,Related resources>>
-
+ifndef::site-gen-antora[]
 == Renaming Default Branch
 
 We have recently transitioned the repository to use the `main` branch by default.
 All remote git usage is handled automatically.
 To update your local repository to use main please use the following commands
 
-____
+----
 git branch -m master main git fetch origin git branch -u origin/main main git remote set-head origin -a
-____
+----
+endif::[]
 
 == Introduction
 

--- a/antora/modules/ROOT/nav.adoc
+++ b/antora/modules/ROOT/nav.adoc
@@ -31,7 +31,7 @@
 ** xref:samples/api/hlsl_shaders/README.adoc[HLSL Shaders]
 *** xref:samples/api/hpp_hlsl_shaders/README.adoc[HLSL Shaders (Vulkan.hpp)]
 ** xref:samples/api/instancing/README.adoc[Instancing]
-*** xref:samples/api/hpp_instancing/README.adoc[Innstancing (Vulkan.hpp)]
+*** xref:samples/api/hpp_instancing/README.adoc[Instancing (Vulkan.hpp)]
 ** xref:samples/api/separate_image_sampler/README.adoc[Separate image sampler]
 *** xref:samples/api/hpp_separate_image_sampler/README.adoc[Separate image sampler (Vulkan.hpp)]
 ** xref:samples/api/terrain_tessellation/README.adoc[Terrain tessellation]

--- a/docs/build.adoc
+++ b/docs/build.adoc
@@ -19,39 +19,9 @@
 = Build Guides
 // omit in toc
 :pp: {plus}{plus}
-
-== Contents
-// omit in toc
-
-* <<cmake-options,CMake Options>>
- ** <<vkb_sample_name,VKB_<sample_name>>>
- ** <<vkb_build_samples,VKB_BUILD_SAMPLES>>
- ** <<vkb_build_tests,VKB_BUILD_TESTS>>
- ** <<vkb_validation_layers,VKB_VALIDATION_LAYERS>>
- ** <<vkb_validation_layers_gpu_assisted,VKB_VALIDATION_LAYERS_GPU_ASSISTED>>
- ** <<vkb_vulkan_debug,VKB_VULKAN_DEBUG>>
- ** <<vkb_warnings_as_errors,VKB_WARNINGS_AS_ERRORS>>
-* <<quality-assurance,Quality Assurance>>
-* <<3d-models,3D models>>
-* <<performance-data,Performance data>>
-* <<windows,Windows>>
- ** <<dependencies,Dependencies>>
- ** <<clang-format-and-visual-studio,Clang Format and Visual Studio>>
- ** <<build-with-cmake,Build with CMake>>
-* <<linux,Linux>>
- ** <<dependencies-1,Dependencies>>
- ** <<build-with-cmake-1,Build with CMake>>
-* <<macos,macOS>>
- ** <<dependencies-2,Dependencies>>
- ** <<build-with-cmake-2,Build with CMake>>
-* <<android,Android>>
- ** <<dependencies-3,Dependencies>>
- ** <<build-with-gradle,Build with Gradle>>
-  *** <<generate-the-gradle-project,Generate the gradle project>>
-  *** <<install-dependencies,Install dependencies>>
-  *** <<build-the-project,Build the project>>
-  *** <<install-the-apk-on-the-device,Install the apk on the device>>
- ** <<build-with-android-studio,Build with Android Studio>>
+ifndef::site-gen-antora[]
+:toc:
+endif::[]
 
 == CMake Options
 

--- a/samples/api/hpp_compute_nbody/README.adoc
+++ b/samples/api/hpp_compute_nbody/README.adoc
@@ -24,5 +24,4 @@ ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_compute_nbody[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/compute_nbody[Compute N-Body] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/compute_nbody[Compute N-Body] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_dynamic_uniform_buffers/README.adoc
+++ b/samples/api/hpp_dynamic_uniform_buffers/README.adoc
@@ -24,5 +24,4 @@ ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_dynamic_uniform_buffers[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/dynamic_uniform_buffers[Dynamic Uniform buffers] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/dynamic_uniform_buffers[Dynamic Uniform buffers] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_hdr/README.adoc
+++ b/samples/api/hpp_hdr/README.adoc
@@ -24,5 +24,4 @@ ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_hdr[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/hdr[High dynamic range] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/hdr[High dynamic range] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_hello_triangle/README.adoc
+++ b/samples/api/hpp_hello_triangle/README.adoc
@@ -24,5 +24,4 @@ ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_hello_triangle[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/hello_triangle[Hello Triangle] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/hello_triangle[Hello Triangle] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_hlsl_shaders/README.adoc
+++ b/samples/api/hpp_hlsl_shaders/README.adoc
@@ -22,6 +22,7 @@ ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_hlsl_shaders[Khronos Vulkan samples github repository].
 endif::[]
 
+NOTE: This is a transcoded version of the API sample that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 This tutorial, along with the accompanying example code, shows how to use shaders written in the High Level Shading Language (HLSL) in Vulkan at runtime, using Vulkan-Hpp.
 

--- a/samples/api/hpp_instancing/README.adoc
+++ b/samples/api/hpp_instancing/README.adoc
@@ -24,5 +24,4 @@ ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_instancing[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/instancing[Instancing] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/instancing[Instancing] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_separate_image_sampler/README.adoc
+++ b/samples/api/hpp_separate_image_sampler/README.adoc
@@ -19,18 +19,13 @@
 :doctype: book
 :pp: {plus}{plus}
 
-=== HPP Separate image sampler
+= Separating samplers and images with Vulkan-Hpp
 
 ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_separate_image_sampler[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/separate_image_sampler[Separate image sampler] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
-
-= Separating samplers and images
-
-This is the tutorial as written in https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/separate_image_sampler[Separate image sampler], with code transcoded to functions and classes from vulkan.hpp.
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/separate_image_sampler[Separate image sampler] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 This tutorial, along with the accompanying example code, shows how to separate samplers and images in a Vulkan application.
 Opposite to combined image and samplers, this allows the application to freely mix an arbitrary set of samplers and images in the shader.

--- a/samples/api/hpp_terrain_tessellation/README.adoc
+++ b/samples/api/hpp_terrain_tessellation/README.adoc
@@ -18,11 +18,10 @@
 ////
 :pp: {plus}{plus}
 
-=== HPP Terrain Tessellation
+=== Terrain Tessellation with Vulkan-Hpp
 
 ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_terrain_tessellation[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/terrain_tessellation[Terrain Tessellation] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/terrain_tessellation[Terrain Tessellation] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_texture_loading/README.adoc
+++ b/samples/api/hpp_texture_loading/README.adoc
@@ -18,11 +18,10 @@
 ////
 :pp: {plus}{plus}
 
-=== HPP Texture Loading
+=== Texture Loading with Vulkan-Hpp 
 
 ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_texture_loading[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/texture_loading[Texture loading] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/texture_loading[Texture loading] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.

--- a/samples/api/hpp_texture_mipmap_generation/README.adoc
+++ b/samples/api/hpp_texture_mipmap_generation/README.adoc
@@ -19,20 +19,15 @@
 :doctype: book
 :pp: {plus}{plus}
 
-=== HPP Texture mipmap generation
+= Run-time mip-map generation with Vulkan-Hpp
 
 ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_texture_mipmap_generation[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/texture_mipmap_generation[Texture mipmap generation] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
-
-= Run-time mip-map generation
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/texture_mipmap_generation[Texture mipmap generation] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 == Overview
-
-This is the readme as written in https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/texture_mipmap_generation[Texture mipmap generation], with code transcoded to functions and classes from vulkan.hpp.
 
 Generates a complete texture mip-chain at runtime from a base image using image blits and proper image barriers.
 

--- a/samples/api/hpp_timestamp_queries/README.adoc
+++ b/samples/api/hpp_timestamp_queries/README.adoc
@@ -19,18 +19,13 @@
 :doctype: book
 :pp: {plus}{plus}
 
-=== HPP timestamp queries
+= Timestamp queries with Vulkan-Hpp
 
 ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/api/hpp_timestamp_queries[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/timestamp_queries[Timestamp queries] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
-
-= Timestamp queries
-
-This is the tutorial as written in https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/timestamp_queries[Timestamp queries], with code transcoded to functions and classes from vulkan.hpp.
+NOTE: A transcoded version of the API sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api/timestamp_queries[Timestamp queries] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 This tutorial, along with the accompanying example code, shows how to use timestamp queries to measure timings on the GPU.
 

--- a/samples/api/texture_mipmap_generation/README.adoc
+++ b/samples/api/texture_mipmap_generation/README.adoc
@@ -252,17 +252,15 @@ This is specified in the `VkImageViewCreateInfo.subresourceRange.levelCount` fie
 
 [,cpp]
 ----
-	VkImageViewCreateInfo view           = vkb::initializers::image_view_create_info();
-	view.image                           = texture.image;
-	view.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-	view.format                          = format;
-	view.components                      = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
-	view.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
-	view.subresourceRange.baseMipLevel   = 0;
-	view.subresourceRange.baseArrayLayer = 0;
-	view.subresourceRange.layerCount     = 1;
-	view.subresourceRange.levelCount     = texture.mip_levels;
-	VK_CHECK(vkCreateImageView(device->get_handle(), &view, nullptr, &texture.view));
-----
- nullptr, &texture.view));
+VkImageViewCreateInfo view           = vkb::initializers::image_view_create_info();
+view.image                           = texture.image;
+view.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
+view.format                          = format;
+view.components                      = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
+view.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+view.subresourceRange.baseMipLevel   = 0;
+view.subresourceRange.baseArrayLayer = 0;
+view.subresourceRange.layerCount     = 1;
+view.subresourceRange.levelCount     = texture.mip_levels;
+VK_CHECK(vkCreateImageView(device->get_handle(), &view, nullptr, &texture.view));
 ----

--- a/samples/performance/hpp_pipeline_cache/README.adoc
+++ b/samples/performance/hpp_pipeline_cache/README.adoc
@@ -16,7 +16,7 @@
 - limitations under the License.
 -
 ////
-= HPP Pipeline Management
+= Pipeline Management with Vulkan-Hpp
 
 ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/hpp_pipeline_cache[Khronos Vulkan samples github repository].
@@ -24,7 +24,7 @@ endif::[]
 
 :pp: {plus}{plus}
 
-A transcoded version of the performance sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/performance/pipeline_cache[Pipeline Cache] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+NOTE: A transcoded version of the performance sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/performance/pipeline_cache[Pipeline Cache] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 == Overview
 

--- a/samples/performance/hpp_swapchain_images/README.adoc
+++ b/samples/performance/hpp_swapchain_images/README.adoc
@@ -19,16 +19,13 @@
 :doctype: book
 :pp: {plus}{plus}
 
-=== HPP Swapchain Images
+= Choosing the right number of swapchain images Vulkan-Hpp
 
 ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/hpp_swapchain_images[Khronos Vulkan samples github repository].
 endif::[]
 
-
-A transcoded version of the performance sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/performance/swapchain_images[Swapchain Images] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
-
-= Choosing the right number of swapchain images
+NOTE: A transcoded version of the performance sample https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/performance/swapchain_images[Swapchain Images] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 == Overview
 

--- a/samples/vulkan_basics.adoc
+++ b/samples/vulkan_basics.adoc
@@ -19,24 +19,9 @@
 = Vulkan essentials
 // omit in toc
 
-== Contents
-// omit in toc
-
-* <<low-level-graphics-for-power-users,Low level graphics for power users>>
-* <<opengl-es-vs-vulkan,OpenGL ES vs.
-Vulkan>>
- ** <<state-management,State management>>
- ** <<api-execution-model,API execution model>>
- ** <<api-threading-model,API threading model>>
- ** <<api-error-checking,API error checking>>
- ** <<render-pass-abstraction,Render pass abstraction>>
- ** <<memory-allocation,Memory allocation>>
- ** <<memory-usage,Memory usage>>
-* <<what-to-expect,What to expect>>
- ** <<neutral,Neutral>>
- ** <<advantages,Advantages>>
- ** <<disadvantages,Disadvantages>>
-* <<conclusions,Conclusions>>
+ifndef::site-gen-antora[]
+:toc:
+endif::[]
 
 == Low level graphics for power users
 


### PR DESCRIPTION
## Description

This PR adds some (mostly minor) documentation formatting issues:

- Fixed the caption levels for hpp sample readmes (which resulted in odd formatting in the Antora site)
- Added a consistent note block to all hpp sample readmes that let's people know this is using Vulkan.hpp
- Removed broken table of contents for some pages (e.g. the main repo) and use asciidocs auto TOC generation, for the Antora build, TOCs are disabled completely because Antora already has a right-hand side navigation
- Fixes some minor formatting issues in navigation and the texture mip map generation tutorial


**This is a pure documentation fix**

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
 