### PR TITLE
Transcoded version of extensions sample mesh_shading based on Vulkan-Hpp

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, Arm Limited and Contributors
+# Copyright (c) 2019-2024, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -126,6 +126,9 @@ set(ORDER_LIST
 	"hpp_terrain_tessellation"
 	"hpp_texture_loading"
 	"hpp_texture_mipmap_generation"
+	
+	#HPP Extension Samples
+	"hpp_mesh_shading"
 	
     #HPP Performance Samples
     "hpp_pipeline_cache"

--- a/samples/README.adoc
+++ b/samples/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2020-2023, Arm Limited and Contributors
+- Copyright (c) 2020-2024, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -342,6 +342,10 @@ There is no vertex shader,  there is only a mesh and fragment shader.
 The mesh shader creates the vertices for the triangle.
 The mesh shading  pipeline includes the task and mesh shaders before going into the fragment shader.
 This replaces the vertex /  geometry shader standard pipeline.
+
+=== xref:./extensions/hpp_mesh_shading/README.adoc[HPP Mesh shading]
+
+A transcoded version of the Extensions sample <<mesh_shading,Mesh shading>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./extensions/open_gl_interop/README.adoc[OpenGL interoperability]
 

--- a/samples/extensions/hpp_mesh_shading/CMakeLists.txt
+++ b/samples/extensions/hpp_mesh_shading/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 Holochip Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+get_filename_component(FOLDER_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+get_filename_component(PARENT_DIR ${CMAKE_CURRENT_LIST_DIR} PATH)
+get_filename_component(CATEGORY_NAME ${PARENT_DIR} NAME)
+
+add_sample_with_tags(
+    ID ${FOLDER_NAME}
+    CATEGORY ${CATEGORY_NAME}
+    AUTHOR "Holochip Corporation"
+    NAME "HPP Mesh shader sample"
+    DESCRIPTION "Example showing how to utilize the EXT_MESH_SHADER pipeline, using Vulkan-Hpp."
+    SHADER_FILES_GLSL
+        "mesh_shading/ms.mesh"
+        "mesh_shading/ps.frag"
+)

--- a/samples/extensions/hpp_mesh_shading/README.adoc
+++ b/samples/extensions/hpp_mesh_shading/README.adoc
@@ -1,0 +1,32 @@
+////
+- Copyright (c) 2024, Holochip Corporation
+-
+- SPDX-License-Identifier: Apache-2.0
+-
+- Licensed under the Apache License, Version 2.0 the "License";
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-
+////
+
+= Mesh shading
+
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/hpp_mesh_shading[Khronos Vulkan samples github repository].
+endif::[]
+
+:pp: {plus}{plus}
+
+NOTE: This is a transcoded version of the extension sample https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/mesh_shading[Mesh Shading] that illustrates the usage of the C{pp} bindings of vulkan provided by Vulkan-Hpp.
+
+This code sample demonstrates how to create the absolute most basic mesh shading example.
+It creates a single  triangle in a mesh shader.
+There is no vertex shader, there is only a mesh shader and a fragment shader.

--- a/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.cpp
+++ b/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.cpp
@@ -1,0 +1,199 @@
+/* Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Basic example for VK_EXT_mesh_shader, using Vulkan-Hpp.
+ * There is only a mesh shader and a fragment shader. The mesh shader creates the vertices for a single triangle.
+ */
+
+#include "hpp_mesh_shading.h"
+
+#include "glsl_compiler.h"
+
+HPPMeshShading::HPPMeshShading()
+{
+	title = "Mesh shading";
+
+	// VK_EXT_mesh_shader depends on VK_KHR_spirv_1_4, which in turn depends on Vulkan 1.1 and VK_KHR_shader_float_controls
+	set_api_version(VK_API_VERSION_1_1);
+
+	add_device_extension(VK_EXT_MESH_SHADER_EXTENSION_NAME);
+	add_device_extension(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
+	add_device_extension(VK_KHR_SPIRV_1_4_EXTENSION_NAME);
+
+	vkb::GLSLCompiler::set_target_environment(glslang::EShTargetSpv, glslang::EShTargetSpv_1_4);
+}
+
+HPPMeshShading::~HPPMeshShading()
+{
+	if (get_device() && get_device()->get_handle())
+	{
+		vk::Device const &device = get_device()->get_handle();
+
+		device.destroyPipeline(pipeline);
+		device.destroyPipelineLayout(pipeline_layout);
+		device.destroyDescriptorSetLayout(descriptor_set_layout);
+	}
+}
+
+bool HPPMeshShading::prepare(const vkb::ApplicationOptions &options)
+{
+	assert(!prepared);
+
+	if (HPPApiVulkanSample::prepare(options))
+	{
+		vk::Device device = get_device()->get_handle();
+
+		descriptor_pool       = device.createDescriptorPool({{}, 2, {}});
+		descriptor_set_layout = device.createDescriptorSetLayout({});
+		descriptor_set        = device.allocateDescriptorSets({descriptor_pool, descriptor_set_layout}).front();
+
+		// Create a blank pipeline layout.
+		// We are not binding any resources to the pipeline in this first sample.
+		pipeline_layout = device.createPipelineLayout({{}, descriptor_set_layout});
+
+		pipeline = create_pipeline();
+
+		build_command_buffers();
+
+		prepared = true;
+	}
+
+	return prepared;
+}
+
+void HPPMeshShading::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
+{
+	// Enable extension features required by this sample
+	// These are passed to device creation via a pNext structure chain
+	auto &meshFeatures      = gpu.request_extension_features<vk::PhysicalDeviceMeshShaderFeaturesEXT>();
+	meshFeatures.meshShader = true;
+}
+
+/*
+    Command buffer generation
+*/
+void HPPMeshShading::build_command_buffers()
+{
+	vk::CommandBufferBeginInfo command_buffer_begin_info;
+
+	std::array<vk::ClearValue, 2> clear_values = {{default_clear_color, vk::ClearDepthStencilValue(0.0f, 0)}};
+
+	vk::RenderPassBeginInfo render_pass_begin_info(render_pass, {}, {{0, 0}, extent}, clear_values);
+
+	for (size_t i = 0; i < draw_cmd_buffers.size(); ++i)
+	{
+		render_pass_begin_info.framebuffer = framebuffers[i];
+
+		vk::CommandBuffer command_buffer = draw_cmd_buffers[i];
+
+		command_buffer.begin(command_buffer_begin_info);
+		command_buffer.beginRenderPass(render_pass_begin_info, vk::SubpassContents::eInline);
+		command_buffer.setViewport(0, {{0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height), 0.0f, 1.0f}});
+		command_buffer.setScissor(0, {{{0, 0}, extent}});
+		command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipeline_layout, 0, descriptor_set, {});
+		command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline);
+
+		// Mesh shaders need the vkCmdDrawMeshTasksExt
+		command_buffer.drawMeshTasksEXT(1, 1, 1);
+
+		draw_ui(command_buffer);
+
+		command_buffer.endRenderPass();
+		command_buffer.end();
+	}
+}
+
+void HPPMeshShading::render(float delta_time)
+{
+	if (prepared)
+	{
+		draw();
+	}
+}
+
+vk::Pipeline HPPMeshShading::create_pipeline()
+{
+	// Load our SPIR-V shaders.
+	std::vector<vk::PipelineShaderStageCreateInfo> shader_stages = {load_shader("mesh_shading/ms.mesh", vk::ShaderStageFlagBits::eMeshEXT),
+	                                                                load_shader("mesh_shading/ps.frag", vk::ShaderStageFlagBits::eFragment)};
+
+	// We will have one viewport and scissor box.
+	vk::PipelineViewportStateCreateInfo viewport_state({}, 1, nullptr, 1, nullptr);
+
+	vk::PipelineRasterizationStateCreateInfo rasterization_state;
+	rasterization_state.polygonMode = vk::PolygonMode::eFill;
+	rasterization_state.cullMode    = vk::CullModeFlagBits::eNone;
+	rasterization_state.frontFace   = vk::FrontFace::eCounterClockwise;
+	rasterization_state.lineWidth   = 1.0f;
+
+	// No multisampling.
+	vk::PipelineMultisampleStateCreateInfo multisample_state({}, vk::SampleCountFlagBits::e1);
+
+	vk::PipelineDepthStencilStateCreateInfo depth_stencil_state;
+	depth_stencil_state.depthTestEnable  = false;
+	depth_stencil_state.depthWriteEnable = true;
+	depth_stencil_state.depthCompareOp   = vk::CompareOp::eGreater;
+	depth_stencil_state.back.compareOp   = vk::CompareOp::eGreater;
+
+	vk::PipelineColorBlendAttachmentState blend_attachment_state;
+	blend_attachment_state.colorWriteMask =
+	    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
+
+	vk::PipelineColorBlendStateCreateInfo color_blend_state({}, false, {}, blend_attachment_state);
+
+	// Specify that these states will be dynamic, i.e. not part of pipeline state object.
+	std::array<vk::DynamicState, 2>    dynamic_state_enables = {vk::DynamicState::eViewport, vk::DynamicState::eScissor};
+	vk::PipelineDynamicStateCreateInfo dynamic_state({}, dynamic_state_enables);
+
+	vk::GraphicsPipelineCreateInfo graphics_pipeline_create_info({},
+	                                                             shader_stages,
+	                                                             nullptr,
+	                                                             nullptr,
+	                                                             nullptr,
+	                                                             &viewport_state,
+	                                                             &rasterization_state,
+	                                                             &multisample_state,
+	                                                             &depth_stencil_state,
+	                                                             &color_blend_state,
+	                                                             &dynamic_state,
+	                                                             pipeline_layout,
+	                                                             render_pass);
+
+	vk::Result   result;
+	vk::Pipeline pipeline;
+	std::tie(result, pipeline) = get_device()->get_handle().createGraphicsPipeline(pipeline_cache, graphics_pipeline_create_info);
+	assert(result == vk::Result::eSuccess);
+
+	return pipeline;
+}
+
+void HPPMeshShading::draw()
+{
+	HPPApiVulkanSample::prepare_frame();
+
+	// Submit to queue
+	submit_info.setCommandBuffers(draw_cmd_buffers[current_buffer]);
+	queue.submit(submit_info);
+
+	HPPApiVulkanSample::submit_frame();
+}
+
+std::unique_ptr<vkb::HPPVulkanSample> create_hpp_mesh_shading()
+{
+	return std::make_unique<HPPMeshShading>();
+}

