### PR TITLE
Change vkb::scene_graph::component::HPPImage from a facade over vkb::sg::Image to a self-contained class using Vulkan-Hpp.

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -192,7 +192,8 @@ set(SCENE_GRAPH_COMPONENT_FILES
     scene_graph/components/transform.cpp
     scene_graph/components/image/astc.cpp
     scene_graph/components/image/ktx.cpp
-    scene_graph/components/image/stb.cpp)
+    scene_graph/components/image/stb.cpp
+    scene_graph/components/hpp_image.cpp)
 
 set(SCENE_GRAPH_SCRIPTS_FILES
     # Header Files

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -846,7 +846,7 @@ vk::ImageLayout HPPApiVulkanSample::descriptor_type_to_image_layout(vk::Descript
 	}
 }
 
-HPPTexture HPPApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::ContentType content_type, vk::SamplerAddressMode address_mode)
+HPPTexture HPPApiVulkanSample::load_texture(const std::string &file, vkb::scene_graph::components::HPPImage::ContentType content_type, vk::SamplerAddressMode address_mode)
 {
 	HPPTexture texture;
 
@@ -927,7 +927,7 @@ HPPTexture HPPApiVulkanSample::load_texture(const std::string &file, vkb::sg::Im
 	return texture;
 }
 
-HPPTexture HPPApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type, vk::SamplerAddressMode address_mode)
+HPPTexture HPPApiVulkanSample::load_texture_array(const std::string &file, vkb::scene_graph::components::HPPImage::ContentType content_type, vk::SamplerAddressMode address_mode)
 {
 	HPPTexture texture{};
 
@@ -1011,7 +1011,7 @@ HPPTexture HPPApiVulkanSample::load_texture_array(const std::string &file, vkb::
 	return texture;
 }
 
-HPPTexture HPPApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type)
+HPPTexture HPPApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::scene_graph::components::HPPImage::ContentType content_type)
 {
 	HPPTexture texture{};
 

--- a/framework/hpp_api_vulkan_sample.h
+++ b/framework/hpp_api_vulkan_sample.h
@@ -168,7 +168,7 @@ class HPPApiVulkanSample : public vkb::HPPVulkanSample
 	 * @param address_mode The address mode to use in u-, v-, and w-direction. Defaults to /c vk::SamplerAddressMode::eRepeat.
 	 */
 	HPPTexture
-	    load_texture(const std::string &file, vkb::sg::Image::ContentType content_type, vk::SamplerAddressMode address_mode = vk::SamplerAddressMode::eRepeat);
+	    load_texture(const std::string &file, vkb::scene_graph::components::HPPImage::ContentType content_type, vk::SamplerAddressMode address_mode = vk::SamplerAddressMode::eRepeat);
 
 	/**
 	 * @brief Loads in a ktx 2D texture array
@@ -176,16 +176,16 @@ class HPPApiVulkanSample : public vkb::HPPVulkanSample
 	 * @param content_type The type of content in the image file
 	 * @param address_mode The address mode to use in u-, v-, and w-direction. Defaults to /c vk::SamplerAddressMode::eClampToEdge.
 	 */
-	HPPTexture load_texture_array(const std::string          &file,
-	                              vkb::sg::Image::ContentType content_type,
-	                              vk::SamplerAddressMode      address_mode = vk::SamplerAddressMode::eClampToEdge);
+	HPPTexture load_texture_array(const std::string                                  &file,
+	                              vkb::scene_graph::components::HPPImage::ContentType content_type,
+	                              vk::SamplerAddressMode                              address_mode = vk::SamplerAddressMode::eClampToEdge);
 
 	/**
 	 * @brief Loads in a ktx 2D texture cubemap
 	 * @param file The filename of the texture to load
 	 * @param content_type The type of content in the image file
 	 */
-	HPPTexture load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type);
+	HPPTexture load_texture_cubemap(const std::string &file, vkb::scene_graph::components::HPPImage::ContentType content_type);
 
 	/**
 	 * @brief Loads in a single model from a GLTF file

--- a/framework/scene_graph/components/hpp_image.cpp
+++ b/framework/scene_graph/components/hpp_image.cpp
@@ -1,0 +1,367 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hpp_image.h"
+
+#include "common/hpp_utils.h"
+#include "platform/filesystem.h"
+#include "scene_graph/components/image/astc.h"
+#include "scene_graph/components/image/ktx.h"
+#include "scene_graph/components/image/stb.h"
+#include <stb_image_resize.h>
+#include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_format_traits.hpp>
+
+namespace vkb
+{
+namespace scene_graph
+{
+namespace components
+{
+bool is_astc(const vk::Format format)
+{
+	return strncmp(vk::compressionScheme(format), "ASTC", 4) == 0;
+}
+
+HPPImage::HPPImage(const std::string &name, std::vector<uint8_t> &&d, std::vector<vkb::scene_graph::components::HPPMipmap> &&m) :
+    Component{name},
+    data{std::move(d)},
+    format{vk::Format::eR8G8B8A8Unorm},
+    mipmaps{std::move(m)}
+{}
+
+std::unique_ptr<vkb::scene_graph::components::HPPImage> HPPImage::load(const std::string &name, const std::string &uri,
+                                                                       ContentType content_type)
+{
+	std::unique_ptr<vkb::scene_graph::components::HPPImage> image{nullptr};
+
+	auto data = fs::read_asset(uri);
+
+	// Get extension
+	auto extension = get_extension(uri);
+
+	// the derived classes Stb, Astc, and Ktx are not transcoded (yet), so we need some more complex casting here...
+	if (extension == "png" || extension == "jpg")
+	{
+		image = std::unique_ptr<vkb::scene_graph::components::HPPImage>(reinterpret_cast<vkb::scene_graph::components::HPPImage *>(
+		    std::make_unique<vkb::sg::Stb>(name, data, static_cast<vkb::sg::Image::ContentType>(content_type)).release()));
+	}
+	else if (extension == "astc")
+	{
+		image = std::unique_ptr<vkb::scene_graph::components::HPPImage>(
+		    reinterpret_cast<vkb::scene_graph::components::HPPImage *>(std::make_unique<vkb::sg::Astc>(name, data).release()));
+	}
+	else if ((extension == "ktx") || (extension == "ktx2"))
+	{
+		image = std::unique_ptr<vkb::scene_graph::components::HPPImage>(reinterpret_cast<vkb::scene_graph::components::HPPImage *>(
+		    std::make_unique<vkb::sg::Ktx>(name, data, static_cast<vkb::sg::Image::ContentType>(content_type)).release()));
+	}
+
+	return image;
+}
+
+std::type_index HPPImage::get_type()
+{
+	return typeid(HPPImage);
+}
+
+void HPPImage::clear_data()
+{
+	data.clear();
+	data.shrink_to_fit();
+}
+
+void HPPImage::coerce_format_to_srgb()
+{
+	// When the color-space of a loaded image is unknown (from KTX1 for example) we
+	// may want to assume that the loaded data is in sRGB format (since it usually is).
+	// In those cases, this helper will get called which will force an existing unorm
+	// format to become an srgb format where one exists. If none exist, the format will
+	// remain unmodified.
+	switch (format)
+	{
+		case vk::Format::eR8Unorm:
+			format = vk::Format::eR8Srgb;
+			break;
+		case vk::Format::eR8G8Unorm:
+			format = vk::Format::eR8G8Srgb;
+			break;
+		case vk::Format::eR8G8B8Unorm:
+			format = vk::Format::eR8G8B8Srgb;
+			break;
+		case vk::Format::eB8G8R8Unorm:
+			format = vk::Format::eB8G8R8Srgb;
+			break;
+		case vk::Format::eR8G8B8A8Unorm:
+			format = vk::Format::eR8G8B8A8Srgb;
+			break;
+		case vk::Format::eB8G8R8A8Unorm:
+			format = vk::Format::eB8G8R8A8Srgb;
+			break;
+		case vk::Format::eA8B8G8R8UnormPack32:
+			format = vk::Format::eA8B8G8R8SrgbPack32;
+			break;
+		case vk::Format::eBc1RgbUnormBlock:
+			format = vk::Format::eBc1RgbSrgbBlock;
+			break;
+		case vk::Format::eBc1RgbaUnormBlock:
+			format = vk::Format::eBc1RgbaSrgbBlock;
+			break;
+		case vk::Format::eBc2UnormBlock:
+			format = vk::Format::eBc2SrgbBlock;
+			break;
+		case vk::Format::eBc3UnormBlock:
+			format = vk::Format::eBc3SrgbBlock;
+			break;
+		case vk::Format::eBc7UnormBlock:
+			format = vk::Format::eBc7SrgbBlock;
+			break;
+		case vk::Format::eEtc2R8G8B8UnormBlock:
+			format = vk::Format::eEtc2R8G8B8SrgbBlock;
+			break;
+		case vk::Format::eEtc2R8G8B8A1UnormBlock:
+			format = vk::Format::eEtc2R8G8B8A1SrgbBlock;
+			break;
+		case vk::Format::eEtc2R8G8B8A8UnormBlock:
+			format = vk::Format::eEtc2R8G8B8A8SrgbBlock;
+			break;
+		case vk::Format::eAstc4x4UnormBlock:
+			format = vk::Format::eAstc4x4SrgbBlock;
+			break;
+		case vk::Format::eAstc5x4UnormBlock:
+			format = vk::Format::eAstc5x4SrgbBlock;
+			break;
+		case vk::Format::eAstc5x5UnormBlock:
+			format = vk::Format::eAstc5x5SrgbBlock;
+			break;
+		case vk::Format::eAstc6x5UnormBlock:
+			format = vk::Format::eAstc6x5SrgbBlock;
+			break;
+		case vk::Format::eAstc6x6UnormBlock:
+			format = vk::Format::eAstc6x6SrgbBlock;
+			break;
+		case vk::Format::eAstc8x5UnormBlock:
+			format = vk::Format::eAstc8x5SrgbBlock;
+			break;
+		case vk::Format::eAstc8x6UnormBlock:
+			format = vk::Format::eAstc8x6SrgbBlock;
+			break;
+		case vk::Format::eAstc8x8UnormBlock:
+			format = vk::Format::eAstc8x8SrgbBlock;
+			break;
+		case vk::Format::eAstc10x5UnormBlock:
+			format = vk::Format::eAstc10x5SrgbBlock;
+			break;
+		case vk::Format::eAstc10x6UnormBlock:
+			format = vk::Format::eAstc10x6SrgbBlock;
+			break;
+		case vk::Format::eAstc10x8UnormBlock:
+			format = vk::Format::eAstc10x8SrgbBlock;
+			break;
+		case vk::Format::eAstc10x10UnormBlock:
+			format = vk::Format::eAstc10x10SrgbBlock;
+			break;
+		case vk::Format::eAstc12x10UnormBlock:
+			format = vk::Format::eAstc12x10SrgbBlock;
+			break;
+		case vk::Format::eAstc12x12UnormBlock:
+			format = vk::Format::eAstc12x12SrgbBlock;
+			break;
+		case vk::Format::ePvrtc12BppUnormBlockIMG:
+			format = vk::Format::ePvrtc12BppSrgbBlockIMG;
+			break;
+		case vk::Format::ePvrtc14BppUnormBlockIMG:
+			format = vk::Format::ePvrtc14BppSrgbBlockIMG;
+			break;
+		case vk::Format::ePvrtc22BppUnormBlockIMG:
+			format = vk::Format::ePvrtc22BppSrgbBlockIMG;
+			break;
+		case vk::Format::ePvrtc24BppUnormBlockIMG:
+			format = vk::Format::ePvrtc24BppSrgbBlockIMG;
+			break;
+		default:
+			break;
+	}
+}
+
+void HPPImage::create_vk_image(vkb::core::HPPDevice &device, vk::ImageViewType image_view_type, vk::ImageCreateFlags flags)
+{
+	assert(!vk_image && !vk_image_view && "Vulkan HPPImage already constructed");
+
+	vk_image = std::make_unique<vkb::core::HPPImage>(device,
+	                                                 get_extent(),
+	                                                 format,
+	                                                 vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eTransferDst,
+	                                                 VMA_MEMORY_USAGE_GPU_ONLY,
+	                                                 vk::SampleCountFlagBits::e1,
+	                                                 to_u32(mipmaps.size()),
+	                                                 layers,
+	                                                 vk::ImageTiling::eOptimal,
+	                                                 flags);
+	vk_image->set_debug_name(get_name());
+
+	vk_image_view = std::make_unique<vkb::core::HPPImageView>(*vk_image, image_view_type);
+	vk_image_view->set_debug_name("View on " + get_name());
+}
+
+void HPPImage::generate_mipmaps()
+{
+	assert(mipmaps.size() == 1 && "Mipmaps already generated");
+
+	if (mipmaps.size() > 1)
+	{
+		return;        // Do not generate again
+	}
+
+	auto extent      = get_extent();
+	auto next_width  = std::max<uint32_t>(1u, extent.width / 2);
+	auto next_height = std::max<uint32_t>(1u, extent.height / 2);
+	auto channels    = 4;
+	auto next_size   = next_width * next_height * channels;
+
+	while (true)
+	{
+		// Make space for next mipmap
+		auto old_size = to_u32(data.size());
+		data.resize(old_size + next_size);
+
+		auto &prev_mipmap = mipmaps.back();
+		// Update mipmaps
+		vkb::scene_graph::components::HPPMipmap next_mipmap{};
+		next_mipmap.level  = prev_mipmap.level + 1;
+		next_mipmap.offset = old_size;
+		next_mipmap.extent = vk::Extent3D(next_width, next_height, 1u);
+
+		// Fill next mipmap memory
+		stbir_resize_uint8(data.data() + prev_mipmap.offset, prev_mipmap.extent.width, prev_mipmap.extent.height, 0,
+		                   data.data() + next_mipmap.offset, next_mipmap.extent.width, next_mipmap.extent.height, 0, channels);
+
+		mipmaps.emplace_back(std::move(next_mipmap));
+
+		// Next mipmap values
+		next_width  = std::max<uint32_t>(1u, next_width / 2);
+		next_height = std::max<uint32_t>(1u, next_height / 2);
+		next_size   = next_width * next_height * channels;
+
+		if (next_width == 1 && next_height == 1)
+		{
+			break;
+		}
+	}
+}
+
+const std::vector<uint8_t> &HPPImage::get_data() const
+{
+	return data;
+}
+
+const vk::Extent3D &HPPImage::get_extent() const
+{
+	assert(!mipmaps.empty());
+	return mipmaps[0].extent;
+}
+
+vk::Format HPPImage::get_format() const
+{
+	return format;
+}
+
+const uint32_t HPPImage::get_layers() const
+{
+	return layers;
+}
+
+const std::vector<vkb::scene_graph::components::HPPMipmap> &HPPImage::get_mipmaps() const
+{
+	return mipmaps;
+}
+
+const std::vector<std::vector<vk::DeviceSize>> &HPPImage::get_offsets() const
+{
+	return offsets;
+}
+
+const vkb::core::HPPImage &HPPImage::get_vk_image() const
+{
+	assert(vk_image && "Vulkan HPPImage was not created");
+	return *vk_image;
+}
+
+const vkb::core::HPPImageView &HPPImage::get_vk_image_view() const
+{
+	assert(vk_image_view && "Vulkan HPPImage view was not created");
+	return *vk_image_view;
+}
+
+vkb::scene_graph::components::HPPMipmap &HPPImage::get_mipmap(const size_t index)
+{
+	assert(index < mipmaps.size());
+	return mipmaps[index];
+}
+
+std::vector<uint8_t> &HPPImage::get_mut_data()
+{
+	return data;
+}
+
+std::vector<vkb::scene_graph::components::HPPMipmap> &HPPImage::get_mut_mipmaps()
+{
+	return mipmaps;
+}
+
+void HPPImage::set_data(const uint8_t *raw_data, size_t size)
+{
+	assert(data.empty() && "HPPImage data already set");
+	data = {raw_data, raw_data + size};
+}
+
+void HPPImage::set_depth(const uint32_t depth)
+{
+	assert(!mipmaps.empty());
+	mipmaps[0].extent.depth = depth;
+}
+
+void HPPImage::set_format(const vk::Format f)
+{
+	format = f;
+}
+
+void HPPImage::set_height(const uint32_t height)
+{
+	assert(!mipmaps.empty());
+	mipmaps[0].extent.height = height;
+}
+
+void HPPImage::set_layers(uint32_t l)
+{
+	layers = l;
+}
+
+void HPPImage::set_offsets(const std::vector<std::vector<vk::DeviceSize>> &o)
+{
+	offsets = o;
+}
+
+void HPPImage::set_width(const uint32_t width)
+{
+	assert(!mipmaps.empty());
+	mipmaps[0].extent.width = width;
+}
+
+}        // namespace components
+}        // namespace scene_graph
+}        // namespace vkb

--- a/framework/scene_graph/components/hpp_image.h
+++ b/framework/scene_graph/components/hpp_image.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,10 +17,9 @@
 
 #pragma once
 
-#include <scene_graph/components/image.h>
-
-#include <core/hpp_device.h>
-#include <core/hpp_image.h>
+#include "core/hpp_device.h"
+#include "scene_graph/component.h"
+#include <vulkan/vulkan.hpp>
 
 namespace vkb
 {
@@ -29,43 +28,80 @@ namespace scene_graph
 namespace components
 {
 /**
- * @brief facade class around vkb::sg::Image, providing a vulkan.hpp-based interface
- *
- * See vkb::sb::Image for documentation
+ * @param format Vulkan format
+ * @return Whether the vulkan format is ASTC
  */
