### PR TITLE
Fix fragment_shading_rate_dynamic sample

### DIFF
--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2023, Holochip
+/* Copyright (c) 2021-2024, Holochip
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -770,7 +770,7 @@ void FragmentShadingRateDynamic::create_compute_pipeline()
 	VK_CHECK(vkCreateComputePipelines(device->get_handle(), pipeline_cache, 1, &pipeline_create_info, VK_NULL_HANDLE,
 	                                  &compute.pipeline));
 
-	for (auto &&compute_buffer : compute_buffers)
+	for (auto &compute_buffer : compute_buffers)
 	{
 		auto create = vkb::initializers::command_buffer_allocate_info(command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1);
 		VK_CHECK(vkAllocateCommandBuffers(get_device().get_handle(), &create, &compute_buffer.command_buffer));


### PR DESCRIPTION
## Description

Fix the declaration of the compute_buffer in a loop as an r-value reference to a simple reference.

Fixes #913

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [X] I have tested every sample to ensure everything runs correctly
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [X] I have tested the sample on at least one compliant Vulkan implementation
