### PR TITLE
Fix system_test app path and adb failed issue

### DIFF
--- a/tests/system_test/system_test.py
+++ b/tests/system_test/system_test.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2019-2021, Arm Limited and Contributors
+Copyright (c) 2019-2024, Arm Limited and Contributors
 
 SPDX-License-Identifier: Apache-2.0
 
@@ -96,7 +96,7 @@ class UnixSubtest(Subtest):
         super().__init__(test_name, platform_type)
 
     def run(self):
-        app_path = "{}app/bin/{}/vulkan_samples".format(build_path, platform.machine())
+        app_path = "{}app/bin/{}/{}/vulkan_samples".format(build_path, build_config, platform.machine())
         return super().run(app_path)
 
 class AndroidSubtest(Subtest):
@@ -104,15 +104,15 @@ class AndroidSubtest(Subtest):
         super().__init__(test_name, "Android")
 
     def run(self):
-        subprocess.run("adb shell am force-stop com.khronos.vulkan_samples")
+        subprocess.run(["adb", "shell", "am", "force-stop", "com.khronos.vulkan_samples"])
         subprocess.run(["adb", "shell", "am", "start", "-W", "-n", "com.khronos.vulkan_samples/com.khronos.vulkan_samples.SampleLauncherActivity", "-e", "test", "{0}".format(self.test_name)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        output = subprocess.check_output("adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp' | cut -d . -f 5 | cut -d ' ' -f 1")
+        output = subprocess.check_output("adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp' | cut -d . -f 5 | cut -d ' ' -f 1", shell=True)
         activity = "".join(output.decode("utf-8").split())
         timeout_counter = 0
         while activity == "vulkan_samples" and timeout_counter <= android_timeout:
             sleep(check_step)
             timeout_counter += check_step
-            output = subprocess.check_output("adb shell \"dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp' | cut -d . -f 5 | cut -d ' ' -f 1\"")
+            output = subprocess.check_output("adb shell \"dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp' | cut -d . -f 5 | cut -d ' ' -f 1\"", shell=True)
             activity = "".join(output.decode("utf-8").split())
         if timeout_counter <= android_timeout:
             subprocess.run(["adb", "pull", "/sdcard/Android/data/com.khronos.vulkan_samples/files/" + outputs_path + self.test_name + image_ext, os.path.join(root_path, outputs_path)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -253,7 +253,7 @@ def main():
             failed += 1
 
     if failed == 0:
-        print("=== Success: All tests passed! ===")        
+        print("=== Success: All tests passed! ===")
         shutil.rmtree(tmp_path)
         exit(0)
     else:
@@ -300,7 +300,7 @@ if __name__ == "__main__":
     # If building for android check that a valid device is plugged in
     if test_android:
         try:
-            subprocess.check_output("adb get-state")
+            subprocess.check_output(["adb", "get-state"])
         except:
             print("Device not found, disabling Android testing")
             test_android = False


### PR DESCRIPTION
[Why]
App path is incorrected for Linux in system_path.
Fix system_test cannot find executable app on Linux. Fix adb command executed failed.

[How]
Set corrected app path for Linux when run system_test. Correct input arguments of subprocess.check_output.

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.md)

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.md#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.md#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.md#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](./../samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](./../antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
