### PR TITLE
Adjust hpp OIT sample position in documentation navgiation

### DIFF
--- a/antora/modules/ROOT/nav.adoc
+++ b/antora/modules/ROOT/nav.adoc
@@ -45,7 +45,7 @@
 ** xref:samples/api/timestamp_queries/README.adoc[Timestamp queries]
 *** xref:samples/api/hpp_timestamp_queries/README.adoc[Timestamp queries (Vulkan-Hpp)]
 ** xref:samples/api/oit_linked_lists/README.adoc[OIT linked lists]
-** xref:samples/api/hpp_oit_linked_lists/README.adoc[OIT linked lists (Vulkan-Hpp)]
+*** xref:samples/api/hpp_oit_linked_lists/README.adoc[OIT linked lists (Vulkan-Hpp)]
 ** xref:samples/api/oit_depth_peeling/README.adoc[OIT depth peeling]
 * xref:samples/extensions/README.adoc[Extension usage samples]
 ** xref:samples/extensions/buffer_device_address/README.adoc[Buffer device address]


### PR DESCRIPTION
## Description

This PR slightly adjust the sample's documentation navigation tree. For samples with a Vulkan.hpp version, the link to that Vulkan.hpp sample version is usually put under the non-hpp sample. This wasn't the case for the OIT sample, which is fixed by this PR.

**Note:** This is a very minor documentation fix.

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)