### PR TITLE
Offline shader prototype

### DIFF
--- a/bldsys/cmake/ShaderData.inl.in
+++ b/bldsys/cmake/ShaderData.inl.in
@@ -1,0 +1,30 @@
+// Copyright 2024 Bradley Austin Davis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "core/shader_module.h"
+
+// This file is generated. Do not edit it directly.
+// Edit @SHADER_FILE@ instead, and this file will automatically be regenerated on the next build
+namespace vkb {
+    namespace shaders {
+        namespace @SHADER_FOLDER@ {
+            const CompiledShader @SHADER_NAME@_@SHADER_TYPE@ {
+                {{ @SHADER_CODE@ }},
+                R"(@SHADER_SOURCE@)",
+                @SHADER_STAGE@
+            };
+        }
+    }
+}

--- a/bldsys/cmake/create_shader_header.cmake
+++ b/bldsys/cmake/create_shader_header.cmake
@@ -1,0 +1,121 @@
+# Copyright 2024 Bradley Austin Davis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# A CMake script to convert SPIR-V files to C++ header files
+# Inputs:
+#   SHADER_SPIRV: The full path of the SPIRV compiled file to convert
+#   SHADER_HEADER: The full path of the header file to generate
+#   SHADER_FILE: The original shader file, relative to the shaders folder
+#   HEADER_TEMPLATE: The full path of the header template file to use
+
+# Spirv headers are little-endian, so if we want to
+# construct a header file that contains the spirv
+# data as an uint32_t literal array, we need to swap the
+# endianness bytes to construct the proper 0xAAAAAAAA literal.
+macro(ENDIAN_SWAP)
+    set(endian_swap_temp "")
+    while (NOT ("${dword}" STREQUAL ""))
+        # Take the first 8 characters from the string
+        string(SUBSTRING ${dword} 0 2 endian_swap_byte)
+        # Remove the first 8 characters from the string
+        string(SUBSTRING ${dword} 2 -1 dword)
+        string(PREPEND endian_swap_temp "${endian_swap_byte}")
+    endwhile()
+    set(dword "${endian_swap_temp}")
+endmacro()
+
+
+
+function(GET_SHADER_STAGE_FOR_TYPE SHADER_TYPE OUTPUT_NAME)
+    if(${SHADER_TYPE} STREQUAL "vert")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_VERTEX_BIT")
+    elseif(${SHADER_TYPE} STREQUAL "tesc")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT")
+    elseif(${SHADER_TYPE} STREQUAL "tese")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT")
+    elseif(${SHADER_TYPE} STREQUAL "geom")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_GEOMETRY_BIT")
+    elseif(${SHADER_TYPE} STREQUAL "geo")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_GEOMETRY_BIT")
+    elseif(${SHADER_TYPE} STREQUAL "frag")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_FRAGMENT_BIT")
+    elseif(${SHADER_TYPE} STREQUAL "comp")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_COMPUTE_BIT")
+    elseif(${SHADER_TYPE} STREQUAL "rgen")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_RAYGEN_BIT_KHR")
+    elseif(${SHADER_TYPE} STREQUAL "rchit")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR")
+    elseif(${SHADER_TYPE} STREQUAL "rmiss")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_MISS_BIT_KHR")
+    elseif(${SHADER_TYPE} STREQUAL "rint")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_INTERSECTION_BIT_KHR")
+    elseif(${SHADER_TYPE} STREQUAL "rahit")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_ANY_HIT_BIT_KHR")
+    elseif(${SHADER_TYPE} STREQUAL "mesh")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_MESH_BIT_EXT")
+    elseif(${SHADER_TYPE} STREQUAL "task")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_TASK_BIT_EXT")
+    elseif(${SHADER_TYPE} STREQUAL "rcall")
+        set(${OUTPUT_NAME} "VK_SHADER_STAGE_CALLABLE_BIT_KHR")
+    else()
+        message(FATAL_ERROR "Unknown shader type ${SHADER_TYPE}")
+    endif()
+    set(${OUTPUT_NAME} "${${OUTPUT_NAME}}" PARENT_SCOPE)
+endfunction()
+
+
+macro(READ_CODE)
+    message(STATUS "Reading SPIRV file: ${SHADER_SPIRV}")
+    file(READ ${SHADER_SPIRV} input_hex HEX)
+    string(LENGTH ${input_hex} SPIRV_NIBBLE_COUNT)
+    math(EXPR SHADER_TOKENS "${SPIRV_NIBBLE_COUNT} / 8")
+
+    set(SHADER_CODE "")
+    set(COUNTER 0)
+    # Iterate through each of the 32 bit tokens from the source file
+    while (NOT ("${input_hex}" STREQUAL ""))
+        if (COUNTER GREATER 8)
+            # Write a newline so that all of the array initializer
+            # gets spread across multiple lines.
+            string(APPEND SHADER_CODE "\n                    ")
+            set(COUNTER 0)
+        endif()
+
+        # Take the first 8 characters from the string
+        string(SUBSTRING ${input_hex} 0 8 dword)
+        # Remove the first 8 characters from the string
+        string(SUBSTRING ${input_hex} 8 -1 input_hex)
+        ENDIAN_SWAP()
+        # Write the hex string to the line with an 0x prefix
+        string(APPEND SHADER_CODE "0x${dword},")
+        # Increment the element counter before the newline.
+        math(EXPR COUNTER "${COUNTER}+1")
+    endwhile()
+endmacro()
+
+
+READ_CODE()
+
+get_filename_component(SHADER_FOLDER ${SHADER_FILE} DIRECTORY)
+get_filename_component(SHADER_NAME ${SHADER_FILE} NAME_WE)
+get_filename_component(SHADER_TYPE ${SHADER_FILE} EXT)
+# Remove the leading dot from the extension to get the shader type
+string(SUBSTRING ${SHADER_TYPE} 1 -1 SHADER_TYPE)
+set(SHADER_SOURCE_FILE "${SHADER_BASE_PATH}/${SHADER_FILE}")
+file(READ ${SHADER_SOURCE_FILE} SHADER_SOURCE)
+get_shader_stage_for_type(${SHADER_TYPE} SHADER_STAGE)
+configure_file("${HEADER_TEMPLATE}" ${SHADER_HEADER} @ONLY)
+
+

