### PR TITLE
Fix validation errors in color_write_enable

### DIFF
--- a/samples/extensions/color_write_enable/color_write_enable.cpp
+++ b/samples/extensions/color_write_enable/color_write_enable.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, Mobica Limited
+/* Copyright (c) 2023-2024, Mobica Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -231,9 +231,10 @@ void ColorWriteEnable::create_attachment(VkFormat format, FrameBufferAttachment 
 // Create attachments for each framebuffer used in the first pipeline
 void ColorWriteEnable::create_attachments()
 {
-	create_attachment(VK_FORMAT_B8G8R8A8_SRGB, &attachments.red);
-	create_attachment(VK_FORMAT_B8G8R8A8_SRGB, &attachments.green);
-	create_attachment(VK_FORMAT_B8G8R8A8_SRGB, &attachments.blue);
+	VkFormat format = render_context->get_format();
+	create_attachment(format, &attachments.red);
+	create_attachment(format, &attachments.green);
+	create_attachment(format, &attachments.blue);
 }
 
 void ColorWriteEnable::request_gpu_features(vkb::PhysicalDevice &gpu)


### PR DESCRIPTION
## Description

The attachments were being created with a format that didn't match the corresponding VkAttachmentDescription in renderPass causing a validation error.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly (only affects one sample)
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Linux