-class HPPImage : private vkb::sg::Image
+bool is_astc(vk::Format format);
+
+/**
+ * @brief Mipmap information
+ */
+struct HPPMipmap
+{
+	uint32_t     level  = 0;                /// Mipmap level
+	uint32_t     offset = 0;                /// Byte offset used for uploading
+	vk::Extent3D extent = {0, 0, 0};        /// Width depth and height of the mipmap
+};
+
+class HPPImage : public vkb::sg::Component
 {
   public:
-	using vkb::sg::Image::get_data;
-	using vkb::sg::Image::get_layers;
-	using vkb::sg::Image::get_mipmaps;
-	using vkb::sg::Image::get_offsets;
+	HPPImage(const std::string &name, std::vector<uint8_t> &&data = {}, std::vector<vkb::scene_graph::components::HPPMipmap> &&mipmaps = {{}});
+	virtual ~HPPImage() = default;
 
-	static std::unique_ptr<HPPImage> load(std::string const &name, std::string const &uri, vkb::sg::Image::ContentType content_type)
+  public:
+	/**
+	 * @brief Type of content held in image.
+	 * This helps to steer the image loaders when deciding what the format should be.
+	 * Some image containers don't know whether the data they contain is sRGB or not.
+	 * Since most applications save color images in sRGB, knowing that an image
+	 * contains color data helps us to better guess its format when unknown.
+	 */
+	enum ContentType
 	{
-		return std::unique_ptr<HPPImage>(reinterpret_cast<HPPImage *>(vkb::sg::Image::load(name, uri, content_type).release()));
-	}
+		Unknown,
+		Color,
+		Other
+	};
 
