### PR TITLE
Remove superfluous calls to set_debug_name

### DIFF
--- a/framework/core/hpp_vulkan_resource.h
+++ b/framework/core/hpp_vulkan_resource.h
@@ -43,17 +43,16 @@ class HPPVulkanResource
 	HPPVulkanResource &operator=(const HPPVulkanResource &) = delete;
 
 	HPPVulkanResource(HPPVulkanResource &&other) :
-	    handle(std::exchange(other.handle, {})), device(std::exchange(other.device, {}))
-	{
-		set_debug_name(std::exchange(other.debug_name, {}));
-	}
+	    handle(std::exchange(other.handle, {})),
+	    device(std::exchange(other.device, {})),
+	    debug_name(std::exchange(other.debug_name, {}))
+	{}
 
 	HPPVulkanResource &operator=(HPPVulkanResource &&other)
 	{
-		handle = std::exchange(other.handle, {});
-		device = std::exchange(other.device, {});
-		set_debug_name(std::exchange(other.debug_name, {}));
-
+		handle     = std::exchange(other.handle, {});
+		device     = std::exchange(other.device, {});
+		debug_name = std::exchange(other.debug_name, {});
 		return *this;
 	}
 

--- a/framework/core/vulkan_resource.h
+++ b/framework/core/vulkan_resource.h
@@ -99,21 +99,17 @@ class VulkanResource
 	VulkanResource &operator=(const VulkanResource &) = delete;
 
 	VulkanResource(VulkanResource &&other) :
-	    handle{other.handle}, device{other.device}
+	    handle(std::exchange(other.handle, VK_NULL_HANDLE)),
+	    device(std::exchange(other.device, {})),
+	    debug_name(std::exchange(other.debug_name, {}))
 	{
-		set_debug_name(other.debug_name);
-
-		other.handle = VK_NULL_HANDLE;
 	}
 
 	VulkanResource &operator=(VulkanResource &&other)
 	{
-		handle = other.handle;
-		device = other.device;
-		set_debug_name(other.debug_name);
-
-		other.handle = VK_NULL_HANDLE;
-
+		handle     = std::exchange(other.handle, {});
+		device     = std::exchange(other.device, {});
+		debug_name = std::exchange(other.debug_name, {});
 		return *this;
 	}
 


### PR DESCRIPTION
## Description

As mentioned in the linked issue, the move constructor and move assignment operator only need to set the member variable `debug_name`.  They do not need to call `set_debug_name` on the handle again, because that would have already happened when the debug name was first set in the original object, with the same handle value.

Fixes #988

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

