### PR TITLE
Refactored API sample hpp_timestamp_queries; includes minor adjustments in API samples hpp_hdr and hpp_terrain_tessellation.

### DIFF
--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -254,6 +254,15 @@ inline vk::ImageView create_image_view(vk::Device           device,
 	return device.createImageView(image_view_create_info);
 }
 
+inline vk::QueryPool create_query_pool(vk::Device device, vk::QueryType query_type, uint32_t query_count, vk::QueryPipelineStatisticFlags pipeline_statistics = {})
+{
+	vk::QueryPoolCreateInfo query_pool_create_info;
+	query_pool_create_info.queryType          = query_type;
+	query_pool_create_info.queryCount         = query_count;
+	query_pool_create_info.pipelineStatistics = pipeline_statistics;
+	return device.createQueryPool(query_pool_create_info);
+}
+
 inline vk::Sampler create_sampler(vk::Device device, vk::Filter filter, vk::SamplerAddressMode sampler_address_mode, float max_anisotropy, float max_LOD)
 {
 	vk::SamplerCreateInfo sampler_create_info;

--- a/samples/api/hpp_hdr/hpp_hdr.h
+++ b/samples/api/hpp_hdr/hpp_hdr.h
@@ -65,7 +65,7 @@ class HPPHDR : public HPPApiVulkanSample
 	};
 
 	// Framebuffer for offscreen rendering
-	struct FrameBufferAttachment
+	struct FramebufferAttachment
 	{
 		vk::Format       format = {};
 		vk::Image        image  = {};
@@ -84,7 +84,7 @@ class HPPHDR : public HPPApiVulkanSample
 	{
 		vk::Extent2D          extent      = {};
 		vk::Framebuffer       framebuffer = {};
-		FrameBufferAttachment color       = {};
+		FramebufferAttachment color       = {};
 		vk::RenderPass        render_pass = {};
 		vk::Sampler           sampler     = {};
 
@@ -132,8 +132,8 @@ class HPPHDR : public HPPApiVulkanSample
 	{
 		vk::Extent2D          extent      = {};
 		vk::Framebuffer       framebuffer = {};
-		FrameBufferAttachment color[2]    = {};
-		FrameBufferAttachment depth       = {};
+		FramebufferAttachment color[2]    = {};
+		FramebufferAttachment depth       = {};
 		vk::RenderPass        render_pass = {};
 		vk::Sampler           sampler     = {};
 
@@ -191,7 +191,7 @@ class HPPHDR : public HPPApiVulkanSample
 	virtual void render(float delta_time) override;
 
 	vk::DeviceMemory      allocate_memory(vk::Image image);
-	FrameBufferAttachment create_attachment(vk::Format format, vk::ImageUsageFlagBits usage);
+	FramebufferAttachment create_attachment(vk::Format format, vk::ImageUsageFlagBits usage);
 	vk::DescriptorPool    create_descriptor_pool();
 	vk::Pipeline          create_bloom_pipeline(uint32_t direction);
 	vk::Pipeline          create_composition_pipeline();
@@ -202,12 +202,12 @@ class HPPHDR : public HPPApiVulkanSample
 	vk::RenderPass        create_render_pass(std::vector<vk::AttachmentDescription> const &attachment_descriptions, vk::SubpassDescription const &subpass_description);
 	void                  draw();
 	void                  load_assets();
+	void                  prepare_bloom();
 	void                  prepare_camera();
+	void                  prepare_composition();
+	void                  prepare_models();
 	void                  prepare_offscreen_buffer();
 	void                  prepare_uniform_buffers();
-	void                  setup_bloom();
-	void                  setup_composition();
-	void                  setup_models();
 	void                  update_composition_descriptor_set();
 	void                  update_bloom_descriptor_set();
 	void                  update_model_descriptor_set(vk::DescriptorSet descriptor_set);

--- a/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
+++ b/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
@@ -477,12 +477,11 @@ void HPPTerrainTessellation::prepare_statistics()
 	if (statistics.query_supported)
 	{
 		// Create query pool
-		vk::QueryPoolCreateInfo query_pool_info({},
-		                                        vk::QueryType::ePipelineStatistics,
-		                                        2,
-		                                        vk::QueryPipelineStatisticFlagBits::eVertexShaderInvocations |
-		                                            vk::QueryPipelineStatisticFlagBits::eTessellationEvaluationShaderInvocations);
-		statistics.query_pool = get_device()->get_handle().createQueryPool(query_pool_info);
+		statistics.query_pool = vkb::common::create_query_pool(get_device()->get_handle(),
+		                                                       vk::QueryType::ePipelineStatistics,
+		                                                       2,
+		                                                       vk::QueryPipelineStatisticFlagBits::eVertexShaderInvocations |
+		                                                           vk::QueryPipelineStatisticFlagBits::eTessellationEvaluationShaderInvocations);
 	}
 }
 

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -35,84 +35,54 @@ HPPTimestampQueries::~HPPTimestampQueries()
 	{
 		vk::Device device = get_device()->get_handle();
 
-		device.destroyQueryPool(time_stamps_query_pool);
-
-		device.destroyPipeline(pipelines.bloom[0]);
-		device.destroyPipeline(pipelines.bloom[1]);
-		device.destroyPipeline(pipelines.composition);
-		device.destroyPipeline(pipelines.reflect);
-		device.destroyPipeline(pipelines.skybox);
-
-		device.destroyPipelineLayout(pipeline_layouts.bloom_filter);
-		device.destroyPipelineLayout(pipeline_layouts.composition);
-		device.destroyPipelineLayout(pipeline_layouts.models);
-
-		device.destroyDescriptorSetLayout(descriptor_set_layouts.bloom_filter);
-		device.destroyDescriptorSetLayout(descriptor_set_layouts.composition);
-		device.destroyDescriptorSetLayout(descriptor_set_layouts.models);
-
-		device.destroyRenderPass(filter_pass.render_pass);
-		device.destroyRenderPass(offscreen.render_pass);
-
-		device.destroyFramebuffer(filter_pass.framebuffer);
-		device.destroyFramebuffer(offscreen.framebuffer);
-
-		device.destroySampler(filter_pass.sampler);
-		device.destroySampler(offscreen.sampler);
-
-		offscreen.depth.destroy(device);
-		offscreen.color[0].destroy(device);
-		offscreen.color[1].destroy(device);
-
-		filter_pass.color.destroy(device);
-
-		device.destroySampler(textures.envmap.sampler);
+		time_stamps.destroy(device);
+		bloom.destroy(device);
+		composition.destroy(device);
+		filter_pass.destroy(device);
+		models.destroy(device, descriptor_pool);
+		offscreen.destroy(device);
+		textures.destroy(device);
 	}
 }
 
 bool HPPTimestampQueries::prepare(const vkb::ApplicationOptions &options)
 {
-	if (!HPPApiVulkanSample::prepare(options))
+	assert(!prepared);
+	if (HPPApiVulkanSample::prepare(options))
 	{
-		return false;
-	}
-
-	// Check if the selected device supports timestamps. A value of zero means no support.
-	vk::PhysicalDeviceLimits const &device_limits = device->get_gpu().get_properties().limits;
-	if (device_limits.timestampPeriod == 0)
-	{
-		throw std::runtime_error{"The selected device does not support timestamp queries!"};
-	}
-
-	// Check if all queues support timestamp queries, if not we need to check on a per-queue basis
-	if (!device_limits.timestampComputeAndGraphics)
-	{
-		// Check if the graphics queue used in this sample supports time stamps
-		vk::QueueFamilyProperties const &graphics_queue_family_properties = device->get_suitable_graphics_queue().get_properties();
-		if (graphics_queue_family_properties.timestampValidBits == 0)
+		// Check if the selected device supports timestamps. A value of zero means no support.
+		vk::PhysicalDeviceLimits const &device_limits = device->get_gpu().get_properties().limits;
+		if (device_limits.timestampPeriod == 0)
 		{
-			throw std::runtime_error{"The selected graphics queue family does not support timestamp queries!"};
+			throw std::runtime_error{"The selected device does not support timestamp queries!"};
 		}
+
+		// Check if all queues support timestamp queries, if not we need to check on a per-queue basis
+		if (!device_limits.timestampComputeAndGraphics)
+		{
+			// Check if the graphics queue used in this sample supports time stamps
+			vk::QueueFamilyProperties const &graphics_queue_family_properties = device->get_suitable_graphics_queue().get_properties();
+			if (graphics_queue_family_properties.timestampValidBits == 0)
+			{
+				throw std::runtime_error{"The selected graphics queue family does not support timestamp queries!"};
+			}
+		}
+
+		prepare_camera();
+		load_assets();
+		prepare_uniform_buffers();
+		prepare_offscreen_buffer();
+		descriptor_pool = create_descriptor_pool();
+		prepare_bloom();
+		prepare_composition();
+		prepare_models();
+		prepare_time_stamps();
+		build_command_buffers();
+
+		prepared = true;
 	}
 
-	camera.type = vkb::CameraType::LookAt;
-	camera.set_position(glm::vec3(0.0f, 0.0f, -4.0f));
-	camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
-
-	// Note: Using reversed depth-buffer for increased precision, so Znear and Zfar are flipped
-	camera.set_perspective(60.0f, (float) extent.width / (float) extent.height, 256.0f, 0.1f);
-
-	load_assets();
-	prepare_uniform_buffers();
-	prepare_offscreen_buffer();
-	prepare_descriptor_set_layout();
-	prepare_pipelines();
-	prepare_descriptor_pool();
-	prepare_descriptor_sets();
-	prepare_time_stamp_queries();
-	build_command_buffers();
-	prepared = true;
-	return true;
+	return prepared;
 }
 
 bool HPPTimestampQueries::resize(const uint32_t width, const uint32_t height)
@@ -139,27 +109,24 @@ void HPPTimestampQueries::build_command_buffers()
 {
 	vk::CommandBufferBeginInfo command_buffer_begin_info;
 
-	for (size_t i = 0; i < draw_cmd_buffers.size(); ++i)
+	for (int32_t i = 0; i < draw_cmd_buffers.size(); ++i)
 	{
-		vk::CommandBuffer const &command_buffer = draw_cmd_buffers[i];
-
+		vk::CommandBuffer command_buffer = draw_cmd_buffers[i];
 		command_buffer.begin(command_buffer_begin_info);
 
 		// Reset the timestamp query pool, so we can start fetching new values into it
-		command_buffer.resetQueryPool(time_stamps_query_pool, 0, static_cast<uint32_t>(time_stamps.size()));
+		command_buffer.resetQueryPool(time_stamps.query_pool, 0, static_cast<uint32_t>(time_stamps.values.size()));
 
 		{
 			/*
 			    First pass: Render scene to offscreen framebuffer
 			*/
-
-			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eTopOfPipe, time_stamps_query_pool, 0);
+			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eTopOfPipe, time_stamps.query_pool, 0);
 
 			std::array<vk::ClearValue, 3> clear_values = {{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
 			                                               vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})),
 			                                               vk::ClearDepthStencilValue(0.0f, 0)}};
