### PR TITLE
Allow HPPVulkanException to be caught as a std::exception

### DIFF
--- a/framework/common/hpp_error.h
+++ b/framework/common/hpp_error.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -30,7 +30,7 @@ namespace common
  *
  * See vkb::VulkanException for documentation
  */
-class HPPVulkanException : private vkb::VulkanException
+class HPPVulkanException : public vkb::VulkanException
 {
   public:
 	HPPVulkanException(vk::Result result, std::string const &msg = "Vulkan error") :


### PR DESCRIPTION
## Description

The private inheritance in HPPVulkanException was preventing the top-level exception handler from catching it as a std::exception. This causes batch mode to abort whenever it sees an unsupported extension in an hpp sample.

This change uses public inheritance instead which fixes the issue.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Linux
