### PR TITLE
Add link to OpenCL ARM sample to Antora navigation, update templates

### DIFF
--- a/antora/modules/ROOT/nav.adoc
+++ b/antora/modules/ROOT/nav.adoc
@@ -64,6 +64,7 @@
 ** xref:samples/extensions/mesh_shader_culling/README.adoc[Mesh shader culling]
 ** xref:samples/extensions/mesh_shading/README.adoc[Mesh shading]
 ** xref:samples/extensions/open_cl_interop/README.adoc[OpenCL interop]
+** xref:samples/extensions/open_cl_interop_arm/README.adoc[OpenCL interop (Arm)]
 ** xref:samples/extensions/open_gl_interop/README.adoc[OpenGL interop]
 ** xref:samples/extensions/portability/README.adoc[Portability]
 ** xref:samples/extensions/push_descriptors/README.adoc[Push descriptors]

--- a/bldsys/cmake/template/README.adoc.in
+++ b/bldsys/cmake/template/README.adoc.in
@@ -82,3 +82,8 @@ The chapter itself can be structured by using sub paragraphs, e.g.:
 ////
 The tutorial should end with a conclusion chapter that recaps the tutorial and (if applicable) talks about pros and cons of the features demonstrated in this sample
 ////
+
+////
+NOTE: Please also add a link to the new samples' README.adoc to the file located in ./antora/modules/ROOT/nav.adoc
+THis is necessary to have the sample show up on the build for the docs site under https://docs.vulkan.org
+////

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -33,3 +33,4 @@ If your PR contains a new or modified sample, these further checks must be carri
 - [ ] Any dependent assets have been merged and published in downstream modules
 - [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
 - [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
+- [ ] For new samples, I have added a link to the [Antora navigation](./../antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site


### PR DESCRIPTION
## Description

This PR adds the vendor-specific OpenCL ARM sample to the navigation for the Antora site so that it's documentation can be accessed from the docs site.

The PR also slightly adds a new entry to the the pull request template checklist for new samples:

> For new samples, I have added a link to the [Antora navigation](./../antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site

**This is a pure documentation fix**

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  