-	void create_vk_image(vkb::core::HPPDevice const &device, vk::ImageViewType image_view_type = vk::ImageViewType::e2D, vk::ImageCreateFlags flags = {})
-	{
-		vkb::sg::Image::create_vk_image(
-		    reinterpret_cast<vkb::Device const &>(device), static_cast<VkImageViewType>(image_view_type), static_cast<VkImageCreateFlags>(flags));
-	}
+	static std::unique_ptr<vkb::scene_graph::components::HPPImage> load(const std::string &name, const std::string &uri, ContentType content_type);
 
-	vk::Extent3D const &get_extent() const
-	{
-		return reinterpret_cast<vk::Extent3D const &>(vkb::sg::Image::get_extent());
-	}
+	// from Component
+	virtual std::type_index get_type() override;
 
-	vkb::core::HPPImage const &get_vk_image() const
-	{
-		return reinterpret_cast<vkb::core::HPPImage const &>(vkb::sg::Image::get_vk_image());
-	}
+	void                                                        clear_data();
+	void                                                        coerce_format_to_srgb();
+	void                                                        create_vk_image(vkb::core::HPPDevice &device, vk::ImageViewType image_view_type = vk::ImageViewType::e2D, vk::ImageCreateFlags flags = {});
+	void                                                        generate_mipmaps();
+	const std::vector<uint8_t>                                 &get_data() const;
+	const vk::Extent3D                                         &get_extent() const;
+	vk::Format                                                  get_format() const;
+	const uint32_t                                              get_layers() const;
+	const std::vector<vkb::scene_graph::components::HPPMipmap> &get_mipmaps() const;
+	const std::vector<std::vector<vk::DeviceSize>>             &get_offsets() const;
+	const vkb::core::HPPImage                                  &get_vk_image() const;
+	const vkb::core::HPPImageView                              &get_vk_image_view() const;
 
