### PR TITLE
Fix markup issues with image_compression_control sample

### DIFF
--- a/samples/performance/README.adoc
+++ b/samples/performance/README.adoc
@@ -53,7 +53,7 @@ This sample will explore a few options to improve both descriptor and buffer man
 
 A transcoded version of the Performance sample <<swapchain_images,Swapchain images>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
-=== xref:./performance/image_compression_control/README.adoc[Image compression control]
+=== xref:./{performance_samplespath}image_compression_control/README.adoc[Image compression control]
 
 This sample shows how to use the extensions https://docs.vulkan.org/spec/latest/appendices/extensions.html#VK_EXT_image_compression_control[`VK_EXT_image_compression_control`] and https://docs.vulkan.org/spec/latest/appendices/extensions.html#VK_EXT_image_compression_control_swapchain[`VK_EXT_image_compression_control_swapchain`] to select between different levels of image compression.
 The UI shows the impact compression has on image size and bandwidth, illustrating the benefits of fixed-rate (visually lossless) compression.

--- a/samples/performance/image_compression_control/README.adoc
+++ b/samples/performance/image_compression_control/README.adoc
@@ -18,6 +18,8 @@
 -
 ////
 
+= Image Compression Control
+
 ////
 The following block adds linkage to this repo in the Vulkan docs site project. It's only visible if the file is viewed via the Antora framework.
 ////
@@ -25,8 +27,6 @@ The following block adds linkage to this repo in the Vulkan docs site project. I
 ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/image_compression_control[Khronos Vulkan samples github repository].
 endif::[]
-
-= Image Compression Control
 
 == Overview
 


### PR DESCRIPTION

## Description

These are very minor markup issues which probably are not visible in the GitHub asciidoc renderer, but cause Antora errors. I will file a separate issue about possibly auto-detecting this sort of thing. I am not going to check off the two dozen checklist items given that the total change is very minor markup changes in two READMEs - when this passes CI it should just be merged.