--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -52,6 +52,7 @@ set(VKB_VALIDATION_LAYERS_SYNCHRONIZATION OFF CACHE BOOL "Enable synchronization
 set(VKB_VULKAN_DEBUG ON CACHE BOOL "Enable VK_EXT_debug_utils or VK_EXT_debug_marker if supported.")
 set(VKB_BUILD_SAMPLES ON CACHE BOOL "Enable generation and building of Vulkan best practice samples.")
 set(VKB_BUILD_TESTS OFF CACHE BOOL "Enable generation and building of Vulkan best practice tests.")
+set(VKB_OFFLINE_SHADERS ON CACHE BOOL "Enable generation of SPIRV shaders and C++ include files with the shader code during build-time instead of runtime.")
 set(VKB_WSI_SELECTION "XCB" CACHE STRING "Select WSI target (XCB, XLIB, WAYLAND, D2D)")
 set(VKB_CLANG_TIDY OFF CACHE STRING "Use CMake Clang Tidy integration")
 set(VKB_CLANG_TIDY_EXTRAS "-header-filter=framework,samples,app;-checks=-*,google-*,-google-runtime-references;--fix;--fix-errors" CACHE STRING "Clang Tidy Parameters")

--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -19,12 +19,57 @@
 
 set(SCRIPT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
+function(COMPILE_SPIRV_SHADER SHADER_FILE SHADER_OUTPUT)
+    message(TRACE "Compiling shader\n\t${SHADER_FILE}\n\t${SHADER_OUTPUT}")
+    if (NOT DEFINED GLSLANG_EXECUTABLE)
+        find_program(GLSLANG_EXECUTABLE glslangValidator HINTS "$ENV{VULKAN_SDK}/bin")
+    endif()
+    add_custom_command(OUTPUT ${SHADER_OUTPUT}
+        COMMAND ${GLSLANG_EXECUTABLE} -V ${SHADER_FILE} -o ${SHADER_OUTPUT}
+        DEPENDS ${SHADER_FILE}
+        COMMENT "Compiling shader ${SHADER_FILE} to SPIRV ${SHADER_OUTPUT}"
+        VERBATIM
+    )
+endfunction()
+
+
+function(OPTIMIZE_SPIRV SPIRV_FILE OPTIMIZED_OUTPUT)
+    message(TRACE "Optimizing shader\n\t${SPIRV_FILE}\n\t${OPTIMIZED_OUTPUT}")
+    if (NOT DEFINED SPIRV_OPT_EXECUTABLE)
+        find_program(SPIRV_OPT_EXECUTABLE spirv-opt HINTS "$ENV{VULKAN_SDK}/bin")
+    endif()
+    add_custom_command(OUTPUT ${OPTIMIZED_OUTPUT}
+        COMMAND ${SPIRV_OPT_EXECUTABLE} -O ${SPIRV_FILE} -o ${OPTIMIZED_OUTPUT}
+        DEPENDS ${SPIRV_FILE}
+        COMMENT "Optimizing SPIRV ${SPIRV_FILE} to SPIRV ${OPTIMIZED_OUTPUT}"
+        VERBATIM
+    )
+endfunction()
+
+function(GENERATE_HEADER SHADER_FILE SPIRV_FILE HEADER_FILE)
+    message(TRACE "Generating C++ header for\n\t${SPIRV_FILE}\n\t${HEADER_FILE}")
+    set(HEADER_TEMPLATE "${CMAKE_SOURCE_DIR}/bldsys/cmake/ShaderData.inl.in")
+    set(SHADER_HEADERGEN_SCRIPT "${CMAKE_SOURCE_DIR}/bldsys/cmake/create_shader_header.cmake")
+    set(SHADER_BASE_PATH "${CMAKE_SOURCE_DIR}/shaders")
+
+    #   SHADER_SPIRV: The full path of the SPIRV compiled file to convert
+    #   SHADER_HEADER: The full path of the header file to generate
+    #   SHADER_FILE: The original shader file, relative to the shaders folder
+    #   HEADER_TEMPLATE: The full path of the header template file to use
+    add_custom_command(OUTPUT ${SHADER_HEADER}
+        COMMAND ${CMAKE_COMMAND} -DHEADER_TEMPLATE=${HEADER_TEMPLATE} -DSHADER_BASE_PATH=${CMAKE_SOURCE_DIR}/shaders -DSHADER_FILE=${SHADER_FILE} -DSHADER_SPIRV=${SPIRV_FILE} -DSHADER_HEADER=${SHADER_HEADER} -P ${SHADER_HEADERGEN_SCRIPT}
+        DEPENDS ${SPIRV_FILE}
+        COMMENT "Generating header ${HEADER_FILE} from SPIRV ${SPIRV_FILE}"
+        VERBATIM
+    )
+endfunction()
+
 function(add_sample)
-    set(options)  
+    set(options)
     set(oneValueArgs ID CATEGORY AUTHOR NAME DESCRIPTION)
     set(multiValueArgs FILES LIBS SHADER_FILES_GLSL)
 
-    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})    
+    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     add_sample_with_tags(
         TYPE "Sample"
@@ -33,7 +78,7 @@ function(add_sample)
         AUTHOR ${TARGET_AUTHOR}
         NAME ${TARGET_NAME}
         DESCRIPTION ${TARGET_DESCRIPTION}
-        TAGS 
+        TAGS
             "any"
         FILES
             ${SRC_FILES}
@@ -63,11 +108,11 @@ function(add_sample_with_tags)
     endif()
 
     # Add GLSL shader files for this sample
-    if (TARGET_SHADER_FILES_GLSL)    
+    if (TARGET_SHADER_FILES_GLSL)
         list(APPEND SHADER_FILES_GLSL ${TARGET_SHADER_FILES_GLSL})
         foreach(SHADER_FILE_GLSL ${SHADER_FILES_GLSL})
             list(APPEND SHADERS_GLSL "${PROJECT_SOURCE_DIR}/shaders/${SHADER_FILE_GLSL}")
-        endforeach()        
+        endforeach()
     endif()
 
     add_project(
@@ -77,7 +122,7 @@ function(add_sample_with_tags)
         AUTHOR ${TARGET_AUTHOR}
         NAME ${TARGET_NAME}
         DESCRIPTION ${TARGET_DESCRIPTION}
-        TAGS 
+        TAGS
             ${TARGET_TAGS}
         FILES
             ${SRC_FILES}
@@ -113,7 +158,7 @@ function(vkb_add_test)
 endfunction()
 
 function(add_project)
-    set(options)  
+    set(options)
     set(oneValueArgs TYPE ID CATEGORY AUTHOR NAME DESCRIPTION)
     set(multiValueArgs TAGS FILES LIBS SHADERS_GLSL)
 
@@ -151,12 +196,28 @@ endif()
     target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
     target_link_libraries(${PROJECT_NAME} PRIVATE framework)
 
+    # Add shaders to project group
+    if (SHADERS_GLSL AND ("OfflineShaders" IN_LIST TARGET_TAGS))
+        foreach(SHADER_ABSOLUTE_PATH  ${SHADERS_GLSL})
+            file(RELATIVE_PATH SHADER_FILE ${CMAKE_SOURCE_DIR}/shaders ${SHADER_ABSOLUTE_PATH})
+            set(SHADER_DEBUG_SPIRV ${CMAKE_BINARY_DIR}/shaders/${SHADER_FILE}.debug.spv)
+            set(SHADER_SPIRV ${CMAKE_BINARY_DIR}/shaders/${SHADER_FILE}.spv)
+            set(SHADER_HEADER ${CMAKE_BINARY_DIR}/shaders/${SHADER_FILE}.inl)
+            compile_spirv_shader(${SHADER_ABSOLUTE_PATH} ${SHADER_DEBUG_SPIRV})
+            optimize_spirv(${SHADER_DEBUG_SPIRV} ${SHADER_SPIRV})
+            generate_header(${SHADER_FILE} ${SHADER_SPIRV} ${SHADER_HEADER})
+            target_sources(${PROJECT_NAME} PRIVATE ${SHADER_HEADER})
+            source_group("\\Shaders\\Compiled" FILES ${SHADER_HEADER})
+        endforeach()
+        target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_BINARY_DIR}/shaders")
+    endif()
+
     # Link against extra project specific libraries
     if(TARGET_LIBS)
         target_link_libraries(${PROJECT_NAME} PUBLIC ${TARGET_LIBS})
     endif()
 
-    # capitalise the first letter of the category  (performance -> Performance) 
+    # capitalise the first letter of the category  (performance -> Performance)
     string(SUBSTRING ${TARGET_CATEGORY} 0 1 FIRST_LETTER)
     string(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
     string(REGEX REPLACE "^.(.*)" "${FIRST_LETTER}\\1" CATEGORY "${TARGET_CATEGORY}")
@@ -164,7 +225,7 @@ endif()
     if(${TARGET_TYPE} STREQUAL "Sample")
         # set sample properties
         set_target_properties(${PROJECT_NAME}
-            PROPERTIES 
+            PROPERTIES
                 SAMPLE_CATEGORY ${TARGET_CATEGORY}
                 SAMPLE_AUTHOR ${TARGET_AUTHOR}
                 SAMPLE_NAME ${TARGET_NAME}

--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -437,6 +437,17 @@ void ApiVulkanSample::create_pipeline_cache()
 	VK_CHECK(vkCreatePipelineCache(device->get_handle(), &pipeline_cache_create_info, nullptr, &pipeline_cache));
 }
 
+VkPipelineShaderStageCreateInfo ApiVulkanSample::load_shader(const std::vector<uint32_t>& spirv, VkShaderStageFlagBits stage) {
+	VkPipelineShaderStageCreateInfo shader_stage = {};
+	shader_stage.sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+	shader_stage.stage                           = stage;
+	shader_stage.module                          = vkb::load_shader(spirv, device->get_handle(), stage);
+	shader_stage.pName                           = "main";
+	assert(shader_stage.module != VK_NULL_HANDLE);
+	shader_modules.push_back(shader_stage.module);
+	return shader_stage;
+}
+
 VkPipelineShaderStageCreateInfo ApiVulkanSample::load_shader(const std::string &file, VkShaderStageFlagBits stage)
 {
 	VkPipelineShaderStageCreateInfo shader_stage = {};

--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -437,7 +437,8 @@ void ApiVulkanSample::create_pipeline_cache()
 	VK_CHECK(vkCreatePipelineCache(device->get_handle(), &pipeline_cache_create_info, nullptr, &pipeline_cache));
 }
 
-VkPipelineShaderStageCreateInfo ApiVulkanSample::load_shader(const std::vector<uint32_t>& spirv, VkShaderStageFlagBits stage) {
+VkPipelineShaderStageCreateInfo ApiVulkanSample::load_shader(const std::vector<uint32_t> &spirv, VkShaderStageFlagBits stage)
+{
 	VkPipelineShaderStageCreateInfo shader_stage = {};
 	shader_stage.sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
 	shader_stage.stage                           = stage;
@@ -1117,7 +1118,7 @@ Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Im
 	// Setup buffer copy regions for each mip level
 	std::vector<VkBufferImageCopy> buffer_copy_regions;
 
-	auto       &mipmaps = texture.image->get_mipmaps();
+	auto &      mipmaps = texture.image->get_mipmaps();
 	const auto &layers  = texture.image->get_layers();
 
 	auto &offsets = texture.image->get_offsets();
@@ -1216,7 +1217,7 @@ Texture ApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::
 	// Setup buffer copy regions for each mip level
 	std::vector<VkBufferImageCopy> buffer_copy_regions;
 
-	auto       &mipmaps = texture.image->get_mipmaps();
+	auto &      mipmaps = texture.image->get_mipmaps();
 	const auto &layers  = texture.image->get_layers();
 
 	auto &offsets = texture.image->get_offsets();
@@ -1314,7 +1315,7 @@ void ApiVulkanSample::draw_model(std::unique_ptr<vkb::sg::SubMesh> &model, VkCom
 	VkDeviceSize offsets[1] = {0};
 
 	const auto &vertex_buffer = model->vertex_buffers.at("vertex_buffer");
-	auto       &index_buffer  = model->index_buffer;
+	auto &      index_buffer  = model->index_buffer;
 
 	vkCmdBindVertexBuffers(command_buffer, 0, 1, vertex_buffer.get(), offsets);
 	vkCmdBindIndexBuffer(command_buffer, index_buffer->get_handle(), 0, model->index_type);

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -345,6 +345,13 @@ class ApiVulkanSample : public vkb::VulkanSample
 	VkPipelineShaderStageCreateInfo load_shader(const std::string &file, VkShaderStageFlagBits stage);
 
 	/**
+	 * @brief Load a SPIR-V shader
+	 * @param file The file location of the shader relative to the shaders folder
+	 * @param stage The shader stage
+	 */
+	VkPipelineShaderStageCreateInfo load_shader(const std::vector<uint32_t> &spirv, VkShaderStageFlagBits stage);
+
+	/**
 	 * @brief Updates the overlay
 	 * @param delta_time The time taken since the last frame
 	 */

--- a/framework/common/vk_common.cpp
+++ b/framework/common/vk_common.cpp
@@ -382,6 +382,11 @@ VkShaderModule load_shader(const std::string &filename, VkDevice device, VkShade
 		return VK_NULL_HANDLE;
 	}
 
+	return load_shader(spirv, device, stage);
+}
+
+VkShaderModule load_shader(const std::vector<uint32_t> &spirv, VkDevice device, VkShaderStageFlagBits stage)
+{
 	VkShaderModule           shader_module;
 	VkShaderModuleCreateInfo module_create_info{};
 	module_create_info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;

--- a/framework/common/vk_common.h
+++ b/framework/common/vk_common.h
@@ -107,6 +107,16 @@ int32_t get_bits_per_pixel(VkFormat format);
 VkShaderModule load_shader(const std::string &filename, VkDevice device, VkShaderStageFlagBits stage);
 
 /**
+ * @brief Helper function to create a VkShaderModule
+ * @param filename The shader location
+ * @param device The logical device
+ * @param stage The shader stage
+ * @return The string to return.
+ */
+VkShaderModule load_shader(const std::vector<uint32_t> &code, VkDevice device, VkShaderStageFlagBits stage);
+
+
+/**
  * @brief Helper function to select a VkSurfaceFormatKHR
  * @param gpu The VkPhysicalDevice to select a format for.
  * @param surface The VkSurfaceKHR to select a format for.

--- a/framework/core/shader_module.h
+++ b/framework/core/shader_module.h
@@ -260,4 +260,20 @@ class ShaderModule
 
 	std::string info_log;
 };
+
+class CompiledShader
+{
+public:
+	// FIXME we'd prefer to use `std::array<uint32_t, @SHADER_TOKENS@>` since it would allow us to declare this `constexpr`
+	// and allocate at compile time instead of runtime, but that's problematic to pass to functions
+	// unless they're able to accept the SPIRV as vk::ArrayProxy (which requires vulkan.hpp)
+	// or std::span (which requires C++20)
+	const std::vector<uint32_t> spirv;
+	const std::string           source;
+	const VkShaderStageFlagBits stage;
+
+	CompiledShader(const std::vector<uint32_t> &spirv, const std::string &source , VkShaderStageFlagBits stage) :
+	    spirv(spirv), source(source), stage(stage) {}
+};
+
 }        // namespace vkb

--- a/samples/extensions/debug_utils/CMakeLists.txt
+++ b/samples/extensions/debug_utils/CMakeLists.txt
@@ -19,11 +19,12 @@ get_filename_component(FOLDER_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 get_filename_component(PARENT_DIR ${CMAKE_CURRENT_LIST_DIR} PATH)
 get_filename_component(CATEGORY_NAME ${PARENT_DIR} NAME)
 
-add_sample(
+add_sample_with_tags(
     ID ${FOLDER_NAME}
     CATEGORY ${CATEGORY_NAME}
     AUTHOR "Sascha Willems"
     NAME "VK_EXT_Debug_Utils"
+    TAGS "OfflineShaders"
     DESCRIPTION "Demonstrates the use of the debug utils extension for tagging and labeling Vulkan objects for debugging applications like RenderDoc"
     SHADER_FILES_GLSL
         "debug_utils/composition.vert"

--- a/samples/extensions/debug_utils/debug_utils.cpp
+++ b/samples/extensions/debug_utils/debug_utils.cpp
@@ -22,12 +22,12 @@
 
 #include "debug_utils.h"
 
-#include "debug_utils/gbuffer.frag.inl"
-#include "debug_utils/gbuffer.vert.inl"
-#include "debug_utils/composition.frag.inl"
-#include "debug_utils/composition.vert.inl"
 #include "debug_utils/bloom.frag.inl"
 #include "debug_utils/bloom.vert.inl"
+#include "debug_utils/composition.frag.inl"
+#include "debug_utils/composition.vert.inl"
+#include "debug_utils/gbuffer.frag.inl"
+#include "debug_utils/gbuffer.vert.inl"
 
 #include "scene_graph/components/sub_mesh.h"
 
@@ -183,8 +183,8 @@ void DebugUtils::queue_end_label(VkQueue queue)
 /*
  * Object naming and tagging functions
  */
-
-void DebugUtils::set_object_name(VkObjectType object_type, uint64_t object_handle, const char *object_name)
+template <>
+void DebugUtils::set_object_name(VkObjectType object_type, const uint64_t &object_handle, const char *object_name)
 {
 	if (!debug_utils_supported)
 	{
@@ -201,7 +201,7 @@ void DebugUtils::set_object_name(VkObjectType object_type, uint64_t object_handl
  * This sample uses a modified version of the shader loading function that adds a tag to the shader
  * The tag includes the source GLSL that can then be displayed by a debugging application
  */
-VkPipelineShaderStageCreateInfo DebugUtils::debug_load_shader(const vkb::CompiledShader& compiledShader)
+VkPipelineShaderStageCreateInfo DebugUtils::debug_load_shader(const vkb::CompiledShader &compiledShader)
 {
 	VkPipelineShaderStageCreateInfo shader_stage = {};
 	shader_stage.sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
@@ -240,46 +240,46 @@ void DebugUtils::debug_name_objects()
 	{
 		return;
 	}
-	set_object_name(VK_OBJECT_TYPE_BUFFER, (uint64_t) uniform_buffers.matrices->get_handle(), "Matrices uniform buffer");
+	set_object_name(VK_OBJECT_TYPE_BUFFER, uniform_buffers.matrices->get_handle(), "Matrices uniform buffer");
 
-	set_object_name(VK_OBJECT_TYPE_PIPELINE, (uint64_t) pipelines.skysphere, "Skysphere pipeline");
-	set_object_name(VK_OBJECT_TYPE_PIPELINE, (uint64_t) pipelines.composition, "Skysphere pipeline");
-	set_object_name(VK_OBJECT_TYPE_PIPELINE, (uint64_t) pipelines.sphere, "Sphere rendering pipeline");
-	set_object_name(VK_OBJECT_TYPE_PIPELINE, (uint64_t) pipelines.bloom[0], "Horizontal bloom filter pipeline");
-	set_object_name(VK_OBJECT_TYPE_PIPELINE, (uint64_t) pipelines.bloom[1], "Vertical bloom filter pipeline");
+	set_object_name(VK_OBJECT_TYPE_PIPELINE, pipelines.skysphere, "Skysphere pipeline");
+	set_object_name(VK_OBJECT_TYPE_PIPELINE, pipelines.composition, "Skysphere pipeline");
+	set_object_name(VK_OBJECT_TYPE_PIPELINE, pipelines.sphere, "Sphere rendering pipeline");
+	set_object_name(VK_OBJECT_TYPE_PIPELINE, pipelines.bloom[0], "Horizontal bloom filter pipeline");
+	set_object_name(VK_OBJECT_TYPE_PIPELINE, pipelines.bloom[1], "Vertical bloom filter pipeline");
 
-	set_object_name(VK_OBJECT_TYPE_PIPELINE_LAYOUT, (uint64_t) pipeline_layouts.models, "Model rendering pipeline layout");
-	set_object_name(VK_OBJECT_TYPE_PIPELINE_LAYOUT, (uint64_t) pipeline_layouts.composition, "Composition pass pipeline layout");
-	set_object_name(VK_OBJECT_TYPE_PIPELINE_LAYOUT, (uint64_t) pipeline_layouts.bloom_filter, "Bloom filter pipeline layout");
+	set_object_name(VK_OBJECT_TYPE_PIPELINE_LAYOUT, pipeline_layouts.models, "Model rendering pipeline layout");
+	set_object_name(VK_OBJECT_TYPE_PIPELINE_LAYOUT, pipeline_layouts.composition, "Composition pass pipeline layout");
+	set_object_name(VK_OBJECT_TYPE_PIPELINE_LAYOUT, pipeline_layouts.bloom_filter, "Bloom filter pipeline layout");
 
-	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET, (uint64_t) descriptor_sets.sphere, "Sphere model descriptor set");
-	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET, (uint64_t) descriptor_sets.skysphere, "Sky sphere model descriptor set");
-	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET, (uint64_t) descriptor_sets.composition, "Composition pass descriptor set");
-	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET, (uint64_t) descriptor_sets.bloom_filter, "Bloom filter descriptor set");
+	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET, descriptor_sets.sphere, "Sphere model descriptor set");
+	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET, descriptor_sets.skysphere, "Sky sphere model descriptor set");
+	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET, descriptor_sets.composition, "Composition pass descriptor set");
+	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET, descriptor_sets.bloom_filter, "Bloom filter descriptor set");
 
-	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, (uint64_t) descriptor_set_layouts.models, "Model rendering descriptor set layout");
-	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, (uint64_t) descriptor_set_layouts.composition, "Composition pass set layout");
-	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, (uint64_t) descriptor_set_layouts.bloom_filter, "Bloom filter descriptor set layout");
+	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, descriptor_set_layouts.models, "Model rendering descriptor set layout");
+	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, descriptor_set_layouts.composition, "Composition pass set layout");
+	set_object_name(VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, descriptor_set_layouts.bloom_filter, "Bloom filter descriptor set layout");
 
