### PR TITLE
Fix for crashes caused by hpp interface differences

### DIFF
--- a/framework/core/hpp_debug.cpp
+++ b/framework/core/hpp_debug.cpp
@@ -85,8 +85,8 @@ void HPPDebugMarkerExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buf
 
 HPPScopedDebugLabel::HPPScopedDebugLabel(const HPPDebugUtils &debug_utils,
                                          vk::CommandBuffer    command_buffer,
-                                         std::string const   &name,
-                                         glm::vec4 const     color) :
+                                         std::string const &  name,
+                                         glm::vec4 const      color) :
     debug_utils{&debug_utils}, command_buffer{VK_NULL_HANDLE}
 {
 	if (!name.empty())

--- a/framework/core/hpp_debug.cpp
+++ b/framework/core/hpp_debug.cpp
@@ -36,9 +36,9 @@ void HPPDebugUtilsExtDebugUtils::set_debug_tag(
 	device.setDebugUtilsObjectTagEXT(tag_info);
 }
 
-void HPPDebugUtilsExtDebugUtils::cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color) const
+void HPPDebugUtilsExtDebugUtils::cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const
 {
-	vk::DebugUtilsLabelEXT label_info(name, reinterpret_cast<std::array<float, 4> const &>(color));
+	vk::DebugUtilsLabelEXT label_info(name, reinterpret_cast<std::array<float, 4> const &>(*&color[0]));
 	command_buffer.beginDebugUtilsLabelEXT(label_info);
 }
 
@@ -47,9 +47,9 @@ void HPPDebugUtilsExtDebugUtils::cmd_end_label(vk::CommandBuffer command_buffer)
 	command_buffer.endDebugUtilsLabelEXT();
 }
 
-void HPPDebugUtilsExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color) const
+void HPPDebugUtilsExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const
 {
-	vk::DebugUtilsLabelEXT label_info(name, reinterpret_cast<std::array<float, 4> const &>(color));
+	vk::DebugUtilsLabelEXT label_info(name, reinterpret_cast<std::array<float, 4> const &>(*&color[0]));
 	command_buffer.insertDebugUtilsLabelEXT(label_info);
 }
 
@@ -66,9 +66,9 @@ void HPPDebugMarkerExtDebugUtils::set_debug_tag(
 	device.debugMarkerSetObjectTagEXT(tag_info);
 }
 
-void HPPDebugMarkerExtDebugUtils::cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color) const
+void HPPDebugMarkerExtDebugUtils::cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const
 {
-	vk::DebugMarkerMarkerInfoEXT marker_info(name, reinterpret_cast<std::array<float, 4> const &>(color));
+	vk::DebugMarkerMarkerInfoEXT marker_info(name, reinterpret_cast<std::array<float, 4> const &>(*&color[0]));
 	command_buffer.debugMarkerBeginEXT(marker_info);
 }
 
@@ -77,16 +77,16 @@ void HPPDebugMarkerExtDebugUtils::cmd_end_label(vk::CommandBuffer command_buffer
 	command_buffer.debugMarkerEndEXT();
 }
 
-void HPPDebugMarkerExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color) const
+void HPPDebugMarkerExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const
 {
-	vk::DebugMarkerMarkerInfoEXT marker_info(name, reinterpret_cast<std::array<float, 4> const &>(color));
+	vk::DebugMarkerMarkerInfoEXT marker_info(name, reinterpret_cast<std::array<float, 4> const &>(*&color[0]));
 	command_buffer.debugMarkerInsertEXT(marker_info);
 }
 
 HPPScopedDebugLabel::HPPScopedDebugLabel(const HPPDebugUtils &debug_utils,
                                          vk::CommandBuffer    command_buffer,
                                          std::string const   &name,
-                                         glm::vec4 const     &color) :
+                                         glm::vec4 const     color) :
     debug_utils{&debug_utils}, command_buffer{VK_NULL_HANDLE}
 {
 	if (!name.empty())
@@ -98,7 +98,7 @@ HPPScopedDebugLabel::HPPScopedDebugLabel(const HPPDebugUtils &debug_utils,
 	}
 }
 
-HPPScopedDebugLabel::HPPScopedDebugLabel(const vkb::core::HPPCommandBuffer &command_buffer, std::string const &name, glm::vec4 const &color) :
+HPPScopedDebugLabel::HPPScopedDebugLabel(const vkb::core::HPPCommandBuffer &command_buffer, std::string const &name, glm::vec4 const color) :
     HPPScopedDebugLabel{command_buffer.get_device().get_debug_utils(), command_buffer.get_handle(), name, color}
 {
 }

