### PR TITLE
Add 3-tap-to-hide GUI gesture

### DIFF
--- a/docs/misc.adoc
+++ b/docs/misc.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2019-2023, Arm Limited and Contributors
+- Copyright (c) 2019-2024, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -45,8 +45,8 @@
 | -
 
 | toggle GUI
-| +++<kbd>+++left click+++</kbd>+++
-| +++<kbd>+++tap+++</kbd>+++
+| +++<kbd>+++F1+++</kbd>+++
+| 3 finger +++<kbd>+++tap+++</kbd>+++
 
 | toggle Debug Window
 | +++<kbd>+++right click+++</kbd>+++

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2023, Arm Limited and Contributors
- * Copyright (c) 2019-2023, Sascha Willems
+/* Copyright (c) 2018-2024, Arm Limited and Contributors
+ * Copyright (c) 2019-2024, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -1061,6 +1061,10 @@ bool Gui::input_event(const InputEvent &input_event)
 				{
 					two_finger_tap = true;
 				}
+				else if (touch_event.get_touch_points() == 3)
+				{
+					three_finger_tap = true;
+				}
 			}
 		}
 		if (press_up)
@@ -1086,6 +1090,15 @@ bool Gui::input_event(const InputEvent &input_event)
 					else
 					{
 						two_finger_tap = false;
+					}
+
+					if (three_finger_tap && touch_event.get_touch_points() == 3)
+					{
+						visible = !visible;
+					}
+					else
+					{
+						three_finger_tap = false;
 					}
 				}
 			}

--- a/framework/gui.h
+++ b/framework/gui.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2023, Arm Limited and Contributors
- * Copyright (c) 2019-2023, Sascha Willems
+/* Copyright (c) 2018-2024, Arm Limited and Contributors
+ * Copyright (c) 2019-2024, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -477,6 +477,8 @@ class Gui
 
 	/// Whether or not the GUI has detected a multi touch gesture
 	bool two_finger_tap = false;
+
+	bool three_finger_tap = false;
 
 	bool show_graph_file_output = false;
 

--- a/framework/hpp_gui.cpp
+++ b/framework/hpp_gui.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -989,6 +989,10 @@ bool HPPGui::input_event(const InputEvent &input_event)
 				{
 					two_finger_tap = true;
 				}
+				else if (touch_event.get_touch_points() == 3)
+				{
+					three_finger_tap = true;
+				}
 			}
 		}
 		if (press_up)
@@ -1014,6 +1018,15 @@ bool HPPGui::input_event(const InputEvent &input_event)
 					else
 					{
 						two_finger_tap = false;
+					}
+
+					if (three_finger_tap && touch_event.get_touch_points() == 3)
+					{
+						visible = !visible;
+					}
+					else
+					{
+						three_finger_tap = false;
 					}
 				}
 			}

--- a/framework/hpp_gui.h
+++ b/framework/hpp_gui.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -437,6 +437,7 @@ class HPPGui
 	Timer                                    timer;        // Used to measure duration of input events
 	bool                                     prev_visible           = true;
 	bool                                     two_finger_tap         = false;        // Whether or not the GUI has detected a multi touch gesture
+	bool                                     three_finger_tap       = false;
 	bool                                     show_graph_file_output = false;
 };
 }        // namespace vkb


### PR DESCRIPTION
## Description

#672 disabled the click/tap gesture to hide the UI. On smaller screens, particularly when more than 2 lanes of stats are enabled (in Performance samples), the UI takes most of the space, and does not allow to inspect the rendered scene in detail. In this case, it would still be useful to have a way to hide it.

To avoid accidentally hiding the UI when panning the camera, this change re-introduces the gesture, but as a 3-finger tap, so that it is more intentional (a 2-finger tap can still be used to display the debug window in Performance samples).

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)