--- a/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.h
+++ b/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.h
@@ -1,0 +1,57 @@
+/* Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Basic example for VK_EXT_mesh_shader, using Vulkan-Hpp.
+ * There is only a mesh shader and a fragment shader. The mesh shader creates the vertices for a single triangle.
+ */
+
+#pragma once
+
+#include <hpp_api_vulkan_sample.h>
+
+// #include "api_vulkan_sample.h"
+// #include "glsl_compiler.h"
+
+class HPPMeshShading : public HPPApiVulkanSample
+{
+  public:
+	HPPMeshShading();
+	~HPPMeshShading() override;
+
+  private:
+	// from vkb::Application
+	bool prepare(const vkb::ApplicationOptions &options) override;
+
+	// from vkb::HPPVulkanSample
+	void request_gpu_features(vkb::core::HPPPhysicalDevice &gpu) override;
+
+	// from HPPApiVulkanSample
+	void build_command_buffers() override;
+	void render(float delta_time) override;
+
+	vk::Pipeline create_pipeline();
+	void         draw();
+
+  private:
+	vk::Pipeline            pipeline              = nullptr;
+	vk::PipelineLayout      pipeline_layout       = nullptr;
+	vk::DescriptorSet       descriptor_set        = nullptr;
+	vk::DescriptorSetLayout descriptor_set_layout = nullptr;
+};
+
+std::unique_ptr<vkb::HPPVulkanSample> create_hpp_mesh_shading();


### PR DESCRIPTION
## Description

Introduces a new Vulkan-Hpp-based sample, which is a transcoded version of the `mesh_shading` extensions sample.

Build tested on Win10 with VS2022. The samples are tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/README.adoc)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
