### PR TITLE
Fix HWCPipe errors in samples with no counters

### DIFF
--- a/framework/stats/hwcpipe_stats_provider.h
+++ b/framework/stats/hwcpipe_stats_provider.h
@@ -91,6 +91,8 @@ class HWCPipeStatsProvider : public StatsProvider
   private:
 	std::unique_ptr<hwcpipe::sampler<>> sampler;
 
+	size_t requested_stats_count{0};
+
 	// Only stats which are available and were requested end up in stat_data
 	StatDataMap stat_data;
 


### PR DESCRIPTION
## Description

Samples with no HW counter stats were logging an error every frame because HWCPipe was configured with 0 counters. This fix introduces a flag to only sample if at least 1 counter was requested.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