-	vkb::core::HPPImageView const &get_vk_image_view() const
-	{
-		return reinterpret_cast<vkb::core::HPPImageView const &>(vkb::sg::Image::get_vk_image_view());
-	}
+  protected:
+	vkb::scene_graph::components::HPPMipmap              &get_mipmap(size_t index);
+	std::vector<uint8_t>                                 &get_mut_data();
+	std::vector<vkb::scene_graph::components::HPPMipmap> &get_mut_mipmaps();
+	void                                                  set_data(const uint8_t *raw_data, size_t size);
+	void                                                  set_depth(uint32_t depth);
+	void                                                  set_format(vk::Format format);
+	void                                                  set_height(uint32_t height);
+	void                                                  set_layers(uint32_t layers);
+	void                                                  set_offsets(const std::vector<std::vector<vk::DeviceSize>> &offsets);
+	void                                                  set_width(uint32_t width);
+
+  private:
+	std::vector<uint8_t>                                 data;
+	vk::Format                                           format = vk::Format::eUndefined;
+	uint32_t                                             layers = 1;
+	std::vector<vkb::scene_graph::components::HPPMipmap> mipmaps{{}};
+	std::vector<std::vector<vk::DeviceSize>>             offsets;        // Offsets stored like offsets[array_layer][mipmap_layer]
+	std::unique_ptr<vkb::core::HPPImage>                 vk_image;
+	std::unique_ptr<vkb::core::HPPImageView>             vk_image_view;
 };
 
 }        // namespace components

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
@@ -386,8 +386,8 @@ void HPPComputeNBody::initializeCamera()
 
 void HPPComputeNBody::load_assets()
 {
-	textures.particle = load_texture("textures/particle_rgba.ktx", vkb::sg::Image::Color);
-	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx", vkb::sg::Image::Color);
+	textures.particle = load_texture("textures/particle_rgba.ktx", vkb::scene_graph::components::HPPImage::Color);
+	textures.gradient = load_texture("textures/particle_gradient_rgba.ktx", vkb::scene_graph::components::HPPImage::Color);
 }
 
 void HPPComputeNBody::prepare_compute()