-	set_object_name(VK_OBJECT_TYPE_IMAGE, (uint64_t) textures.skysphere.image->get_vk_image().get_handle(), "Sky sphere texture");
-	set_object_name(VK_OBJECT_TYPE_IMAGE, (uint64_t) offscreen.depth.image, "Offscreen pass depth image");
-	set_object_name(VK_OBJECT_TYPE_IMAGE, (uint64_t) offscreen.depth.image, "Offscreen pass depth image");
-	set_object_name(VK_OBJECT_TYPE_IMAGE, (uint64_t) offscreen.color[0].image, "Offscreen pass color image 0");
-	set_object_name(VK_OBJECT_TYPE_IMAGE, (uint64_t) offscreen.color[1].image, "Offscreen pass color image 1");
-	set_object_name(VK_OBJECT_TYPE_IMAGE, (uint64_t) filter_pass.color[0].image, "Bloom filter pass color image");
+	set_object_name(VK_OBJECT_TYPE_IMAGE, textures.skysphere.image->get_vk_image().get_handle(), "Sky sphere texture");
+	set_object_name(VK_OBJECT_TYPE_IMAGE, offscreen.depth.image, "Offscreen pass depth image");
+	set_object_name(VK_OBJECT_TYPE_IMAGE, offscreen.depth.image, "Offscreen pass depth image");
+	set_object_name(VK_OBJECT_TYPE_IMAGE, offscreen.color[0].image, "Offscreen pass color image 0");
+	set_object_name(VK_OBJECT_TYPE_IMAGE, offscreen.color[1].image, "Offscreen pass color image 1");
+	set_object_name(VK_OBJECT_TYPE_IMAGE, filter_pass.color[0].image, "Bloom filter pass color image");
 
