### PR TITLE
Remove useless -H cmake parameter from docs & scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,12 +47,12 @@ jobs:
         name: Configure and build
         shell: pwsh
         run: |
-          cmake -H"." -B"build/${{ matrix.platform }}" -G"NMake Makefiles" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DCMAKE_C_COMPILER_LAUNCHER=C:\\Users\\runneradmin\\.cargo\\bin\\sccache -DCMAKE_CXX_COMPILER_LAUNCHER=C:\\Users\\runneradmin\\.cargo\\bin\\sccache
+          cmake -B"build/${{ matrix.platform }}" -G"NMake Makefiles" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DCMAKE_C_COMPILER_LAUNCHER=C:\\Users\\runneradmin\\.cargo\\bin\\sccache -DCMAKE_CXX_COMPILER_LAUNCHER=C:\\Users\\runneradmin\\.cargo\\bin\\sccache
           cmake --build "build/${{ matrix.platform }}" --target vulkan_samples --config ${{ matrix.build_type }}  -j 1
       - if: ${{ matrix.platform != 'windows' }}
         name: Configure and build
         run: |
-          cmake -H"." -B"build/${{ matrix.platform }}" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON
+          cmake -B"build/${{ matrix.platform }}" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON
           cmake --build "build/${{ matrix.platform }}" --target vulkan_samples --config ${{ matrix.build_type }} ${{ env.PARALLEL }}
 
   build_d2d:
@@ -73,7 +73,7 @@ jobs:
         with:
           key: ${{ github.job }}-${{ matrix.os }}
       - name: Configure
