### PR TITLE
Fix UB in descriptor_set_layout.cpp

### DIFF
--- a/framework/core/descriptor_set_layout.cpp
+++ b/framework/core/descriptor_set_layout.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -156,6 +156,7 @@ DescriptorSetLayout::DescriptorSetLayout(Device &                           devi
 	create_info.pBindings    = bindings.data();
 
 	// Handle update-after-bind extensions
+	VkDescriptorSetLayoutBindingFlagsCreateInfoEXT binding_flags_create_info{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT};
 	if (std::find_if(resource_set.begin(), resource_set.end(),
 	                 [](const ShaderResource &shader_resource) { return shader_resource.mode == ShaderResourceMode::UpdateAfterBind; }) != resource_set.end())
 	{
@@ -171,7 +172,6 @@ DescriptorSetLayout::DescriptorSetLayout(Device &                           devi
 			throw std::runtime_error("Invalid binding, couldn't create descriptor set layout.");
 		}
 
-		VkDescriptorSetLayoutBindingFlagsCreateInfoEXT binding_flags_create_info{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT};
 		binding_flags_create_info.bindingCount  = to_u32(binding_flags.size());
 		binding_flags_create_info.pBindingFlags = binding_flags.data();
 


### PR DESCRIPTION
## Description

Move the scope of an extension structure so that it has the same call as the parent structure to which it may be attached via a `pNext` chain.

Fixes #986

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