--- a/samples/api/hpp_hdr/hpp_hdr.cpp
+++ b/samples/api/hpp_hdr/hpp_hdr.cpp
@@ -531,7 +531,7 @@ void HPPHDR::load_assets()
 	models.transforms.push_back(torus_matrix);
 
 	// Load HDR cube map
-	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::sg::Image::Color);
+	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::scene_graph::components::HPPImage::Color);
 }
 
 void HPPHDR::prepare_camera()

--- a/samples/api/hpp_hlsl_shaders/hpp_hlsl_shaders.cpp
+++ b/samples/api/hpp_hlsl_shaders/hpp_hlsl_shaders.cpp
@@ -348,7 +348,7 @@ void HPPHlslShaders::generate_quad()
 
 void HPPHlslShaders::load_assets()
 {
-	texture = load_texture("textures/metalplate01_rgba.ktx", vkb::sg::Image::Color);
+	texture = load_texture("textures/metalplate01_rgba.ktx", vkb::scene_graph::components::HPPImage::Color);
 }
 
 void HPPHlslShaders::update_descriptor_sets()

--- a/samples/api/hpp_instancing/hpp_instancing.cpp
+++ b/samples/api/hpp_instancing/hpp_instancing.cpp
@@ -382,8 +382,8 @@ void HPPInstancing::load_assets()
 	rocks.mesh  = load_model("scenes/rock.gltf");
 	planet.mesh = load_model("scenes/planet.gltf");
 
