### PR TITLE
Fix image transitions among Samples using Dynamic_Rendering

### DIFF
--- a/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
+++ b/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
@@ -372,6 +372,10 @@ void DynamicRendering::build_command_buffers()
 		{
 			vkb::image_layout_transition(draw_cmd_buffer,
 			                             swapchain_buffers[i].image,
+			                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+			                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+			                             0,
+			                             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
 			                             VK_IMAGE_LAYOUT_UNDEFINED,
 			                             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
 			                             range);

--- a/samples/extensions/shader_object/shader_object.cpp
+++ b/samples/extensions/shader_object/shader_object.cpp
@@ -968,7 +968,7 @@ void ShaderObject::build_command_buffers()
 		// Barriers for images that are rendered to
 		vkb::image_layout_transition(draw_cmd_buffer,
 		                             output_images[current_output_format].image,
-		                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+		                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 		                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 		                             0,
 		                             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,


### PR DESCRIPTION
With new versions of VVL for Samples which are using Dynamic_Rendering it appear synchronization issue described here:
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7193#top

I identify all Samples which are using that extension and I fix it.

Note: For Shader_Object Sample I need to wait for fix regarding latest union of C or C++ framework (It can't be tested right now)