### PR TITLE
Remove RTP feature request from ray_queries

### DIFF
--- a/samples/extensions/ray_queries/ray_queries.cpp
+++ b/samples/extensions/ray_queries/ray_queries.cpp
@@ -1,4 +1,5 @@
-/* Copyright (c) 2021-2023, Holochip Corporation
+/* Copyright (c) 2021-2024, Holochip Corporation
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -115,8 +116,7 @@ void RayQueries::request_gpu_features(vkb::PhysicalDevice &gpu)
 	RequestFeature(gpu)
 	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES, &VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress)
 	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR, &VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructure)
-	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR, &VkPhysicalDeviceRayQueryFeaturesKHR::rayQuery)
-	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR, &VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipeline);
+	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR, &VkPhysicalDeviceRayQueryFeaturesKHR::rayQuery);
 }
 
 void RayQueries::render(float delta_time)


### PR DESCRIPTION
## Description

The `ray_queries` sample requests the RTP feature support from the GPU, although I can't see why this is done as the RQ extension has no dependency on the RTP extension, and RTP isn't used in the sample.  Unsurprisingly removing it has no effect on the devices I've tried it on.

This isn't an issue on desktop GPUs where RTP and RQ are always supported together, but on mobile many device manufacturers only support RQ.  Interestingly on the device I tested it on, a Vivo X90 Pro, the hardware supports RTP but it's been disabled at the driver level - I only can assume the sample still works because that effort was botched.

Tested on:
* Vivo X90 Pro (Mali-G715-Immortalis MC11)
* NVidia 3090 FE (535.154.05, Linux)

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [X] I have tested every sample to ensure everything runs correctly
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [X] I have tested the sample on at least one compliant Vulkan implementation
- [X] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [X] Any dependent assets have been merged and published in downstream modules
- [X] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/README.adoc)
- [X] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [X] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
