### PR TITLE
Add new plugin for GPU selection via command line

### DIFF
--- a/app/plugins/gpu_selection/gpu_selection.cpp
+++ b/app/plugins/gpu_selection/gpu_selection.cpp
@@ -1,0 +1,48 @@
+/* Copyright (c) 2023, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gpu_selection.h"
+
+#include <algorithm>
+
+#include "core/instance.h"
+#include "core/hpp_instance.h"
+
+namespace plugins
+{
+GpuSelection::GpuSelection() :
+    GpuSelectionTags("GPU selection",
+                     "A collection of flags to select the GPU to run the samples on",
+                     {}, {&gpu_selection_options_group})
+{
+}
+
+bool GpuSelection::is_active(const vkb::CommandParser &parser)
+{
+	return true;
+}
+
+void GpuSelection::init(const vkb::CommandParser &parser)
+{
+	// @todo: required?
+	if (parser.contains(&selected_gpu_index))
+	{
+		vkb::Instance::selected_gpu_index = parser.as<uint32_t>(&selected_gpu_index);
+		vkb::core::HPPInstance::selected_gpu_index = parser.as<uint32_t>(&selected_gpu_index);
+	}
+}
+}        // namespace plugins

--- a/app/plugins/gpu_selection/gpu_selection.cpp
+++ b/app/plugins/gpu_selection/gpu_selection.cpp
@@ -19,8 +19,8 @@
 
 #include <algorithm>
 
-#include "core/instance.h"
 #include "core/hpp_instance.h"
+#include "core/instance.h"
 
 namespace plugins
 {
@@ -41,7 +41,7 @@ void GpuSelection::init(const vkb::CommandParser &parser)
 	// @todo: required?
 	if (parser.contains(&selected_gpu_index))
 	{
-		vkb::Instance::selected_gpu_index = parser.as<uint32_t>(&selected_gpu_index);
+		vkb::Instance::selected_gpu_index          = parser.as<uint32_t>(&selected_gpu_index);
 		vkb::core::HPPInstance::selected_gpu_index = parser.as<uint32_t>(&selected_gpu_index);
 	}
 }

--- a/app/plugins/gpu_selection/gpu_selection.h
+++ b/app/plugins/gpu_selection/gpu_selection.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2023, Sascha Willems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "platform/plugins/plugin_base.h"
+
+namespace plugins
+{
+class GpuSelection;
+
+using GpuSelectionTags = vkb::PluginBase<GpuSelection, vkb::tags::Passive>;
+
+/**
+ * @brief GPU selection options
+ *
+ * Explicitly select a GPU to run the samples on
+ *
+ */
+class GpuSelection : public GpuSelectionTags
+{
+  public:
+	GpuSelection();
+
+	virtual ~GpuSelection() = default;
+
+	virtual bool is_active(const vkb::CommandParser &parser) override;
+
+	virtual void init(const vkb::CommandParser &options) override;
+
+	vkb::FlagCommand selected_gpu_index = {vkb::FlagType::OneValue, "gpu", "", "If flag is set, hides the user interface at startup"};
+
+	vkb::CommandGroup gpu_selection_options_group = {"GPU selection Options", {&selected_gpu_index}};
+};
+}        // namespace plugins

--- a/framework/core/hpp_instance.cpp
+++ b/framework/core/hpp_instance.cpp
@@ -138,6 +138,8 @@ std::vector<const char *> get_optimal_validation_layers(const std::vector<vk::La
 	return {};
 }
 
