### PR TITLE
Update HWCPipe

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, Arm Limited and Contributors
+# Copyright (c) 2019-2024, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -215,7 +215,6 @@ set(STATS_FILES
     stats/stats_common.h
     stats/stats_provider.h
     stats/frame_time_stats_provider.h
-    stats/hwcpipe_stats_provider.h
     stats/vulkan_stats_provider.h
     stats/hpp_stats.h
 
@@ -223,7 +222,6 @@ set(STATS_FILES
     stats/stats.cpp
     stats/stats_provider.cpp
     stats/frame_time_stats_provider.cpp
-    stats/hwcpipe_stats_provider.cpp
     stats/vulkan_stats_provider.cpp)
 
 set(CORE_FILES
@@ -365,9 +363,11 @@ set(ANDROID_FILES
     # Header Files
     platform/android/android_platform.h
     platform/android/android_window.h
+    stats/hwcpipe_stats_provider.h
     # Source Files
     platform/android/android_platform.cpp
-    platform/android/android_window.cpp)
+    platform/android/android_window.cpp
+    stats/hwcpipe_stats_provider.cpp)
 
 set(WINDOWS_FILES
     # Header Files
@@ -521,7 +521,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
     glslang
     SPIRV
     vma
-    hwcpipe
     spirv-cross-glsl
     glslang-default-resource-limits
     spdlog
@@ -537,7 +536,7 @@ endif()
 if(ANDROID)
     # Import game-activity static lib inside the game-activity_static prefab module.
     find_package(game-activity REQUIRED CONFIG)
-    target_link_libraries(${PROJECT_NAME} PUBLIC log android game-activity::game-activity_static)
+    target_link_libraries(${PROJECT_NAME} PUBLIC hwcpipe log android game-activity::game-activity_static)
 else()
     if (DIRECT_TO_DISPLAY)
         target_link_libraries(${PROJECT_NAME} PRIVATE dl)

--- a/framework/stats/hwcpipe_stats_provider.cpp
+++ b/framework/stats/hwcpipe_stats_provider.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2023, Arm Limited and Contributors
- * Copyright (c) 2020-2023, Broadcom Inc.
+/* Copyright (c) 2018-2024, Arm Limited and Contributors
+ * Copyright (c) 2020-2024, Broadcom Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -18,6 +18,26 @@
 
 #include "hwcpipe_stats_provider.h"
 
+namespace
+{
+const char *get_product_family_name(hwcpipe::device::product_id::gpu_family f)
+{
+	using gpu_family = hwcpipe::device::product_id::gpu_family;
+
+	switch (f)
+	{
+		case gpu_family::bifrost:
+			return "Bifrost";
+		case gpu_family::midgard:
+			return "Midgard";
+		case gpu_family::valhall:
+			return "Valhall";
+		default:
+			return "Unknown";
+	}
+}
+}        // namespace
+
 namespace vkb
 {
 HWCPipeStatsProvider::HWCPipeStatsProvider(std::set<StatIndex> &requested_stats)
@@ -25,114 +45,67 @@ HWCPipeStatsProvider::HWCPipeStatsProvider(std::set<StatIndex> &requested_stats)
 	// Mapping of stats to their hwcpipe availability
 	// clang-format off
 	StatDataMap hwcpipe_stats = {
-	    {StatIndex::cpu_cycles,            {hwcpipe::CpuCounter::Cycles}},
-	    {StatIndex::cpu_instructions,      {hwcpipe::CpuCounter::Instructions}},
-	    {StatIndex::cpu_cache_miss_ratio,  {hwcpipe::CpuCounter::CacheMisses,  StatScaling::ByCounter, hwcpipe::CpuCounter::CacheReferences}},
-	    {StatIndex::cpu_branch_miss_ratio, {hwcpipe::CpuCounter::BranchMisses, StatScaling::ByCounter, hwcpipe::CpuCounter::BranchInstructions}},
-	    {StatIndex::cpu_l1_accesses,       {hwcpipe::CpuCounter::L1Accesses}},
-	    {StatIndex::cpu_instr_retired,     {hwcpipe::CpuCounter::InstrRetired}},
-	    {StatIndex::cpu_l2_accesses,       {hwcpipe::CpuCounter::L2Accesses}},
-	    {StatIndex::cpu_l3_accesses,       {hwcpipe::CpuCounter::L3Accesses}},
-	    {StatIndex::cpu_bus_reads,         {hwcpipe::CpuCounter::BusReads}},
-	    {StatIndex::cpu_bus_writes,        {hwcpipe::CpuCounter::BusWrites}},
-	    {StatIndex::cpu_mem_reads,         {hwcpipe::CpuCounter::MemReads}},
-	    {StatIndex::cpu_mem_writes,        {hwcpipe::CpuCounter::MemWrites}},
-	    {StatIndex::cpu_ase_spec,          {hwcpipe::CpuCounter::ASESpec}},
-	    {StatIndex::cpu_vfp_spec,          {hwcpipe::CpuCounter::VFPSpec}},
-	    {StatIndex::cpu_crypto_spec,       {hwcpipe::CpuCounter::CryptoSpec}},
-	    {StatIndex::gpu_cycles,            {hwcpipe::GpuCounter::GpuCycles}},
-	    {StatIndex::gpu_vertex_cycles,     {hwcpipe::GpuCounter::VertexComputeCycles}},
-	    {StatIndex::gpu_load_store_cycles, {hwcpipe::GpuCounter::ShaderLoadStoreCycles}},
-	    {StatIndex::gpu_tiles,             {hwcpipe::GpuCounter::Tiles}},
-	    {StatIndex::gpu_killed_tiles,      {hwcpipe::GpuCounter::TransactionEliminations}}, 
-	    {StatIndex::gpu_fragment_cycles,   {hwcpipe::GpuCounter::FragmentCycles}},
-	    {StatIndex::gpu_fragment_jobs,     {hwcpipe::GpuCounter::FragmentJobs}},
-	    {StatIndex::gpu_ext_reads,         {hwcpipe::GpuCounter::ExternalMemoryReadAccesses}},
-	    {StatIndex::gpu_ext_writes,        {hwcpipe::GpuCounter::ExternalMemoryWriteAccesses}},
-	    {StatIndex::gpu_ext_read_stalls,   {hwcpipe::GpuCounter::ExternalMemoryReadStalls}},
-	    {StatIndex::gpu_ext_write_stalls,  {hwcpipe::GpuCounter::ExternalMemoryWriteStalls}},
-	    {StatIndex::gpu_ext_read_bytes,    {hwcpipe::GpuCounter::ExternalMemoryReadBytes}},
-	    {StatIndex::gpu_ext_write_bytes,   {hwcpipe::GpuCounter::ExternalMemoryWriteBytes}},
-	    {StatIndex::gpu_tex_cycles,        {hwcpipe::GpuCounter::ShaderTextureCycles}}};
+	    {StatIndex::gpu_cycles,            {hwcpipe_counter::MaliGPUActiveCy}},
+	    {StatIndex::gpu_vertex_cycles,     {hwcpipe_counter::MaliNonFragQueueActiveCy}},
+	    {StatIndex::gpu_load_store_cycles, {hwcpipe_counter::MaliLSIssueCy}},
+	    {StatIndex::gpu_tiles,             {hwcpipe_counter::MaliFragTile}},
+	    {StatIndex::gpu_killed_tiles,      {hwcpipe_counter::MaliFragTileKill}},
+	    {StatIndex::gpu_fragment_cycles,   {hwcpipe_counter::MaliFragQueueActiveCy}},
+	    {StatIndex::gpu_fragment_jobs,     {hwcpipe_counter::MaliFragQueueJob}},
+	    {StatIndex::gpu_ext_reads,         {hwcpipe_counter::MaliExtBusRdBt}},
+	    {StatIndex::gpu_ext_writes,        {hwcpipe_counter::MaliExtBusWrBt}},
+	    {StatIndex::gpu_ext_read_stalls,   {hwcpipe_counter::MaliExtBusRdStallCy}},
+	    {StatIndex::gpu_ext_write_stalls,  {hwcpipe_counter::MaliExtBusWrStallCy}},
+	    {StatIndex::gpu_ext_read_bytes,    {hwcpipe_counter::MaliExtBusRdBy}},
+	    {StatIndex::gpu_ext_write_bytes,   {hwcpipe_counter::MaliExtBusWrBy}},
+	    {StatIndex::gpu_tex_cycles,        {hwcpipe_counter::MaliTexIssueCy}}};
 	// clang-format on
 
-	hwcpipe::CpuCounterSet enabled_cpu_counters{};
-	hwcpipe::GpuCounterSet enabled_gpu_counters{};
-
-	for (const auto &stat : requested_stats)
+	// Detect all GPUs & print some info
+	for (const auto &gpu : hwcpipe::find_gpus())
 	{
-		auto res = hwcpipe_stats.find(stat);
-		if (res != hwcpipe_stats.end())
-		{
-			stat_data[stat] = hwcpipe_stats[stat];
-
-			switch (res->second.type)
-			{
-				case StatType::Cpu:
-					enabled_cpu_counters.insert(res->second.cpu_counter);
-					if (res->second.divisor_cpu_counter != hwcpipe::CpuCounter::MaxValue)
-					{
-						enabled_cpu_counters.insert(res->second.divisor_cpu_counter);
-					}
-					break;
-				case StatType::Gpu:
-					enabled_gpu_counters.insert(res->second.gpu_counter);
-					if (res->second.divisor_gpu_counter != hwcpipe::GpuCounter::MaxValue)
-					{
-						enabled_gpu_counters.insert(res->second.divisor_gpu_counter);
-					}
-					break;
-			}
-		}
+		LOGI("HWCPipe: ------------------------------------------------------------");
+		LOGI("HWCPipe:  GPU Device {}:", gpu.get_device_number());
+		LOGI("HWCPipe: ------------------------------------------------------------");
+		LOGI("HWCPipe:     Product Family:  {}", get_product_family_name(gpu.get_product_id().get_gpu_family()));
+		LOGI("HWCPipe:     Number of Cores: {}", gpu.num_shader_cores());
+		LOGI("HWCPipe:     Bus Width:       {}", gpu.bus_width());
 	}
 
-	hwcpipe = std::make_unique<hwcpipe::HWCPipe>(enabled_cpu_counters, enabled_gpu_counters);
-
-	// Now that we've made a hwcpipe with the counters we'd like, remove any that
-	// aren't actually supported
-	for (auto iter = stat_data.begin(); iter != stat_data.end();)
+	// Probe device 0 (i.e. /dev/mali0)
+	auto gpu = hwcpipe::gpu(0);
+	if (!gpu)
 	{
-		switch (iter->second.type)
+		LOGE("HWCPipe: Mali GPU device 0 is missing");
+	}
+
+	auto config     = hwcpipe::sampler_config(gpu);
+	auto counter_db = hwcpipe::counter_database{};
+
+	std::error_code ec;
+	for (const auto &stat : requested_stats)
+	{
+		auto it = hwcpipe_stats.find(stat);
+		if (it != hwcpipe_stats.end())
 		{
-			case StatType::Cpu:
+			hwcpipe::counter_metadata meta;
+
+			auto ec = counter_db.describe_counter(it->second.counter, meta);
+			if (ec)
 			{
-				if (hwcpipe->cpu_profiler())
-				{
-					const auto &cpu_supp = hwcpipe->cpu_profiler()->supported_counters();
-					if (cpu_supp.find(iter->second.cpu_counter) == cpu_supp.end())
-					{
-						iter = stat_data.erase(iter);
-					}
-					else
-					{
-						++iter;
-					}
-				}
-				else
-				{
-					iter = stat_data.erase(iter);
-				}
-				break;
+				LOGE("HWCPipe: unknown counter");
 			}
-			case StatType::Gpu:
+
+			ec = config.add_counter(it->second.counter);
+			if (ec)
 			{
-				if (hwcpipe->gpu_profiler())
-				{
-					const auto &gpu_supp = hwcpipe->gpu_profiler()->supported_counters();
-					if (gpu_supp.find(iter->second.gpu_counter) == gpu_supp.end())
-					{
-						iter = stat_data.erase(iter);
-					}
-					else
-					{
-						++iter;
-					}
-				}
-				else
-				{
-					iter = stat_data.erase(iter);
-				}
-				break;
+				LOGE("HWCPipe: '{}' counter not supported by this GPU.", meta.name);
+			}
+			else
+			{
+				stat_data[stat] = hwcpipe_stats[stat];
+
+				LOGI("HWCPipe: enabled '{}' counter", meta.name);
 			}
 		}
 	}
@@ -144,7 +117,24 @@ HWCPipeStatsProvider::HWCPipeStatsProvider(std::set<StatIndex> &requested_stats)
 		requested_stats.erase(iter.first);
 	}
 
-	hwcpipe->run();
+	sampler = std::make_unique<hwcpipe::sampler<>>(config);
+
+	ec = sampler->start_sampling();
+	if (ec)
+	{
+		LOGE("HWCPipe: {}", ec.message());
+	}
+}
+
+HWCPipeStatsProvider::~HWCPipeStatsProvider()
+{
+	std::error_code ec;
+
+	ec = sampler->stop_sampling();
+	if (ec)
+	{
+		LOGE("HWCPipe: {}", ec.message());
+	}
 }
 
 bool HWCPipeStatsProvider::is_available(StatIndex index) const
@@ -168,41 +158,48 @@ const StatGraphData &HWCPipeStatsProvider::get_graph_data(StatIndex index) const
 	return default_graph_map[index];
 }
 
-static double get_cpu_counter_value(const hwcpipe::CpuMeasurements *cpu, hwcpipe::CpuCounter counter)
+static double get_gpu_counter_value(const hwcpipe::counter_sample &sample)
 {
-	auto hwcpipe_ctr = cpu->find(counter);
-	if (hwcpipe_ctr != cpu->end())
+	switch (sample.type)
 	{
-		return hwcpipe_ctr->second.get<double>();
+		case hwcpipe::counter_sample::type::uint64:
+			return sample.value.uint64;
+		case hwcpipe::counter_sample::type::float64:
+			return sample.value.float64;
+		default:
+			return 0.0;
 	}
-	return 0.0;
-}
-
-static double get_gpu_counter_value(const hwcpipe::GpuMeasurements *gpu, hwcpipe::GpuCounter counter)
-{
-	auto hwcpipe_ctr = gpu->find(counter);
-	if (hwcpipe_ctr != gpu->end())
-	{
-		return hwcpipe_ctr->second.get<double>();
-	}
-	return 0.0;
 }
 
 StatsProvider::Counters HWCPipeStatsProvider::sample(float delta_time)
 {
-	Counters              res;
-	hwcpipe::Measurements m = hwcpipe->sample();
+	Counters res;
 
-	// Map from hwcpipe measurement to our sample result for each counter
-	for (auto iter : stat_data)
+	std::error_code ec;
+
+	ec = sampler->sample_now();
+	if (ec)
 	{
-		StatIndex       index = iter.first;
-		const StatData &data  = iter.second;
-
-		double d = 0.0;
-		if (data.type == StatType::Cpu)
+		LOGE("HWCPipe: {}", ec.message());
+	}
+	else
+	{
+		// Map from hwcpipe measurement to our sample result for each counter
+		for (auto iter : stat_data)
 		{
-			d = get_cpu_counter_value(m.cpu, data.cpu_counter);
+			StatIndex       index = iter.first;
+			const StatData &data  = iter.second;
+
+			hwcpipe::counter_sample sample;
+
+			ec = sampler->get_counter_value(data.counter, sample);
+			if (ec)
+			{
+				LOGE("HWCPipe: {}", ec.message());
+				continue;
+			}
+
+			auto d = get_gpu_counter_value(sample);
 
 			if (data.scaling == StatScaling::ByDeltaTime && delta_time != 0.0f)
 			{
@@ -210,7 +207,14 @@ StatsProvider::Counters HWCPipeStatsProvider::sample(float delta_time)
 			}
 			else if (data.scaling == StatScaling::ByCounter)
 			{
-				double divisor = get_cpu_counter_value(m.cpu, data.divisor_cpu_counter);
+				ec = sampler->get_counter_value(data.divisor, sample);
+				if (ec)
+				{
+					LOGE("HWCPipe: {}", ec.message());
+					continue;
+				}
+
+				double divisor = get_gpu_counter_value(sample);
 				if (divisor != 0.0)
 				{
 					d /= divisor;
@@ -220,29 +224,9 @@ StatsProvider::Counters HWCPipeStatsProvider::sample(float delta_time)
 					d = 0.0;
 				}
 			}
-		}
-		else if (data.type == StatType::Gpu)
-		{
-			d = get_gpu_counter_value(m.gpu, data.gpu_counter);
 
-			if (data.scaling == StatScaling::ByDeltaTime && delta_time != 0.0f)
-			{
-				d /= delta_time;
-			}
-			else if (data.scaling == StatScaling::ByCounter)
-			{
-				double divisor = get_gpu_counter_value(m.gpu, data.divisor_gpu_counter);
-				if (divisor != 0.0)
-				{
-					d /= divisor;
-				}
-				else
-				{
-					d = 0.0;
-				}
-			}
+			res[index].result = d;
 		}
-		res[index].result = d;
 	}
 
 	return res;

--- a/framework/stats/hwcpipe_stats_provider.h
+++ b/framework/stats/hwcpipe_stats_provider.h
@@ -41,9 +41,10 @@ class HWCPipeStatsProvider : public StatsProvider
   private:
 	struct StatData
 	{
-		hwcpipe_counter counter;
-		StatScaling     scaling;
-		hwcpipe_counter divisor;
+		hwcpipe_counter              counter;
+		std::vector<hwcpipe_counter> fallback_list;
+		StatScaling                  scaling;
+		hwcpipe_counter              divisor;
 
 		StatData() = default;
 	};

--- a/framework/stats/stats.cpp
+++ b/framework/stats/stats.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2023, Arm Limited and Contributors
- * Copyright (c) 2020-2023, Broadcom Inc.
+/* Copyright (c) 2018-2024, Arm Limited and Contributors
+ * Copyright (c) 2020-2024, Broadcom Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -20,7 +20,9 @@
 #include "core/device.h"
 
 #include "frame_time_stats_provider.h"
-#include "hwcpipe_stats_provider.h"
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+#	include "hwcpipe_stats_provider.h"
+#endif
 #include "vulkan_stats_provider.h"
 
 namespace vkb
@@ -63,7 +65,9 @@ void Stats::request_stats(const std::set<StatIndex> &wanted_stats,
 	// All supported stats will be removed from the given 'stats' set by the provider's constructor
 	// so subsequent providers only see requests for stats that aren't already supported.
 	providers.emplace_back(std::make_unique<FrameTimeStatsProvider>(stats));
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
 	providers.emplace_back(std::make_unique<HWCPipeStatsProvider>(stats));
+#endif
 	providers.emplace_back(std::make_unique<VulkanStatsProvider>(stats, sampling_config, render_context));
 
 	// In continuous sampling mode we still need to update the frame times as if we are polling

--- a/samples/performance/command_buffer_usage/README.adoc
+++ b/samples/performance/command_buffer_usage/README.adoc
@@ -73,6 +73,8 @@ Similarly having more threads than buffers may have a performance impact.
 To keep all threads busy, the sample resizes the thread pool for low number of buffers.
 The sample slider can help illustrate these trade-offs and their impact on performance, as shown by the performance graphs.
 
+NOTE: Since the time of writing this tutorial, the CPU counter provider, HWCPipe, has been updated and it no longer provides CPU cycles. These may still be measured using external tools, as shown later.
+
 In this case, a scene with a high number of draw calls (~1800, this number may be found in the link:../../../docs/misc.adoc#debug-window[debug window]) shows a 15% improvement in performance when dividing the workload among 8 buffers across 8 threads:
 
 image::./images/single_threading.png[Single-threaded]

--- a/samples/performance/command_buffer_usage/README.adoc
+++ b/samples/performance/command_buffer_usage/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2019-2023, Arm Limited and Contributors
+- Copyright (c) 2019-2024, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/performance/multithreading_render_passes/README.adoc
+++ b/samples/performance/multithreading_render_passes/README.adoc
@@ -68,6 +68,8 @@ This sample shows the difference between recording both render passes into a sin
 
 Below are screenshots of the sample running on a phone with a Mali G72 GPU:
 
+NOTE: Since the time of writing this tutorial, the CPU counter provider, HWCPipe, has been updated and it no longer provides CPU cycles. These may still be measured using external tools, as shown later.
+
 image::./images/no_multi_threading.png[Single Thread]
 
 Using two threads gives a 10ms frame time improvement and CPU cycles show an increase in CPU utilization:

--- a/samples/performance/multithreading_render_passes/README.adoc
+++ b/samples/performance/multithreading_render_passes/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2021-2023, Arm Limited and Contributors
+- Copyright (c) 2021-2024, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, Arm Limited and Contributors
+# Copyright (c) 2019-2024, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -268,10 +268,11 @@ set_target_properties(spirv-cross-msl PROPERTIES FOLDER "ThirdParty" POSITION_IN
 set_target_properties(spirv-cross-reflect PROPERTIES FOLDER "ThirdParty" POSITION_INDEPENDENT_CODE ON)
 set_target_properties(spirv-cross-util PROPERTIES FOLDER "ThirdParty" POSITION_INDEPENDENT_CODE ON)
 
+if(ANDROID)
 # hwcpipe
 add_subdirectory(hwcpipe)
-
 set_target_properties(hwcpipe PROPERTIES FOLDER "ThirdParty" POSITION_INDEPENDENT_CODE ON)
+endif()
 
 # stb
 add_library(stb INTERFACE)


### PR DESCRIPTION
## Description

Update the HWCPipe submodule to use the latest 2.0 release. This adds support for many more GPU counters over a wider range of Arm devices. It cannot be build for desktop, so added some flags so that the HWCPipe provider is only built for Android.

Note that HWCPipe 2.0 removed support for CPU counters. These were only used in two of our samples though, and added a note in their tutorials. Open to suggestions for a better CPU counter stats provider. For instance, we could adapt the older build of HWCPipe 1.0 to only provide CPU counters.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements) - Only build on Android