--- a/framework/core/hpp_debug.cpp
+++ b/framework/core/hpp_debug.cpp
@@ -85,7 +85,7 @@ void HPPDebugMarkerExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buf
 
 HPPScopedDebugLabel::HPPScopedDebugLabel(const HPPDebugUtils &debug_utils,
                                          vk::CommandBuffer    command_buffer,
-                                         std::string const &  name,
+                                         std::string const   &name,
                                          glm::vec4 const      color) :
     debug_utils{&debug_utils}, command_buffer{VK_NULL_HANDLE}
 {

--- a/framework/core/hpp_debug.h
+++ b/framework/core/hpp_debug.h
@@ -115,13 +115,13 @@ class HPPDummyDebugUtils final : public vkb::core::HPPDebugUtils
 	inline void set_debug_tag(vk::Device, vk::ObjectType, uint64_t, uint64_t, const void *, size_t) const override
 	{}
 
-	inline void cmd_begin_label(vk::CommandBuffer, const char *, glm::vec4 const ) const override
+	inline void cmd_begin_label(vk::CommandBuffer, const char *, glm::vec4 const) const override
 	{}
 
 	inline void cmd_end_label(vk::CommandBuffer) const override
 	{}
 
-	inline void cmd_insert_label(vk::CommandBuffer, const char *, glm::vec4 const ) const override
+	inline void cmd_insert_label(vk::CommandBuffer, const char *, glm::vec4 const) const override
 	{}
 };
 

--- a/framework/core/hpp_debug.h
+++ b/framework/core/hpp_debug.h
@@ -48,7 +48,7 @@ class HPPDebugUtils
 	/**
 	 * @brief Inserts a command to begin a new debug label/marker scope.
 	 */
-	virtual void cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color = {}) const = 0;
+	virtual void cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color = {}) const = 0;
 
 	/**
 	 * @brief Inserts a command to end the current debug label/marker scope.
@@ -58,7 +58,7 @@ class HPPDebugUtils
 	/**
 	 * @brief Inserts a (non-scoped) debug label/marker in the command buffer.
 	 */
-	virtual void cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color = {}) const = 0;
+	virtual void cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color = {}) const = 0;
 };
 
 /**
@@ -74,11 +74,11 @@ class HPPDebugUtilsExtDebugUtils final : public vkb::core::HPPDebugUtils
 	void set_debug_tag(
 	    vk::Device device, vk::ObjectType object_type, uint64_t object_handle, uint64_t tag_name, const void *tag_data, size_t tag_data_size) const override;
 
-	void cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color) const override;
+	void cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const override;
 
 	void cmd_end_label(vk::CommandBuffer command_buffer) const override;
 
-	void cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color) const override;
+	void cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const override;
 };
 
 /**
@@ -94,11 +94,11 @@ class HPPDebugMarkerExtDebugUtils final : public vkb::core::HPPDebugUtils
 	void set_debug_tag(
 	    vk::Device device, vk::ObjectType object_type, uint64_t object_handle, uint64_t tag_name, const void *tag_data, size_t tag_data_size) const override;
 
-	void cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color) const override;
+	void cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const override;
 
 	void cmd_end_label(vk::CommandBuffer command_buffer) const override;
 
-	void cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const &color) const override;
+	void cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const override;
 };
 
 /**
@@ -115,13 +115,13 @@ class HPPDummyDebugUtils final : public vkb::core::HPPDebugUtils
 	inline void set_debug_tag(vk::Device, vk::ObjectType, uint64_t, uint64_t, const void *, size_t) const override
 	{}
 
-	inline void cmd_begin_label(vk::CommandBuffer, const char *, glm::vec4 const &) const override
+	inline void cmd_begin_label(vk::CommandBuffer, const char *, glm::vec4 const ) const override
 	{}
 
 	inline void cmd_end_label(vk::CommandBuffer) const override
 	{}
 
-	inline void cmd_insert_label(vk::CommandBuffer, const char *, glm::vec4 const &) const override
+	inline void cmd_insert_label(vk::CommandBuffer, const char *, glm::vec4 const ) const override
 	{}
 };
 
@@ -134,9 +134,9 @@ class HPPDummyDebugUtils final : public vkb::core::HPPDebugUtils
 class HPPScopedDebugLabel final
 {
   public:
-	HPPScopedDebugLabel(const vkb::core::HPPDebugUtils &debug_utils, vk::CommandBuffer command_buffer, std::string const &name, glm::vec4 const &color = {});
+	HPPScopedDebugLabel(const vkb::core::HPPDebugUtils &debug_utils, vk::CommandBuffer command_buffer, std::string const &name, glm::vec4 const color = {});
 
-	HPPScopedDebugLabel(const vkb::core::HPPCommandBuffer &command_buffer, std::string const &name, glm::vec4 const &color = {});
+	HPPScopedDebugLabel(const vkb::core::HPPCommandBuffer &command_buffer, std::string const &name, glm::vec4 const color = {});
 
 	~HPPScopedDebugLabel();
 


### PR DESCRIPTION
## Description

There is a difference in interfaces between DebugUtils and HPPDebugUtils introduced by https://github.com/KhronosGroup/Vulkan-Samples/pull/788

DebugUtils accepts the color argument as glm::vec4 const color whereas HPPDebugUtils takes a reference instead. This ends up causing a color of <0,0,0,0> being reinterpreted as a reference, which doesn't end well.

This change makes the HPPDebugUtils interface match DebugUtils again.

Fixes #817

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  