### PR TITLE
Remove [HPP]Device::create_buffer(), replace by using vkb::core::[HPP]Buffer

### DIFF
--- a/framework/core/buffer.cpp
+++ b/framework/core/buffer.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -51,9 +51,9 @@ Buffer::Buffer(Device const &device, VkDeviceSize size, VkBufferUsageFlags buffe
 
 	VmaAllocationInfo allocation_info{};
 	auto              result = vmaCreateBuffer(device.get_memory_allocator(),
-                                  &buffer_info, &memory_info,
-                                  &handle, &allocation,
-                                  &allocation_info);
+	                                           &buffer_info, &memory_info,
+	                                           &handle, &allocation,
+	                                           &allocation_info);
 
 	if (result != VK_SUCCESS)
 	{
@@ -150,7 +150,7 @@ uint64_t Buffer::get_device_address()
 	return vkGetBufferDeviceAddressKHR(device->get_handle(), &buffer_device_address_info);
 }
 
-void Buffer::update(void *data, size_t size, size_t offset)
+void Buffer::update(void const *data, size_t size, size_t offset)
 {
 	update(reinterpret_cast<const uint8_t *>(data), size, offset);
 }

--- a/framework/core/buffer.h
+++ b/framework/core/buffer.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2021, Arm Limited and Contributors
+/* Copyright (c) 2019-2023, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -39,7 +39,7 @@ class Buffer : public VulkanResource<VkBuffer, VK_OBJECT_TYPE_BUFFER, const Devi
 	 * @param flags The allocation create flags
 	 * @param queue_family_indices optional queue family indices
 	 */
