### PR TITLE
Use hpp-specific cache.data in sample hpp_pipeline_cache.

### DIFF
--- a/samples/performance/hpp_pipeline_cache/hpp_pipeline_cache.cpp
+++ b/samples/performance/hpp_pipeline_cache/hpp_pipeline_cache.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -43,7 +43,7 @@ HPPPipelineCache::~HPPPipelineCache()
 		device->get_handle().destroyPipelineCache(pipeline_cache);
 	}
 
-	vkb::fs::write_temp(device->get_resource_cache().serialize(), "cache.data");
+	vkb::fs::write_temp(device->get_resource_cache().serialize(), "hpp_cache.data");
 }
 
 bool HPPPipelineCache::prepare(const vkb::ApplicationOptions &options)
@@ -83,7 +83,7 @@ bool HPPPipelineCache::prepare(const vkb::ApplicationOptions &options)
 	std::vector<uint8_t> data_cache;
 	try
 	{
-		data_cache = vkb::fs::read_temp("cache.data");
+		data_cache = vkb::fs::read_temp("hpp_cache.data");
 	}
 	catch (std::runtime_error &ex)
 	{


### PR DESCRIPTION
## Description

For whatever reason, the cache data written by the hpp_pipeline_cache sample is somewhat longer than that written by the pipeline_cache sample. Thus, if you run pipeline_cache after hpp_pipeline_cache, you get a failure.
To prevent that from happening, I introduce a dedicated hpp_cache.data file.
The better approach would be to adjust the difference, but I can't get a grip on it.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [xI have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.md#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](./../antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
