### PR TITLE
Fix sccache usage in Windows CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         name: Configure and build
         shell: pwsh
         run: |
-          cmake -B"build/${{ matrix.platform }}" -G"NMake Makefiles" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DCMAKE_C_COMPILER_LAUNCHER=C:\\Users\\runneradmin\\.cargo\\bin\\sccache -DCMAKE_CXX_COMPILER_LAUNCHER=C:\\Users\\runneradmin\\.cargo\\bin\\sccache
+          cmake -B"build/${{ matrix.platform }}" -G"Ninja" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DCMAKE_C_COMPILER_LAUNCHER=C:\\Users\\runneradmin\\.cargo\\bin\\sccache -DCMAKE_CXX_COMPILER_LAUNCHER=C:\\Users\\runneradmin\\.cargo\\bin\\sccache
           cmake --build "build/${{ matrix.platform }}" --target vulkan_samples --config ${{ matrix.build_type }}  -j 1
       - if: ${{ matrix.platform != 'windows' }}
         name: Configure and build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, Arm Limited and Contributors
+# Copyright (c) 2020-2024, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -14,33 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 if(NOT DEFINED CMAKE_C_COMPILER_LAUNCHER AND NOT DEFINED CMAKE_CXX_COMPILER_LAUNCHER)
-find_program(CCACHE_FOUND ccache)
-find_program(SCCACHE_FOUND sccache)
-if(CCACHE_FOUND AND NOT SCCACHE_FOUND)
-    message("setting CCACHE to ${CCACHE_FOUND}")
-    set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_FOUND})
-    set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_FOUND})
-elseif(SCCACHE_FOUND AND NOT CCACHE_FOUND)
-    message("setting CCACHE to ${CCACHE_FOUND}")
-    set(CMAKE_C_COMPILER_LAUNCHER ${SCCACHE_FOUND})
-    set(CMAKE_CXX_COMPILER_LAUNCHER ${SCCACHE_FOUND})
-endif(CCACHE_FOUND AND NOT SCCACHE_FOUND)
-endif()
-if(DEFINED CMAKE_C_COMPILER_LAUNCHER)
-if(WIN32)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-        string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-    elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-        string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-        string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-    elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-        string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-        string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+    find_program(CCACHE_FOUND ccache)
+    find_program(SCCACHE_FOUND sccache)
+    if (SCCACHE_FOUND)
+        message("setting SCCACHE to ${SCCACHE_FOUND}")
+        set(CMAKE_C_COMPILER_LAUNCHER ${SCCACHE_FOUND})
+        set(CMAKE_CXX_COMPILER_LAUNCHER ${SCCACHE_FOUND})
+    elseif(CCACHE_FOUND)
+        message("setting CCACHE to ${CCACHE_FOUND}")
+        set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_FOUND})
+        set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_FOUND})
     endif()
-endif()
 endif()
 
 cmake_minimum_required(VERSION 3.16)
@@ -49,6 +34,15 @@ cmake_minimum_required(VERSION 3.16)
 add_compile_definitions($<$<CONFIG:DEBUG>:VKB_DEBUG>)
 
 project(vulkan_samples)
+
+if(MSVC AND (DEFINED CMAKE_C_COMPILER_LAUNCHER))
+    message(DEBUG "Setting MSVC flags to /Z7 for ccache compatibility.  Current flags: ${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+    message(DEBUG "New flags: ${CMAKE_CXX_FLAGS_DEBUG}")
+endif()
 
 # create output folder
 file(MAKE_DIRECTORY output)


### PR DESCRIPTION
## Description

This corrects a couple problems preventing the Windows CI builds from using sccache.  

Fix for #896 and reduces windows build significantly.