+Optional<uint32_t> HPPInstance::selected_gpu_index;
+
 namespace
 {
 bool enable_extension(const char                                 *required_ext_name,
@@ -413,6 +415,17 @@ vk::Instance HPPInstance::get_handle() const
 vkb::core::HPPPhysicalDevice &HPPInstance::get_suitable_gpu(vk::SurfaceKHR surface)
 {
 	assert(!gpus.empty() && "No physical devices were found on the system.");
+
+	// A GPU can be explicitly selected via the command line (see plugins/gpu_selection.cpp), this overrides the below GPU selection algorithm
+	if (selected_gpu_index.has_value())
+	{
+		LOGI("Explicitly selecting GPU {}", selected_gpu_index.value());
+		if (selected_gpu_index.value() > gpus.size() - 1)
+		{
+			throw std::runtime_error("Selected GPU index is not within no. of available GPUs");
+		}
+		return *gpus[selected_gpu_index.value()];
+	}
 
 	// Find a discrete GPU
 	for (auto &gpu : gpus)

--- a/framework/core/hpp_instance.cpp
+++ b/framework/core/hpp_instance.cpp
@@ -405,24 +405,6 @@ const std::vector<const char *> &HPPInstance::get_extensions()
 	return enabled_extensions;
 }
 
-vkb::core::HPPPhysicalDevice &HPPInstance::get_first_gpu()
-{
-	assert(!gpus.empty() && "No physical devices were found on the system.");
-
-	// Find a discrete GPU
-	for (auto &gpu : gpus)
-	{
-		if (gpu->get_properties().deviceType == vk::PhysicalDeviceType::eDiscreteGpu)
-		{
-			return *gpu;
-		}
-	}
-
-	// Otherwise just pick the first one
-	LOGW("Couldn't find a discrete physical device, picking default GPU");
-	return *gpus[0];
-}
-
 vk::Instance HPPInstance::get_handle() const
 {
 	return handle;

--- a/framework/core/hpp_instance.h
+++ b/framework/core/hpp_instance.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -74,12 +74,6 @@ class HPPInstance
 	HPPInstance &operator=(HPPInstance &&) = delete;
 
 	const std::vector<const char *> &get_extensions();
-
-	/**
-	 * @brief Tries to find the first available discrete GPU
-	 * @returns A valid physical device
-	 */
-	HPPPhysicalDevice &get_first_gpu();
 
 	vk::Instance get_handle() const;
 

--- a/framework/core/hpp_instance.h
+++ b/framework/core/hpp_instance.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <common/hpp_error.h>
+#include "common/optional.h"
 #include <unordered_map>
 #include <vulkan/vulkan.hpp>
 
@@ -43,6 +44,11 @@ class HPPInstance
 {
   public:
 	/**
+	 * @brief Can be set from the GPU selection plugin to explicitly select a GPU instead
+	 */
+	static Optional<uint32_t> selected_gpu_index;
+
+	/**
 	 * @brief Initializes the connection to Vulkan
 	 * @param application_name The name of the application
 	 * @param required_extensions The extensions requested to be enabled
@@ -51,9 +57,9 @@ class HPPInstance
 	 * @param api_version The Vulkan API version that the instance will be using
 	 * @throws runtime_error if the required extensions and validation layers are not found
 	 */
-	HPPInstance(const std::string &                           application_name,
+	HPPInstance(const std::string                            &application_name,
 	            const std::unordered_map<const char *, bool> &required_extensions        = {},
-	            const std::vector<const char *> &             required_validation_layers = {},
+	            const std::vector<const char *>              &required_validation_layers = {},
 	            bool                                          headless                   = false,
 	            uint32_t                                      api_version                = VK_API_VERSION_1_0);
 

--- a/framework/core/hpp_instance.h
+++ b/framework/core/hpp_instance.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <common/hpp_error.h>
 #include "common/optional.h"
+#include <common/hpp_error.h>
 #include <unordered_map>
 #include <vulkan/vulkan.hpp>
 

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -460,24 +460,6 @@ void Instance::query_gpus()
 	}
 }
 
-PhysicalDevice &Instance::get_first_gpu()
-{
-	assert(!gpus.empty() && "No physical devices were found on the system.");
-
-	// Find a discrete GPU
-	for (auto &gpu : gpus)
-	{
-		if (gpu->get_properties().deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
-		{
-			return *gpu;
-		}
-	}
-
-	// Otherwise just pick the first one
-	LOGW("Couldn't find a discrete physical device, picking default GPU");
-	return *gpus[0];
-}
-
 PhysicalDevice &Instance::get_suitable_gpu(VkSurfaceKHR surface)
 {
 	assert(!gpus.empty() && "No physical devices were found on the system.");

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "common/helpers.h"
+#include "common/optional.h"
 #include "common/vk_common.h"
 
 namespace vkb
@@ -40,6 +41,11 @@ class Instance
 {
   public:
 	/**
+	 * @brief Can be set from the GPU selection plugin to explicitly select a GPU instead
+	 */
+	static Optional<uint32_t> selected_gpu_index;
+
+	/**
 	 * @brief Initializes the connection to Vulkan
 	 * @param application_name The name of the application
 	 * @param required_extensions The extensions requested to be enabled
@@ -48,9 +54,9 @@ class Instance
 	 * @param api_version The Vulkan API version that the instance will be using
 	 * @throws runtime_error if the required extensions and validation layers are not found
 	 */
-	Instance(const std::string &                           application_name,
+	Instance(const std::string                            &application_name,
 	         const std::unordered_map<const char *, bool> &required_extensions        = {},
-	         const std::vector<const char *> &             required_validation_layers = {},
+	         const std::vector<const char *>              &required_validation_layers = {},
 	         bool                                          headless                   = false,
 	         uint32_t                                      api_version                = VK_API_VERSION_1_0);
 
@@ -93,17 +99,17 @@ class Instance
 	const std::vector<const char *> &get_extensions();
 
 	/**
-	* @brief Returns a const ref to the properties of all requested layers in this instance
-	* @returns The VkLayerProperties for all requested layers in this instance
-	*/
+	 * @brief Returns a const ref to the properties of all requested layers in this instance
+	 * @returns The VkLayerProperties for all requested layers in this instance
+	 */
 	const std::vector<VkLayerProperties> &get_layer_properties();
 
 	/**
-	* @brief Finds layer properties for the layer with the given name
-	* @param layerName The layer to search for
-	* @param properties A reference to a VkLayerProperties struct to populate
-	* @returns True if the layer was found and populated, false otherwise
-	*/
+	 * @brief Finds layer properties for the layer with the given name
+	 * @param layerName The layer to search for
+	 * @param properties A reference to a VkLayerProperties struct to populate
+	 * @returns True if the layer was found and populated, false otherwise
+	 */
 	bool get_layer_properties(const char *layerName, VkLayerProperties &properties);
 
   private:

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2021, Arm Limited and Contributors
+/* Copyright (c) 2018-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -81,12 +81,6 @@ class Instance
 	 * @returns A valid physical device
 	 */
 	PhysicalDevice &get_suitable_gpu(VkSurfaceKHR);
-
-	/**
-	 * @brief Tries to find the first available discrete GPU
-	 * @returns A valid physical device
-	 */
-	PhysicalDevice &get_first_gpu();
 
 	/**
 	 * @brief Checks if the given extension is enabled in the VkInstance


### PR DESCRIPTION
## Description

This PR adds a new plugin that adds GPU selection via command line. With this plugin, a user can now override the default GPU selection and explicitly request a GPU by a given index. This is esp. useful if you want to debug/test samples on GPUs other than your main GPU. I currently use this to test and fix things using swiftshader as a second ICD on my system. This PR also removes the `get_first_gpu` instance function that wasn't used anywhere.

The plugin itself is pretty simple, and GPU selection is done as follows:

```
sample instancing --gpu 1
```

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
 