### PR TITLE
Change vkb::rendering::HPPRenderFrame from a facade over vkb::RenderFrame to a self-contained class using Vulkan-Hpp.

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -48,6 +48,7 @@ set(FRAMEWORK_FILES
     hpp_resource_cache.h
     hpp_resource_record.h
     hpp_resource_replay.h
+    hpp_semaphore_pool.h
     hpp_vulkan_sample.h
     # Source Files
     gui.cpp
@@ -133,6 +134,7 @@ set(RENDERING_FILES
     rendering/render_target.cpp
     rendering/subpass.cpp
     rendering/hpp_render_context.cpp
+    rendering/hpp_render_frame.cpp
     rendering/hpp_render_target.cpp)
 
 set(RENDERING_SUBPASSES_FILES

--- a/framework/common/hpp_resource_caching.h
+++ b/framework/common/hpp_resource_caching.h
@@ -30,7 +30,7 @@ struct hash<std::map<Key, Value>>
 	{
 		size_t result = 0;
 		vkb::hash_combine(result, bindings.size());
-		for (auto &binding : bindings)
+		for (auto const &binding : bindings)
 		{
 			vkb::hash_combine(result, binding.first);
 			vkb::hash_combine(result, binding.second);
@@ -274,6 +274,8 @@ struct hash<vkb::rendering::HPPRenderTarget>
 
 namespace vkb
 {
+namespace common
+{
 /**
  * @brief facade helper functions and structs around the functions and structs in common/resource_caching, providing a vulkan.hpp-based interface
  */
@@ -402,4 +404,5 @@ T &request_resource(vkb::core::HPPDevice &device, vkb::HPPResourceRecord *record
 
 	return res_it->second;
 }
+}        // namespace common
 }        // namespace vkb

--- a/framework/core/hpp_descriptor_pool.h
+++ b/framework/core/hpp_descriptor_pool.h
@@ -34,6 +34,8 @@ class HPPDevice;
 class HPPDescriptorPool : private vkb::DescriptorPool
 {
   public:
+	using vkb::DescriptorPool::reset;
+
 	HPPDescriptorPool(vkb::core::HPPDevice &device, const vkb::core::HPPDescriptorSetLayout &descriptor_set_layout, uint32_t pool_size = MAX_SETS_PER_POOL) :
 	    vkb::DescriptorPool(reinterpret_cast<vkb::Device &>(device), reinterpret_cast<vkb::DescriptorSetLayout const &>(descriptor_set_layout), pool_size)
 	{}

--- a/framework/core/hpp_descriptor_set.h
+++ b/framework/core/hpp_descriptor_set.h
@@ -33,6 +33,9 @@ namespace core
 class HPPDescriptorSet : private vkb::DescriptorSet
 {
   public:
+	using vkb::DescriptorSet::apply_writes;
+	using vkb::DescriptorSet::update;
+
 	HPPDescriptorSet(vkb::core::HPPDevice                       &device,
 	                 const vkb::core::HPPDescriptorSetLayout    &descriptor_set_layout,
 	                 vkb::core::HPPDescriptorPool               &descriptor_pool,

--- a/framework/core/hpp_descriptor_set_layout.h
+++ b/framework/core/hpp_descriptor_set_layout.h
@@ -59,6 +59,11 @@ class HPPDescriptorSetLayout : private vkb::DescriptorSetLayout
 		return std::unique_ptr<vk::DescriptorSetLayoutBinding>(
 		    reinterpret_cast<vk::DescriptorSetLayoutBinding *>(vkb::DescriptorSetLayout::get_layout_binding(binding_index).release()));
 	}
+
+	vk::DescriptorBindingFlagsEXT get_layout_binding_flag(const uint32_t binding_index) const
+	{
+		return static_cast<vk::DescriptorBindingFlagsEXT>(vkb::DescriptorSetLayout::get_layout_binding_flag(binding_index));
+	}
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_device.h
+++ b/framework/core/hpp_device.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <core/hpp_command_buffer.h>
+#include <core/hpp_command_pool.h>
 #include <core/hpp_debug.h>
 #include <core/hpp_physical_device.h>
 #include <core/hpp_queue.h>
@@ -31,7 +32,6 @@ namespace vkb
 namespace core
 {
 class HPPBuffer;
-class HPPCommandPool;
 
 class HPPDevice : public vkb::core::HPPVulkanResource<vk::Device>
 {

--- a/framework/hpp_buffer_pool.h
+++ b/framework/hpp_buffer_pool.h
@@ -56,6 +56,17 @@ class HPPBufferAllocation : private vkb::BufferAllocation
  */
 class HPPBufferBlock : private vkb::BufferBlock
 {
+  public:
+	vkb::HPPBufferAllocation allocate(vk::DeviceSize size)
+	{
+		vkb::BufferAllocation ba = vkb::BufferBlock::allocate(static_cast<VkDeviceSize>(size));
+		return std::move(*(reinterpret_cast<vkb::HPPBufferAllocation *>(&ba)));
+	}
+
+	bool can_allocate(vk::DeviceSize size) const
+	{
+		return vkb::BufferBlock::can_allocate(static_cast<VkDeviceSize>(size));
+	}
 };
 
 /**
@@ -65,5 +76,19 @@ class HPPBufferBlock : private vkb::BufferBlock
  */
 class HPPBufferPool : private vkb::BufferPool
 {
+  public:
+	using vkb::BufferPool::reset;
+
+	HPPBufferPool(
+	    vkb::core::HPPDevice &device, vk::DeviceSize block_size, vk::BufferUsageFlags usage, VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_CPU_TO_GPU) :
+	    vkb::BufferPool(
+	        reinterpret_cast<vkb::Device &>(device), static_cast<VkDeviceSize>(block_size), static_cast<VkBufferUsageFlags>(usage), memory_usage)
+	{
+	}
+
+	vkb::HPPBufferBlock &request_buffer_block(vk::DeviceSize minimum_size, bool minimal = false)
+	{
+		return reinterpret_cast<vkb::HPPBufferBlock &>(vkb::BufferPool::request_buffer_block(static_cast<VkDeviceSize>(minimum_size), minimal));
+	}
 };
 }        // namespace vkb

--- a/framework/hpp_resource_cache.cpp
+++ b/framework/hpp_resource_cache.cpp
@@ -32,7 +32,7 @@ T &request_resource(
 {
 	std::lock_guard<std::mutex> guard(resource_mutex);
 
-	auto &res = request_resource(device, &recorder, resources, args...);
+	auto &res = vkb::common::request_resource(device, &recorder, resources, args...);
 
 	return res;
 }

--- a/framework/hpp_semaphore_pool.h
+++ b/framework/hpp_semaphore_pool.h
@@ -1,0 +1,53 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "semaphore_pool.h"
+
+namespace vkb
+{
+/**
+ * @brief facade class around vkb::SemaphorePool, providing a vulkan.hpp-based interface
+ *
+ * See vkb::SemaphorePool for documentation
+ */
+class HPPSemaphorePool : private vkb::SemaphorePool
+{
+  public:
+	using vkb::SemaphorePool::reset;
+
+	HPPSemaphorePool(vkb::core::HPPDevice &device) :
+	    vkb::SemaphorePool(reinterpret_cast<vkb::Device &>(device))
+	{}
+
+	void release_owned_semaphore(vk::Semaphore semaphore)
+	{
+		vkb::SemaphorePool::release_owned_semaphore(static_cast<VkSemaphore>(semaphore));
+	}
+
+	vk::Semaphore request_semaphore()
+	{
+		return static_cast<vk::Semaphore>(vkb::SemaphorePool::request_semaphore());
+	}
+
+	vk::Semaphore request_semaphore_with_ownership()
+	{
+		return static_cast<vk::Semaphore>(vkb::SemaphorePool::request_semaphore_with_ownership());
+	}
+};
+}        // namespace vkb

--- a/framework/rendering/hpp_render_frame.cpp
+++ b/framework/rendering/hpp_render_frame.cpp
@@ -1,0 +1,312 @@
+/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hpp_render_frame.h"
+#include <common/hpp_resource_caching.h>
+
+constexpr uint32_t BUFFER_POOL_BLOCK_SIZE = 256;
+
+namespace vkb
+{
+namespace rendering
+{
+HPPRenderFrame::HPPRenderFrame(vkb::core::HPPDevice &device, std::unique_ptr<vkb::rendering::HPPRenderTarget> &&render_target, size_t thread_count) :
+    device{device},
+    fence_pool{device},
+    semaphore_pool{device},
+    swapchain_render_target{std::move(render_target)},
+    thread_count{thread_count}
+{
+	for (auto &usage_it : supported_usage_map)
+	{
+		auto [buffer_pools_it, inserted] = buffer_pools.emplace(usage_it.first, std::vector<std::pair<vkb::HPPBufferPool, vkb::HPPBufferBlock *>>{});
+		if (!inserted)
+		{
+			throw std::runtime_error("Failed to insert buffer pool");
+		}
+
+		for (size_t i = 0; i < thread_count; ++i)
+		{
+			buffer_pools_it->second.push_back(std::make_pair(vkb::HPPBufferPool{device, BUFFER_POOL_BLOCK_SIZE * 1024 * usage_it.second, usage_it.first}, nullptr));
+		}
+	}
+
+	for (size_t i = 0; i < thread_count; ++i)
+	{
+		descriptor_pools.push_back(std::make_unique<std::unordered_map<std::size_t, vkb::core::HPPDescriptorPool>>());
+		descriptor_sets.push_back(std::make_unique<std::unordered_map<std::size_t, vkb::core::HPPDescriptorSet>>());
+	}
+}
+
+vkb::HPPBufferAllocation HPPRenderFrame::allocate_buffer(const vk::BufferUsageFlags usage, const vk::DeviceSize size, size_t thread_index)
+{
+	assert(thread_index < thread_count && "Thread index is out of bounds");
+
+	// Find a pool for this usage
+	auto buffer_pool_it = buffer_pools.find(usage);
+	if (buffer_pool_it == buffer_pools.end())
+	{
+		LOGE("No buffer pool for buffer usage " + vk::to_string(usage));
+		return vkb::HPPBufferAllocation{};
+	}
+
+	assert(thread_index < buffer_pool_it->second.size());
+	auto &buffer_pool  = buffer_pool_it->second[thread_index].first;
+	auto &buffer_block = buffer_pool_it->second[thread_index].second;
+
+	bool want_minimal_block = buffer_allocation_strategy == BufferAllocationStrategy::OneAllocationPerBuffer;
+
+	if (want_minimal_block || !buffer_block || !buffer_block->can_allocate(size))
+	{
+		// If we are creating a buffer for each allocation of there is no block associated with the pool or the current block is too small
+		// for this allocation, request a new buffer block
+		buffer_block = &buffer_pool.request_buffer_block(size, want_minimal_block);
+	}
+
+	return buffer_block->allocate(to_u32(size));
+}
+
+void HPPRenderFrame::clear_descriptors()
+{
+	for (auto &desc_sets_per_thread : descriptor_sets)
+	{
+		desc_sets_per_thread->clear();
+	}
+
+	for (auto &desc_pools_per_thread : descriptor_pools)
+	{
+		for (auto &desc_pool : *desc_pools_per_thread)
+		{
+			desc_pool.second.reset();
+		}
+	}
+}
+
+std::vector<uint32_t> HPPRenderFrame::collect_bindings_to_update(const vkb::core::HPPDescriptorSetLayout    &descriptor_set_layout,
+                                                                 const BindingMap<vk::DescriptorBufferInfo> &buffer_infos,
+                                                                 const BindingMap<vk::DescriptorImageInfo>  &image_infos)
+{
+	std::set<uint32_t> bindings_to_update;
+
+	auto aggregate_binding_to_update = [&bindings_to_update, &descriptor_set_layout](const auto &infos_map) {
+		for (const auto &[binding_index, ignored] : infos_map)
+		{
+			if (!(descriptor_set_layout.get_layout_binding_flag(binding_index) & vk::DescriptorBindingFlagBits::eUpdateAfterBind))
+			{
+				bindings_to_update.insert(binding_index);
+			}
+		}
+	};
+	aggregate_binding_to_update(buffer_infos);
+	aggregate_binding_to_update(image_infos);
+
+	return {bindings_to_update.begin(), bindings_to_update.end()};
+}
+
+std::vector<std::unique_ptr<vkb::core::HPPCommandPool>> &HPPRenderFrame::get_command_pools(const vkb::core::HPPQueue             &queue,
+                                                                                           vkb::core::HPPCommandBuffer::ResetMode reset_mode)
+{
+	auto command_pool_it = command_pools.find(queue.get_family_index());
+
+	if (command_pool_it != command_pools.end())
+	{
+		assert(!command_pool_it->second.empty());
+		if (command_pool_it->second[0]->get_reset_mode() != reset_mode)
+		{
+			device.get_handle().waitIdle();
+
+			// Delete pools
+			command_pools.erase(command_pool_it);
+		}
+		else
+		{
+			return command_pool_it->second;
+		}
+	}
+
+	bool inserted                       = false;
+	std::tie(command_pool_it, inserted) = command_pools.emplace(queue.get_family_index(), std::vector<std::unique_ptr<vkb::core::HPPCommandPool>>{});
+	if (!inserted)
+	{
+		throw std::runtime_error("Failed to insert command pool");
+	}
+
+	for (size_t i = 0; i < thread_count; i++)
+	{
+		command_pool_it->second.push_back(std::make_unique<vkb::core::HPPCommandPool>(device, queue.get_family_index(), this, i, reset_mode));
+	}
+
+	return command_pool_it->second;
+}
+
+vkb::core::HPPDevice &HPPRenderFrame::get_device()
+{
+	return device;
+}
+
+const vkb::HPPFencePool &HPPRenderFrame::get_fence_pool() const
+{
+	return fence_pool;
+}
+
+vkb::rendering::HPPRenderTarget &HPPRenderFrame::get_render_target()
+{
+	return *swapchain_render_target;
+}
+
+vkb::rendering::HPPRenderTarget const &HPPRenderFrame::get_render_target() const
+{
+	return *swapchain_render_target;
+}
+
+const vkb::HPPSemaphorePool &HPPRenderFrame::get_semaphore_pool() const
+{
+	return semaphore_pool;
+}
+
+void HPPRenderFrame::release_owned_semaphore(vk::Semaphore semaphore)
+{
+	semaphore_pool.release_owned_semaphore(semaphore);
+}
+
+vkb::core::HPPCommandBuffer &HPPRenderFrame::request_command_buffer(const vkb::core::HPPQueue             &queue,
+                                                                    vkb::core::HPPCommandBuffer::ResetMode reset_mode,
+                                                                    vk::CommandBufferLevel                 level,
+                                                                    size_t                                 thread_index)
+{
+	assert(thread_index < thread_count && "Thread index is out of bounds");
+
+	auto &command_pools = get_command_pools(queue, reset_mode);
+
+	auto command_pool_it =
+	    std::find_if(command_pools.begin(),
+	                 command_pools.end(),
+	                 [&thread_index](std::unique_ptr<vkb::core::HPPCommandPool> &cmd_pool) { return cmd_pool->get_thread_index() == thread_index; });
+	assert(command_pool_it != command_pools.end());
+
+	return (*command_pool_it)->request_command_buffer(level);
+}
+
+vk::DescriptorSet HPPRenderFrame::request_descriptor_set(const vkb::core::HPPDescriptorSetLayout    &descriptor_set_layout,
+                                                         const BindingMap<vk::DescriptorBufferInfo> &buffer_infos,
+                                                         const BindingMap<vk::DescriptorImageInfo>  &image_infos,
+                                                         bool                                        update_after_bind,
+                                                         size_t                                      thread_index)
+{
+	assert(thread_index < thread_count && "Thread index is out of bounds");
+
+	assert(thread_index < descriptor_pools.size());
+	auto &descriptor_pool = vkb::common::request_resource(device, nullptr, *descriptor_pools[thread_index], descriptor_set_layout);
+	if (descriptor_management_strategy == DescriptorManagementStrategy::StoreInCache)
+	{
+		// The bindings we want to update before binding, if empty we update all bindings
+		std::vector<uint32_t> bindings_to_update;
+		// If update after bind is enabled, we store the binding index of each binding that need to be updated before being bound
+		if (update_after_bind)
+		{
+			bindings_to_update = collect_bindings_to_update(descriptor_set_layout, buffer_infos, image_infos);
+		}
+
+		// Request a descriptor set from the render frame, and write the buffer infos and image infos of all the specified bindings
+		assert(thread_index < descriptor_sets.size());
+		auto &descriptor_set =
+		    vkb::common::request_resource(device, nullptr, *descriptor_sets[thread_index], descriptor_set_layout, descriptor_pool, buffer_infos, image_infos);
+		descriptor_set.update(bindings_to_update);
+		return descriptor_set.get_handle();
+	}
+	else
+	{
+		// Request a descriptor pool, allocate a descriptor set, write buffer and image data to it
+		vkb::core::HPPDescriptorSet descriptor_set{device, descriptor_set_layout, descriptor_pool, buffer_infos, image_infos};
+		descriptor_set.apply_writes();
+		return descriptor_set.get_handle();
+	}
+}
+
+vk::Fence HPPRenderFrame::request_fence()
+{
+	return fence_pool.request_fence();
+}
+
+vk::Semaphore HPPRenderFrame::request_semaphore()
+{
+	return semaphore_pool.request_semaphore();
+}
+
+vk::Semaphore HPPRenderFrame::request_semaphore_with_ownership()
+{
+	return semaphore_pool.request_semaphore_with_ownership();
+}
+
+void HPPRenderFrame::reset()
+{
+	VK_CHECK(fence_pool.wait());
+
+	fence_pool.reset();
+
+	for (auto &command_pools_per_queue : command_pools)
+	{
+		for (auto &command_pool : command_pools_per_queue.second)
+		{
+			command_pool->reset_pool();
+		}
+	}
+
+	for (auto &buffer_pools_per_usage : buffer_pools)
+	{
+		for (auto &buffer_pool : buffer_pools_per_usage.second)
+		{
+			buffer_pool.first.reset();
+			buffer_pool.second = nullptr;
+		}
+	}
+
+	semaphore_pool.reset();
+
+	if (descriptor_management_strategy == DescriptorManagementStrategy::CreateDirectly)
+	{
+		clear_descriptors();
+	}
+}
+
+void HPPRenderFrame::set_buffer_allocation_strategy(BufferAllocationStrategy new_strategy)
+{
+	buffer_allocation_strategy = new_strategy;
+}
+
+void HPPRenderFrame::set_descriptor_management_strategy(DescriptorManagementStrategy new_strategy)
+{
+	descriptor_management_strategy = new_strategy;
+}
+
+void HPPRenderFrame::update_descriptor_sets(size_t thread_index)
+{
+	assert(thread_index < descriptor_sets.size());
+	auto &thread_descriptor_sets = *descriptor_sets[thread_index];
+	for (auto &descriptor_set_it : thread_descriptor_sets)
+	{
+		descriptor_set_it.second.update();
+	}
+}
+
+void HPPRenderFrame::update_render_target(std::unique_ptr<vkb::rendering::HPPRenderTarget> &&render_target)
+{
+	swapchain_render_target = std::move(render_target);
+}
+
+}        // namespace rendering
+}        // namespace vkb


### PR DESCRIPTION
## Description

Includes
- a modified header `vkb/rendering/hpp_render_frame.h` and a new implementation file `vkb/rendering/hpp_render_frame.cpp`
- a new facade class `HPPSemaphorePool`;
- some minor adjustments in `framework/common/hpp_resource_caching.h`, `framework/core/hpp_device.h`, and `framework/hpp_resource_cache.cpp`;
- some minor extensions in the facade classes `vkb::core::HPPDescriptorPool`, `vkb::core::HPPDescriptorSet`, `vkb::core::HPPDescriptorSetLayout`, `vkb::HPPBufferBlock`, and `vkb::HPPBufferPool`.

Build tested on Win10 with VS2022. All hpp-based samples tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](./../antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