-	set_object_name(VK_OBJECT_TYPE_IMAGE, (uint64_t) depth_stencil.image, "Base depth/stencil image");
+	set_object_name(VK_OBJECT_TYPE_IMAGE, depth_stencil.image, "Base depth/stencil image");
 	for (size_t i = 0; i < swapchain_buffers.size(); i++)
 	{
 		std::string name = "Swapchain image" + std::to_string(i);
-		set_object_name(VK_OBJECT_TYPE_IMAGE, (uint64_t) swapchain_buffers[i].image, name.c_str());
+		set_object_name(VK_OBJECT_TYPE_IMAGE, swapchain_buffers[i].image, name.c_str());
 	}
 
-	set_object_name(VK_OBJECT_TYPE_SAMPLER, (uint64_t) offscreen.sampler, "Offscreen pass sampler");
-	set_object_name(VK_OBJECT_TYPE_SAMPLER, (uint64_t) filter_pass.sampler, "Bloom filter pass sampler");
+	set_object_name(VK_OBJECT_TYPE_SAMPLER, offscreen.sampler, "Offscreen pass sampler");
+	set_object_name(VK_OBJECT_TYPE_SAMPLER, filter_pass.sampler, "Bloom filter pass sampler");
 
-	set_object_name(VK_OBJECT_TYPE_RENDER_PASS, (uint64_t) offscreen.render_pass, "Offscreen pass render pass");
-	set_object_name(VK_OBJECT_TYPE_RENDER_PASS, (uint64_t) filter_pass.render_pass, "Bloom filter pass render pass");
+	set_object_name(VK_OBJECT_TYPE_RENDER_PASS, offscreen.render_pass, "Offscreen pass render pass");
+	set_object_name(VK_OBJECT_TYPE_RENDER_PASS, filter_pass.render_pass, "Bloom filter pass render pass");
 }
 
 void DebugUtils::request_gpu_features(vkb::PhysicalDevice &gpu)

