### PR TITLE
Fix used render pass in graphics pipeline creation.

### DIFF
--- a/samples/api/hpp_hdr/hpp_hdr.cpp
+++ b/samples/api/hpp_hdr/hpp_hdr.cpp
@@ -287,7 +287,7 @@ vk::Pipeline HPPHDR::create_bloom_pipeline(uint32_t direction)
 	                                             {blend_attachment_state},
 	                                             depth_stencil_state,
 	                                             bloom.pipeline_layout,
-	                                             render_pass);
+	                                             direction == 1 ? render_pass : filter_pass.render_pass);
 }
 
 vk::Pipeline HPPHDR::create_composition_pipeline()


### PR DESCRIPTION
## Description

When creating a graphics pipeline, a render pass compatible to those used with this pipeline has to be provided. This sample accidentally used the same for both pipelines but needs to differentiate between the two passes.

Build tested on Win10 with VS2022; run tested on Win10 with NVIDIA GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