-	Buffer(Device const &               device,
+	Buffer(Device const                &device,
 	       VkDeviceSize                 size,
 	       VkBufferUsageFlags           buffer_usage,
 	       VmaMemoryUsage               memory_usage,
@@ -64,7 +64,7 @@ class Buffer : public VulkanResource<VkBuffer, VK_OBJECT_TYPE_BUFFER, const Devi
 		{
 			return {};
 		}
-		auto &         buffer = iter->second;
+		auto          &buffer = iter->second;
 		std::vector<T> out;
 
 		const size_t sz = buffer.get_size();
@@ -128,7 +128,7 @@ class Buffer : public VulkanResource<VkBuffer, VK_OBJECT_TYPE_BUFFER, const Devi
 	 * @param size The amount of bytes to copy
 	 * @param offset The offset to start the copying into the mapped data
 	 */
-	void update(void *data, size_t size, size_t offset = 0);
+	void update(void const *data, size_t size, size_t offset = 0);
 
 	/**
 	 * @brief Copies a vector of bytes into the buffer
@@ -136,6 +136,18 @@ class Buffer : public VulkanResource<VkBuffer, VK_OBJECT_TYPE_BUFFER, const Devi
 	 * @param offset The offset to start the copying into the mapped data
 	 */
 	void update(const std::vector<uint8_t> &data, size_t offset = 0);
+
+	template <typename T, size_t N>
+	void update(std::array<T, N> const &data, size_t offset = 0)
+	{
+		update(data.data(), data.size() * sizeof(T), offset);
+	}
+
+	template <typename T>
+	void update(std::vector<T> const &data, size_t offset = 0)
+	{
+		update(data.data(), data.size() * sizeof(T), offset);
+	}
 
 	/**
 	 * @brief Copies an object as byte data into the buffer

--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -148,17 +148,6 @@ class Device : public core::VulkanResource<VkDevice, VK_OBJECT_TYPE_DEVICE>
 	uint32_t get_memory_type(uint32_t bits, VkMemoryPropertyFlags properties, VkBool32 *memory_type_found = nullptr) const;
 
 	/**
-	 * @brief Creates a vulkan buffer
-	 * @param usage The buffer usage
-	 * @param properties The memory properties
-	 * @param size The size of the buffer
-	 * @param memory The pointer to the buffer memory
-	 * @param data The data to place inside the buffer
-	 * @returns A valid VkBuffer
-	 */
-	VkBuffer create_buffer(VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, VkDeviceSize size, VkDeviceMemory *memory, void *data = nullptr);
-
-	/**
 	 * @brief Copies a buffer from one to another
 	 * @param src The buffer to copy from
 	 * @param dst The buffer to copy to

--- a/framework/core/hpp_buffer.cpp
+++ b/framework/core/hpp_buffer.cpp
@@ -143,7 +143,7 @@ uint64_t HPPBuffer::get_device_address() const
 	return get_device().get_handle().getBufferAddressKHR({get_handle()});
 }
 
-void HPPBuffer::update(void *data, size_t size, size_t offset)
+void HPPBuffer::update(void const *data, size_t size, size_t offset)
 {
 	update(reinterpret_cast<const uint8_t *>(data), size, offset);
 }

--- a/framework/core/hpp_buffer.h
+++ b/framework/core/hpp_buffer.h
@@ -53,8 +53,8 @@ class HPPBuffer : public vkb::core::HPPVulkanResource<vk::Buffer>
 	HPPBuffer &operator=(const HPPBuffer &) = delete;
 	HPPBuffer &operator=(HPPBuffer &&)      = delete;
 
-	VmaAllocation  get_allocation() const;
-	const uint8_t *get_data() const;
+	VmaAllocation    get_allocation() const;
+	const uint8_t   *get_data() const;
 	vk::DeviceMemory get_memory() const;
 
 	/**
@@ -97,7 +97,7 @@ class HPPBuffer : public vkb::core::HPPVulkanResource<vk::Buffer>
 	 * @param size The amount of bytes to copy
 	 * @param offset The offset to start the copying into the mapped data
 	 */
-	void update(void *data, size_t size, size_t offset = 0);
+	void update(void const *data, size_t size, size_t offset = 0);
 
 	/**
 	 * @brief Copies a vector of bytes into the buffer
@@ -105,6 +105,12 @@ class HPPBuffer : public vkb::core::HPPVulkanResource<vk::Buffer>
 	 * @param offset The offset to start the copying into the mapped data
 	 */
 	void update(const std::vector<uint8_t> &data, size_t offset = 0);
+
+	template <typename T>
+	void update(std::vector<T> const &data, size_t offset = 0)
+	{
+		update(data.data(), data.size() * sizeof(T), offset);
+	}
 
 	/**
 	 * @brief Copies an object as byte data into the buffer

--- a/framework/core/hpp_device.cpp
+++ b/framework/core/hpp_device.cpp
@@ -386,39 +386,6 @@ vkb::core::HPPQueue const &HPPDevice::get_suitable_graphics_queue() const
 	return get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);
 }
 
-std::pair<vk::Buffer, vk::DeviceMemory> HPPDevice::create_buffer(vk::BufferUsageFlags usage, vk::MemoryPropertyFlags properties, vk::DeviceSize size, void *data) const
-{
-	vk::Device device = get_handle();
-
-	// Create the buffer handle
-	vk::BufferCreateInfo buffer_create_info({}, size, usage, vk::SharingMode::eExclusive);
-	vk::Buffer           buffer = device.createBuffer(buffer_create_info);
-
-	// Create the memory backing up the buffer handle
-	vk::MemoryRequirements memory_requirements = device.getBufferMemoryRequirements(buffer);
-	vk::MemoryAllocateInfo memory_allocation(memory_requirements.size, get_gpu().get_memory_type(memory_requirements.memoryTypeBits, properties));
-	vk::DeviceMemory       memory = device.allocateMemory(memory_allocation);
-
-	// If a pointer to the buffer data has been passed, map the buffer and copy over the
-	if (data != nullptr)
-	{
-		void *mapped = device.mapMemory(memory, 0, size);
-		memcpy(mapped, data, static_cast<size_t>(size));
-		// If host coherency hasn't been requested, do a manual flush to make writes visible
-		if (!(properties & vk::MemoryPropertyFlagBits::eHostCoherent))
-		{
-			vk::MappedMemoryRange mapped_range(memory, 0, size);
-			device.flushMappedMemoryRanges(mapped_range);
-		}
-		device.unmapMemory(memory);
-	}
-
-	// Attach the memory to the buffer object
-	device.bindBufferMemory(buffer, memory, 0);
-
-	return std::make_pair(buffer, memory);
-}
-
 std::pair<vk::Image, vk::DeviceMemory> HPPDevice::create_image(vk::Format format, vk::Extent2D const &extent, uint32_t mip_levels, vk::ImageUsageFlags usage, vk::MemoryPropertyFlags properties) const
 {
 	vk::Device device = get_handle();

--- a/framework/core/hpp_device.h
+++ b/framework/core/hpp_device.h
@@ -88,16 +88,6 @@ class HPPDevice : public vkb::core::HPPVulkanResource<vk::Device>
 	vkb::core::HPPCommandPool &get_command_pool();
 
 	/**
-	 * @brief Creates a vulkan buffer
-	 * @param usage The buffer usage
-	 * @param properties The memory properties
-	 * @param size The size of the buffer
-	 * @param data The data to place inside the buffer
-	 * @returns A valid vk::Buffer and a corresponding vk::DeviceMemory
-	 */
-	std::pair<vk::Buffer, vk::DeviceMemory> create_buffer(vk::BufferUsageFlags usage, vk::MemoryPropertyFlags properties, vk::DeviceSize size, void *data = nullptr) const;
-
-	/**
 	 * @brief Creates a vulkan image and associated device memory
 	 * @param format The image format
 	 * @param extent The image extent

--- a/samples/api/hpp_instancing/hpp_instancing.h
+++ b/samples/api/hpp_instancing/hpp_instancing.h
@@ -39,16 +39,9 @@ class HPPInstancing : public HPPApiVulkanSample
 	// Contains the instanced data
 	struct InstanceBuffer
 	{
-		vk::Buffer               buffer;
-		vk::DescriptorBufferInfo descriptor;
-		vk::DeviceMemory         memory;
-		size_t                   size = 0;
-
-		void destroy(vk::Device device)
-		{
-			device.destroyBuffer(buffer);
-			device.freeMemory(memory);
-		}
+		std::unique_ptr<vkb::core::HPPBuffer> buffer;
+		vk::DescriptorBufferInfo              descriptor;
+		size_t                                size = 0;
 	};
 
 	// Per-instance data block

--- a/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
+++ b/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
@@ -406,19 +406,13 @@ void HPPTerrainTessellation::generate_terrain()
 	uint32_t vertex_buffer_size = vertex_count * sizeof(Vertex);
 	uint32_t index_buffer_size  = index_count * sizeof(uint32_t);
 
-	struct
-	{
-		vk::Buffer       buffer;
-		vk::DeviceMemory memory;
-	} vertex_staging, index_staging;
-
 	// Create staging buffers
 
-	std::tie(vertex_staging.buffer, vertex_staging.memory) = get_device()->create_buffer(
-	    vk::BufferUsageFlagBits::eTransferSrc, vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent, vertex_buffer_size, vertices.data());
+	vkb::core::HPPBuffer vertex_staging(*device, vertex_buffer_size, vk::BufferUsageFlagBits::eTransferSrc, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	vertex_staging.update(vertices);
 
-	std::tie(index_staging.buffer, index_staging.memory) = get_device()->create_buffer(
-	    vk::BufferUsageFlagBits::eTransferSrc, vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent, index_buffer_size, indices.data());
+	vkb::core::HPPBuffer index_staging(*device, index_buffer_size, vk::BufferUsageFlagBits::eTransferSrc, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	index_staging.update(indices);
 
 	terrain.vertices = std::make_unique<vkb::core::HPPBuffer>(
 	    *get_device(), vertex_buffer_size, vk::BufferUsageFlagBits::eVertexBuffer | vk::BufferUsageFlagBits::eTransferDst, VMA_MEMORY_USAGE_GPU_ONLY);
@@ -426,19 +420,12 @@ void HPPTerrainTessellation::generate_terrain()
 	terrain.indices = std::make_unique<vkb::core::HPPBuffer>(
 	    *get_device(), index_buffer_size, vk::BufferUsageFlagBits::eIndexBuffer | vk::BufferUsageFlagBits::eTransferDst, VMA_MEMORY_USAGE_GPU_ONLY);
 
-	vk::Device vkDevice = get_device()->get_handle();
-
 	// Copy from staging buffers
-	vk::CommandBuffer copy_command = vkb::common::allocate_command_buffer(vkDevice, device->get_command_pool().get_handle());
+	vk::CommandBuffer copy_command = vkb::common::allocate_command_buffer(device->get_handle(), device->get_command_pool().get_handle());
 	copy_command.begin(vk::CommandBufferBeginInfo());
-	copy_command.copyBuffer(vertex_staging.buffer, terrain.vertices->get_handle(), {{0, 0, vertex_buffer_size}});
-	copy_command.copyBuffer(index_staging.buffer, terrain.indices->get_handle(), {{0, 0, index_buffer_size}});
+	copy_command.copyBuffer(vertex_staging.get_handle(), terrain.vertices->get_handle(), {{0, 0, vertex_buffer_size}});
+	copy_command.copyBuffer(index_staging.get_handle(), terrain.indices->get_handle(), {{0, 0, index_buffer_size}});
 	get_device()->flush_command_buffer(copy_command, queue, true);
-
-	vkDevice.destroyBuffer(vertex_staging.buffer);
-	vkDevice.freeMemory(vertex_staging.memory);
-	vkDevice.destroyBuffer(index_staging.buffer);
-	vkDevice.freeMemory(index_staging.memory);
 }
 
 void HPPTerrainTessellation::load_assets()

--- a/samples/api/instancing/instancing.h
+++ b/samples/api/instancing/instancing.h
@@ -55,10 +55,9 @@ class Instancing : public ApiVulkanSample
 	// Contains the instanced data
 	struct InstanceBuffer
 	{
-		VkBuffer               buffer = VK_NULL_HANDLE;
-		VkDeviceMemory         memory = VK_NULL_HANDLE;
-		size_t                 size   = 0;
-		VkDescriptorBufferInfo descriptor;
+		std::unique_ptr<vkb::core::Buffer> buffer;
+		size_t                             size = 0;
+		VkDescriptorBufferInfo             descriptor;
 	} instance_buffer;
 
 	struct UBOVS

--- a/samples/api/terrain_tessellation/terrain_tessellation.cpp
+++ b/samples/api/terrain_tessellation/terrain_tessellation.cpp
@@ -60,8 +60,6 @@ TerrainTessellation::~TerrainTessellation()
 		if (query_pool != VK_NULL_HANDLE)
 		{
 			vkDestroyQueryPool(get_device().get_handle(), query_pool, nullptr);
-			vkDestroyBuffer(get_device().get_handle(), query_result.buffer, nullptr);
-			vkFreeMemory(get_device().get_handle(), query_result.memory, nullptr);
 		}
 	}
 }
@@ -102,23 +100,6 @@ void TerrainTessellation::request_gpu_features(vkb::PhysicalDevice &gpu)
 // Setup pool and buffer for storing pipeline statistics results
 void TerrainTessellation::setup_query_result_buffer()
 {
-	uint32_t buffer_size = 2 * sizeof(uint64_t);
-
-	VkMemoryRequirements memory_requirements;
-	VkMemoryAllocateInfo memory_allocation = vkb::initializers::memory_allocate_info();
-	VkBufferCreateInfo   buffer_create_info =
-	    vkb::initializers::buffer_create_info(
-	        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-	        buffer_size);
-
-	// Results are saved in a host visible buffer for easy access by the application
-	VK_CHECK(vkCreateBuffer(get_device().get_handle(), &buffer_create_info, nullptr, &query_result.buffer));
-	vkGetBufferMemoryRequirements(get_device().get_handle(), query_result.buffer, &memory_requirements);
-	memory_allocation.allocationSize  = memory_requirements.size;
-	memory_allocation.memoryTypeIndex = get_device().get_memory_type(memory_requirements.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-	VK_CHECK(vkAllocateMemory(get_device().get_handle(), &memory_allocation, nullptr, &query_result.memory));
-	VK_CHECK(vkBindBufferMemory(get_device().get_handle(), query_result.buffer, query_result.memory, 0));
-
 	// Create query pool
 	if (get_device().get_gpu().get_features().pipelineStatisticsQuery)
 	{
@@ -270,10 +251,10 @@ void TerrainTessellation::build_command_buffers()
 // Generate a terrain quad patch for feeding to the tessellation control shader
 void TerrainTessellation::generate_terrain()
 {
-	const uint32_t patch_size   = 64;
-	const float    uv_scale     = 1.0f;
-	const uint32_t vertex_count = patch_size * patch_size;
-	Vertex        *vertices     = new Vertex[vertex_count];
+	const uint32_t      patch_size   = 64;
+	const float         uv_scale     = 1.0f;
+	const uint32_t      vertex_count = patch_size * patch_size;
+	std::vector<Vertex> vertices(vertex_count);
 
 	const float wx = 2.0f;
 	const float wy = 2.0f;
@@ -321,9 +302,9 @@ void TerrainTessellation::generate_terrain()
 	}
 
 	// Indices
-	const uint32_t w           = (patch_size - 1);
-	const uint32_t index_count = w * w * 4;
-	uint32_t      *indices     = new uint32_t[index_count];
+	const uint32_t        w           = (patch_size - 1);
+	const uint32_t        index_count = w * w * 4;
+	std::vector<uint32_t> indices(index_count);
 	for (auto x = 0; x < w; x++)
 	{
 		for (auto y = 0; y < w; y++)
@@ -340,27 +321,13 @@ void TerrainTessellation::generate_terrain()
 	uint32_t vertex_buffer_size = vertex_count * sizeof(Vertex);
 	uint32_t index_buffer_size  = index_count * sizeof(uint32_t);
 
-	struct
-	{
-		VkBuffer       buffer;
-		VkDeviceMemory memory;
-	} vertex_staging, index_staging;
-
 	// Create staging buffers
 
-	vertex_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    vertex_buffer_size,
-	    &vertex_staging.memory,
-	    vertices);
+	vkb::core::Buffer vertex_staging(get_device(), vertex_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	vertex_staging.update(vertices);
 
-	index_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    index_buffer_size,
-	    &index_staging.memory,
-	    indices);
+	vkb::core::Buffer index_staging(get_device(), index_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	index_staging.update(indices);
 
 	terrain.vertices = std::make_unique<vkb::core::Buffer>(get_device(),
 	                                                       vertex_buffer_size,
@@ -380,7 +347,7 @@ void TerrainTessellation::generate_terrain()
 	copy_region.size = vertex_buffer_size;
 	vkCmdCopyBuffer(
 	    copy_command,
-	    vertex_staging.buffer,
+	    vertex_staging.get_handle(),
 	    terrain.vertices->get_handle(),
 	    1,
 	    &copy_region);
@@ -388,20 +355,12 @@ void TerrainTessellation::generate_terrain()
 	copy_region.size = index_buffer_size;
 	vkCmdCopyBuffer(
 	    copy_command,
-	    index_staging.buffer,
+	    index_staging.get_handle(),
 	    terrain.indices->get_handle(),
 	    1,
 	    &copy_region);
 
 	device->flush_command_buffer(copy_command, queue, true);
-
-	vkDestroyBuffer(get_device().get_handle(), vertex_staging.buffer, nullptr);
-	vkFreeMemory(get_device().get_handle(), vertex_staging.memory, nullptr);
-	vkDestroyBuffer(get_device().get_handle(), index_staging.buffer, nullptr);
-	vkFreeMemory(get_device().get_handle(), index_staging.memory, nullptr);
-
-	delete[] vertices;
-	delete[] indices;
 }
 
 void TerrainTessellation::setup_descriptor_pool()

--- a/samples/api/terrain_tessellation/terrain_tessellation.h
+++ b/samples/api/terrain_tessellation/terrain_tessellation.h
@@ -106,11 +106,6 @@ class TerrainTessellation : public ApiVulkanSample
 	} descriptor_sets;
 
 	// Pipeline statistics
-	struct
-	{
-		VkBuffer       buffer;
-		VkDeviceMemory memory;
-	} query_result;
 	VkQueryPool query_pool        = VK_NULL_HANDLE;
 	uint64_t    pipeline_stats[2] = {0};
 

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -1009,32 +1009,14 @@ void ExtendedDynamicState2::model_data_creation()
 	                                          UINT32_MAX,
 	                                          2, 3, 6, 7};
 
-	struct
-	{
-		VkBuffer       buffer;
-		VkDeviceMemory memory;
-	} vertex_pos_staging, vertex_norm_staging, index_staging;
+	vkb::core::Buffer vertex_pos_staging(get_device(), vertex_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	vertex_pos_staging.update(vertices_pos);
 
-	vertex_pos_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    vertex_buffer_size,
-	    &vertex_pos_staging.memory,
-	    vertices_pos.data());
+	vkb::core::Buffer vertex_norm_staging(get_device(), vertex_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	vertex_norm_staging.update(vertices_norm);
 
-	vertex_norm_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    vertex_buffer_size,
-	    &vertex_norm_staging.memory,
-	    vertices_norm.data());
-
-	index_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    index_buffer_size,
-	    &index_staging.memory,
-	    indices.data());
+	vkb::core::Buffer index_staging(get_device(), index_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	index_staging.update(indices);
 
 	cube.vertices_pos = std::make_unique<vkb::core::Buffer>(get_device(),
 	                                                        vertex_buffer_size,
@@ -1061,14 +1043,14 @@ void ExtendedDynamicState2::model_data_creation()
 	copy_region.size = vertex_buffer_size;
 	vkCmdCopyBuffer(
 	    copy_command,
-	    vertex_pos_staging.buffer,
+	    vertex_pos_staging.get_handle(),
 	    cube.vertices_pos->get_handle(),
 	    1,
 	    &copy_region);
 
 	vkCmdCopyBuffer(
 	    copy_command,
-	    vertex_norm_staging.buffer,
+	    vertex_norm_staging.get_handle(),
 	    cube.vertices_norm->get_handle(),
 	    1,
 	    &copy_region);
@@ -1076,19 +1058,12 @@ void ExtendedDynamicState2::model_data_creation()
 	copy_region.size = index_buffer_size;
 	vkCmdCopyBuffer(
 	    copy_command,
-	    index_staging.buffer,
+	    index_staging.get_handle(),
 	    cube.indices->get_handle(),
 	    1,
 	    &copy_region);
 
 	device->flush_command_buffer(copy_command, queue, true);
-
-	vkDestroyBuffer(get_device().get_handle(), vertex_pos_staging.buffer, nullptr);
-	vkFreeMemory(get_device().get_handle(), vertex_pos_staging.memory, nullptr);
-	vkDestroyBuffer(get_device().get_handle(), vertex_norm_staging.buffer, nullptr);
-	vkFreeMemory(get_device().get_handle(), vertex_norm_staging.memory, nullptr);
-	vkDestroyBuffer(get_device().get_handle(), index_staging.buffer, nullptr);
-	vkFreeMemory(get_device().get_handle(), index_staging.memory, nullptr);
 }
 
 /**

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.h
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.h
@@ -43,7 +43,7 @@ class ExtendedDynamicState2 : public ApiVulkanSample
 		bool                           time_tick        = false;
 	} gui_settings;
 
-	/* Buffer used in all pipelines */
+	/* Buffer used inw all pipelines */
 	struct UBOCOMM
 	{
 		glm::mat4 projection;

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.h
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.h
@@ -43,7 +43,7 @@ class ExtendedDynamicState2 : public ApiVulkanSample
 		bool                           time_tick        = false;
 	} gui_settings;
 
-	/* Buffer used inw all pipelines */
+	/* Buffer used in all pipelines */
 	struct UBOCOMM
 	{
 		glm::mat4 projection;

--- a/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
+++ b/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
@@ -609,32 +609,14 @@ void LogicOpDynamicState::model_data_creation()
 	                                          UINT32_MAX,
 	                                          2, 3, 6, 7};
 
-	struct
-	{
-		VkBuffer       buffer{VK_NULL_HANDLE};
-		VkDeviceMemory memory{VK_NULL_HANDLE};
-	} vertex_pos_staging, vertex_norm_staging, index_staging;
+	vkb::core::Buffer vertex_pos_staging(get_device(), vertex_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	vertex_pos_staging.update(vertices_pos);
 
-	vertex_pos_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    vertex_buffer_size,
-	    &vertex_pos_staging.memory,
-	    vertices_pos.data());
+	vkb::core::Buffer vertex_norm_staging(get_device(), vertex_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	vertex_norm_staging.update(vertices_norm);
 
-	vertex_norm_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    vertex_buffer_size,
-	    &vertex_norm_staging.memory,
-	    vertices_norm.data());
-
-	index_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    index_buffer_size,
-	    &index_staging.memory,
-	    indices.data());
+	vkb::core::Buffer index_staging(get_device(), index_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	index_staging.update(indices);
 
 	cube.vertices_pos = std::make_unique<vkb::core::Buffer>(get_device(),
 	                                                        vertex_buffer_size,
@@ -659,14 +641,14 @@ void LogicOpDynamicState::model_data_creation()
 	copy_region.size = vertex_buffer_size;
 	vkCmdCopyBuffer(
 	    copy_command,
-	    vertex_pos_staging.buffer,
+	    vertex_pos_staging.get_handle(),
 	    cube.vertices_pos->get_handle(),
 	    1,
 	    &copy_region);
 
 	vkCmdCopyBuffer(
 	    copy_command,
-	    vertex_norm_staging.buffer,
+	    vertex_norm_staging.get_handle(),
 	    cube.vertices_norm->get_handle(),
 	    1,
 	    &copy_region);
@@ -674,19 +656,12 @@ void LogicOpDynamicState::model_data_creation()
 	copy_region.size = index_buffer_size;
 	vkCmdCopyBuffer(
 	    copy_command,
-	    index_staging.buffer,
+	    index_staging.get_handle(),
 	    cube.indices->get_handle(),
 	    1,
 	    &copy_region);
 
 	device->flush_command_buffer(copy_command, queue, true);
-
-	vkDestroyBuffer(get_device().get_handle(), vertex_pos_staging.buffer, VK_NULL_HANDLE);
-	vkFreeMemory(get_device().get_handle(), vertex_pos_staging.memory, VK_NULL_HANDLE);
-	vkDestroyBuffer(get_device().get_handle(), vertex_norm_staging.buffer, VK_NULL_HANDLE);
-	vkFreeMemory(get_device().get_handle(), vertex_norm_staging.memory, VK_NULL_HANDLE);
-	vkDestroyBuffer(get_device().get_handle(), index_staging.buffer, VK_NULL_HANDLE);
-	vkFreeMemory(get_device().get_handle(), index_staging.memory, VK_NULL_HANDLE);
 }
 
 /**

--- a/samples/extensions/memory_budget/memory_budget.cpp
+++ b/samples/extensions/memory_budget/memory_budget.cpp
@@ -45,8 +45,6 @@ MemoryBudget::~MemoryBudget()
 		vkDestroyPipeline(get_device().get_handle(), pipelines.starfield, nullptr);
 		vkDestroyPipelineLayout(get_device().get_handle(), pipeline_layout, nullptr);
 		vkDestroyDescriptorSetLayout(get_device().get_handle(), descriptor_set_layout, nullptr);
-		vkDestroyBuffer(get_device().get_handle(), instance_buffer.buffer, nullptr);
-		vkFreeMemory(get_device().get_handle(), instance_buffer.memory, nullptr);
 		vkDestroySampler(get_device().get_handle(), textures.rocks.sampler, nullptr);
 		vkDestroySampler(get_device().get_handle(), textures.planet.sampler, nullptr);
 	}
@@ -130,7 +128,7 @@ void MemoryBudget::build_command_buffers()
 		// Binding point 0 : Mesh vertex buffer
 		vkCmdBindVertexBuffers(draw_cmd_buffers[i], 0, 1, rock_vertex_buffer.get(), offsets);
 		// Binding point 1 : Instance data buffer
-		vkCmdBindVertexBuffers(draw_cmd_buffers[i], 1, 1, &instance_buffer.buffer, offsets);
+		vkCmdBindVertexBuffers(draw_cmd_buffers[i], 1, 1, &instance_buffer.buffer->get_handle(), offsets);
 		vkCmdBindIndexBuffer(draw_cmd_buffers[i], rock_index_buffer->get_handle(), 0, VK_INDEX_TYPE_UINT32);
 		// Render instances
 		vkCmdDrawIndexed(draw_cmd_buffers[i], models.rock->vertex_indices, MESH_DENSITY, 0, 0, 0);
@@ -475,24 +473,10 @@ void MemoryBudget::prepare_instance_data()
 	// On devices with separate memory types for host visible and device local memory this will result in better performance
 	// On devices with unified memory types (DEVICE_LOCAL_BIT and HOST_VISIBLE_BIT supported at once) this isn't necessary, and you could skip the staging
 
-	struct
-	{
-		VkDeviceMemory memory;
-		VkBuffer       buffer;
-	} staging_buffer{};
+	vkb::core::Buffer staging_buffer(get_device(), instance_buffer.size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	staging_buffer.update(instance_data);
 
-	staging_buffer.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    instance_buffer.size,
-	    &staging_buffer.memory,
-	    instance_data.data());
-
-	instance_buffer.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-	    VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-	    instance_buffer.size,
-	    &instance_buffer.memory);
+	instance_buffer.buffer = std::make_unique<vkb::core::Buffer>(get_device(), instance_buffer.size, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, VMA_MEMORY_USAGE_GPU_ONLY);
 
 	// Copy to staging buffer
 	VkCommandBuffer copy_command = device->create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
@@ -501,20 +485,16 @@ void MemoryBudget::prepare_instance_data()
 	copy_region.size         = instance_buffer.size;
 	vkCmdCopyBuffer(
 	    copy_command,
-	    staging_buffer.buffer,
-	    instance_buffer.buffer,
+	    staging_buffer.get_handle(),
+	    instance_buffer.buffer->get_handle(),
 	    1,
 	    &copy_region);
 
 	device->flush_command_buffer(copy_command, queue, true);
 
 	instance_buffer.descriptor.range  = instance_buffer.size;
-	instance_buffer.descriptor.buffer = instance_buffer.buffer;
+	instance_buffer.descriptor.buffer = instance_buffer.buffer->get_handle();
 	instance_buffer.descriptor.offset = 0;
-
-	// Destroy staging resources
-	vkDestroyBuffer(get_device().get_handle(), staging_buffer.buffer, nullptr);
-	vkFreeMemory(get_device().get_handle(), staging_buffer.memory, nullptr);
 }
 
 void MemoryBudget::prepare_uniform_buffers()

--- a/samples/extensions/memory_budget/memory_budget.h
+++ b/samples/extensions/memory_budget/memory_budget.h
@@ -74,10 +74,9 @@ class MemoryBudget : public ApiVulkanSample
 	// Contains the instanced data
 	struct InstanceBuffer
 	{
-		VkBuffer               buffer = VK_NULL_HANDLE;
-		VkDeviceMemory         memory = VK_NULL_HANDLE;
-		size_t                 size   = 0;
-		VkDescriptorBufferInfo descriptor{};
+		std::unique_ptr<vkb::core::Buffer> buffer;
+		size_t                             size = 0;
+		VkDescriptorBufferInfo             descriptor{};
 	} instance_buffer;
 
 	struct UBOVS

--- a/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.cpp
+++ b/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.cpp
@@ -531,25 +531,11 @@ void VertexDynamicState::model_data_creation()
 	                                          3, 7, 6,
 	                                          6, 2, 3};
 
-	struct
-	{
-		VkBuffer       buffer;
-		VkDeviceMemory memory;
-	} vertex_staging, index_staging;
+	vkb::core::Buffer vertex_staging(get_device(), vertex_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	vertex_staging.update(vertices);
 
-	vertex_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    vertex_buffer_size,
-	    &vertex_staging.memory,
-	    vertices.data());
-
-	index_staging.buffer = get_device().create_buffer(
-	    VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-	    index_buffer_size,
-	    &index_staging.memory,
-	    indices.data());
+	vkb::core::Buffer index_staging(get_device(), index_buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	index_staging.update(indices);
 
 	cube.vertices = std::make_unique<vkb::core::Buffer>(get_device(),
 	                                                    vertex_buffer_size,
@@ -569,7 +555,7 @@ void VertexDynamicState::model_data_creation()
 	copy_region.size = vertex_buffer_size;
 	vkCmdCopyBuffer(
 	    copy_command,
-	    vertex_staging.buffer,
+	    vertex_staging.get_handle(),
 	    cube.vertices->get_handle(),
 	    1,
 	    &copy_region);
@@ -577,17 +563,12 @@ void VertexDynamicState::model_data_creation()
 	copy_region.size = index_buffer_size;
 	vkCmdCopyBuffer(
 	    copy_command,
-	    index_staging.buffer,
+	    index_staging.get_handle(),
 	    cube.indices->get_handle(),
 	    1,
 	    &copy_region);
 
 	device->flush_command_buffer(copy_command, queue, true);
-
-	vkDestroyBuffer(get_device().get_handle(), vertex_staging.buffer, nullptr);
-	vkFreeMemory(get_device().get_handle(), vertex_staging.memory, nullptr);
-	vkDestroyBuffer(get_device().get_handle(), index_staging.buffer, nullptr);
-	vkFreeMemory(get_device().get_handle(), index_staging.memory, nullptr);
 }
 
 std::unique_ptr<vkb::VulkanSample> create_vertex_dynamic_state()


### PR DESCRIPTION
## Description

In most cases when you call `[HPP]Device::create_buffer`, you get such a warning from the validation layer:
> Validation Performance Warning: [ UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation ] | MessageID = 0xb3d4346b | BindBufferMemory(): Trying to bind VkBuffer 0x40b43c0000000049[] to a memory block which is fully consumed by the buffer. The required size of the allocation is 262144, but smaller buffers like this should be sub-allocated from larger memory blocks. (Current threshold is 1048576 bytes.)

Of course the actual buffer id and size varies...
To resolve that, I have removed that function in both device classes and instantiate a `vkb::core::[HPP]Buffer` instead wherever it was used. That is, in the samples `api/hpp_instancing`, `api/hpp_terrain_tessellation`, `api/hpp_texture_mipmap_generation`, `api/instancing`, `api/terrain_tessellation`, `extensions/extended_dynamic_state2`, `extensions/logic_op_dynamic_state`, `extensions/memory_budget`, `extensions/shader_object`, and `extensions/vertex_dynamic_state`.
To ease usage, I have slightly adjusted and extended the `[HPP]Buffer` classes.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Resolves #816.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
  
## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](./../antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
