### PR TITLE
Removed a useless paragraph from the oit_linked_list sample README

### DIFF
--- a/samples/api/oit_linked_lists/README.adoc
+++ b/samples/api/oit_linked_lists/README.adoc
@@ -80,10 +80,6 @@ The artifacts resulting from a low number of sorted fragments per pixel can be o
 | 
 |===
 
-== Requirements
-
-The sample requires _fragmentStoresAndAtomics_ from VkPhysicalDeviceFeatures.
-
 == Tests
 
 This sample was tested on Windows.


### PR DESCRIPTION
## Description

Removed a paragraph that was flagged as useless in the oit_linked_list sample's README.