### PR TITLE
Make command line help easier to understand

### DIFF
--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -118,8 +118,7 @@ ExitCode Platform::initialize(const std::vector<Plugin *> &plugins)
 
 	if (!app_requested())
 	{
-		LOGE("An app was not requested, can not continue");
-		return ExitCode::Help;
+		return ExitCode::NoSample;
 	}
 
 	create_window(window_properties);
@@ -137,8 +136,7 @@ ExitCode Platform::main_loop()
 {
 	if (!app_requested())
 	{
-		LOGE("An app was not requested, can not continue");
-		return ExitCode::Close;
+		return ExitCode::NoSample;
 	}
 
 	while (!window->should_close() && !close_requested)
@@ -235,6 +233,20 @@ void Platform::terminate(ExitCode code)
 		{
 			LOGI(line);
 		}
+	}
+
+	if (code == ExitCode::NoSample)
+	{
+		LOGI("");
+		LOGI("No sample was requested or the selected sample is not available");
+		LOGI("");
+		LOGI("To run a specific sample use the \"sample\" argument, e.g.");
+		LOGI("");
+		LOGI("\tvulkan_samples sample hello_triangle");
+		LOGI("");
+		LOGI("To get a list of aviailable samples, use the \"samples\" argument")
+		LOGI("To get a list of available command line options, use the \"-h\" or \"--help\" argument");
+		LOGI("");
 	}
 
 	if (active_app)

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -238,13 +238,13 @@ void Platform::terminate(ExitCode code)
 	if (code == ExitCode::NoSample)
 	{
 		LOGI("");
-		LOGI("No sample was requested or the selected sample is not available");
+		LOGI("No sample was requested or the selected sample does not exist");
 		LOGI("");
 		LOGI("To run a specific sample use the \"sample\" argument, e.g.");
 		LOGI("");
 		LOGI("\tvulkan_samples sample hello_triangle");
 		LOGI("");
-		LOGI("To get a list of aviailable samples, use the \"samples\" argument")
+		LOGI("To get a list of available samples, use the \"samples\" argument")
 		LOGI("To get a list of available command line options, use the \"-h\" or \"--help\" argument");
 		LOGI("");
 	}

--- a/framework/platform/platform.h
+++ b/framework/platform/platform.h
@@ -44,6 +44,7 @@ namespace vkb
 enum class ExitCode
 {
 	Success = 0, /* App executed as expected */
+	NoSample,    /* App should show help how to run a sample */
 	Help,        /* App should show help */
 	Close,       /* App has been requested to close at initialization */
 	FatalError   /* App encountered an unexpected error */


### PR DESCRIPTION
## Description

A common complaint, both here at github as well as social channels like Discord, is how to actually run our samples. You need to specify the name of a sample after an argument called `sample`. If you don't do that you get a huge list of all available options starting with an error text that's not easy to understand:

![2024-03-08 17_35_11-V__Vulkan-KHR-Samples_Vulkan-Samples-Fork_build_windows_app_bin_debug_AMD64_vulk](https://github.com/KhronosGroup/Vulkan-Samples/assets/10283127/76b56262-ace2-476e-971d-b05def4dfc0c)

Not only is this a lot of text that'll confuse people, but the actual command on how to run a sample is somewhere at the bottom of this.

This PR simplifies all of this, and if you now run the application without a sample or with a sample name that doesn't exist you get a proper help text that's much easier to understand:

![2024-03-08 18_22_36-V__Vulkan-KHR-Samples_Vulkan-Samples-Fork_build_windows_app_bin_debug_AMD64_vulk](https://github.com/KhronosGroup/Vulkan-Samples/assets/10283127/773e52df-7ce9-4c32-91c2-9acd9ec2ab67)

![image](https://github.com/KhronosGroup/Vulkan-Samples/assets/10283127/049e10a0-c828-4e00-b880-cbd8fff0da47)

This message also tells people about the two other important arguments: getting a list of available samples and a list of all available command line arguments.

This should make it much easier to understand how to launch samples for new users.

Fixes #966

Tested on Windows 11 and Ubuntu 22.04 (via WSL2)

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