-	rocks.texture  = load_texture_array("textures/texturearray_rocks_color_rgba.ktx", vkb::sg::Image::Color);
-	planet.texture = load_texture("textures/lavaplanet_color_rgba.ktx", vkb::sg::Image::Color);
+	rocks.texture  = load_texture_array("textures/texturearray_rocks_color_rgba.ktx", vkb::scene_graph::components::HPPImage::Color);
+	planet.texture = load_texture("textures/lavaplanet_color_rgba.ktx", vkb::scene_graph::components::HPPImage::Color);
 }
 
 void HPPInstancing::initialize_camera()

--- a/samples/api/hpp_separate_image_sampler/hpp_separate_image_sampler.cpp
+++ b/samples/api/hpp_separate_image_sampler/hpp_separate_image_sampler.cpp
@@ -332,7 +332,7 @@ void HPPSeparateImageSampler::generate_quad()
 
 void HPPSeparateImageSampler::load_assets()
 {
-	texture = load_texture("textures/metalplate01_rgba.ktx", vkb::sg::Image::Color);
+	texture = load_texture("textures/metalplate01_rgba.ktx", vkb::scene_graph::components::HPPImage::Color);
 }
 
 // Prepare and initialize uniform buffer containing shader uniforms

--- a/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
+++ b/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
@@ -444,13 +444,13 @@ void HPPTerrainTessellation::generate_terrain()
 void HPPTerrainTessellation::load_assets()
 {
 	sky_sphere.geometry = load_model("scenes/geosphere.gltf");
-	sky_sphere.texture  = load_texture("textures/skysphere_rgba.ktx", vkb::sg::Image::Color);
+	sky_sphere.texture  = load_texture("textures/skysphere_rgba.ktx", vkb::scene_graph::components::HPPImage::Color);
 
 	// Terrain textures are stored in a texture array with layers corresponding to terrain height; create a repeating sampler
-	terrain.terrain_array = load_texture_array("textures/terrain_texturearray_rgba.ktx", vkb::sg::Image::Color, vk::SamplerAddressMode::eRepeat);
+	terrain.terrain_array = load_texture_array("textures/terrain_texturearray_rgba.ktx", vkb::scene_graph::components::HPPImage::Color, vk::SamplerAddressMode::eRepeat);
 
 	// Height data is stored in a one-channel texture; create a mirroring sampler
-	terrain.height_map = load_texture("textures/terrain_heightmap_r16.ktx", vkb::sg::Image::Other, vk::SamplerAddressMode::eMirroredRepeat);
+	terrain.height_map = load_texture("textures/terrain_heightmap_r16.ktx", vkb::scene_graph::components::HPPImage::Other, vk::SamplerAddressMode::eMirroredRepeat);
 }
 
 void HPPTerrainTessellation::prepare_camera()

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -420,7 +420,7 @@ void HPPTimestampQueries::load_assets()
 	models.transforms.push_back(torus_matrix);
 
 	// Load HDR cube map
-	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::sg::Image::Color);
+	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::scene_graph::components::HPPImage::Color);
 }
 
 void HPPTimestampQueries::prepare_descriptor_pool()


### PR DESCRIPTION
## Description

Build tested on Win10 with VS2022. All hpp-based samples tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
