### PR TITLE
Fix implicitly resetting command buffers in extension samples.

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -421,6 +421,15 @@ void ApiVulkanSample::destroy_command_buffers()
 	vkFreeCommandBuffers(device->get_handle(), cmd_pool, static_cast<uint32_t>(draw_cmd_buffers.size()), draw_cmd_buffers.data());
 }
 
+void ApiVulkanSample::recreate_current_command_buffer()
+{
+	auto &cmd = draw_cmd_buffers[current_buffer];
+	assert(cmd);
+	vkFreeCommandBuffers(get_device().get_handle(), cmd_pool, 1, &cmd);
+	VkCommandBufferAllocateInfo command_buffer_allocate_info{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr, cmd_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1};
+	VK_CHECK(vkAllocateCommandBuffers(get_device().get_handle(), &command_buffer_allocate_info, &cmd));
+}
+
 void ApiVulkanSample::create_pipeline_cache()
 {
 	VkPipelineCacheCreateInfo pipeline_cache_create_info = {};

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -327,6 +327,11 @@ class ApiVulkanSample : public vkb::VulkanSample
 	void destroy_command_buffers();
 
 	/**
+	 * @brief Recreate the current command buffer draw_cmd_buffer[current_buffer]
+	 */
+	void recreate_current_command_buffer();
+
+	/**
 	 * @brief Create a cache pool for rendering pipelines
 	 */
 	void create_pipeline_cache();

--- a/samples/extensions/buffer_device_address/buffer_device_address.cpp
+++ b/samples/extensions/buffer_device_address/buffer_device_address.cpp
@@ -366,6 +366,7 @@ void BufferDeviceAddress::render(float delta_time)
 	VkViewport viewport = {0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f};
 	VkRect2D   scissor  = {{0, 0}, {width, height}};
 
+	recreate_current_command_buffer();
 	auto cmd         = draw_cmd_buffers[current_buffer];
 	auto begin_info  = vkb::initializers::command_buffer_begin_info();
 	begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -73,6 +73,7 @@ void DescriptorIndexing::render(float delta_time)
 	VkViewport viewport = {0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f};
 	VkRect2D   scissor  = {{0, 0}, {width, height}};
 
+	recreate_current_command_buffer();
 	auto cmd         = draw_cmd_buffers[current_buffer];
 	auto begin_info  = vkb::initializers::command_buffer_begin_info();
 	begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;

--- a/samples/extensions/dynamic_blending/dynamic_blending.cpp
+++ b/samples/extensions/dynamic_blending/dynamic_blending.cpp
@@ -189,7 +189,7 @@ void DynamicBlending::update_uniform_buffers()
 
 	reverse = plane0.z < plane1.z;
 
-	build_command_buffers();
+	rebuild_command_buffers();
 }
 
 void DynamicBlending::setup_descriptor_pool()
@@ -372,7 +372,7 @@ void DynamicBlending::randomize_color(std::array<float, 4> &color, bool alpha)
 void DynamicBlending::update_color_uniform()
 {
 	update_color();
-	build_command_buffers();
+	rebuild_command_buffers();
 }
 
 void DynamicBlending::build_command_buffers()

--- a/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.cpp
+++ b/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.cpp
@@ -284,7 +284,7 @@ void DynamicLineRasterization::update_uniform_buffers()
 
 	camera_ubo->convert_and_update(cam);
 
-	build_command_buffers();
+	rebuild_command_buffers();
 }
 
 void DynamicLineRasterization::create_descriptor_set()
@@ -457,7 +457,7 @@ void DynamicLineRasterization::on_update_ui_overlay(vkb::Drawer &drawer)
 {
 	auto build_command_buffers_when = [this](bool drawer_action) {
 		if (drawer_action)
-			build_command_buffers();
+			rebuild_command_buffers();
 	};
 
 	auto uint16_to_hex_string = [](const char *caption, uint16_t value) {
@@ -484,7 +484,7 @@ void DynamicLineRasterization::on_update_ui_overlay(vkb::Drawer &drawer)
 			{
 				gui_settings.stipple_pattern = array_to_uint16(gui_settings.stipple_pattern_arr);
 
-				build_command_buffers();
+				rebuild_command_buffers();
 			}
 			ImGui::PopID();
 			if (i % 8 != 7)

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -1397,6 +1397,7 @@ void RaytracingExtended::draw()
 	VK_CHECK(vkQueueSubmit(queue, 1, &submit, device->request_fence()));
 	device->get_fence_pool().wait();
 
+	recreate_current_command_buffer();
 	VkCommandBufferBeginInfo begin = vkb::initializers::command_buffer_begin_info();
 	VK_CHECK(vkBeginCommandBuffer(draw_cmd_buffers[i], &begin));
 

--- a/samples/extensions/shader_object/shader_object.cpp
+++ b/samples/extensions/shader_object/shader_object.cpp
@@ -1580,7 +1580,7 @@ void ShaderObject::render(float delta_time)
 		update_uniform_buffers();
 	}
 
-	build_command_buffers();
+	rebuild_command_buffers();
 
 	draw(delta_time);
 


### PR DESCRIPTION
## Description

Some extension samples are failing with a validation layer error on implicitly resetting a command buffer created from a command pool that does not have the `VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT` bit set.

- `dynamic_blending`, `dynamic_line_rasterization`, and `shader_object` need to call `rebuild_command_buffers`, instead of `build_command_buffers`, at various places in order to recreate the complete set of command buffers before building them again;
- `buffer_device_address`, `descriptor_indexing`, and `ray_tracing_extended` need to call the newly added `APIVulkanSample::recreate_current_command_buffer ` before building that command buffer again.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](./../antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
