### PR TITLE
Remove transient bit for depth image usage flags

### DIFF
--- a/framework/rendering/hpp_render_target.cpp
+++ b/framework/rendering/hpp_render_target.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -28,7 +28,7 @@ const HPPRenderTarget::CreateFunc HPPRenderTarget::DEFAULT_CREATE_FUNC = [](core
 
 	core::HPPImage depth_image{swapchain_image.get_device(), swapchain_image.get_extent(),
 	                           depth_format,
-	                           vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eTransientAttachment,
+	                           vk::ImageUsageFlagBits::eDepthStencilAttachment,
 	                           VMA_MEMORY_USAGE_GPU_ONLY};
 
 	std::vector<core::HPPImage> images;

--- a/framework/rendering/render_target.cpp
+++ b/framework/rendering/render_target.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2023, Arm Limited and Contributors
+/* Copyright (c) 2019-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -43,7 +43,7 @@ const RenderTarget::CreateFunc RenderTarget::DEFAULT_CREATE_FUNC = [](core::Imag
 
 	core::Image depth_image{swapchain_image.get_device(), swapchain_image.get_extent(),
 	                        depth_format,
-	                        VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT,
+	                        VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
 	                        VMA_MEMORY_USAGE_GPU_ONLY};
 
 	std::vector<core::Image> images;


### PR DESCRIPTION
## Description

With a couple of samples (at least `afbc`, `command_buffer_usage`, and `[hpp_]pipeline_cache`), you get this validation layer warning:
`Validation Performance Warning: [ UNASSIGNED-BestPractices-vkCreateFramebuffer-attachment-should-not-be-transient ] | MessageID = 0xc80d9cbd | vkCreateFramebuffer():  Attachment 1 in VkFramebuffer uses loadOp/storeOps which need to access physical memory, but the image backing the image view has VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT set. Physical memory will need to be backed lazily to this image, potentially causing stalls.`
Removing the transient bit from the depth_image resolves it.
But I'm not sure, if that's the correct resolution of this warning. Maybe one should adjust the corresponding loadOp/storeOps instead.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ x I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
