### PR TITLE
Refactor detection of extension support in api sample swapchain_recreation

### DIFF
--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -40,51 +40,6 @@ void SwapchainRecreation::get_queue()
 	}
 }
 
-void SwapchainRecreation::check_for_maintenance1()
-{
-	const char *use_maintenance1 = std::getenv("USE_MAINTENANCE1");
-	has_maintenance1             = use_maintenance1 == nullptr || strcmp(use_maintenance1, "no") != 0;
-
-	if (!has_maintenance1)
-	{
-		LOGI("Disabling usage of VK_EXT_surface_maintenance1 due to USE_MAINTENANCE1=no");
-		return;
-	}
-
-	VkResult result = volkInitialize();
-	if (result)
-	{
-		throw vkb::VulkanException(result, "Failed to initialize volk.");
-	}
-
-	// Check to see if VK_EXT_surface_maintenance1 is supported in the first place.
-	// Assume that VK_EXT_swapchain_maintenance1 is also supported in that case.
-	uint32_t instance_extension_count;
-	VK_CHECK(vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, nullptr));
-
-	std::vector<VkExtensionProperties> available_instance_extensions(instance_extension_count);
-	VK_CHECK(vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, available_instance_extensions.data()));
-
-	const bool has_ext = std::find_if(available_instance_extensions.begin(),
-	                                  available_instance_extensions.end(),
-	                                  [](auto const &ep) {
-		                                  return strcmp(ep.extensionName, VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME) == 0;
-	                                  }) != available_instance_extensions.end();
-
-	if (has_ext)
-	{
-		// It is indeed supported.
-		add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
-		add_instance_extension(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME);
-		add_device_extension(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME);
-		return;
-	}
-
-	// Extension is not supported by the driver or loader.
-	LOGI("Skipping unsupported VK_EXT_surface_maintenance1");
-	has_maintenance1 = false;
-}
-
 void SwapchainRecreation::query_surface_format()
 {
 	surface_format = vkb::select_surface_format(get_gpu_handle(), get_surface());
@@ -933,6 +888,19 @@ VkDevice SwapchainRecreation::get_device_handle()
 
 SwapchainRecreation::SwapchainRecreation()
 {
+	const char *use_maintenance1 = std::getenv("USE_MAINTENANCE1");
+
+	if ((use_maintenance1 == nullptr) || (strcmp(use_maintenance1, "no") != 0))
+	{
+		// Request sample-specific extensions as optional
+		add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, true);
+		add_instance_extension(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME, true);
+		add_device_extension(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME, true);
+	}
+	else
+	{
+		LOGI("Disabling usage of VK_EXT_surface_maintenance1 due to USE_MAINTENANCE1=no");
+	}
 }
 
 SwapchainRecreation::~SwapchainRecreation()
@@ -995,16 +963,13 @@ SwapchainRecreation::~SwapchainRecreation()
 	}
 }
 
-bool SwapchainRecreation::prepare(const vkb::ApplicationOptions &options)
+std::unique_ptr<vkb::Device> SwapchainRecreation::create_device(vkb::PhysicalDevice &gpu)
 {
-	// Add the relevant instance extensions before creating the instance in
-	// VulkanSample::prepare.
-	check_for_maintenance1();
+	std::unique_ptr<vkb::Device> device = vkb::VulkanSample<vkb::BindingType::C>::create_device(gpu);
 
-	if (!VulkanSample::prepare(options))
-	{
-		return false;
-	}
+	has_maintenance1 = get_instance().is_enabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME) &&
+	                   get_instance().is_enabled(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME) &&
+	                   device->is_enabled(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME);
 
 	LOGI("------------------------------------");
 	LOGI("USAGE:");
@@ -1018,7 +983,7 @@ bool SwapchainRecreation::prepare(const vkb::ApplicationOptions &options)
 	}
 	LOGI("------------------------------------");
 
-	return true;
+	return device;
 }
 
 void SwapchainRecreation::create_render_context()

--- a/samples/api/swapchain_recreation/swapchain_recreation.h
+++ b/samples/api/swapchain_recreation/swapchain_recreation.h
@@ -102,8 +102,6 @@ class SwapchainRecreation : public vkb::VulkanSample<vkb::BindingType::C>
 
 	void prepare_render_context() override;
 
-	bool prepare(const vkb::ApplicationOptions &options) override;
-
 	void update(float delta_time) override;
 
 	bool resize(uint32_t width, uint32_t height) override;
@@ -170,8 +168,9 @@ class SwapchainRecreation : public vkb::VulkanSample<vkb::BindingType::C>
 	// User toggles.
 	bool recreate_swapchain_on_present_mode_change = false;
 
+	std::unique_ptr<vkb::Device> create_device(vkb::PhysicalDevice &gpu) override;
+
 	void get_queue();
-	void check_for_maintenance1();
 	void query_surface_format();
 	void query_present_modes();
 	void query_compatible_present_modes(VkPresentModeKHR present_mode);


### PR DESCRIPTION
## Description

Detection of extension support has been moved from a special function called from SwapchainRecreation::prepare() into the SwapchainRecreation constructor and an override of the VulkanSample::create_device() function.
That way, there's no need for a separate initialization of volk and enumerating the extensions, which is already done in the framework.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
