### PR TITLE
Allow dynamic_blending sample to work in more cases

### DIFF
--- a/samples/extensions/dynamic_blending/dynamic_blending.cpp
+++ b/samples/extensions/dynamic_blending/dynamic_blending.cpp
@@ -486,12 +486,15 @@ void DynamicBlending::build_command_buffers()
 
 void DynamicBlending::build_command_buffer_for_plane(VkCommandBuffer &command_buffer, FacePreferences preferences)
 {
-	std::array<VkColorComponentFlags, 1> color_bit = {
-	    (preferences.color_bit_enabled[0] ? VK_COLOR_COMPONENT_R_BIT : 0u) |
-	    (preferences.color_bit_enabled[1] ? VK_COLOR_COMPONENT_G_BIT : 0u) |
-	    (preferences.color_bit_enabled[2] ? VK_COLOR_COMPONENT_B_BIT : 0u) |
-	    (preferences.color_bit_enabled[3] ? VK_COLOR_COMPONENT_A_BIT : 0u)};
-	vkCmdSetColorWriteMaskEXT(command_buffer, 0, 1, color_bit.data());
+	if (eds_feature_support.extendedDynamicState3ColorWriteMask)
+	{
+		std::array<VkColorComponentFlags, 1> color_bit = {
+		    (preferences.color_bit_enabled[0] ? VK_COLOR_COMPONENT_R_BIT : 0u) |
+		    (preferences.color_bit_enabled[1] ? VK_COLOR_COMPONENT_G_BIT : 0u) |
+		    (preferences.color_bit_enabled[2] ? VK_COLOR_COMPONENT_B_BIT : 0u) |
+		    (preferences.color_bit_enabled[3] ? VK_COLOR_COMPONENT_A_BIT : 0u)};
+		vkCmdSetColorWriteMaskEXT(command_buffer, 0, 1, color_bit.data());
+	}
 	vkCmdDrawIndexed(command_buffer, preferences.index_count, 1, preferences.index_offset, 0, 0);
 }
 

--- a/samples/extensions/dynamic_blending/dynamic_blending.h
+++ b/samples/extensions/dynamic_blending/dynamic_blending.h
@@ -118,6 +118,8 @@ class DynamicBlending : public ApiVulkanSample
 	VkDescriptorSet       descriptor_set;
 	VkPipeline            pipeline;
 
+	VkPhysicalDeviceExtendedDynamicState3FeaturesEXT eds_feature_support;
+
 	std::array<float, 4> clear_color = {0.5f, 0.5f, 0.5f, 1.0f};
 	int32_t              current_blend_color_operator_index;
 	int32_t              current_blend_alpha_operator_index;


### PR DESCRIPTION
## Description

Allow dynamic_blending sample to work on more hardware.
Feature support is checked and functionality reduced where applicable rather than just not running.
This now runs on my hardware (which doesn't support dynamic advanced blending changes).

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. (Tested only on Linux)
 

