### PR TITLE
use correct address computation for image descriptor buffer

### DIFF
--- a/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
+++ b/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, Sascha Willems
+/* Copyright (c) 2024, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
+++ b/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
@@ -304,7 +304,7 @@ void DescriptorBufferBasic::prepare_descriptor_buffer()
 		VkDescriptorGetInfoEXT image_descriptor_info{VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT};
 		image_descriptor_info.type                       = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 		image_descriptor_info.data.pCombinedImageSampler = &image_descriptor;
-		vkGetDescriptorEXT(get_device().get_handle(), &image_descriptor_info, descriptor_buffer_properties.combinedImageSamplerDescriptorSize, image_descriptor_buf_ptr + i * uniform_binding_descriptor.size + uniform_binding_descriptor.offset);
+		vkGetDescriptorEXT(get_device().get_handle(), &image_descriptor_info, descriptor_buffer_properties.combinedImageSamplerDescriptorSize, image_descriptor_buf_ptr + i * image_binding_descriptor.size + image_binding_descriptor.offset);
 	}
 
 	// For uniform buffers we only need to put their buffer device addresses into the descriptor buffers


### PR DESCRIPTION
Image descriptor storage pointer uses size and offset from uniform binding descriptor. Use correct image descriptor offset & size instead.