### PR TITLE
Support copyright check with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,19 @@ repos:
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
+    -   id: check-added-large-files
     -   id: trailing-whitespace
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v15.0.7'
     hooks:
     -   id: clang-format
         'types_or': [c++, c]
+-   repo: local
+    hooks:
+    -   id: copyright-check
+        name: copyright-check
+        entry: ./scripts/copyright.py main --fix
+        language: script
+        types: [python]
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
## Description

Adds support to automatically update copyrights using the command `./scripts/copyright.py main --fix`. The hope is that this will help reduce the time contributors spend fixing copyrights manually or updating a PR after CI failures

I tested by altering a single line in `buffer_pool.cpp`. Here we can see that the pre-commit failed. The copyright was correctly updated for the file and placed in unstaged changes (as is expected with pre-commit)

<img width="530" alt="image" src="https://github.com/KhronosGroup/Vulkan-Samples/assets/6977035/59be4150-8f76-45a1-950d-de4ab87eef16">
