### PR TITLE
Don't ask to press return at the end of showing help on non-Windows platforms

### DIFF
--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -248,7 +248,7 @@ void Platform::terminate(ExitCode code)
 	// Halt on all unsuccessful exit codes unless ForceClose is in use
 	if (code != ExitCode::Success && !using_plugin<::plugins::ForceClose>())
 	{
-#if !(defined PLATFORM__ANDROID || defined PLATFORM__LINUX)
+#ifdef PLATFORM__WINDOWS
 		std::cout << "Press return to continue";
 		std::cin.get();
 #endif

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -248,7 +248,7 @@ void Platform::terminate(ExitCode code)
 	// Halt on all unsuccessful exit codes unless ForceClose is in use
 	if (code != ExitCode::Success && !using_plugin<::plugins::ForceClose>())
 	{
-#ifndef ANDROID
+#if !(defined PLATFORM__ANDROID || defined PLATFORM__LINUX)
 		std::cout << "Press return to continue";
 		std::cin.get();
 #endif

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -245,14 +245,14 @@ void Platform::terminate(ExitCode code)
 
 	on_platform_close();
 
+#ifdef PLATFORM__WINDOWS
 	// Halt on all unsuccessful exit codes unless ForceClose is in use
 	if (code != ExitCode::Success && !using_plugin<::plugins::ForceClose>())
 	{
-#ifdef PLATFORM__WINDOWS
 		std::cout << "Press return to continue";
 		std::cin.get();
-#endif
 	}
+#endif
 }
 
 void Platform::close()


### PR DESCRIPTION
## Description

Having to press return at the end of listing the samples or showing the help has been pretty annoying.
I suspect it's there for Windows users primarily to prevent to command window closing.
It was already excluded on Android platforms, I've also now excluded it on Linux platforms.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

