### PR TITLE
Fix build error of ‘exchange’ is not a member of ‘std’

### DIFF
--- a/framework/core/vulkan_resource.h
+++ b/framework/core/vulkan_resource.h
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cstdint>
 #include <type_traits>
+#include <utility>
 
 namespace vkb
 {


### PR DESCRIPTION
Fixes #1010