-
-			vk::RenderPassBeginInfo render_pass_begin_info(offscreen.render_pass, offscreen.framebuffer, {{0, 0}, offscreen.extent}, clear_values);
+			vk::RenderPassBeginInfo       render_pass_begin_info(offscreen.render_pass, offscreen.framebuffer, {{0, 0}, offscreen.extent}, clear_values);
 			command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
 
 			vk::Viewport viewport(0.0f, 0.0f, static_cast<float>(offscreen.extent.width), static_cast<float>(offscreen.extent.height), 0.0f, 1.0f);
@@ -171,32 +138,30 @@ void HPPTimestampQueries::build_command_buffers()
 			// Skybox
 			if (display_skybox)
 			{
-				command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipelines.skybox);
-				command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layouts.models, 0, descriptor_sets.skybox, {});
-
-				draw_model(models.skybox, command_buffer);
+				command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.skybox.pipeline);
+				command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.skybox.descriptor_set, {});
+				draw_model(models.skybox.meshes[0], command_buffer);
 			}
 
 			// 3D object
-			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipelines.reflect);
-			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layouts.models, 0, descriptor_sets.object, {});
-
-			draw_model(models.objects[models.object_index], command_buffer);
+			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, models.objects.pipeline);
+			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, models.pipeline_layout, 0, models.objects.descriptor_set, {});
+			draw_model(models.objects.meshes[models.object_index], command_buffer);
 
 			command_buffer.endRenderPass();
 
-			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, time_stamps_query_pool, 1);
+			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, time_stamps.query_pool, 1);
 		}
 
 		/*
 		    Second render pass: First bloom pass
 		*/
-		if (bloom)
+		if (bloom.enabled)
 		{
-			vk::ClearValue clear_value{vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}}))};
+			vk::ClearValue clear_value(vk::ClearColorValue(std::array<float, 4>({{0.0f, 0.0f, 0.0f, 0.0f}})));
 
 			// Bloom filter
-			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eTopOfPipe, time_stamps_query_pool, 2);
+			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eTopOfPipe, time_stamps.query_pool, 2);
 
 			vk::RenderPassBeginInfo render_pass_begin_info(filter_pass.render_pass, filter_pass.framebuffer, {{0, 0}, filter_pass.extent}, clear_value);
 			command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
@@ -207,18 +172,17 @@ void HPPTimestampQueries::build_command_buffers()
 			vk::Rect2D scissor({0, 0}, filter_pass.extent);
 			command_buffer.setScissor(0, scissor);
 
-			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layouts.bloom_filter, 0, descriptor_sets.bloom_filter, {});
-
-			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipelines.bloom[1]);
+			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, bloom.pipeline_layout, 0, bloom.descriptor_set, {});
+			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[1]);
 			command_buffer.draw(3, 1, 0, 0);
 
 			command_buffer.endRenderPass();
 
