### PR TITLE
Fix validation error in graphics_pipeline_library

### DIFF
--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023, Sascha Willems
+/* Copyright (c) 2022-2024, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -411,9 +411,10 @@ void GraphicsPipelineLibrary::prepare_new_pipeline()
 	linking_info.pLibraries   = libraries.data();
 
 	VkGraphicsPipelineCreateInfo executable_pipeline_create_info{};
-	executable_pipeline_create_info.sType  = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-	executable_pipeline_create_info.pNext  = &linking_info;
-	executable_pipeline_create_info.layout = pipeline_layout;
+	executable_pipeline_create_info.sType      = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+	executable_pipeline_create_info.pNext      = &linking_info;
+	executable_pipeline_create_info.layout     = pipeline_layout;
+	executable_pipeline_create_info.renderPass = render_pass;
 	if (link_time_optimization)
 	{
 		// If link time optimization is activated in the UI, we set the VK_PIPELINE_CREATE_LINK_TIME_OPTIMIZATION_BIT_EXT flag which will let the implementation do additional optimizations at link time


### PR DESCRIPTION
## Description

A valid render pass was required when creating a graphics pipeline.

"If the dynamicRendering feature is not enabled and the pipeline requires pre-rasterization shader state, fragment shader state, or fragment output interface state, renderPass must not be VK_NULL_HANDLE"

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly - only affects one sample
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Linux