-        run: cmake -H"." -B"build/ubuntu-latest-d2d" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DVKB_WSI_SELECTION=D2D
+        run: cmake -B"build/ubuntu-latest-d2d" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DVKB_WSI_SELECTION=D2D
       - name: "Build Ubuntu in Release with VKB_WSI_SELECTION=D2D"
         run: cmake --build "build/ubuntu-latest-d2d" --target vulkan_samples --config Release ${{ env.PARALLEL }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,7 +77,7 @@ jobs:
       id: count-diff
       run: echo "line-count=$(echo "${{ steps.clang-diff.outputs.changes }}" | grep -c +++)" >> $GITHUB_OUTPUT
     - name: Assert
-      run: if test ${{ steps.count-diff.outputs.line-count }} -gt 0; then echo "${{ steps.clang-diff.outputs.changes }}"; exit 1; fi 
+      run: if test ${{ steps.count-diff.outputs.line-count }} -gt 0; then echo "${{ steps.clang-diff.outputs.changes }}"; exit 1; fi
 
   clang_tidy:
     name: Clang Tidy Check
@@ -91,6 +91,6 @@ jobs:
       with:
         submodules: "recursive"
     - run: git config --global --add safe.directory /__w/Vulkan-Samples/Vulkan-Samples
-    - run: cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -H. -Bbuild/clang
+    - run: cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -Bbuild/clang
     - run: |
         /usr/bin/run-clang-tidy -j $(($(nproc)/2+1)) -p build/clang -header-filter=framework,samples,app -checks=-*,google-*,-google-runtime-references -quiet ${{ needs.changed-files.outputs.all }}

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -28,4 +28,4 @@ jobs:
           sudo apt-get update
           sudo apt install xorg-dev libglu1-mesa-dev
 
-      - run: cmake -Htests/external_project -Bbuild -DVKB_BUILD_SAMPLES=OFF
+      - run: cmake tests/external_project -Bbuild -DVKB_BUILD_SAMPLES=OFF

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -32,7 +32,7 @@ jobs:
           sudo apt install xorg-dev libglu1-mesa-dev
 
       - name: Configure
-        run: cmake -H"." -B"build/${{ matrix.platform }}" -DVKB_BUILD_TESTS=ON
+        run: cmake -B"build/${{ matrix.platform }}" -DVKB_BUILD_TESTS=ON
 
       - name: "Build Components ${{ matrix.platform }} in ${{ matrix.build_type }}"
         run: cmake --build "build/${{ matrix.platform }}" --target vkb__components --config ${{ matrix.build_type }} ${{ env.PARALLEL }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ ClangTidy:
     - linux
     - docker
   script:
-    - cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -H. -Bbuild/clang
+    - cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -Bbuild/clang
     - python3 /usr/local/bin/run-clang-tidy.py -j $(($(nproc)/2+1)) -p build/clang -clang-tidy-binary=clang-tidy-10 -header-filter=framework,samples,vulkan_samples -checks=-*,google-*,-google-runtime-references -quiet framework/* samples/* vulkan_samples/* tests/*
 
 Linux:
@@ -70,7 +70,7 @@ Linux:
     - linux
     - docker
   script:
-    - cmake -G "Unix Makefiles" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON
+    - cmake -G "Unix Makefiles" -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON
     - cmake --build build/linux --target vulkan_samples --config Release -- -j$(($(nproc)/2+1))
 
 Windows:
@@ -85,7 +85,7 @@ Windows:
     - gpu
     - windows
   script:
-    - cmake -G"Visual Studio 15 2017 Win64" -H. -Bbuild/windows -DVKB_BUILD_TESTS:BOOL=ON -DVKB_BUILD_SAMPLES:BOOL=ON
+    - cmake -G"Visual Studio 15 2017 Win64" -Bbuild/windows -DVKB_BUILD_TESTS:BOOL=ON -DVKB_BUILD_SAMPLES:BOOL=ON
     - cmake --build build/windows --target vulkan_samples --config Release
 
 Android:
@@ -101,7 +101,7 @@ Android:
     - linux
     - docker
   script:
-    - cmake -G "Unix Makefiles" -H. -Bbuild/android -DCMAKE_TOOLCHAIN_FILE=bldsys/toolchain/android_gradle.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON
+    - cmake -G "Unix Makefiles" -Bbuild/android -DCMAKE_TOOLCHAIN_FILE=bldsys/toolchain/android_gradle.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON
     - cmake --build build/android --config Release --target vulkan_samples_package -- -j$(($(nproc)/2+1))
 
 GenerateSample:
@@ -145,7 +145,7 @@ LinuxExternalProject:
     - linux
     - docker
   script:
-    - cmake -Htests/external_project -Bbuild -DVKB_BUILD_SAMPLES=OFF
+    - cmake tests/external_project -Bbuild -DVKB_BUILD_SAMPLES=OFF
 
 WindowsExternalProject:
   stage: Package
@@ -155,7 +155,7 @@ WindowsExternalProject:
     - gpu
     - windows
   script:
-    - cmake -Htests/external_project -Bbuild -DVKB_BUILD_SAMPLES=OFF
+    - cmake tests/external_project -Bbuild -DVKB_BUILD_SAMPLES=OFF
 
 AndroidExternalProject:
   stage: Package
@@ -166,4 +166,4 @@ AndroidExternalProject:
     - linux
     - docker
   script:
-    - cmake -DCMAKE_TOOLCHAIN_FILE=../../bldsys/toolchain/android_gradle.cmake -Htests/external_project -Bbuild -DVKB_BUILD_SAMPLES=OFF
+    - cmake -DCMAKE_TOOLCHAIN_FILE=../../bldsys/toolchain/android_gradle.cmake tests/external_project -Bbuild -DVKB_BUILD_SAMPLES=OFF

--- a/docs/build.adoc
+++ b/docs/build.adoc
@@ -171,7 +171,7 @@ cmake -G"Visual Studio 15 2017 Win64" -S . -Bbuild/windows
 (Prior to CMake v3.13)
 
 ----
-cmake -G"Visual Studio 15 2017 Win64" -H. -Bbuild/windows
+cmake -G"Visual Studio 15 2017 Win64" . -Bbuild/windows
 ----
 
 (New in CMake v3.14.
@@ -218,7 +218,7 @@ sudo apt-get install cmake g++ xorg-dev libglu1-mesa-dev
 `Step 1.` The following command will generate the project
 
 ----
-cmake -G "Unix Makefiles" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release
+cmake -G "Unix Makefiles" -Bbuild/linux -DCMAKE_BUILD_TYPE=Release
 ----
 
 `Step 2.` Build the project
@@ -249,7 +249,7 @@ cmake --build build/linux --config Release --target vulkan_samples -j$(nproc)
 `Step 1.` The following command will generate the project
 
 ----
-cmake -H. -Bbuild/mac -DCMAKE_BUILD_TYPE=Release
+cmake -Bbuild/mac -DCMAKE_BUILD_TYPE=Release
 ----
 
 `Step 2.` Build the project

--- a/tests/generate_sample/generate_sample_test.py
+++ b/tests/generate_sample/generate_sample_test.py
@@ -60,13 +60,13 @@ def build():
     generate_command = ""
     build_command = ""
     if platform.system() == "Windows":
-        generate_command = "cmake -G\"Visual Studio 15 2017 Win64\" -H. -Bbuild/windows -DVKB_BUILD_SAMPLES=ON"
+        generate_command = "cmake -G\"Visual Studio 15 2017 Win64\" -Bbuild/windows -DVKB_BUILD_SAMPLES=ON"
         build_command = "cmake --build build/windows --config Release --target vulkan_samples"
     elif platform.system() == "Linux":
-        generate_command = "cmake -G \"Unix Makefiles\" -H. -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_SAMPLES=ON"
+        generate_command = "cmake -G \"Unix Makefiles\" -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_SAMPLES=ON"
         build_command = "cmake --build build/linux --config Release --target vulkan_samples"
     elif platform.system() == "Darwin":
-        generate_command = "cmake -H. -Bbuild/mac -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_SAMPLES=ON"
+        generate_command = "cmake . -Bbuild/mac -DCMAKE_BUILD_TYPE=Release -DVKB_BUILD_SAMPLES=ON"
         build_command = "cmake --build build/mac --config Release --target vulkan_samples"
     else:
         print("Error: Platform not supported")


### PR DESCRIPTION
## Description

The -H cmake command line option prints the help text, except that all instances of it were followed by a dot, signifying that the current folder is the place to look for the CMakeLists.txt. So usage changes from `cmake -H.` to `cmake .` and has the exact same behavior.

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [ ] My changes do not add any regressions

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  