-			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, time_stamps_query_pool, 3);
+			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, time_stamps.query_pool, 3);
 		}
 
 		/*
-		    Note: Explicit synchronization is not required between the render pass, as this is done implicit via sub pass dependencies
+		    Note: Explicit synchronization is not required between the render pass, as this is done implicitly via sub pass dependencies
 		*/
 
 		/*
@@ -229,7 +193,7 @@ void HPPTimestampQueries::build_command_buffers()
 			                                               vk::ClearDepthStencilValue(0.0f, 0)}};
 
 			// Final composition
-			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eTopOfPipe, time_stamps_query_pool, bloom ? 4 : 2);
+			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eTopOfPipe, time_stamps.query_pool, bloom.enabled ? 4 : 2);
 
 			vk::RenderPassBeginInfo render_pass_begin_info(render_pass, framebuffers[i], {{0, 0}, extent}, clear_values);
 			command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
@@ -240,16 +204,16 @@ void HPPTimestampQueries::build_command_buffers()
 			vk::Rect2D scissor({0, 0}, extent);
 			command_buffer.setScissor(0, scissor);
 
-			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layouts.composition, 0, descriptor_sets.composition, {});
+			command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, composition.pipeline_layout, 0, composition.descriptor_set, {});
 
 			// Scene
-			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipelines.composition);
+			command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, composition.pipeline);
 			command_buffer.draw(3, 1, 0, 0);
 
 			// Bloom
-			if (bloom)
+			if (bloom.enabled)
 			{
-				command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipelines.bloom[0]);
+				command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, bloom.pipelines[0]);
 				command_buffer.draw(3, 1, 0, 0);
 			}
 
@@ -257,7 +221,7 @@ void HPPTimestampQueries::build_command_buffers()
 
 			command_buffer.endRenderPass();
 
-			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, time_stamps_query_pool, bloom ? 5 : 3);
+			command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, time_stamps.query_pool, bloom.enabled ? 5 : 3);
 		}
 
 		command_buffer.end();
@@ -277,7 +241,7 @@ void HPPTimestampQueries::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 		{
 			update_params();
 		}
-		if (drawer.checkbox("Bloom", &bloom))
+		if (drawer.checkbox("Bloom", &bloom.enabled))
 		{
 			rebuild_command_buffers();
 		}
@@ -292,11 +256,11 @@ void HPPTimestampQueries::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 		// The timestampPeriod property of the device tells how many nanoseconds such a timestep translates to on the selected device
 		float timestampFrequency = device->get_gpu().get_properties().limits.timestampPeriod;
 
-		drawer.text("Pass 1: Offscreen scene rendering: %.3f ms", float(time_stamps[1] - time_stamps[0]) * timestampFrequency / 1000000.0f);
-		drawer.text("Pass 2: %s %.3f ms", (bloom ? "First bloom pass" : "Scene display"), float(time_stamps[3] - time_stamps[2]) * timestampFrequency / 1000000.0f);
-		if (bloom)
+		drawer.text("Pass 1: Offscreen scene rendering: %.3f ms", float(time_stamps.values[1] - time_stamps.values[0]) * timestampFrequency / 1000000.0f);
+		drawer.text("Pass 2: %s %.3f ms", (bloom.enabled ? "First bloom pass" : "Scene display"), float(time_stamps.values[3] - time_stamps.values[2]) * timestampFrequency / 1000000.0f);
+		if (bloom.enabled)
 		{
-			drawer.text("Pass 3: Second bloom pass %.3f ms", float(time_stamps[5] - time_stamps[4]) * timestampFrequency / 1000000.0f);
+			drawer.text("Pass 3: Second bloom pass %.3f ms", float(time_stamps.values[5] - time_stamps.values[4]) * timestampFrequency / 1000000.0f);
 			drawer.set_dirty(true);
 		}
 	}
@@ -304,64 +268,265 @@ void HPPTimestampQueries::on_update_ui_overlay(vkb::HPPDrawer &drawer)
 
 void HPPTimestampQueries::render(float delta_time)
 {
-	if (!prepared)
-		return;
-	draw();
-	if (camera.updated)
-		update_uniform_buffers();
+	if (prepared)
+	{
+		draw();
+		if (camera.updated)
+		{
+			update_uniform_buffers();
+		}
+	}
 }
 
-void HPPTimestampQueries::create_attachment(vk::Format format, vk::ImageUsageFlagBits usage, FramebufferAttachment *attachment)
+vk::DeviceMemory HPPTimestampQueries::allocate_memory(vk::Image image)
 {
-	attachment->format = format;
+	vk::MemoryRequirements memory_requirements = get_device()->get_handle().getImageMemoryRequirements(image);
 
-	vk::ImageAspectFlags aspect_mask;
-	switch (usage)
+	vk::MemoryAllocateInfo memory_allocate_info(memory_requirements.size,
+	                                            get_device()->get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
+
+	return get_device()->get_handle().allocateMemory(memory_allocate_info);
+}
+
+HPPTimestampQueries::FramebufferAttachment HPPTimestampQueries::create_attachment(vk::Format format, vk::ImageUsageFlagBits usage)
+{
+	vk::Image        image  = create_image(format, usage);
+	vk::DeviceMemory memory = allocate_memory(image);
+	get_device()->get_handle().bindImageMemory(image, memory, 0);
+	vk::ImageView view =
+	    vkb::common::create_image_view(get_device()->get_handle(), image, vk::ImageViewType::e2D, format, vkb::common::get_image_aspect_flags(usage, format));
+
+	return {format, image, memory, view};
+}
+
+vk::DescriptorPool HPPTimestampQueries::create_descriptor_pool()
+{
+	std::array<vk::DescriptorPoolSize, 2> pool_sizes = {{{vk::DescriptorType::eUniformBuffer, 4}, {vk::DescriptorType::eCombinedImageSampler, 6}}};
+	return get_device()->get_handle().createDescriptorPool({{}, 4, pool_sizes});
+}
+
+vk::Pipeline HPPTimestampQueries::create_bloom_pipeline(uint32_t direction)
+{
+	std::vector<vk::PipelineShaderStageCreateInfo> shader_stages{load_shader("hdr/bloom.vert", vk::ShaderStageFlagBits::eVertex),
+	                                                             load_shader("hdr/bloom.frag", vk::ShaderStageFlagBits::eFragment)};
+
+	// Set constant parameters via specialization constants
+	vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
+
+	vk::SpecializationInfo specialization_info(1, &specialization_map_entry, sizeof(uint32_t), &direction);
+	shader_stages[1].pSpecializationInfo = &specialization_info;
+
+	vk::PipelineColorBlendAttachmentState blend_attachment_state;
+	blend_attachment_state.blendEnable         = true;
+	blend_attachment_state.colorBlendOp        = vk::BlendOp::eAdd;
+	blend_attachment_state.srcColorBlendFactor = vk::BlendFactor::eOne;
+	blend_attachment_state.dstColorBlendFactor = vk::BlendFactor::eOne;
+	blend_attachment_state.alphaBlendOp        = vk::BlendOp::eAdd;
+	blend_attachment_state.srcAlphaBlendFactor = vk::BlendFactor::eSrcAlpha;
+	blend_attachment_state.dstAlphaBlendFactor = vk::BlendFactor::eDstAlpha;
+	blend_attachment_state.colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+
+	// Note: Using reversed depth-buffer for increased precision, so Greater depth values are kept
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+	depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
+	depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
+	depth_stencil_state.front          = depth_stencil_state.back;
+
+	// Empty vertex input state, full screen triangles are generated by the vertex shader
+	return vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+	                                             pipeline_cache,
+	                                             shader_stages,
+	                                             {},
+	                                             vk::PrimitiveTopology::eTriangleList,
+	                                             0,
+	                                             vk::PolygonMode::eFill,
+	                                             vk::CullModeFlagBits::eFront,
+	                                             vk::FrontFace::eCounterClockwise,
+	                                             {blend_attachment_state},
+	                                             depth_stencil_state,
+	                                             bloom.pipeline_layout,
+	                                             direction == 1 ? render_pass : filter_pass.render_pass);
+}
+
+vk::Pipeline HPPTimestampQueries::create_composition_pipeline()
+{
+	std::vector<vk::PipelineShaderStageCreateInfo> shader_stages{load_shader("hdr/composition.vert", vk::ShaderStageFlagBits::eVertex),
+	                                                             load_shader("hdr/composition.frag", vk::ShaderStageFlagBits::eFragment)};
+
+	vk::PipelineColorBlendAttachmentState blend_attachment_state;
+	blend_attachment_state.colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+
+	// Note: Using reversed depth-buffer for increased precision, so Greater depth values are kept
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+	depth_stencil_state.depthCompareOp = vk::CompareOp::eGreater;
+	depth_stencil_state.back.compareOp = vk::CompareOp::eAlways;
+	depth_stencil_state.front          = depth_stencil_state.back;
+
+	// Empty vertex input state, full screen triangles are generated by the vertex shader
+	return vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+	                                             pipeline_cache,
+	                                             shader_stages,
+	                                             {},
+	                                             vk::PrimitiveTopology::eTriangleList,
+	                                             0,
+	                                             vk::PolygonMode::eFill,
+	                                             vk::CullModeFlagBits::eFront,
+	                                             vk::FrontFace::eCounterClockwise,
+	                                             {blend_attachment_state},
+	                                             depth_stencil_state,
+	                                             composition.pipeline_layout,
+	                                             render_pass);
+}
+
+vk::RenderPass HPPTimestampQueries::create_filter_render_pass()
+{
+	// Set up separate renderpass with references to the color and depth attachments
+	vk::AttachmentDescription attachment_description;
+	attachment_description.samples        = vk::SampleCountFlagBits::e1;
+	attachment_description.loadOp         = vk::AttachmentLoadOp::eClear;
+	attachment_description.storeOp        = vk::AttachmentStoreOp::eStore;
+	attachment_description.stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
+	attachment_description.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+	attachment_description.initialLayout  = vk::ImageLayout::eUndefined;
+	attachment_description.finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
+	attachment_description.format         = filter_pass.color.format;
+
+	vk::AttachmentReference color_reference(0, vk::ImageLayout::eColorAttachmentOptimal);
+	vk::SubpassDescription  subpass({}, vk::PipelineBindPoint::eGraphics, {}, color_reference);
+
+	return create_render_pass({attachment_description}, subpass);
+}
+
+vk::Image HPPTimestampQueries::create_image(vk::Format format, vk::ImageUsageFlagBits usage)
+{
+	vk::ImageCreateInfo image_create_info;
+	image_create_info.imageType   = vk::ImageType::e2D;
+	image_create_info.format      = format;
+	image_create_info.extent      = vk::Extent3D(offscreen.extent, 1);
+	image_create_info.mipLevels   = 1;
+	image_create_info.arrayLayers = 1;
+	image_create_info.samples     = vk::SampleCountFlagBits::e1;
+	image_create_info.tiling      = vk::ImageTiling::eOptimal;
+	image_create_info.usage       = usage | vk::ImageUsageFlagBits::eSampled;
+
+	return get_device()->get_handle().createImage(image_create_info);
+}
+
+vk::Pipeline HPPTimestampQueries::create_models_pipeline(uint32_t shaderType, vk::CullModeFlagBits cullMode, bool depthTestAndWrite)
+{
+	std::vector<vk::PipelineShaderStageCreateInfo> shader_stages{load_shader("hdr/gbuffer.vert", vk::ShaderStageFlagBits::eVertex),
+	                                                             load_shader("hdr/gbuffer.frag", vk::ShaderStageFlagBits::eFragment)};
+
+	// Set constant parameters via specialization constants
+	vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
+
+	// Set constant parameters via specialization constants
+	vk::SpecializationInfo specialization_info = vk::SpecializationInfo(1, &specialization_map_entry, sizeof(uint32_t), &shaderType);
+	shader_stages[0].pSpecializationInfo       = &specialization_info;
+	shader_stages[1].pSpecializationInfo       = &specialization_info;
+
+	// Vertex bindings an attributes for model rendering
+	// Binding description
+	vk::VertexInputBindingDescription vertex_input_binding(0, sizeof(HPPVertex), vk::VertexInputRate::eVertex);
+
+	// Attribute descriptions
+	std::vector<vk::VertexInputAttributeDescription> vertex_input_attributes = {{0, 0, vk::Format::eR32G32B32Sfloat, 0},
+	                                                                            {1, 0, vk::Format::eR32G32B32Sfloat, 3 * sizeof(float)}};
+
+	vk::PipelineVertexInputStateCreateInfo vertex_input_state({}, vertex_input_binding, vertex_input_attributes);
+
+	std::vector<vk::PipelineColorBlendAttachmentState> blend_attachment_states(2);
+	blend_attachment_states[0].colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+	blend_attachment_states[1].colorWriteMask = blend_attachment_states[0].colorWriteMask;
+
+	// Note: Using reversed depth-buffer for increased precision, so Greater depth values are kept
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+	depth_stencil_state.depthCompareOp   = vk::CompareOp::eGreater;
+	depth_stencil_state.depthWriteEnable = depthTestAndWrite;
+	depth_stencil_state.depthTestEnable  = depthTestAndWrite;
+	depth_stencil_state.back.compareOp   = vk::CompareOp::eAlways;
+	depth_stencil_state.front            = depth_stencil_state.back;
+
+	return vkb::common::create_graphics_pipeline(get_device()->get_handle(),
+	                                             pipeline_cache,
+	                                             shader_stages,
+	                                             vertex_input_state,
+	                                             vk::PrimitiveTopology::eTriangleList,
+	                                             0,
+	                                             vk::PolygonMode::eFill,
+	                                             cullMode,
+	                                             vk::FrontFace::eCounterClockwise,
+	                                             blend_attachment_states,
+	                                             depth_stencil_state,
+	                                             models.pipeline_layout,
+	                                             offscreen.render_pass);
+}
+
+vk::RenderPass HPPTimestampQueries::create_offscreen_render_pass()
+{
+	// Set up separate renderpass with references to the color and depth attachments
+	std::vector<vk::AttachmentDescription> attachment_descriptions(3);
+
+	// Init attachment properties
+	for (uint32_t i = 0; i < 3; ++i)
 	{
-		case vk::ImageUsageFlagBits::eColorAttachment:
-			assert(!vkb::common::is_depth_format(format));
-			aspect_mask = vk::ImageAspectFlagBits::eColor;
-			break;
-		case vk::ImageUsageFlagBits::eDepthStencilAttachment:
-			assert(vkb::common::is_depth_format(format));
-			aspect_mask = vk::ImageAspectFlagBits::eDepth;
-			// Stencil aspect should only be set on depth + stencil formats
-			if (vkb::common::is_depth_stencil_format(format))
-			{
-				aspect_mask |= vk::ImageAspectFlagBits::eStencil;
-			}
-			break;
-		default:
-			assert(false);
+		attachment_descriptions[i].samples        = vk::SampleCountFlagBits::e1;
+		attachment_descriptions[i].loadOp         = vk::AttachmentLoadOp::eClear;
+		attachment_descriptions[i].storeOp        = vk::AttachmentStoreOp::eStore;
+		attachment_descriptions[i].stencilLoadOp  = vk::AttachmentLoadOp::eDontCare;
+		attachment_descriptions[i].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+		attachment_descriptions[i].initialLayout  = vk::ImageLayout::eUndefined;
+		attachment_descriptions[i].finalLayout    = vk::ImageLayout::eShaderReadOnlyOptimal;
 	}
+	attachment_descriptions[2].finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
 
-	vk::ImageCreateInfo image_create_info({},
-	                                      vk::ImageType::e2D,
-	                                      format,
-	                                      vk::Extent3D(offscreen.extent, 1),
-	                                      1,
-	                                      1,
-	                                      vk::SampleCountFlagBits::e1,
-	                                      vk::ImageTiling::eOptimal,
-	                                      usage | vk::ImageUsageFlagBits::eSampled,
-	                                      vk::SharingMode::eExclusive,
-	                                      {},
-	                                      vk::ImageLayout::eUndefined);
-	attachment->image = get_device()->get_handle().createImage(image_create_info);
+	// Formats
+	attachment_descriptions[0].format = offscreen.color[0].format;
+	attachment_descriptions[1].format = offscreen.color[1].format;
+	attachment_descriptions[2].format = offscreen.depth.format;
 
-	vk::MemoryRequirements memory_requirements = get_device()->get_handle().getImageMemoryRequirements(attachment->image);
-	vk::MemoryAllocateInfo memory_allocate_info(
-	    memory_requirements.size, get_device()->get_gpu().get_memory_type(memory_requirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal));
-	attachment->mem = get_device()->get_handle().allocateMemory(memory_allocate_info);
-	get_device()->get_handle().bindImageMemory(attachment->image, attachment->mem, 0);
+	std::array<vk::AttachmentReference, 2> color_references{{{0, vk::ImageLayout::eColorAttachmentOptimal},
+	                                                         {1, vk::ImageLayout::eColorAttachmentOptimal}}};
 
-	vk::ImageViewCreateInfo image_view_create_info({},
-	                                               attachment->image,
-	                                               vk::ImageViewType::e2D,
-	                                               format,
-	                                               {vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eG, vk::ComponentSwizzle::eB, vk::ComponentSwizzle::eA},
-	                                               {aspect_mask, 0, 1, 0, 1});
-	attachment->view = get_device()->get_handle().createImageView(image_view_create_info);
+	vk::AttachmentReference depth_reference(2, vk::ImageLayout::eDepthStencilAttachmentOptimal);
+
+	vk::SubpassDescription subpass({}, vk::PipelineBindPoint::eGraphics, nullptr, color_references, nullptr, &depth_reference);
+
+	return create_render_pass(attachment_descriptions, subpass);
+}
+
+vk::RenderPass HPPTimestampQueries::create_render_pass(std::vector<vk::AttachmentDescription> const &attachment_descriptions, vk::SubpassDescription const &subpass_description)
+{
+	// Use subpass dependencies for attachment layout transitions
+	std::array<vk::SubpassDependency, 2> subpass_dependencies;
+
+	subpass_dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+	subpass_dependencies[0].dstSubpass = 0;
+	// End of previous commands
+	subpass_dependencies[0].srcStageMask  = vk::PipelineStageFlagBits::eBottomOfPipe;
+	subpass_dependencies[0].srcAccessMask = vk::AccessFlagBits::eNoneKHR;
+	// Read/write from/to depth
+	subpass_dependencies[0].dstStageMask  = vk::PipelineStageFlagBits::eEarlyFragmentTests;
+	subpass_dependencies[0].dstAccessMask = vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
+	// Write to attachment
+	subpass_dependencies[0].dstStageMask |= vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	subpass_dependencies[0].dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
+
+	subpass_dependencies[1].srcSubpass = 0;
+	subpass_dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+	// End of write to attachment
+	subpass_dependencies[1].srcStageMask  = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	subpass_dependencies[1].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
+	// Attachment later read using sampler in 'bloom[0]' pipeline
+	subpass_dependencies[1].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
+	subpass_dependencies[1].dstAccessMask = vk::AccessFlagBits::eShaderRead;
+
+	vk::RenderPassCreateInfo render_pass_create_info({}, attachment_descriptions, subpass_description, subpass_dependencies);
+
+	return get_device()->get_handle().createRenderPass(render_pass_create_info);
 }
 
 void HPPTimestampQueries::draw()
@@ -369,7 +534,6 @@ void HPPTimestampQueries::draw()
 	HPPApiVulkanSample::prepare_frame();
 
 	submit_info.setCommandBuffers(draw_cmd_buffers[current_buffer]);
-
 	queue.submit(submit_info);
 
 	HPPApiVulkanSample::submit_frame();
@@ -381,17 +545,17 @@ void HPPTimestampQueries::draw()
 void HPPTimestampQueries::get_time_stamp_results()
 {
 	// The number of timestamps changes if the bloom pass is disabled
-	uint32_t count = static_cast<uint32_t>(bloom ? time_stamps.size() : time_stamps.size() - 2);
+	uint32_t count = static_cast<uint32_t>(bloom.enabled ? time_stamps.values.size() : time_stamps.values.size() - 2);
 
 	// Fetch the time stamp results written in the command buffer submissions
 	// A note on the flags used:
 	//	vk::QueryResultFlagBits::e64: Results will have 64 bits. As time stamp values are on nano-seconds, this flag should always be used to avoid 32 bit overflows
 	//  vk::QueryResultFlagBits::eWait: Since we want to immediately display the results, we use this flag to have the CPU wait until the results are available
-	vk::Result result = device->get_handle().getQueryPoolResults(time_stamps_query_pool,
+	vk::Result result = device->get_handle().getQueryPoolResults(time_stamps.query_pool,
 	                                                             0,
 	                                                             count,
-	                                                             time_stamps.size() * sizeof(uint64_t),
-	                                                             time_stamps.data(),
+	                                                             time_stamps.values.size() * sizeof(uint64_t),
+	                                                             time_stamps.values.data(),
 	                                                             sizeof(uint64_t),
 	                                                             vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait);
 	assert(result == vk::Result::eSuccess);
@@ -400,167 +564,84 @@ void HPPTimestampQueries::get_time_stamp_results()
 void HPPTimestampQueries::load_assets()
 {
 	// Models
-	models.skybox                      = load_model("scenes/cube.gltf");
+	models.skybox.meshes.emplace_back(load_model("scenes/cube.gltf"));
 	std::vector<std::string> filenames = {"geosphere.gltf", "teapot.gltf", "torusknot.gltf"};
 	object_names                       = {"Sphere", "Teapot", "Torusknot"};
 	for (auto file : filenames)
 	{
-		auto object = load_model("scenes/" + file);
-		models.objects.emplace_back(std::move(object));
+		models.objects.meshes.emplace_back(load_model("scenes/" + file));
 	}
 
 	// Transforms
 	auto geosphere_matrix = glm::mat4(1.0f);
-	auto teapot_matrix    = glm::mat4(1.0f);
-	teapot_matrix         = glm::scale(teapot_matrix, glm::vec3(10.0f, 10.0f, 10.0f));
-	teapot_matrix         = glm::rotate(teapot_matrix, glm::radians(180.0f), glm::vec3(1.0f, 0.0f, 0.0f));
-	auto torus_matrix     = glm::mat4(1.0f);
 	models.transforms.push_back(geosphere_matrix);
+
+	auto teapot_matrix = glm::mat4(1.0f);
+	teapot_matrix      = glm::scale(teapot_matrix, glm::vec3(10.0f, 10.0f, 10.0f));
+	teapot_matrix      = glm::rotate(teapot_matrix, glm::radians(180.0f), glm::vec3(1.0f, 0.0f, 0.0f));
 	models.transforms.push_back(teapot_matrix);
+
+	auto torus_matrix = glm::mat4(1.0f);
 	models.transforms.push_back(torus_matrix);
 
 	// Load HDR cube map
 	textures.envmap = load_texture_cubemap("textures/uffizi_rgba16f_cube.ktx", vkb::scene_graph::components::HPPImage::Color);
 }
 
-void HPPTimestampQueries::prepare_descriptor_pool()
+void HPPTimestampQueries::prepare_bloom()
 {
-	std::array<vk::DescriptorPoolSize, 2> pool_sizes = {{{vk::DescriptorType::eUniformBuffer, 4}, {vk::DescriptorType::eCombinedImageSampler, 6}}};
-	vk::DescriptorPoolCreateInfo          descriptor_pool_create_info({}, 4, pool_sizes);
-	descriptor_pool = get_device()->get_handle().createDescriptorPool(descriptor_pool_create_info);
+	std::array<vk::DescriptorSetLayoutBinding, 2> bindings = {{{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	                                                           {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}}};
+
+	vk::Device device           = get_device()->get_handle();
+	bloom.descriptor_set_layout = device.createDescriptorSetLayout({{}, bindings});
+	bloom.pipeline_layout       = device.createPipelineLayout({{}, bloom.descriptor_set_layout});
+	bloom.pipelines[0]          = create_bloom_pipeline(1);
+	bloom.pipelines[1]          = create_bloom_pipeline(0);
+	bloom.descriptor_set        = vkb::common::allocate_descriptor_set(device, descriptor_pool, bloom.descriptor_set_layout);
+	update_bloom_descriptor_set();
 }
 
-void HPPTimestampQueries::prepare_descriptor_set_layout()
+void HPPTimestampQueries::prepare_camera()
 {
-	{
-		std::array<vk::DescriptorSetLayoutBinding, 3> models_descriptor_set_layout_bindings = {
-		    {{0, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex},
-		     {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-		     {2, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment}}};
+	camera.type = vkb::CameraType::LookAt;
+	camera.set_position(glm::vec3(0.0f, 0.0f, -4.0f));
+	camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
 
-		vk::DescriptorSetLayoutCreateInfo models_descriptor_set_layout_create_info({}, models_descriptor_set_layout_bindings);
-
-		descriptor_set_layouts.models = get_device()->get_handle().createDescriptorSetLayout(models_descriptor_set_layout_create_info);
-
-#if defined(ANDROID)
-		vk::PipelineLayoutCreateInfo models_pipeline_layout_create_info({}, 1, &descriptor_set_layouts.models);
-#else
-		vk::PipelineLayoutCreateInfo models_pipeline_layout_create_info({}, descriptor_set_layouts.models);
-#endif
-
-		pipeline_layouts.models = get_device()->get_handle().createPipelineLayout(models_pipeline_layout_create_info);
-	}
-
-	// Bloom filter
-	{
-		std::array<vk::DescriptorSetLayoutBinding, 2> bloom_descriptor_set_layout_bindings = {
-		    {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-		     {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}}};
-
-		vk::DescriptorSetLayoutCreateInfo bloom_descriptor_set_layout_create_info({}, bloom_descriptor_set_layout_bindings);
-		descriptor_set_layouts.bloom_filter = get_device()->get_handle().createDescriptorSetLayout(bloom_descriptor_set_layout_create_info);
-
-#if defined(ANDROID)
-		vk::PipelineLayoutCreateInfo bloom_pipeline_layout_create_info({}, 1, &descriptor_set_layouts.bloom_filter);
-#else
-		vk::PipelineLayoutCreateInfo bloom_pipeline_layout_create_info({}, descriptor_set_layouts.bloom_filter);
-#endif
-		pipeline_layouts.bloom_filter = get_device()->get_handle().createPipelineLayout(bloom_pipeline_layout_create_info);
-	}
-
-	// G-Buffer composition
-	{
-		std::array<vk::DescriptorSetLayoutBinding, 2> composition_descriptor_set_layout_bindings = {
-		    {{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-		     {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}}};
-
-		vk::DescriptorSetLayoutCreateInfo composition_descriptor_set_layout_create_info({}, composition_descriptor_set_layout_bindings);
-
-		descriptor_set_layouts.composition = get_device()->get_handle().createDescriptorSetLayout(composition_descriptor_set_layout_create_info);
-
-#if defined(ANDROID)
-		vk::PipelineLayoutCreateInfo composition_pipeline_layout_create_info({}, 1, &descriptor_set_layouts.composition);
-#else
-		vk::PipelineLayoutCreateInfo composition_pipeline_layout_create_info({}, descriptor_set_layouts.composition);
-#endif
-		pipeline_layouts.composition = get_device()->get_handle().createPipelineLayout(composition_pipeline_layout_create_info);
-	}
+	// Note: Using reversed depth-buffer for increased precision, so Znear and Zfar are flipped
+	camera.set_perspective(60.0f, static_cast<float>(extent.width) / static_cast<float>(extent.height), 256.0f, 0.1f);
 }
 
-void HPPTimestampQueries::prepare_descriptor_sets()
+void HPPTimestampQueries::prepare_composition()
 {
-#if defined(ANDROID)
-	vk::DescriptorSetAllocateInfo alloc_info(descriptor_pool, 1, &descriptor_set_layouts.models);
-#else
-	vk::DescriptorSetAllocateInfo alloc_info(descriptor_pool, descriptor_set_layouts.models);
-#endif
-	vk::DescriptorBufferInfo matrix_buffer_descriptor(uniform_buffers.matrices->get_handle(), 0, VK_WHOLE_SIZE);
-	vk::DescriptorImageInfo  environment_image_descriptor(textures.envmap.sampler, textures.envmap.image->get_vk_image_view().get_handle(), vk::ImageLayout::eShaderReadOnlyOptimal);
-	vk::DescriptorBufferInfo params_buffer_descriptor(uniform_buffers.params->get_handle(), 0, VK_WHOLE_SIZE);
+	std::array<vk::DescriptorSetLayoutBinding, 2> bindings = {{{0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	                                                           {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment}}};
 
-	// 3D object descriptor set
-	{
-		descriptor_sets.object = get_device()->get_handle().allocateDescriptorSets(alloc_info).front();
+	vk::Device device                 = get_device()->get_handle();
+	composition.descriptor_set_layout = device.createDescriptorSetLayout({{}, bindings});
+	composition.pipeline_layout       = device.createPipelineLayout({{}, composition.descriptor_set_layout});
+	composition.pipeline              = create_composition_pipeline();
+	composition.descriptor_set        = vkb::common::allocate_descriptor_set(device, descriptor_pool, composition.descriptor_set_layout);
+	update_composition_descriptor_set();
+}
 
-		std::array<vk::WriteDescriptorSet, 3> write_descriptor_sets = {
-		    {{descriptor_sets.object, 0, {}, vk::DescriptorType::eUniformBuffer, {}, matrix_buffer_descriptor},
-		     {descriptor_sets.object, 1, {}, vk::DescriptorType::eCombinedImageSampler, environment_image_descriptor},
-		     {descriptor_sets.object, 2, {}, vk::DescriptorType::eUniformBuffer, {}, params_buffer_descriptor}}};
+void HPPTimestampQueries::prepare_models()
+{
+	std::array<vk::DescriptorSetLayoutBinding, 3> bindings = {{{0, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex},
+	                                                           {1, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	                                                           {2, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment}}};
 
-		get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
-	}
+	vk::Device device            = get_device()->get_handle();
+	models.descriptor_set_layout = device.createDescriptorSetLayout({{}, bindings});
+	models.pipeline_layout       = device.createPipelineLayout({{}, models.descriptor_set_layout});
 
-	// Sky box descriptor set
-	{
-		descriptor_sets.skybox = get_device()->get_handle().allocateDescriptorSets(alloc_info).front();
+	models.objects.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
+	update_model_descriptor_set(models.objects.descriptor_set);
+	models.objects.pipeline = create_models_pipeline(1, vk::CullModeFlagBits::eFront, true);
 
-		std::array<vk::WriteDescriptorSet, 3> write_descriptor_sets = {
-		    {{descriptor_sets.skybox, 0, {}, vk::DescriptorType::eUniformBuffer, {}, matrix_buffer_descriptor},
-		     {descriptor_sets.skybox, 1, {}, vk::DescriptorType::eCombinedImageSampler, environment_image_descriptor},
-		     {descriptor_sets.skybox, 2, {}, vk::DescriptorType::eUniformBuffer, {}, params_buffer_descriptor}}};
-
-		get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
-	}
-
-	// Bloom filter
-	{
-#if defined(ANDROID)
-		vk::DescriptorSetAllocateInfo bloom_alloc_info(descriptor_pool, 1, &descriptor_set_layouts.bloom_filter);
-#else
-		vk::DescriptorSetAllocateInfo bloom_alloc_info(descriptor_pool, descriptor_set_layouts.bloom_filter);
-#endif
-
-		descriptor_sets.bloom_filter = get_device()->get_handle().allocateDescriptorSets(bloom_alloc_info).front();
-
-		std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
-		                                                             {offscreen.sampler, offscreen.color[1].view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
-
-		std::array<vk::WriteDescriptorSet, 2> write_descriptor_sets = {
-		    {{descriptor_sets.bloom_filter, 0, {}, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
-		     {descriptor_sets.bloom_filter, 1, {}, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
-
-		get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
-	}
-
-	// Composition descriptor set
-	{
-#if defined(ANDROID)
-		vk::DescriptorSetAllocateInfo composition_alloc_info(descriptor_pool, 1, &descriptor_set_layouts.composition);
-#else
-		vk::DescriptorSetAllocateInfo composition_alloc_info(descriptor_pool, descriptor_set_layouts.composition);
-#endif
-
-		descriptor_sets.composition = get_device()->get_handle().allocateDescriptorSets(composition_alloc_info).front();
-
-		std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
-		                                                             {offscreen.sampler, filter_pass.color.view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
-
-		std::array<vk::WriteDescriptorSet, 2> write_descriptor_sets = {
-		    {{descriptor_sets.composition, 0, {}, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
-		     {descriptor_sets.composition, 1, {}, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
-
-		get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
-	}
+	models.skybox.descriptor_set = vkb::common::allocate_descriptor_set(device, descriptor_pool, models.descriptor_set_layout);
+	update_model_descriptor_set(models.skybox.descriptor_set);
+	models.skybox.pipeline = create_models_pipeline(0, vk::CullModeFlagBits::eBack, false);
 }
 
 // Prepare a new framebuffer and attachments for offscreen rendering (G-Buffer)
@@ -573,102 +654,18 @@ void HPPTimestampQueries::prepare_offscreen_buffer()
 
 		// We are using two 128-Bit RGBA floating point color buffers for this sample
 		// In a performance or bandwidth-limited scenario you should consider using a format with lower precision
-		create_attachment(vk::Format::eR32G32B32A32Sfloat, vk::ImageUsageFlagBits::eColorAttachment, &offscreen.color[0]);
-		create_attachment(vk::Format::eR32G32B32A32Sfloat, vk::ImageUsageFlagBits::eColorAttachment, &offscreen.color[1]);
+		offscreen.color[0] = create_attachment(vk::Format::eR32G32B32A32Sfloat, vk::ImageUsageFlagBits::eColorAttachment);
+		offscreen.color[1] = create_attachment(vk::Format::eR32G32B32A32Sfloat, vk::ImageUsageFlagBits::eColorAttachment);
 		// Depth attachment
-		create_attachment(depth_format, vk::ImageUsageFlagBits::eDepthStencilAttachment, &offscreen.depth);
+		offscreen.depth = create_attachment(depth_format, vk::ImageUsageFlagBits::eDepthStencilAttachment);
 
-		// Init attachment properties
-		std::array<vk::AttachmentDescription, 3> attachment_descriptions = {{{{},
-		                                                                      offscreen.color[0].format,
-		                                                                      vk::SampleCountFlagBits::e1,
-		                                                                      vk::AttachmentLoadOp::eClear,
-		                                                                      vk::AttachmentStoreOp::eStore,
-		                                                                      vk::AttachmentLoadOp::eDontCare,
-		                                                                      vk::AttachmentStoreOp::eDontCare,
-		                                                                      vk::ImageLayout::eUndefined,
-		                                                                      vk::ImageLayout::eShaderReadOnlyOptimal},
-		                                                                     {{},
-		                                                                      offscreen.color[1].format,
-		                                                                      vk::SampleCountFlagBits::e1,
-		                                                                      vk::AttachmentLoadOp::eClear,
-		                                                                      vk::AttachmentStoreOp::eStore,
-		                                                                      vk::AttachmentLoadOp::eDontCare,
-		                                                                      vk::AttachmentStoreOp::eDontCare,
-		                                                                      vk::ImageLayout::eUndefined,
-		                                                                      vk::ImageLayout::eShaderReadOnlyOptimal},
-		                                                                     {{},
-		                                                                      offscreen.depth.format,
-		                                                                      vk::SampleCountFlagBits::e1,
-		                                                                      vk::AttachmentLoadOp::eClear,
-		                                                                      vk::AttachmentStoreOp::eStore,
-		                                                                      vk::AttachmentLoadOp::eDontCare,
-		                                                                      vk::AttachmentStoreOp::eDontCare,
-		                                                                      vk::ImageLayout::eUndefined,
-		                                                                      vk::ImageLayout::eDepthStencilAttachmentOptimal}}};
+		offscreen.render_pass = create_offscreen_render_pass();
 
-		// Set up separate renderpass with references to the color and depth attachments
-		std::array<vk::AttachmentReference, 2> color_references = {{{0, vk::ImageLayout::eColorAttachmentOptimal},
-		                                                            {1, vk::ImageLayout::eColorAttachmentOptimal}}};
-
-		vk::AttachmentReference depth_reference(2, vk::ImageLayout::eDepthStencilAttachmentOptimal);
-
-		vk::SubpassDescription subpass({}, vk::PipelineBindPoint::eGraphics, {}, color_references, {}, &depth_reference);
-
-		// Use subpass dependencies for attachment layout transitions
-		std::array<vk::SubpassDependency, 2> dependencies;
-
-		dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
-		dependencies[0].dstSubpass      = 0;
-		dependencies[0].dependencyFlags = vk::DependencyFlagBits::eByRegion;
-		// End of previous commands
-		dependencies[0].srcStageMask  = vk::PipelineStageFlagBits::eBottomOfPipe;
-		dependencies[0].srcAccessMask = vk::AccessFlagBits::eNoneKHR;
-		// Read/write from/to depth
-		dependencies[0].dstStageMask  = vk::PipelineStageFlagBits::eEarlyFragmentTests;
-		dependencies[0].dstAccessMask = vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite;
-		// Write to attachment
-		dependencies[0].dstStageMask |= vk::PipelineStageFlagBits::eColorAttachmentOutput;
-		dependencies[0].dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
-
-		dependencies[1].srcSubpass      = 0;
-		dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
-		dependencies[1].dependencyFlags = vk::DependencyFlagBits::eByRegion;
-		// End of write to attachment
-		dependencies[1].srcStageMask  = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-		dependencies[1].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
-		// Attachment later read using sampler in 'composition' pipeline
-		dependencies[1].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
-		dependencies[1].dstAccessMask = vk::AccessFlagBits::eShaderRead;
-
-		vk::RenderPassCreateInfo render_pass_create_info({}, attachment_descriptions, subpass, dependencies);
-
-		offscreen.render_pass = get_device()->get_handle().createRenderPass(render_pass_create_info);
-
-		std::array<vk::ImageView, 3> attachments = {{offscreen.color[0].view, offscreen.color[1].view, offscreen.depth.view}};
-
-		vk::FramebufferCreateInfo framebuffer_create_info({}, offscreen.render_pass, attachments, offscreen.extent.width, offscreen.extent.height, 1);
-
-		offscreen.framebuffer = get_device()->get_handle().createFramebuffer(framebuffer_create_info);
+		offscreen.framebuffer = vkb::common::create_framebuffer(
+		    get_device()->get_handle(), offscreen.render_pass, {offscreen.color[0].view, offscreen.color[1].view, offscreen.depth.view}, offscreen.extent);
 
 		// Create sampler to sample from the color attachments
-		vk::SamplerCreateInfo sampler_create_info({},
-		                                          vk::Filter::eNearest,
-		                                          vk::Filter::eNearest,
-		                                          vk::SamplerMipmapMode::eLinear,
-		                                          vk::SamplerAddressMode::eClampToEdge,
-		                                          vk::SamplerAddressMode::eClampToEdge,
-		                                          vk::SamplerAddressMode::eClampToEdge,
-		                                          0.0f,
-		                                          {},
-		                                          1.0f,
-		                                          {},
-		                                          {},
-		                                          0.0f,
-		                                          1.0f,
-		                                          vk::BorderColor::eFloatOpaqueWhite);
-
-		offscreen.sampler = get_device()->get_handle().createSampler(sampler_create_info);
+		offscreen.sampler = vkb::common::create_sampler(get_device()->get_handle(), vk::Filter::eNearest, vk::SamplerAddressMode::eClampToEdge, 1.0f, 1.0f);
 	}
 
 	// Bloom separable filter pass
@@ -678,233 +675,18 @@ void HPPTimestampQueries::prepare_offscreen_buffer()
 		// Color attachments
 
 		// One floating point color buffer
-		create_attachment(vk::Format::eR32G32B32A32Sfloat, vk::ImageUsageFlagBits::eColorAttachment, &filter_pass.color);
+		filter_pass.color = create_attachment(vk::Format::eR32G32B32A32Sfloat, vk::ImageUsageFlagBits::eColorAttachment);
 
-		// Set up separate renderpass with references to the color attachment
-		// Init attachment properties
-		vk::AttachmentDescription attachment_description({},
-		                                                 filter_pass.color.format,
-		                                                 vk::SampleCountFlagBits::e1,
-		                                                 vk::AttachmentLoadOp::eClear,
-		                                                 vk::AttachmentStoreOp::eStore,
-		                                                 vk::AttachmentLoadOp::eDontCare,
-		                                                 vk::AttachmentStoreOp::eDontCare,
-		                                                 vk::ImageLayout::eUndefined,
-		                                                 vk::ImageLayout::eShaderReadOnlyOptimal);
-
-		vk::AttachmentReference color_reference(0, vk::ImageLayout::eColorAttachmentOptimal);
-
-		vk::SubpassDescription subpass({}, vk::PipelineBindPoint::eGraphics, {}, color_reference);
-
-		// Use subpass dependencies for attachment layout transitions
-		std::array<vk::SubpassDependency, 2> dependencies;
-
-		dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
-		dependencies[0].dstSubpass      = 0;
-		dependencies[0].dependencyFlags = vk::DependencyFlagBits::eByRegion;
-		// End of previous commands
-		dependencies[0].srcStageMask  = vk::PipelineStageFlagBits::eBottomOfPipe;
-		dependencies[0].srcAccessMask = vk::AccessFlagBits::eNoneKHR;
-		// Read from image in fragment shader
-		dependencies[0].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
-		dependencies[0].dstAccessMask = vk::AccessFlagBits::eShaderRead;
-		// Write to attachment
-		dependencies[0].dstStageMask |= vk::PipelineStageFlagBits::eColorAttachmentOutput;
-		dependencies[0].dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
-
-		dependencies[1].srcSubpass      = 0;
-		dependencies[1].dstSubpass      = VK_SUBPASS_EXTERNAL;
-		dependencies[1].dependencyFlags = vk::DependencyFlagBits::eByRegion;
-		// End of write to attachment
-		dependencies[1].srcStageMask  = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-		dependencies[1].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
-		// Attachment later read using sampler in 'bloom[0]' pipeline
-		dependencies[1].dstStageMask  = vk::PipelineStageFlagBits::eFragmentShader;
-		dependencies[1].dstAccessMask = vk::AccessFlagBits::eShaderRead;
-
-		vk::RenderPassCreateInfo render_pass_create_info({}, attachment_description, subpass, dependencies);
-
-		filter_pass.render_pass = get_device()->get_handle().createRenderPass(render_pass_create_info);
-
-		vk::ImageView attachment = filter_pass.color.view;
-
-		vk::FramebufferCreateInfo framebuffer_create_info({}, filter_pass.render_pass, attachment, filter_pass.extent.width, filter_pass.extent.height, 1);
-
-		filter_pass.framebuffer = get_device()->get_handle().createFramebuffer(framebuffer_create_info);
-
-		// Create sampler to sample from the color attachments
-		vk::SamplerCreateInfo sampler_create_info({},
-		                                          vk::Filter::eNearest,
-		                                          vk::Filter::eNearest,
-		                                          vk::SamplerMipmapMode::eLinear,
-		                                          vk::SamplerAddressMode::eClampToEdge,
-		                                          vk::SamplerAddressMode::eClampToEdge,
-		                                          vk::SamplerAddressMode::eClampToEdge,
-		                                          0.0f,
-		                                          {},
-		                                          1.0f,
-		                                          {},
-		                                          {},
-		                                          0.0f,
-		                                          1.0f,
-		                                          vk::BorderColor::eFloatOpaqueWhite);
-
-		filter_pass.sampler = get_device()->get_handle().createSampler(sampler_create_info);
+		filter_pass.render_pass = create_filter_render_pass();
+		filter_pass.framebuffer = vkb::common::create_framebuffer(get_device()->get_handle(), filter_pass.render_pass, {filter_pass.color.view}, filter_pass.extent);
+		filter_pass.sampler     = vkb::common::create_sampler(get_device()->get_handle(), vk::Filter::eNearest, vk::SamplerAddressMode::eClampToEdge, 1.0f, 1.0f);
 	}
 }
 
-void HPPTimestampQueries::prepare_pipelines()
+void HPPTimestampQueries::prepare_time_stamps()
 {
-	std::array<vk::PipelineShaderStageCreateInfo, 2> shader_stages;
-
-	// Empty vertex input state, full screen triangles are generated by the vertex shader
-	vk::PipelineVertexInputStateCreateInfo empty_input_state;
-
-	vk::PipelineInputAssemblyStateCreateInfo input_assembly_state({}, vk::PrimitiveTopology::eTriangleList);
-
-	vk::PipelineViewportStateCreateInfo viewport_state({}, 1, {}, 1, {});
-
-	vk::PipelineRasterizationStateCreateInfo rasterization_state(
-	    {}, false, {}, vk::PolygonMode::eFill, {}, vk::FrontFace::eCounterClockwise, {}, {}, {}, {}, 1.0f);
-
-	vk::PipelineMultisampleStateCreateInfo multisample_state({}, vk::SampleCountFlagBits::e1);
-
-	// Note: Using reversed depth-buffer for increased precision, so Greater depth values are kept
-	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state({}, false, false, vk::CompareOp::eGreater, {}, {}, {}, {{}, {}, {}, vk::CompareOp::eAlways});
-
-	vk::PipelineColorBlendStateCreateInfo color_blend_state;
-
-	std::array<vk::DynamicState, 2> dynamic_state_enables = {{vk::DynamicState::eViewport, vk::DynamicState::eScissor}};
-
-	vk::PipelineDynamicStateCreateInfo dynamic_state({}, dynamic_state_enables);
-
-	vk::GraphicsPipelineCreateInfo pipeline_create_info({},
-	                                                    shader_stages,
-	                                                    &empty_input_state,
-	                                                    &input_assembly_state,
-	                                                    nullptr,
-	                                                    &viewport_state,
-	                                                    &rasterization_state,
-	                                                    &multisample_state,
-	                                                    &depth_stencil_state,
-	                                                    &color_blend_state,
-	                                                    &dynamic_state,
-	                                                    {},
-	                                                    {},
-	                                                    {},
-	                                                    nullptr,
-	                                                    -1);
-
-	std::array<vk::PipelineColorBlendAttachmentState, 2> blend_attachment_states = {{{false,
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG |
-	                                                                                      vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA},
-	                                                                                 {false,
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  {},
-	                                                                                  vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG |
-	                                                                                      vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA}}};
-
-	// Full screen pipelines
-
-	// Final fullscreen composition pass pipeline
-	shader_stages[0]                  = load_shader("hdr/composition.vert", vk::ShaderStageFlagBits::eVertex);
-	shader_stages[1]                  = load_shader("hdr/composition.frag", vk::ShaderStageFlagBits::eFragment);
-	pipeline_create_info.layout       = pipeline_layouts.composition;
-	pipeline_create_info.renderPass   = render_pass;
-	rasterization_state.cullMode      = vk::CullModeFlagBits::eFront;
-	color_blend_state.attachmentCount = 1;
-	color_blend_state.pAttachments    = blend_attachment_states.data();
-
-	vk::Result result;
-	std::tie(result, pipelines.composition) = get_device()->get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info);
-	assert(result == vk::Result::eSuccess);
-
-	// Bloom pass
-	shader_stages[0] = static_cast<VkPipelineShaderStageCreateInfo>(load_shader("hdr/bloom.vert", vk::ShaderStageFlagBits::eVertex));
-	shader_stages[1] = static_cast<VkPipelineShaderStageCreateInfo>(load_shader("hdr/bloom.frag", vk::ShaderStageFlagBits::eFragment));
-
-	vk::PipelineColorBlendAttachmentState blend_attachment_state(true,
-	                                                             vk::BlendFactor::eOne,
-	                                                             vk::BlendFactor::eOne,
-	                                                             vk::BlendOp::eAdd,
-	                                                             vk::BlendFactor::eSrcAlpha,
-	                                                             vk::BlendFactor::eDstAlpha,
-	                                                             vk::BlendOp::eAdd,
-	                                                             vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG |
-	                                                                 vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA);
-	color_blend_state.pAttachments = &blend_attachment_state;
-
-	// Set constant parameters via specialization constants
-	vk::SpecializationMapEntry specialization_map_entry(0, 0, sizeof(uint32_t));
-	uint32_t                   dir = 1;
-	vk::SpecializationInfo     specialization_info(1, &specialization_map_entry, sizeof(dir), &dir);
-	shader_stages[1].pSpecializationInfo = &specialization_info;
-
-	std::tie(result, pipelines.bloom[0]) = get_device()->get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info);
-	assert(result == vk::Result::eSuccess);
-
-	// Second blur pass (into separate framebuffer)
-	pipeline_create_info.renderPass = filter_pass.render_pass;
-	dir                             = 0;
-
-	std::tie(result, pipelines.bloom[1]) = get_device()->get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info);
-	assert(result == vk::Result::eSuccess);
-
-	// Object rendering pipelines
-	rasterization_state.cullMode = vk::CullModeFlagBits::eBack;
-
-	// Vertex bindings an attributes for model rendering
-	// Binding description
-	vk::VertexInputBindingDescription vertex_input_bindings(0, sizeof(HPPVertex), vk::VertexInputRate::eVertex);
-
-	// Attribute descriptions
-	std::array<vk::VertexInputAttributeDescription, 2> vertex_input_attributes = {{{0, 0, vk::Format::eR32G32B32Sfloat, 0},                          // Position
-	                                                                               {1, 0, vk::Format::eR32G32B32Sfloat, 3 * sizeof(float)}}};        // Normal
-
-	vk::PipelineVertexInputStateCreateInfo vertex_input_state({}, vertex_input_bindings, vertex_input_attributes);
-
-	pipeline_create_info.pVertexInputState = &vertex_input_state;
-
-	// Skybox pipeline (background cube)
-	blend_attachment_state.blendEnable = false;
-	pipeline_create_info.layout        = pipeline_layouts.models;
-	pipeline_create_info.renderPass    = offscreen.render_pass;
-	color_blend_state.attachmentCount  = 2;
-	color_blend_state.pAttachments     = blend_attachment_states.data();
-
-	shader_stages[0] = static_cast<VkPipelineShaderStageCreateInfo>(load_shader("hdr/gbuffer.vert", vk::ShaderStageFlagBits::eVertex));
-	shader_stages[1] = static_cast<VkPipelineShaderStageCreateInfo>(load_shader("hdr/gbuffer.frag", vk::ShaderStageFlagBits::eFragment));
-
-	// Set constant parameters via specialization constants
-	uint32_t shadertype                  = 0;
-	specialization_info.pData            = &shadertype;
-	shader_stages[0].pSpecializationInfo = &specialization_info;
-	shader_stages[1].pSpecializationInfo = &specialization_info;
-
-	std::tie(result, pipelines.skybox) = get_device()->get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info);
-	assert(result == vk::Result::eSuccess);
-
-	// Object rendering pipeline
-	shadertype = 1;
-
-	// Enable depth test and write
-	depth_stencil_state.depthWriteEnable = true;
-	depth_stencil_state.depthTestEnable  = true;
-	// Flip cull mode
-	rasterization_state.cullMode = vk::CullModeFlagBits::eFront;
-
-	std::tie(result, pipelines.reflect) = get_device()->get_handle().createGraphicsPipeline(pipeline_cache, pipeline_create_info);
-	assert(result == vk::Result::eSuccess);
+	// Create the query pool object used to get the GPU time tamps
+	time_stamps.query_pool = vkb::common::create_query_pool(get_device()->get_handle(), vk::QueryType::eTimestamp, static_cast<uint32_t>(time_stamps.values.size()));
 }
 
 // Prepare and initialize uniform buffer containing shader uniforms
@@ -912,7 +694,7 @@ void HPPTimestampQueries::prepare_uniform_buffers()
 {
 	// Matrices vertex shader uniform buffer
 	uniform_buffers.matrices = std::make_unique<vkb::core::HPPBuffer>(*get_device(),
-	                                                                  sizeof(ubo_vs),
+	                                                                  sizeof(ubo_matrices),
 	                                                                  vk::BufferUsageFlagBits::eUniformBuffer,
 	                                                                  VMA_MEMORY_USAGE_CPU_TO_GPU);
 
@@ -926,11 +708,47 @@ void HPPTimestampQueries::prepare_uniform_buffers()
 	update_params();
 }
 
-void HPPTimestampQueries::prepare_time_stamp_queries()
+void HPPTimestampQueries::update_composition_descriptor_set()
 {
-	// Create the query pool object used to get the GPU time tamps
-	vk::QueryPoolCreateInfo query_pool_create_info({}, vk::QueryType::eTimestamp, static_cast<uint32_t>(time_stamps.size()));
-	time_stamps_query_pool = get_device()->get_handle().createQueryPool(query_pool_create_info);
+	std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
+	                                                             {offscreen.sampler, filter_pass.color.view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
+
+	std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
+	    {{composition.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
+	     {composition.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
+
+	get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
+}
+
+void HPPTimestampQueries::update_bloom_descriptor_set()
+{
+	std::array<vk::DescriptorImageInfo, 2> color_descriptors = {{{offscreen.sampler, offscreen.color[0].view, vk::ImageLayout::eShaderReadOnlyOptimal},
+	                                                             {offscreen.sampler, offscreen.color[1].view, vk::ImageLayout::eShaderReadOnlyOptimal}}};
+
+	std::array<vk::WriteDescriptorSet, 2> sampler_write_descriptor_sets = {
+	    {{bloom.descriptor_set, 0, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[0]},
+	     {bloom.descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, color_descriptors[1]}}};
+
+	get_device()->get_handle().updateDescriptorSets(sampler_write_descriptor_sets, {});
+}
+
+void HPPTimestampQueries::update_model_descriptor_set(vk::DescriptorSet descriptor_set)
+{
+	vk::DescriptorBufferInfo matrix_buffer_descriptor(uniform_buffers.matrices->get_handle(), 0, VK_WHOLE_SIZE);
+
+	vk::DescriptorImageInfo environment_image_descriptor(
+	    textures.envmap.sampler,
+	    textures.envmap.image->get_vk_image_view().get_handle(),
+	    descriptor_type_to_image_layout(vk::DescriptorType::eCombinedImageSampler, textures.envmap.image->get_vk_image_view().get_format()));
+
+	vk::DescriptorBufferInfo params_buffer_descriptor(uniform_buffers.params->get_handle(), 0, VK_WHOLE_SIZE);
+
+	std::array<vk::WriteDescriptorSet, 3> write_descriptor_sets = {
+	    {{descriptor_set, 0, 0, vk::DescriptorType::eUniformBuffer, {}, matrix_buffer_descriptor},
+	     {descriptor_set, 1, 0, vk::DescriptorType::eCombinedImageSampler, environment_image_descriptor},
+	     {descriptor_set, 2, 0, vk::DescriptorType::eUniformBuffer, {}, params_buffer_descriptor}}};
+
+	get_device()->get_handle().updateDescriptorSets(write_descriptor_sets, {});
 }
 
 void HPPTimestampQueries::update_params()
@@ -940,10 +758,10 @@ void HPPTimestampQueries::update_params()
 
 void HPPTimestampQueries::update_uniform_buffers()
 {
-	ubo_vs.projection       = camera.matrices.perspective;
-	ubo_vs.modelview        = camera.matrices.view * models.transforms[models.object_index];
-	ubo_vs.skybox_modelview = camera.matrices.view;
-	uniform_buffers.matrices->convert_and_update(ubo_vs);
+	ubo_matrices.projection       = camera.matrices.perspective;
+	ubo_matrices.modelview        = camera.matrices.view * models.transforms[models.object_index];
+	ubo_matrices.skybox_modelview = camera.matrices.view;
+	uniform_buffers.matrices->convert_and_update(ubo_matrices);
 }
 
 std::unique_ptr<vkb::Application> create_hpp_timestamp_queries()

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.h
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.h
@@ -21,33 +21,56 @@
 
 #pragma once
 
-#include "hpp_api_vulkan_sample.h"
+#include <hpp_api_vulkan_sample.h>
 
 class HPPTimestampQueries : public HPPApiVulkanSample
 {
+  public:
+	HPPTimestampQueries();
+	~HPPTimestampQueries();
+
   private:
-	struct DescriptorSetLayouts
+	struct Bloom
 	{
-		vk::DescriptorSetLayout bloom_filter;
-		vk::DescriptorSetLayout composition;
-		vk::DescriptorSetLayout models;
+		bool                    enabled               = true;
+		vk::DescriptorSetLayout descriptor_set_layout = {};
+		vk::DescriptorSet       descriptor_set;
+		vk::PipelineLayout      pipeline_layout;
+		vk::Pipeline            pipelines[2];
+
+		void destroy(vk::Device device)
+		{
+			device.destroyPipeline(pipelines[0]);
+			device.destroyPipeline(pipelines[1]);
+			device.destroyPipelineLayout(pipeline_layout);
+			device.destroyDescriptorSetLayout(descriptor_set_layout);
+			// no need to free the descriptor_set, as it's implicitly free'd with the descriptor_pool
+		}
 	};
 
-	struct DescriptorSets
+	struct Composition
 	{
-		vk::DescriptorSet bloom_filter;
-		vk::DescriptorSet composition;
-		vk::DescriptorSet object;
-		vk::DescriptorSet skybox;
+		vk::DescriptorSetLayout descriptor_set_layout = {};
+		vk::DescriptorSet       descriptor_set        = {};
+		vk::PipelineLayout      pipeline_layout       = {};
+		vk::Pipeline            pipeline              = {};
+
+		void destroy(vk::Device device)
+		{
+			device.destroyPipeline(pipeline);
+			device.destroyPipelineLayout(pipeline_layout);
+			device.destroyDescriptorSetLayout(descriptor_set_layout);
+			// no need to free the descriptor_set, as it's implicitly free'd with the descriptor_pool
+		}
 	};
 
 	// Framebuffer for offscreen rendering
 	struct FramebufferAttachment
 	{
-		vk::Format       format;
-		vk::Image        image;
-		vk::DeviceMemory mem;
-		vk::ImageView    view;
+		vk::Format       format = {};
+		vk::Image        image  = {};
+		vk::DeviceMemory mem    = {};
+		vk::ImageView    view   = {};
 
 		void destroy(vk::Device device)
 		{
@@ -57,65 +80,96 @@ class HPPTimestampQueries : public HPPApiVulkanSample
 		}
 	};
 
-	struct FilterPassData
+	struct FilterPass
 	{
-		FramebufferAttachment color;
-		vk::Extent2D          extent;
-		vk::Framebuffer       framebuffer;
-		vk::RenderPass        render_pass;
-		vk::Sampler           sampler;
+		vk::Extent2D          extent      = {};
+		vk::Framebuffer       framebuffer = {};
+		FramebufferAttachment color       = {};
+		vk::RenderPass        render_pass = {};
+		vk::Sampler           sampler     = {};
+
+		void destroy(vk::Device device)
+		{
+			device.destroySampler(sampler);
+			device.destroyFramebuffer(framebuffer);
+			device.destroyRenderPass(render_pass);
+			color.destroy(device);
+		}
+	};
+
+	struct Geometry
+	{
+		vk::DescriptorSet                                                      descriptor_set = {};
+		vk::Pipeline                                                           pipeline       = {};
+		std::vector<std::unique_ptr<vkb::scene_graph::components::HPPSubMesh>> meshes         = {};
+
+		void destroy(vk::Device device, vk::DescriptorPool descriptor_pool)
+		{
+			// no need to free the descriptor_set, as it's implicitly free'd with the descriptor_pool
+			device.destroyPipeline(pipeline);
+		}
 	};
 
 	struct Models
 	{
-		int32_t                                                                object_index = 0;
-		std::vector<std::unique_ptr<vkb::scene_graph::components::HPPSubMesh>> objects;
-		std::unique_ptr<vkb::scene_graph::components::HPPSubMesh>              skybox;
-		std::vector<glm::mat4>                                                 transforms;
+		vk::DescriptorSetLayout descriptor_set_layout = {};
+		vk::PipelineLayout      pipeline_layout       = {};
+		Geometry                objects               = {};
+		Geometry                skybox                = {};
+		std::vector<glm::mat4>  transforms            = {};
+		int32_t                 object_index          = 0;
+
+		void destroy(vk::Device device, vk::DescriptorPool descriptor_pool)
+		{
+			objects.destroy(device, descriptor_pool);
+			skybox.destroy(device, descriptor_pool);
+			device.destroyPipelineLayout(pipeline_layout);
+			device.destroyDescriptorSetLayout(descriptor_set_layout);
+		}
 	};
 
-	struct OffscreenData
+	struct Offscreen
 	{
-		FramebufferAttachment color[2];
-		FramebufferAttachment depth;
-		vk::Extent2D          extent;
-		vk::Framebuffer       framebuffer;
-		vk::RenderPass        render_pass;
-		vk::Sampler           sampler;
-	};
+		vk::Extent2D          extent      = {};
+		vk::Framebuffer       framebuffer = {};
+		FramebufferAttachment color[2]    = {};
+		FramebufferAttachment depth       = {};
+		vk::RenderPass        render_pass = {};
+		vk::Sampler           sampler     = {};
 
-	struct PipelineLayouts
-	{
-		vk::PipelineLayout bloom_filter;
-		vk::PipelineLayout composition;
-		vk::PipelineLayout models;
-	};
-
-	struct Pipelines
-	{
-		vk::Pipeline bloom[2];
-		vk::Pipeline composition;
-		vk::Pipeline reflect;
-		vk::Pipeline skybox;
+		void destroy(vk::Device device)
+		{
+			device.destroySampler(sampler);
+			device.destroyFramebuffer(framebuffer);
+			device.destroyRenderPass(render_pass);
+			color[0].destroy(device);
+			color[1].destroy(device);
+			depth.destroy(device);
+		}
 	};
 
 	struct Textures
 	{
 		HPPTexture envmap;
+
+		void destroy(vk::Device device)
+		{
+			device.destroySampler(envmap.sampler);
+		}
 	};
 
-	struct UBOParams
+	struct TimeStamps
 	{
-		float exposure = 1.0f;
+		std::array<uint64_t, 6> values;            // GPU time stamps will be stored in an array
+		vk::QueryPool           query_pool;        // A query pool is required to use GPU time stamps
+
+		void destroy(vk::Device device)
+		{
+			device.destroyQueryPool(query_pool);
+		}
 	};
 
-	struct UBOs
-	{
-		std::unique_ptr<vkb::core::HPPBuffer> matrices;
-		std::unique_ptr<vkb::core::HPPBuffer> params;
-	};
-
-	struct UBOVS
+	struct UBOMatrices
 	{
 		glm::mat4 projection;
 		glm::mat4 modelview;
@@ -123,54 +177,69 @@ class HPPTimestampQueries : public HPPApiVulkanSample
 		float     modelscale = 0.05f;
 	};
 
-  public:
-	HPPTimestampQueries();
-	~HPPTimestampQueries();
+	struct UBOParams
+	{
+		float exposure = 1.0f;
+	};
+
+	struct UniformBuffers
+	{
+		std::unique_ptr<vkb::core::HPPBuffer> matrices;
+		std::unique_ptr<vkb::core::HPPBuffer> params;
+	};
 
   private:
 	// from vkb::Application
-	bool prepare(const vkb::ApplicationOptions &options) override;
-	bool resize(const uint32_t width, const uint32_t height) override;
+	virtual bool prepare(const vkb::ApplicationOptions &options) override;
+	virtual bool resize(const uint32_t width, const uint32_t height) override;
 
 	// from HPPVulkanSample
-	void request_gpu_features(vkb::core::HPPPhysicalDevice &gpu) override;
+	virtual void request_gpu_features(vkb::core::HPPPhysicalDevice &gpu) override;
 
 	// from HPPApiVulkanSample
-	void build_command_buffers() override;
-	void on_update_ui_overlay(vkb::HPPDrawer &drawer) override;
-	void render(float delta_time) override;
+	virtual void build_command_buffers() override;
+	virtual void on_update_ui_overlay(vkb::HPPDrawer &drawer) override;
+	virtual void render(float delta_time) override;
 
-	void create_attachment(vk::Format format, vk::ImageUsageFlagBits usage, FramebufferAttachment *attachment);
-	void draw();
-	void get_time_stamp_results();
-	void load_assets();
-	void prepare_descriptor_pool();
-	void prepare_descriptor_set_layout();
-	void prepare_descriptor_sets();
-	void prepare_offscreen_buffer();
-	void prepare_pipelines();
-	void prepare_uniform_buffers();
-	void prepare_time_stamp_queries();
-	void update_params();
-	void update_uniform_buffers();
+	vk::DeviceMemory      allocate_memory(vk::Image image);
+	FramebufferAttachment create_attachment(vk::Format format, vk::ImageUsageFlagBits usage);
+	vk::DescriptorPool    create_descriptor_pool();
+	vk::Pipeline          create_bloom_pipeline(uint32_t direction);
+	vk::Pipeline          create_composition_pipeline();
+	vk::RenderPass        create_filter_render_pass();
+	vk::Image             create_image(vk::Format format, vk::ImageUsageFlagBits usage);
+	vk::Pipeline          create_models_pipeline(uint32_t shaderType, vk::CullModeFlagBits cullMode, bool depthTestAndWrite);
+	vk::RenderPass        create_offscreen_render_pass();
+	vk::RenderPass        create_render_pass(std::vector<vk::AttachmentDescription> const &attachment_descriptions, vk::SubpassDescription const &subpass_description);
+	void                  draw();
+	void                  get_time_stamp_results();
+	void                  load_assets();
+	void                  prepare_bloom();
+	void                  prepare_camera();
+	void                  prepare_composition();
+	void                  prepare_models();
+	void                  prepare_offscreen_buffer();
+	void                  prepare_time_stamps();
+	void                  prepare_uniform_buffers();
+	void                  update_composition_descriptor_set();
+	void                  update_bloom_descriptor_set();
+	void                  update_model_descriptor_set(vk::DescriptorSet descriptor_set);
+	void                  update_params();
+	void                  update_uniform_buffers();
 
   private:
-	bool                     bloom = true;
-	DescriptorSetLayouts     descriptor_set_layouts;
-	DescriptorSets           descriptor_sets;
+	Bloom                    bloom;
+	Composition              composition;
 	bool                     display_skybox = true;
-	FilterPassData           filter_pass;
+	FilterPass               filter_pass;
 	Models                   models;
 	std::vector<std::string> object_names;
-	OffscreenData            offscreen;
-	PipelineLayouts          pipeline_layouts;
-	Pipelines                pipelines;
+	Offscreen                offscreen;
 	Textures                 textures;
-	std::array<uint64_t, 6>  time_stamps;                   // GPU time stamps will be stored in an array
-	vk::QueryPool            time_stamps_query_pool;        // A query pool is required to use GPU time stamps
+	TimeStamps               time_stamps;
+	UBOMatrices              ubo_matrices;
 	UBOParams                ubo_params;
-	UBOVS                    ubo_vs;
-	UBOs                     uniform_buffers;
+	UniformBuffers           uniform_buffers;
 };
 
 std::unique_ptr<vkb::Application> create_hpp_timestamp_queries();


### PR DESCRIPTION
## Description

Besides the refactoring of the sample `hpp_timestamp_queries`, this PR includes
- new helper function `vkb::common::create_query_pool` in `framework/common/hpp_vk_common.hpp` and
- minor adjustments in the samples `hpp_hdr` and `hpp_terrain_tessellation`.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](./../antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
