### PR TITLE
Allow explicit skips in batch mode

### DIFF
--- a/app/plugins/batch_mode/batch_mode.cpp
+++ b/app/plugins/batch_mode/batch_mode.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2023, Arm Limited and Contributors
+/* Copyright (c) 2020-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -65,7 +65,30 @@ void BatchMode::init(const vkb::CommandParser &parser)
 		categories = parser.as<std::vector<std::string>>(&categories_flag);
 	}
 
+	std::unordered_set<std::string> skips;
+	if (parser.contains(&skip_flag))
+	{
+		skips = parser.as<std::unordered_set<std::string>>(&skip_flag);
+	}
+
 	sample_list = apps::get_samples(categories, tags);
+	if (!skips.empty())
+	{
+		std::vector<apps::AppInfo *> filtered_list;
+		filtered_list.reserve(sample_list.size());
+
+		std::copy_if(
+		    sample_list.begin(), sample_list.end(),
+		    std::back_inserter(filtered_list),
+		    [&](const apps::AppInfo *app) {
+			    return skips.find(app->id) == skips.end();
+		    });
+
+		if (filtered_list.size() != sample_list.size())
+		{
+			sample_list.swap(filtered_list);
+		}
+	}
 
 	if (sample_list.empty())
 	{

--- a/app/plugins/batch_mode/batch_mode.h
+++ b/app/plugins/batch_mode/batch_mode.h
@@ -32,11 +32,11 @@ using BatchModeTags = vkb::PluginBase<vkb::tags::Entrypoint, vkb::tags::FullCont
 
 /**
  * @brief Batch Mode
- * 
+ *
  * Run a subset of samples. The next sample in the set will start after the current sample being executed has finished. Using --wrap-to-start will start again from the first sample after the last sample is executed.
- * 
+ *
  * Usage: vulkan_samples batch --duration 3 --category performance --tag arm
- * 
+ *
  */
 class BatchMode : public BatchModeTags
 {
@@ -62,7 +62,9 @@ class BatchMode : public BatchModeTags
 
 	vkb::FlagCommand categories_flag{vkb::FlagType::ManyValues, "category", "C", "Filter samples by categories"};
 
-	vkb::SubCommand batch_cmd{"batch", "Enable batch mode", {&duration_flag, &wrap_flag, &tags_flag, &categories_flag}};
+	vkb::FlagCommand skip_flag{vkb::FlagType::ManyValues, "skip", "", "Skip a sample by id"};
+
+	vkb::SubCommand batch_cmd{"batch", "Enable batch mode", {&duration_flag, &wrap_flag, &tags_flag, &categories_flag, &skip_flag}};
 
   private:
 	/// The list of suitable samples to be run in conjunction with batch mode

--- a/framework/platform/parser.h
+++ b/framework/platform/parser.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2023, Arm Limited and Contributors
+/* Copyright (c) 2021-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <string>
 #include <typeindex>
+#include <unordered_set>
 #include <vector>
 
 namespace vkb
@@ -303,6 +304,13 @@ template <>
 inline bool CommandParser::convert_type(const std::vector<std::string> &values, std::vector<std::string> *type) const
 {
 	*type = values;
+	return true;
+}
+
+template <>
+inline bool CommandParser::convert_type(const std::vector<std::string> &values, std::unordered_set<std::string> *type) const
+{
+	*type = std::unordered_set<std::string>(values.begin(), values.end());
 	return true;
 }
 

--- a/framework/platform/parsers/CLI11.cpp
+++ b/framework/platform/parsers/CLI11.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2023, Arm Limited and Contributors
+/* Copyright (c) 2021-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -16,6 +16,8 @@
  */
 
 #include "CLI11.h"
+
+#include <climits>
 
 #include "common/logging.h"
 #include "common/strings.h"
@@ -100,7 +102,8 @@ void CLI11CommandParser::parse(CLI11CommandContext *context, FlagCommand *comman
 {
 	CLI::Option *flag;
 
-	switch (command->get_flag_type())
+	auto flagType = command->get_flag_type();
+	switch (flagType)
 	{
 		case FlagType::FlagOnly:
 			flag = context->cli11->add_flag(command->get_name(), command->get_help_line());
@@ -109,6 +112,13 @@ void CLI11CommandParser::parse(CLI11CommandContext *context, FlagCommand *comman
 		case FlagType::ManyValues:
 			flag = context->cli11->add_option(command->get_name(), command->get_help_line());
 			break;
+		default:
+			throw std::runtime_error("Unknown flag type");
+	}
+
+	if (flagType == FlagType::ManyValues)
+	{
+		flag = flag->expected(1, INT_MAX);
 	}
 
 	_options.emplace(command, flag);


### PR DESCRIPTION
## Description

Batch mode is extremely useful for testing a change hasn't impacted the behavior of any samples (say, but crashing or producing a black screen).

However, if there are known crash issues in examples (that are present on the main branch) such as #913  then batch mode only becomes useful until you hit that broken example.

This change adds a flag that allows batch mode to skip examples by id that would normally be included otherwise.

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [X] I have tested every sample to ensure everything runs correctly
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

Fixes #936