--- a/samples/extensions/debug_utils/debug_utils.h
+++ b/samples/extensions/debug_utils/debug_utils.h
@@ -135,7 +135,7 @@ class DebugUtils : public ApiVulkanSample
 	void                            queue_insert_label(VkQueue queue, const char *label_name, std::vector<float> color);
 	void                            queue_end_label(VkQueue queue);
 	void                            set_object_name(VkObjectType object_type, uint64_t object_handle, const char *object_name);
-	VkPipelineShaderStageCreateInfo debug_load_shader(const std::string &file, VkShaderStageFlagBits stage);
+	VkPipelineShaderStageCreateInfo debug_load_shader(const vkb::CompiledShader &compiledShader);
 	void                            debug_name_objects();
 	virtual void                    request_gpu_features(vkb::PhysicalDevice &gpu) override;
 	void                            build_command_buffers() override;

--- a/samples/extensions/debug_utils/debug_utils.h
+++ b/samples/extensions/debug_utils/debug_utils.h
@@ -127,14 +127,19 @@ class DebugUtils : public ApiVulkanSample
 
 	DebugUtils();
 	~DebugUtils();
-	void                            debug_check_extension();
-	void                            cmd_begin_label(VkCommandBuffer command_buffer, const char *label_name, std::vector<float> color);
-	void                            cmd_insert_label(VkCommandBuffer command_buffer, const char *label_name, std::vector<float> color);
-	void                            cmd_end_label(VkCommandBuffer command_buffer);
-	void                            queue_begin_label(VkQueue queue, const char *label_name, std::vector<float> color);
-	void                            queue_insert_label(VkQueue queue, const char *label_name, std::vector<float> color);
-	void                            queue_end_label(VkQueue queue);
-	void                            set_object_name(VkObjectType object_type, uint64_t object_handle, const char *object_name);
+	void debug_check_extension();
+	void cmd_begin_label(VkCommandBuffer command_buffer, const char *label_name, std::vector<float> color);
+	void cmd_insert_label(VkCommandBuffer command_buffer, const char *label_name, std::vector<float> color);
+	void cmd_end_label(VkCommandBuffer command_buffer);
+	void queue_begin_label(VkQueue queue, const char *label_name, std::vector<float> color);
+	void queue_insert_label(VkQueue queue, const char *label_name, std::vector<float> color);
+	void queue_end_label(VkQueue queue);
+	//void                            set_object_name(VkObjectType object_type, uint64_t object_handle, const char *object_name);
+	template <typename T>
+	void set_object_name(VkObjectType object_type, const T &object_handle, const char *object_name)
+	{
+		set_object_name(object_type, reinterpret_cast<const uint64_t &>(object_handle), object_name);
+	}
 	VkPipelineShaderStageCreateInfo debug_load_shader(const vkb::CompiledShader &compiledShader);
 	void                            debug_name_objects();
 	virtual void                    request_gpu_features(vkb::PhysicalDevice &gpu) override;


### PR DESCRIPTION
## Description

Initial work to prototype a solution for #802 

The idea here is to take the shader source files that are used by given sample and compile them to SPIRV, and then make them available to the application at build-time rather than requiring any runtime compilation step.

DONE:
* Individual samples can be tagged with "OfflineShaders" and this will cause any `SHADER_FILES_GLSL` declared in the sample to be targeted for compilation, and will generate the following artifacts
  * A `SHADER.debug.spv` file that is the result of `glslangValidator` compilation
  * A `SHADER.spv` which is the result of running `spirv-opt` on the above file
  * A `SHADER.inl`  header file which contains the compile SPIRV as a `std::vector<uint32_t>` (should be changed to `std::array<uint32_t, N>` so that the structure can be `constexpr`).  The header structure also contains the stage bit and the original source code (which was required because I unwisely picked `debug_utils` as my test sample, without realizing that it depended on having the source code to attach to the shader object as a tag.
  

TODO:

* Support shader variants
* Support HLSL
* Figure out a way to declare pipelines and variants in the sample addition code, the way shader files are now for the individual GLSL
* Generate a reflection structure as part of the process that can be used to easily configure descriptor sets
* Make `CompiledShader` structure `constexpr` friendly.




## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
