### PR TITLE
Fix wrong reset of command buffers in sample fragment_shading_rate_dynamic.

### DIFF
--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -580,11 +580,11 @@ void FragmentShadingRateDynamic::build_command_buffers()
 		VK_CHECK(vkEndCommandBuffer(render_target._command_buffer));
 	};
 
-	// small_command_buffers are not controlled by ApiVulkanSample, that is we need to explicitly reset them here!
-	vkResetCommandPool(get_device().get_handle(), command_pool, 0);
-
 	for (int32_t i = 0; i < draw_cmd_buffers.size(); ++i)
 	{
+		// small_command_buffers are not controlled by ApiVulkanSample, that is we need to explicitly reset them here!
+		VK_CHECK(vkResetCommandBuffer(small_command_buffers[i], 0));
+
 		assert(subpass_extent.width > 0 && subpass_extent.width <= width && subpass_extent.height > 0 &&
 		       subpass_extent.height <= height);
 		RenderTarget small_target{
@@ -1128,6 +1128,7 @@ bool FragmentShadingRateDynamic::prepare(const vkb::ApplicationOptions &options)
 	camera.set_perspective(60.0f, static_cast<float>(width) / static_cast<float>(height), 256.0f, 0.1f);
 
 	auto command_pool_create = vkb::initializers::command_pool_create_info();
+	command_pool_create.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 	vkCreateCommandPool(get_device().get_handle(), &command_pool_create, VK_NULL_HANDLE, &command_pool);
 
 	load_assets();


### PR DESCRIPTION
## Description

Without this fix, I got the following validation layer error when running the fragment_shading_rate_dynamic sample:

`Validation Error: [ VUID-vkQueueSubmit-pCommandBuffers-00070 ] Object 0: handle = 0x223ba20f060, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xaeecdc0b | vkQueueSubmit(): pSubmits[0].pCommandBuffers[0] VkCommandBuffer 0x223ba20f060[] is unrecorded and contains no commands. The Vulkan spec states: Each element of the pCommandBuffers member of each element of pSubmits must be in the pending or executable state (https://vulkan.lunarg.com/doc/view/1.3.275.0/windows/1.3-extensions/vkspec.html#VUID-vkQueueSubmit-pCommandBuffers-00070)`

The reason was, that the call to `vkResetCommandPool` not only reset the `small_command_buffers`, but also the `compute_buffer[].command_buffer`s.

Creating the `command_pool` with `VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT` and resetting the `small_command_buffers` by calls to `vkResetCommandBuffer` resolves that error.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
