### PR TITLE
Refactor getting/adding extension features to create a VkDevice with.

### DIFF
--- a/framework/core/device.cpp
+++ b/framework/core/device.cpp
@@ -89,11 +89,17 @@ Device::Device(PhysicalDevice                        &gpu,
 	if (is_extension_supported("VK_KHR_performance_query") &&
 	    is_extension_supported("VK_EXT_host_query_reset"))
 	{
-		auto perf_counter_features     = gpu.request_extension_features<VkPhysicalDevicePerformanceQueryFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR);
-		auto host_query_reset_features = gpu.request_extension_features<VkPhysicalDeviceHostQueryResetFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES);
+		auto perf_counter_features =
+		    gpu.get_extension_features<VkPhysicalDevicePerformanceQueryFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR);
+		auto host_query_reset_features =
+		    gpu.get_extension_features<VkPhysicalDeviceHostQueryResetFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES);
 
 		if (perf_counter_features.performanceCounterQueryPools && host_query_reset_features.hostQueryReset)
 		{
+			gpu.add_extension_features<VkPhysicalDevicePerformanceQueryFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR)
+			    .performanceCounterQueryPools = VK_TRUE;
+			gpu.add_extension_features<VkPhysicalDeviceHostQueryResetFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES).hostQueryReset =
+			    VK_TRUE;
 			enabled_extensions.push_back("VK_KHR_performance_query");
 			enabled_extensions.push_back("VK_EXT_host_query_reset");
 			LOGI("Performance query enabled");

--- a/framework/core/hpp_device.cpp
+++ b/framework/core/hpp_device.cpp
@@ -89,11 +89,13 @@ HPPDevice::HPPDevice(vkb::core::HPPPhysicalDevice               &gpu,
 	// live in the same command buffer as beginQuery
 	if (is_extension_supported(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME) && is_extension_supported(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME))
 	{
-		auto perf_counter_features     = gpu.request_extension_features<vk::PhysicalDevicePerformanceQueryFeaturesKHR>();
-		auto host_query_reset_features = gpu.request_extension_features<vk::PhysicalDeviceHostQueryResetFeatures>();
+		auto perf_counter_features     = gpu.get_extension_features<vk::PhysicalDevicePerformanceQueryFeaturesKHR>();
+		auto host_query_reset_features = gpu.get_extension_features<vk::PhysicalDeviceHostQueryResetFeatures>();
 
 		if (perf_counter_features.performanceCounterQueryPools && host_query_reset_features.hostQueryReset)
 		{
+			gpu.add_extension_features<vk::PhysicalDevicePerformanceQueryFeaturesKHR>().performanceCounterQueryPools = true;
+			gpu.add_extension_features<vk::PhysicalDeviceHostQueryResetFeatures>().hostQueryReset                    = true;
 			enabled_extensions.push_back(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
 			enabled_extensions.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
 			LOGI("Performance query enabled");

--- a/framework/core/physical_device.h
+++ b/framework/core/physical_device.h
@@ -64,8 +64,8 @@ class PhysicalDevice
 
 	void enumerate_queue_family_performance_query_counters(
 	    uint32_t                            queue_family_index,
-	    uint32_t *                          count,
-	    VkPerformanceCounterKHR *           counters,
+	    uint32_t                           *count,
+	    VkPerformanceCounterKHR            *counters,
 	    VkPerformanceCounterDescriptionKHR *descriptions) const;
 
 	const VkPhysicalDeviceFeatures get_requested_features() const;
@@ -79,7 +79,35 @@ class PhysicalDevice
 	void *get_extension_feature_chain() const;
 
 	/**
-	 * @brief Requests a third party extension to be used by the framework
+	 * @brief Get an extension features struct
+	 *
+	 *        Gets the actual extension features struct with the supported flags set.
+	 *        The flags you're interested in can be set in a corresponding struct in the structure chain
+	 *        by calling PhysicalDevice::add_extension_features()
+	 * @param type The VkStructureType for the extension you are requesting
+	 * @returns The extension feature struct
+	 */
+	template <typename T>
+	T get_extension_features(VkStructureType type)
+	{
+		// We cannot request extension features if the physical device properties 2 instance extension isn't enabled
+		if (!instance.is_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
+		{
+			throw std::runtime_error("Couldn't request feature from device as " + std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) +
+			                         " isn't enabled!");
+		}
+
+		// Get the extension features
+		T                            features{type};
+		VkPhysicalDeviceFeatures2KHR physical_device_features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR};
+		physical_device_features.pNext = &features;
+		vkGetPhysicalDeviceFeatures2KHR(handle, &physical_device_features);
+
+		return features;
+	}
+
+	/**
+	 * @brief Add an extension features struct to the structure chain used for device creation
 	 *
 	 *        To have the features enabled, this function must be called before the logical device
 	 *        is created. To do this request sample specific features inside
@@ -89,45 +117,31 @@ class PhysicalDevice
 	 *        modify the struct returned by this function, it will propagate the changes to the logical
 	 *        device.
 	 * @param type The VkStructureType for the extension you are requesting
-	 * @returns The extension feature struct
+	 * @returns A reference to extension feature struct in the structure chain
 	 */
 	template <typename T>
-	T &request_extension_features(VkStructureType type)
+	T &add_extension_features(VkStructureType type)
 	{
 		// We cannot request extension features if the physical device properties 2 instance extension isn't enabled
 		if (!instance.is_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
 		{
-			throw std::runtime_error("Couldn't request feature from device as " + std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) + " isn't enabled!");
+			throw std::runtime_error("Couldn't request feature from device as " + std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) +
+			                         " isn't enabled!");
 		}
 
-		// If the type already exists in the map, return a casted pointer to get the extension feature struct
-		auto extension_features_it = extension_features.find(type);
-		if (extension_features_it != extension_features.end())
+		// Add an (empty) extension features into the map of extension features
+		auto [it, added] = extension_features.insert({type, std::make_shared<T>(T{type})});
+		if (added)
 		{
-			return *static_cast<T *>(extension_features_it->second.get());
+			// if it was actually added, also add it to the structure chain
+			if (last_requested_extension_feature)
+			{
+				static_cast<T *>(it->second.get())->pNext = last_requested_extension_feature;
+			}
+			last_requested_extension_feature = it->second.get();
 		}
 
-		// Get the extension feature
-		VkPhysicalDeviceFeatures2KHR physical_device_features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR};
-		T                            extension{type};
-		physical_device_features.pNext = &extension;
-		vkGetPhysicalDeviceFeatures2KHR(handle, &physical_device_features);
-
-		// Insert the extension feature into the extension feature map so its ownership is held
-		extension_features.insert({type, std::make_shared<T>(extension)});
-
-		// Pull out the dereferenced void pointer, we can assume its type based on the template
-		auto *extension_ptr = static_cast<T *>(extension_features.find(type)->second.get());
-
-		// If an extension feature has already been requested, we shift the linked list down by one
-		// Making this current extension the new base pointer
-		if (last_requested_extension_feature)
-		{
-			extension_ptr->pNext = last_requested_extension_feature;
-		}
-		last_requested_extension_feature = extension_ptr;
-
-		return *extension_ptr;
+		return *static_cast<T *>(it->second.get());
 	}
 
 	/**

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -95,8 +95,8 @@ bool HPPTimestampQueries::resize(const uint32_t width, const uint32_t height)
 void HPPTimestampQueries::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 {
 	// We need to enable the command pool reset feature in the extension struct
-	auto &requested_extension_features          = gpu.request_extension_features<vk::PhysicalDeviceHostQueryResetFeaturesEXT>();
-	requested_extension_features.hostQueryReset = true;
+	assert(gpu.get_extension_features<vk::PhysicalDeviceHostQueryResetFeaturesEXT>().hostQueryReset);
+	gpu.add_extension_features<vk::PhysicalDeviceHostQueryResetFeaturesEXT>().hostQueryReset = true;
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -95,8 +95,7 @@ bool HPPTimestampQueries::resize(const uint32_t width, const uint32_t height)
 void HPPTimestampQueries::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 {
 	// We need to enable the command pool reset feature in the extension struct
-	assert(gpu.get_extension_features<vk::PhysicalDeviceHostQueryResetFeaturesEXT>().hostQueryReset);
-	gpu.add_extension_features<vk::PhysicalDeviceHostQueryResetFeaturesEXT>().hostQueryReset = true;
+	HPP_REQUEST_REQUIRED_FEATURE(gpu, vk::PhysicalDeviceHostQueryResetFeaturesEXT, hostQueryReset);
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/api/timestamp_queries/timestamp_queries.cpp
+++ b/samples/api/timestamp_queries/timestamp_queries.cpp
@@ -73,10 +73,7 @@ TimestampQueries::~TimestampQueries()
 void TimestampQueries::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// We need to enable the command pool reset feature in the extension struct
-	assert(
-	    gpu.get_extension_features<VkPhysicalDeviceHostQueryResetFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT).hostQueryReset);
-	gpu.add_extension_features<VkPhysicalDeviceHostQueryResetFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT).hostQueryReset =
-	    VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceHostQueryResetFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT, hostQueryReset);
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/api/timestamp_queries/timestamp_queries.cpp
+++ b/samples/api/timestamp_queries/timestamp_queries.cpp
@@ -73,8 +73,10 @@ TimestampQueries::~TimestampQueries()
 void TimestampQueries::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// We need to enable the command pool reset feature in the extension struct
-	auto &requested_extension_features          = gpu.request_extension_features<VkPhysicalDeviceHostQueryResetFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT);
-	requested_extension_features.hostQueryReset = VK_TRUE;
+	assert(
+	    gpu.get_extension_features<VkPhysicalDeviceHostQueryResetFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT).hostQueryReset);
+	gpu.add_extension_features<VkPhysicalDeviceHostQueryResetFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT).hostQueryReset =
+	    VK_TRUE;
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/extensions/buffer_device_address/buffer_device_address.cpp
+++ b/samples/extensions/buffer_device_address/buffer_device_address.cpp
@@ -428,10 +428,10 @@ void BufferDeviceAddress::render(float delta_time)
 void BufferDeviceAddress::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Need to enable the bufferDeviceAddress feature.
-	assert(gpu.get_extension_features<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR)
-	           .bufferDeviceAddress);
-	gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR)
-	    .bufferDeviceAddress = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceBufferDeviceAddressFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR,
+	                         bufferDeviceAddress);
 }
 
 std::unique_ptr<vkb::VulkanSampleC> create_buffer_device_address()

--- a/samples/extensions/buffer_device_address/buffer_device_address.cpp
+++ b/samples/extensions/buffer_device_address/buffer_device_address.cpp
@@ -428,9 +428,10 @@ void BufferDeviceAddress::render(float delta_time)
 void BufferDeviceAddress::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Need to enable the bufferDeviceAddress feature.
-	auto &features = gpu.request_extension_features<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(
-	    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR);
-	features.bufferDeviceAddress = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR)
+	           .bufferDeviceAddress);
+	gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR)
+	    .bufferDeviceAddress = VK_TRUE;
 }
 
 std::unique_ptr<vkb::VulkanSampleC> create_buffer_device_address()

--- a/samples/extensions/color_write_enable/color_write_enable.cpp
+++ b/samples/extensions/color_write_enable/color_write_enable.cpp
@@ -239,10 +239,10 @@ void ColorWriteEnable::create_attachments()
 
 void ColorWriteEnable::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	{
-		auto &features            = gpu.request_extension_features<VkPhysicalDeviceColorWriteEnableFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT);
-		features.colorWriteEnable = VK_TRUE;
-	}
+	assert(gpu.get_extension_features<VkPhysicalDeviceColorWriteEnableFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT)
+	           .colorWriteEnable);
+	gpu.add_extension_features<VkPhysicalDeviceColorWriteEnableFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT)
+	    .colorWriteEnable = VK_TRUE;
 	{
 		auto &features            = gpu.get_mutable_requested_features();
 		features.independentBlend = VK_TRUE;
@@ -544,7 +544,7 @@ void ColorWriteEnable::on_update_ui_overlay(vkb::Drawer &drawer)
 		                                                ImGuiColorEditFlags_NoSidePreview |
 		                                                    ImGuiColorEditFlags_NoSmallPreview |
 		                                                    ImGuiColorEditFlags_Float |
-                                                        ImGuiColorEditFlags_HDR))
+		                                                    ImGuiColorEditFlags_HDR))
 		{
 			rebuild_command_buffers();
 		}

--- a/samples/extensions/color_write_enable/color_write_enable.cpp
+++ b/samples/extensions/color_write_enable/color_write_enable.cpp
@@ -239,10 +239,11 @@ void ColorWriteEnable::create_attachments()
 
 void ColorWriteEnable::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	assert(gpu.get_extension_features<VkPhysicalDeviceColorWriteEnableFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT)
-	           .colorWriteEnable);
-	gpu.add_extension_features<VkPhysicalDeviceColorWriteEnableFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT)
-	    .colorWriteEnable = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceColorWriteEnableFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT,
+	                         colorWriteEnable);
+
 	{
 		auto &features            = gpu.get_mutable_requested_features();
 		features.independentBlend = VK_TRUE;

--- a/samples/extensions/conditional_rendering/conditional_rendering.cpp
+++ b/samples/extensions/conditional_rendering/conditional_rendering.cpp
@@ -45,10 +45,10 @@ ConditionalRendering::~ConditionalRendering()
 void ConditionalRendering::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// We need to enable conditional rendering using a new feature struct
-	assert(gpu.get_extension_features<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT)
-	           .conditionalRendering);
-	gpu.add_extension_features<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT)
-	    .conditionalRendering = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceConditionalRenderingFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT,
+	                         conditionalRendering);
 }
 
 void ConditionalRendering::build_command_buffers()

--- a/samples/extensions/conditional_rendering/conditional_rendering.cpp
+++ b/samples/extensions/conditional_rendering/conditional_rendering.cpp
@@ -45,8 +45,10 @@ ConditionalRendering::~ConditionalRendering()
 void ConditionalRendering::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// We need to enable conditional rendering using a new feature struct
-	auto &requested_extension_features                = gpu.request_extension_features<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT);
-	requested_extension_features.conditionalRendering = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT)
+	           .conditionalRendering);
+	gpu.add_extension_features<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT)
+	    .conditionalRendering = VK_TRUE;
 }
 
 void ConditionalRendering::build_command_buffers()

--- a/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
+++ b/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
@@ -71,16 +71,16 @@ void DescriptorBufferBasic::request_gpu_features(vkb::PhysicalDevice &gpu)
 	// Enable features required for this example
 
 	// We need device addresses for buffers in certain places
-	assert(gpu.get_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
-	           .bufferDeviceAddress);
-	gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
-	    .bufferDeviceAddress = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceBufferDeviceAddressFeatures,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES,
+	                         bufferDeviceAddress);
 
 	// We need to enable the descriptor buffer feature of the VK_EXT_descriptor_buffer extension
-	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT)
-	           .descriptorBuffer);
-	gpu.add_extension_features<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT).descriptorBuffer =
-	    VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDescriptorBufferFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT,
+	                         descriptorBuffer);
 }
 
 void DescriptorBufferBasic::build_command_buffers()

--- a/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
+++ b/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
@@ -71,12 +71,16 @@ void DescriptorBufferBasic::request_gpu_features(vkb::PhysicalDevice &gpu)
 	// Enable features required for this example
 
 	// We need device addresses for buffers in certain places
-	auto &requested_buffer_device_address_features               = gpu.request_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES);
-	requested_buffer_device_address_features.bufferDeviceAddress = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
+	           .bufferDeviceAddress);
+	gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
+	    .bufferDeviceAddress = VK_TRUE;
 
 	// We need to enable the descriptor buffer feature of the VK_EXT_descriptor_buffer extension
-	auto &requested_buffer_descriptor_buffer_features            = gpu.request_extension_features<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT);
-	requested_buffer_descriptor_buffer_features.descriptorBuffer = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT)
+	           .descriptorBuffer);
+	gpu.add_extension_features<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT).descriptorBuffer =
+	    VK_TRUE;
 }
 
 void DescriptorBufferBasic::build_command_buffers()

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -542,38 +542,41 @@ void DescriptorIndexing::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	gpu.get_mutable_requested_features().shaderSampledImageArrayDynamicIndexing = VK_TRUE;
 
-	auto &features =
-	    gpu.add_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT);
-
-	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
-	           .shaderSampledImageArrayNonUniformIndexing);
-	features.shaderSampledImageArrayNonUniformIndexing = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDescriptorIndexingFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
+	                         shaderSampledImageArrayNonUniformIndexing);
 
 	// These are required to support the 4 descriptor binding flags we use in this sample.
-	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
-	           .descriptorBindingSampledImageUpdateAfterBind);
-	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
-	           .descriptorBindingPartiallyBound);
-	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
-	           .descriptorBindingUpdateUnusedWhilePending);
-	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
-	           .descriptorBindingVariableDescriptorCount);
-	features.descriptorBindingSampledImageUpdateAfterBind = VK_TRUE;
-	features.descriptorBindingPartiallyBound              = VK_TRUE;
-	features.descriptorBindingUpdateUnusedWhilePending    = VK_TRUE;
-	features.descriptorBindingVariableDescriptorCount     = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDescriptorIndexingFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
+	                         descriptorBindingSampledImageUpdateAfterBind);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDescriptorIndexingFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
+	                         descriptorBindingPartiallyBound);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDescriptorIndexingFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
+	                         descriptorBindingUpdateUnusedWhilePending);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDescriptorIndexingFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
+	                         descriptorBindingVariableDescriptorCount);
 
 	// Enables use of runtimeDescriptorArrays in SPIR-V shaders.
-	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
-	           .runtimeDescriptorArray);
-	features.runtimeDescriptorArray = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDescriptorIndexingFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
+	                         runtimeDescriptorArray);
 
 	// There are lot of properties associated with descriptor_indexing, grab them here.
 	descriptor_indexing_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT;
 
 	VkPhysicalDeviceProperties2KHR device_properties{};
-	device_properties.sType              = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
-	device_properties.pNext              = &descriptor_indexing_properties;
+	device_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
+	device_properties.pNext = &descriptor_indexing_properties;
 	vkGetPhysicalDeviceProperties2KHR(gpu.get_handle(), &device_properties);
 }
 

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -542,27 +542,36 @@ void DescriptorIndexing::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	gpu.get_mutable_requested_features().shaderSampledImageArrayDynamicIndexing = VK_TRUE;
 
-	auto &features = gpu.request_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(
-	    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT);
+	auto &features =
+	    gpu.add_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT);
 
+	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
+	           .shaderSampledImageArrayNonUniformIndexing);
 	features.shaderSampledImageArrayNonUniformIndexing = VK_TRUE;
 
 	// These are required to support the 4 descriptor binding flags we use in this sample.
+	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
+	           .descriptorBindingSampledImageUpdateAfterBind);
+	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
+	           .descriptorBindingPartiallyBound);
+	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
+	           .descriptorBindingUpdateUnusedWhilePending);
+	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
+	           .descriptorBindingVariableDescriptorCount);
 	features.descriptorBindingSampledImageUpdateAfterBind = VK_TRUE;
 	features.descriptorBindingPartiallyBound              = VK_TRUE;
 	features.descriptorBindingUpdateUnusedWhilePending    = VK_TRUE;
 	features.descriptorBindingVariableDescriptorCount     = VK_TRUE;
 
 	// Enables use of runtimeDescriptorArrays in SPIR-V shaders.
+	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
+	           .runtimeDescriptorArray);
 	features.runtimeDescriptorArray = VK_TRUE;
 
 	// There are lot of properties associated with descriptor_indexing, grab them here.
-	auto vkGetPhysicalDeviceProperties2KHR =
-	    reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(vkGetInstanceProcAddr(get_instance().get_handle(), "vkGetPhysicalDeviceProperties2KHR"));
-	assert(vkGetPhysicalDeviceProperties2KHR);
-	VkPhysicalDeviceProperties2KHR device_properties{};
-
 	descriptor_indexing_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT;
+
+	VkPhysicalDeviceProperties2KHR device_properties{};
 	device_properties.sType              = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
 	device_properties.pNext              = &descriptor_indexing_properties;
 	vkGetPhysicalDeviceProperties2KHR(gpu.get_handle(), &device_properties);

--- a/samples/extensions/dynamic_blending/dynamic_blending.cpp
+++ b/samples/extensions/dynamic_blending/dynamic_blending.cpp
@@ -149,18 +149,29 @@ void DynamicBlending::prepare_scene()
 
 void DynamicBlending::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	// Query the extended dynamic state support
-	eds_feature_support =
-	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT);
-	assert(eds_feature_support.extendedDynamicState3ColorBlendEnable);        // We must have this or the sample isn't useful
+	// We must have this or the sample isn't useful
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
+	                         extendedDynamicState3ColorBlendEnable);
 
 	// Only request the features that we support
-	auto &features =
-	    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT);
-	features.extendedDynamicState3ColorWriteMask     = eds_feature_support.extendedDynamicState3ColorWriteMask;
-	features.extendedDynamicState3ColorBlendEnable   = eds_feature_support.extendedDynamicState3ColorBlendEnable;
-	features.extendedDynamicState3ColorBlendAdvanced = eds_feature_support.extendedDynamicState3ColorBlendAdvanced;
-	features.extendedDynamicState3ColorBlendEquation = eds_feature_support.extendedDynamicState3ColorBlendEquation;
+	REQUEST_OPTIONAL_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
+	                         extendedDynamicState3ColorWriteMask);
+	REQUEST_OPTIONAL_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
+	                         extendedDynamicState3ColorBlendEnable);
+	REQUEST_OPTIONAL_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
+	                         extendedDynamicState3ColorBlendAdvanced);
+	REQUEST_OPTIONAL_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
+	                         extendedDynamicState3ColorBlendEquation);
 
 	{
 		assert(gpu.get_extension_features<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT).advancedBlendCoherentOperations);

--- a/samples/extensions/dynamic_blending/dynamic_blending.cpp
+++ b/samples/extensions/dynamic_blending/dynamic_blending.cpp
@@ -150,25 +150,21 @@ void DynamicBlending::prepare_scene()
 void DynamicBlending::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Query the extended dynamic state support
-	eds_feature_support       = {};
-	eds_feature_support.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT;
+	eds_feature_support =
+	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT);
+	assert(eds_feature_support.extendedDynamicState3ColorBlendEnable);        // We must have this or the sample isn't useful
 
-	VkPhysicalDeviceFeatures2KHR features2{};
-	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
-	features2.pNext = &eds_feature_support;
-	vkGetPhysicalDeviceFeatures2KHR(gpu.get_handle(), &features2);
+	// Only request the features that we support
+	auto &features =
+	    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT);
+	features.extendedDynamicState3ColorWriteMask     = eds_feature_support.extendedDynamicState3ColorWriteMask;
+	features.extendedDynamicState3ColorBlendEnable   = eds_feature_support.extendedDynamicState3ColorBlendEnable;
+	features.extendedDynamicState3ColorBlendAdvanced = eds_feature_support.extendedDynamicState3ColorBlendAdvanced;
+	features.extendedDynamicState3ColorBlendEquation = eds_feature_support.extendedDynamicState3ColorBlendEquation;
 
 	{
-		// Only request the features that we support
-		auto &features                                   = gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT);
-		features.extendedDynamicState3ColorWriteMask     = eds_feature_support.extendedDynamicState3ColorWriteMask;
-		features.extendedDynamicState3ColorBlendEnable   = VK_TRUE;        // We must have this or the sample isn't useful
-		features.extendedDynamicState3ColorBlendAdvanced = eds_feature_support.extendedDynamicState3ColorBlendAdvanced;
-		features.extendedDynamicState3ColorBlendEquation = eds_feature_support.extendedDynamicState3ColorBlendEquation;
-	}
-	{
-		auto &features                           = gpu.request_extension_features<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT);
-		features.advancedBlendCoherentOperations = VK_TRUE;
+		assert(gpu.get_extension_features<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT).advancedBlendCoherentOperations);
+		gpu.add_extension_features<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT).advancedBlendCoherentOperations = VK_TRUE;
 	}
 }
 

--- a/samples/extensions/dynamic_blending/dynamic_blending.cpp
+++ b/samples/extensions/dynamic_blending/dynamic_blending.cpp
@@ -173,10 +173,10 @@ void DynamicBlending::request_gpu_features(vkb::PhysicalDevice &gpu)
 	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
 	                         extendedDynamicState3ColorBlendEquation);
 
-	{
-		assert(gpu.get_extension_features<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT).advancedBlendCoherentOperations);
-		gpu.add_extension_features<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT).advancedBlendCoherentOperations = VK_TRUE;
-	}
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT,
+	                         advancedBlendCoherentOperations);
 }
 
 void DynamicBlending::prepare_uniform_buffers()

--- a/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.cpp
+++ b/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.cpp
@@ -429,50 +429,46 @@ void DynamicLineRasterization::build_command_buffers()
 
 void DynamicLineRasterization::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	{
-		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
-		           .smoothLines);
-		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
-		           .stippledSmoothLines);
-		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
-		           .bresenhamLines);
-		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
-		           .stippledBresenhamLines);
-		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
-		           .rectangularLines);
-		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
-		           .stippledRectangularLines);
-		auto &features =
-		    gpu.add_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT);
-		features.smoothLines              = VK_TRUE;
-		features.stippledSmoothLines      = VK_TRUE;
-		features.bresenhamLines           = VK_TRUE;
-		features.stippledBresenhamLines   = VK_TRUE;
-		features.rectangularLines         = VK_TRUE;
-		features.stippledRectangularLines = VK_TRUE;
-	}
-	{
-		assert(gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
-		           .extendedDynamicState);
-		gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
-		    .extendedDynamicState = VK_TRUE;
-	}
-	{
-		assert(
-		    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT)
-		        .extendedDynamicState3PolygonMode);
-		assert(
-		    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT)
-		        .extendedDynamicState3LineRasterizationMode);
-		assert(
-		    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT)
-		        .extendedDynamicState3LineStippleEnable);
-		auto &features =
-		    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT);
-		features.extendedDynamicState3PolygonMode           = VK_TRUE;
-		features.extendedDynamicState3LineRasterizationMode = VK_TRUE;
-		features.extendedDynamicState3LineStippleEnable     = VK_TRUE;
-	}
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceLineRasterizationFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT, smoothLines);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceLineRasterizationFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT,
+	                         stippledSmoothLines);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceLineRasterizationFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT,
+	                         bresenhamLines);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceLineRasterizationFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT,
+	                         stippledBresenhamLines);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceLineRasterizationFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT,
+	                         rectangularLines);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceLineRasterizationFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT,
+	                         stippledRectangularLines);
+
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicStateFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
+	                         extendedDynamicState);
+
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
+	                         extendedDynamicState3PolygonMode);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
+	                         extendedDynamicState3LineRasterizationMode);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
+	                         extendedDynamicState3LineStippleEnable);
+
 	{
 		auto &features            = gpu.get_mutable_requested_features();
 		features.fillModeNonSolid = VK_TRUE;

--- a/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.cpp
+++ b/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.cpp
@@ -430,8 +430,20 @@ void DynamicLineRasterization::build_command_buffers()
 void DynamicLineRasterization::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	{
-		auto &features = gpu.request_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(
-		    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT);
+		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
+		           .smoothLines);
+		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
+		           .stippledSmoothLines);
+		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
+		           .bresenhamLines);
+		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
+		           .stippledBresenhamLines);
+		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
+		           .rectangularLines);
+		assert(gpu.get_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT)
+		           .stippledRectangularLines);
+		auto &features =
+		    gpu.add_extension_features<VkPhysicalDeviceLineRasterizationFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT);
 		features.smoothLines              = VK_TRUE;
 		features.stippledSmoothLines      = VK_TRUE;
 		features.bresenhamLines           = VK_TRUE;
@@ -440,13 +452,23 @@ void DynamicLineRasterization::request_gpu_features(vkb::PhysicalDevice &gpu)
 		features.stippledRectangularLines = VK_TRUE;
 	}
 	{
-		auto &features =
-		    gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT);
-		features.extendedDynamicState = VK_TRUE;
+		assert(gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
+		           .extendedDynamicState);
+		gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
+		    .extendedDynamicState = VK_TRUE;
 	}
 	{
+		assert(
+		    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT)
+		        .extendedDynamicState3PolygonMode);
+		assert(
+		    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT)
+		        .extendedDynamicState3LineRasterizationMode);
+		assert(
+		    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT)
+		        .extendedDynamicState3LineStippleEnable);
 		auto &features =
-		    gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT);
+		    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT);
 		features.extendedDynamicState3PolygonMode           = VK_TRUE;
 		features.extendedDynamicState3LineRasterizationMode = VK_TRUE;
 		features.extendedDynamicState3LineStippleEnable     = VK_TRUE;

--- a/samples/extensions/dynamic_primitive_clipping/dynamic_primitive_clipping.cpp
+++ b/samples/extensions/dynamic_primitive_clipping/dynamic_primitive_clipping.cpp
@@ -88,14 +88,14 @@ void DynamicPrimitiveClipping::request_gpu_features(vkb::PhysicalDevice &gpu)
 	}
 
 	// Features required by vkCmdSetDepthClipEnableEXT().
-	{
-		auto &features           = gpu.request_extension_features<VkPhysicalDeviceDepthClipEnableFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT);
-		features.depthClipEnable = VK_TRUE;
-	}
-	{
-		auto &features                                = gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT);
-		features.extendedDynamicState3DepthClipEnable = VK_TRUE;
-	}
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDepthClipEnableFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT,
+	                         depthClipEnable);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT,
+	                         extendedDynamicState3DepthClipEnable);
 }
 
 void DynamicPrimitiveClipping::build_command_buffers()

--- a/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
+++ b/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
@@ -93,10 +93,10 @@ void DynamicRendering::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	if (enable_dynamic)
 	{
-		assert(gpu.get_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR)
-		           .dynamicRendering);
-		gpu.add_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR)
-		    .dynamicRendering = VK_TRUE;
+		REQUEST_REQUIRED_FEATURE(gpu,
+		                         VkPhysicalDeviceDynamicRenderingFeaturesKHR,
+		                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR,
+		                         dynamicRendering);
 	}
 
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
+++ b/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
@@ -93,8 +93,10 @@ void DynamicRendering::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	if (enable_dynamic)
 	{
-		auto &requested_dynamic_rendering            = gpu.request_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR);
-		requested_dynamic_rendering.dynamicRendering = VK_TRUE;
+		assert(gpu.get_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR)
+		           .dynamicRendering);
+		gpu.add_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR)
+		    .dynamicRendering = VK_TRUE;
 	}
 
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
+++ b/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
@@ -71,15 +71,12 @@ void DynamicRenderingLocalRead::request_gpu_features(vkb::PhysicalDevice &gpu)
 		gpu.get_mutable_requested_features().samplerAnisotropy = true;
 	}
 #if defined(USE_DYNAMIC_RENDERING)
-	auto &requested_dynamic_rendering_features            = gpu.request_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR);
-	requested_dynamic_rendering_features.dynamicRendering = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceDynamicRenderingFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR, dynamicRendering);
 
-	auto &requested_dynamic_rendering_local_read_features                     = gpu.request_extension_features<VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR);
-	requested_dynamic_rendering_local_read_features.dynamicRenderingLocalRead = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR, dynamicRenderingLocalRead);
 
 	// To simplify barrier setup used for dynamic rendering, we use sync2
-	auto &requested_synchronisation2_features            = gpu.request_extension_features<VkPhysicalDeviceSynchronization2FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR);
-	requested_synchronisation2_features.synchronization2 = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceSynchronization2FeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR, synchronization2);
 #endif
 }
 

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -739,23 +739,20 @@ void ExtendedDynamicState2::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
-	REQUEST_REQUIRED_FEATURE(gpu,
-	                         VkPhysicalDeviceExtendedDynamicState2FeaturesEXT,
-	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT,
-	                         extendedDynamicState2);
+	REQUEST_REQUIRED_FEATURE(
+	    gpu, VkPhysicalDeviceExtendedDynamicState2FeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT, extendedDynamicState2);
 	REQUEST_REQUIRED_FEATURE(gpu,
 	                         VkPhysicalDeviceExtendedDynamicState2FeaturesEXT,
 	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT,
 	                         extendedDynamicState2PatchControlPoints);
 
-	REQUEST_REQUIRED_FEATURE(gpu,
-	                         VkPhysicalDeviceExtendedDynamicStateFeaturesEXT,
-	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
-	                         extendedDynamicState);
+	REQUEST_REQUIRED_FEATURE(
+	    gpu, VkPhysicalDeviceExtendedDynamicStateFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT, extendedDynamicState);
 
-	auto &requested_primitive_topology_restart_features =
-	    gpu.request_extension_features<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT);
-	requested_primitive_topology_restart_features.primitiveTopologyListRestart = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT,
+	                         primitiveTopologyListRestart);
 
 	// Tessellation shader support is required for this example
 	auto &requested_features = gpu.get_mutable_requested_features();

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -739,14 +739,21 @@ void ExtendedDynamicState2::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
+	assert(
+	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
+	        .extendedDynamicState2);
+	assert(
+	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
+	        .extendedDynamicState2PatchControlPoints);
 	auto &requested_extended_dynamic_state2_features =
-	    gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT);
+	    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT);
 	requested_extended_dynamic_state2_features.extendedDynamicState2                   = VK_TRUE;
 	requested_extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints = VK_TRUE;
 
-	auto &requested_extended_dynamic_state_feature =
-	    gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT);
-	requested_extended_dynamic_state_feature.extendedDynamicState = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
+	           .extendedDynamicState);
+	gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
+	    .extendedDynamicState = VK_TRUE;
 
 	auto &requested_primitive_topology_restart_features =
 	    gpu.request_extension_features<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT);

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -739,21 +739,19 @@ void ExtendedDynamicState2::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
-	assert(
-	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
-	        .extendedDynamicState2);
-	assert(
-	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
-	        .extendedDynamicState2PatchControlPoints);
-	auto &requested_extended_dynamic_state2_features =
-	    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT);
-	requested_extended_dynamic_state2_features.extendedDynamicState2                   = VK_TRUE;
-	requested_extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState2FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT,
+	                         extendedDynamicState2);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState2FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT,
+	                         extendedDynamicState2PatchControlPoints);
 
-	assert(gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
-	           .extendedDynamicState);
-	gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
-	    .extendedDynamicState = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicStateFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
+	                         extendedDynamicState);
 
 	auto &requested_primitive_topology_restart_features =
 	    gpu.request_extension_features<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT);

--- a/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.cpp
+++ b/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.cpp
@@ -388,12 +388,10 @@ void FragmentShaderBarycentric::on_update_ui_overlay(vkb::Drawer &drawer)
  */
 void FragmentShaderBarycentric::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	assert(gpu
-	           .get_extension_features<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR>(
-	               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR)
-	           .fragmentShaderBarycentric);
-	gpu.add_extension_features<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR)
-	    .fragmentShaderBarycentric = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR,
+	                         fragmentShaderBarycentric);
 
 	if (gpu.get_features().samplerAnisotropy)
 	{

--- a/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.cpp
+++ b/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.cpp
@@ -388,9 +388,12 @@ void FragmentShaderBarycentric::on_update_ui_overlay(vkb::Drawer &drawer)
  */
 void FragmentShaderBarycentric::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	auto &requested_fragment_shader_barycentric_features =
-	    gpu.request_extension_features<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR);
-	requested_fragment_shader_barycentric_features.fragmentShaderBarycentric = VK_TRUE;
+	assert(gpu
+	           .get_extension_features<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR>(
+	               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR)
+	           .fragmentShaderBarycentric);
+	gpu.add_extension_features<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR)
+	    .fragmentShaderBarycentric = VK_TRUE;
 
 	if (gpu.get_features().samplerAnisotropy)
 	{

--- a/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
+++ b/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
@@ -52,10 +52,10 @@ void FragmentShadingRate::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable the shading rate attachment feature required by this sample
 	// These are passed to device creation via a pNext structure chain
-	assert(gpu.get_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR)
-	           .attachmentFragmentShadingRate);
-	gpu.add_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR)
-	    .attachmentFragmentShadingRate = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceFragmentShadingRateFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR,
+	                         attachmentFragmentShadingRate);
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
+++ b/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
@@ -52,10 +52,10 @@ void FragmentShadingRate::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable the shading rate attachment feature required by this sample
 	// These are passed to device creation via a pNext structure chain
-	auto &requested_extension_features                         = gpu.request_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR);
-	requested_extension_features.attachmentFragmentShadingRate = VK_TRUE;
-	requested_extension_features.pipelineFragmentShadingRate   = VK_FALSE;
-	requested_extension_features.primitiveFragmentShadingRate  = VK_FALSE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR)
+	           .attachmentFragmentShadingRate);
+	gpu.add_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR)
+	    .attachmentFragmentShadingRate = VK_TRUE;
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -64,11 +64,14 @@ void FragmentShadingRateDynamic::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable the shading rate attachment feature required by this sample
 	// These are passed to device creation via a pNext structure chain
-	auto &requested_extension_features = gpu.request_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(
-	    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR);
+	assert(gpu.get_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR)
+	           .attachmentFragmentShadingRate);
+	assert(gpu.get_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR)
+	           .pipelineFragmentShadingRate);
+	auto &requested_extension_features =
+	    gpu.add_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR);
 	requested_extension_features.attachmentFragmentShadingRate = VK_TRUE;
 	requested_extension_features.pipelineFragmentShadingRate   = VK_TRUE;
-	requested_extension_features.primitiveFragmentShadingRate  = VK_FALSE;
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -64,14 +64,14 @@ void FragmentShadingRateDynamic::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable the shading rate attachment feature required by this sample
 	// These are passed to device creation via a pNext structure chain
-	assert(gpu.get_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR)
-	           .attachmentFragmentShadingRate);
-	assert(gpu.get_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR)
-	           .pipelineFragmentShadingRate);
-	auto &requested_extension_features =
-	    gpu.add_extension_features<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR);
-	requested_extension_features.attachmentFragmentShadingRate = VK_TRUE;
-	requested_extension_features.pipelineFragmentShadingRate   = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceFragmentShadingRateFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR,
+	                         attachmentFragmentShadingRate);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceFragmentShadingRateFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR,
+	                         pipelineFragmentShadingRate);
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
@@ -62,11 +62,10 @@ GraphicsPipelineLibrary::GraphicsPipelineLibrary()
 void GraphicsPipelineLibrary::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
-	assert(
-	    gpu.get_extension_features<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT)
-	        .graphicsPipelineLibrary);
-	gpu.add_extension_features<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT)
-	    .graphicsPipelineLibrary = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT,
+	                         graphicsPipelineLibrary);
 }
 
 GraphicsPipelineLibrary::~GraphicsPipelineLibrary()

--- a/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
+++ b/samples/extensions/graphics_pipeline_library/graphics_pipeline_library.cpp
@@ -62,8 +62,11 @@ GraphicsPipelineLibrary::GraphicsPipelineLibrary()
 void GraphicsPipelineLibrary::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
-	VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT &requested_graphics_pipeline_libary_features = gpu.request_extension_features<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT);
-	requested_graphics_pipeline_libary_features.graphicsPipelineLibrary                             = VK_TRUE;
+	assert(
+	    gpu.get_extension_features<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT)
+	        .graphicsPipelineLibrary);
+	gpu.add_extension_features<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT)
+	    .graphicsPipelineLibrary = VK_TRUE;
 }
 
 GraphicsPipelineLibrary::~GraphicsPipelineLibrary()

--- a/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
+++ b/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
@@ -427,8 +427,7 @@ void GshaderToMshader::on_update_ui_overlay(vkb::Drawer &drawer)
 
 void GshaderToMshader::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	assert(gpu.get_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader);
-	gpu.add_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceMeshShaderFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, meshShader);
 
 	// we explicitly don't want those features!!
 	requested_vertex_input_features.multiviewMeshShader                    = VK_FALSE;

--- a/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
+++ b/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
@@ -429,10 +429,6 @@ void GshaderToMshader::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceMeshShaderFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, meshShader);
 
-	// we explicitly don't want those features!!
-	requested_vertex_input_features.multiviewMeshShader                    = VK_FALSE;
-	requested_vertex_input_features.primitiveFragmentShadingRateMeshShader = VK_FALSE;
-
 	if (gpu.get_features().geometryShader)
 	{
 		gpu.get_mutable_requested_features().geometryShader = VK_TRUE;

--- a/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
+++ b/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
@@ -427,8 +427,8 @@ void GshaderToMshader::on_update_ui_overlay(vkb::Drawer &drawer)
 
 void GshaderToMshader::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	auto &requested_vertex_input_features      = gpu.request_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT);
-	requested_vertex_input_features.meshShader = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader);
+	gpu.add_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader = VK_TRUE;
 
 	// we explicitly don't want those features!!
 	requested_vertex_input_features.multiviewMeshShader                    = VK_FALSE;

--- a/samples/extensions/host_image_copy/host_image_copy.cpp
+++ b/samples/extensions/host_image_copy/host_image_copy.cpp
@@ -46,8 +46,7 @@ HostImageCopy::~HostImageCopy()
 void HostImageCopy::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable host image copy feature (required for this sample to work)
-	auto &requested_host_image_copy_features         = gpu.request_extension_features<VkPhysicalDeviceHostImageCopyFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT);
-	requested_host_image_copy_features.hostImageCopy = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceHostImageCopyFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT, hostImageCopy);
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.cpp
+++ b/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.cpp
@@ -80,8 +80,7 @@ void HPPMeshShading::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
 	// These are passed to device creation via a pNext structure chain
-	assert(gpu.get_extension_features<vk::PhysicalDeviceMeshShaderFeaturesEXT>().meshShader);
-	gpu.add_extension_features<vk::PhysicalDeviceMeshShaderFeaturesEXT>().meshShader = true;
+	HPP_REQUEST_REQUIRED_FEATURE(gpu, vk::PhysicalDeviceMeshShaderFeaturesEXT, meshShader);
 }
 
 /*

--- a/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.cpp
+++ b/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.cpp
@@ -80,8 +80,8 @@ void HPPMeshShading::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
 	// These are passed to device creation via a pNext structure chain
-	auto &meshFeatures      = gpu.request_extension_features<vk::PhysicalDeviceMeshShaderFeaturesEXT>();
-	meshFeatures.meshShader = true;
+	assert(gpu.get_extension_features<vk::PhysicalDeviceMeshShaderFeaturesEXT>().meshShader);
+	gpu.add_extension_features<vk::PhysicalDeviceMeshShaderFeaturesEXT>().meshShader = true;
 }
 
 /*

--- a/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
+++ b/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
@@ -202,21 +202,19 @@ void LogicOpDynamicState::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
-	assert(
-	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
-	        .extendedDynamicState2);
-	assert(
-	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
-	        .extendedDynamicState2LogicOp);
-	auto &requested_extended_dynamic_state2_features =
-	    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT);
-	requested_extended_dynamic_state2_features.extendedDynamicState2        = VK_TRUE;
-	requested_extended_dynamic_state2_features.extendedDynamicState2LogicOp = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState2FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT,
+	                         extendedDynamicState2);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState2FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT,
+	                         extendedDynamicState2LogicOp);
 
-	assert(gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
-	           .extendedDynamicState);
-	gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
-	    .extendedDynamicState = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicStateFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
+	                         extendedDynamicState);
 
 	if (gpu.get_features().samplerAnisotropy)
 	{

--- a/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
+++ b/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
@@ -202,14 +202,21 @@ void LogicOpDynamicState::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
+	assert(
+	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
+	        .extendedDynamicState2);
+	assert(
+	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
+	        .extendedDynamicState2LogicOp);
 	auto &requested_extended_dynamic_state2_features =
-	    gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT);
+	    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT);
 	requested_extended_dynamic_state2_features.extendedDynamicState2        = VK_TRUE;
 	requested_extended_dynamic_state2_features.extendedDynamicState2LogicOp = VK_TRUE;
 
-	auto &requested_extended_dynamic_state_feature =
-	    gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT);
-	requested_extended_dynamic_state_feature.extendedDynamicState = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
+	           .extendedDynamicState);
+	gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
+	    .extendedDynamicState = VK_TRUE;
 
 	if (gpu.get_features().samplerAnisotropy)
 	{

--- a/samples/extensions/mesh_shader_culling/mesh_shader_culling.cpp
+++ b/samples/extensions/mesh_shader_culling/mesh_shader_culling.cpp
@@ -74,11 +74,12 @@ void MeshShaderCulling::request_gpu_features(vkb::PhysicalDevice &gpu)
 
 	// Enable extension features required by this sample
 	// These are passed to device creation via a pNext structure chain
-	auto &meshFeatures = gpu.request_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(
-	    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT);
-
-	meshFeatures.taskShader = VK_TRUE;
-	meshFeatures.meshShader = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).taskShader);
+	assert(gpu.get_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader);
+	auto &requested_mesh_features =
+	    gpu.add_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT);
+	requested_mesh_features.taskShader = VK_TRUE;
+	requested_mesh_features.meshShader = VK_TRUE;
 
 	// Pipeline statistics
 	auto &requested_features = gpu.get_mutable_requested_features();

--- a/samples/extensions/mesh_shader_culling/mesh_shader_culling.cpp
+++ b/samples/extensions/mesh_shader_culling/mesh_shader_culling.cpp
@@ -56,6 +56,7 @@ void MeshShaderCulling::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Check whether the device supports task and mesh shaders
 	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceMeshShaderFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, meshShader);
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceMeshShaderFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, meshShaderQueries);
 	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceMeshShaderFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, taskShader);
 
 	// Pipeline statistics

--- a/samples/extensions/mesh_shader_culling/mesh_shader_culling.cpp
+++ b/samples/extensions/mesh_shader_culling/mesh_shader_culling.cpp
@@ -55,31 +55,8 @@ MeshShaderCulling::~MeshShaderCulling()
 void MeshShaderCulling::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Check whether the device supports task and mesh shaders
-	VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features;
-	mesh_shader_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT;
-	mesh_shader_features.pNext = VK_NULL_HANDLE;
-	VkPhysicalDeviceFeatures2 features2;
-	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-	features2.pNext = &mesh_shader_features;
-	vkGetPhysicalDeviceFeatures2(gpu.get_handle(), &features2);
-
-	if (!mesh_shader_features.taskShader || !mesh_shader_features.meshShader)
-	{
-		throw vkb::VulkanException(VK_ERROR_FEATURE_NOT_PRESENT, "Selected GPU does not support task and mesh shaders!");
-	}
-	if (!mesh_shader_features.meshShaderQueries)
-	{
-		throw vkb::VulkanException(VK_ERROR_FEATURE_NOT_PRESENT, "Selected GPU does not support mesh shader queries!");
-	}
-
-	// Enable extension features required by this sample
-	// These are passed to device creation via a pNext structure chain
-	assert(gpu.get_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).taskShader);
-	assert(gpu.get_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader);
-	auto &requested_mesh_features =
-	    gpu.add_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT);
-	requested_mesh_features.taskShader = VK_TRUE;
-	requested_mesh_features.meshShader = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceMeshShaderFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, meshShader);
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceMeshShaderFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, taskShader);
 
 	// Pipeline statistics
 	auto &requested_features = gpu.get_mutable_requested_features();

--- a/samples/extensions/mesh_shading/mesh_shading.cpp
+++ b/samples/extensions/mesh_shading/mesh_shading.cpp
@@ -50,9 +50,8 @@ void MeshShading::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
 	// These are passed to device creation via a pNext structure chain
-	auto &meshFeatures = gpu.request_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(
-	    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT);
-	meshFeatures.meshShader = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader);
+	gpu.add_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader = VK_TRUE;
 }
 
 /*

--- a/samples/extensions/mesh_shading/mesh_shading.cpp
+++ b/samples/extensions/mesh_shading/mesh_shading.cpp
@@ -50,8 +50,7 @@ void MeshShading::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
 	// These are passed to device creation via a pNext structure chain
-	assert(gpu.get_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader);
-	gpu.add_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT).meshShader = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceMeshShaderFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, meshShader);
 }
 
 /*

--- a/samples/extensions/patch_control_points/patch_control_points.cpp
+++ b/samples/extensions/patch_control_points/patch_control_points.cpp
@@ -551,21 +551,19 @@ void PatchControlPoints::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
-	assert(
-	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
-	        .extendedDynamicState2);
-	assert(
-	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
-	        .extendedDynamicState2PatchControlPoints);
-	auto &requested_extended_dynamic_state2_features =
-	    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT);
-	requested_extended_dynamic_state2_features.extendedDynamicState2                   = VK_TRUE;
-	requested_extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState2FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT,
+	                         extendedDynamicState2);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicState2FeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT,
+	                         extendedDynamicState2PatchControlPoints);
 
-	assert(gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
-	           .extendedDynamicState);
-	gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
-	    .extendedDynamicState = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceExtendedDynamicStateFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
+	                         extendedDynamicState);
 
 	// Tessellation shader support is required for this example
 	auto &requested_features = gpu.get_mutable_requested_features();

--- a/samples/extensions/patch_control_points/patch_control_points.cpp
+++ b/samples/extensions/patch_control_points/patch_control_points.cpp
@@ -551,14 +551,21 @@ void PatchControlPoints::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
+	assert(
+	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
+	        .extendedDynamicState2);
+	assert(
+	    gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT)
+	        .extendedDynamicState2PatchControlPoints);
 	auto &requested_extended_dynamic_state2_features =
-	    gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT);
+	    gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT);
 	requested_extended_dynamic_state2_features.extendedDynamicState2                   = VK_TRUE;
 	requested_extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints = VK_TRUE;
 
-	auto &requested_extended_dynamic_state_feature =
-	    gpu.request_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT);
-	requested_extended_dynamic_state_feature.extendedDynamicState = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
+	           .extendedDynamicState);
+	gpu.add_extension_features<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT)
+	    .extendedDynamicState = VK_TRUE;
 
 	// Tessellation shader support is required for this example
 	auto &requested_features = gpu.get_mutable_requested_features();

--- a/samples/extensions/ray_queries/ray_queries.cpp
+++ b/samples/extensions/ray_queries/ray_queries.cpp
@@ -38,8 +38,8 @@ struct RequestFeature
 	template <typename T>
 	RequestFeature &request(VkStructureType s_type, VkBool32 T::*member)
 	{
-		auto &member_feature   = gpu.request_extension_features<T>(s_type);
-		member_feature.*member = VK_TRUE;
+		assert(gpu.get_extension_features<T>(s_type).*member);
+		gpu.add_extension_features<T>(s_type).*member = VK_TRUE;
 		return *this;
 	}
 };

--- a/samples/extensions/ray_queries/ray_queries.cpp
+++ b/samples/extensions/ray_queries/ray_queries.cpp
@@ -28,21 +28,6 @@
 namespace
 {
 constexpr uint32_t MIN_THREAD_COUNT = 1;
-struct RequestFeature
-{
-	vkb::PhysicalDevice &gpu;
-	explicit RequestFeature(vkb::PhysicalDevice &gpu) :
-	    gpu(gpu)
-	{}
-
-	template <typename T>
-	RequestFeature &request(VkStructureType s_type, VkBool32 T::*member)
-	{
-		assert(gpu.get_extension_features<T>(s_type).*member);
-		gpu.add_extension_features<T>(s_type).*member = VK_TRUE;
-		return *this;
-	}
-};
 
 template <typename T>
 struct CopyBuffer
@@ -113,10 +98,18 @@ RayQueries::~RayQueries()
 
 void RayQueries::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	RequestFeature(gpu)
-	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES, &VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress)
-	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR, &VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructure)
-	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR, &VkPhysicalDeviceRayQueryFeaturesKHR::rayQuery);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceBufferDeviceAddressFeatures,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES,
+	                         bufferDeviceAddress);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceAccelerationStructureFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR,
+	                         accelerationStructure);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceRayQueryFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR,
+	                         rayQuery);
 }
 
 void RayQueries::render(float delta_time)

--- a/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
+++ b/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
@@ -66,20 +66,20 @@ void RaytracingBasic::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
 	// These are passed to device creation via a pNext structure chain
-	assert(gpu.get_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
-	           .bufferDeviceAddress);
-	gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
-	    .bufferDeviceAddress = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceBufferDeviceAddressFeatures,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES,
+	                         bufferDeviceAddress);
 
-	assert(gpu.get_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR)
-	           .rayTracingPipeline);
-	gpu.add_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR)
-	    .rayTracingPipeline = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceRayTracingPipelineFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR,
+	                         rayTracingPipeline);
 
-	assert(gpu.get_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR)
-	           .accelerationStructure);
-	gpu.add_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR)
-	    .accelerationStructure = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceAccelerationStructureFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR,
+	                         accelerationStructure);
 }
 
 /*

--- a/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
+++ b/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
@@ -66,12 +66,20 @@ void RaytracingBasic::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
 	// These are passed to device creation via a pNext structure chain
-	auto &requested_buffer_device_address_features                  = gpu.request_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES);
-	requested_buffer_device_address_features.bufferDeviceAddress    = VK_TRUE;
-	auto &requested_ray_tracing_features                            = gpu.request_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR);
-	requested_ray_tracing_features.rayTracingPipeline               = VK_TRUE;
-	auto &requested_acceleration_structure_features                 = gpu.request_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR);
-	requested_acceleration_structure_features.accelerationStructure = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
+	           .bufferDeviceAddress);
+	gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
+	    .bufferDeviceAddress = VK_TRUE;
+
+	assert(gpu.get_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR)
+	           .rayTracingPipeline);
+	gpu.add_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR)
+	    .rayTracingPipeline = VK_TRUE;
+
+	assert(gpu.get_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR)
+	           .accelerationStructure);
+	gpu.add_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR)
+	    .accelerationStructure = VK_TRUE;
 }
 
 /*

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -137,25 +137,25 @@ void RaytracingExtended::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
 	// These are passed to device creation via a pNext structure chain
-	assert(gpu.get_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
-	           .bufferDeviceAddress);
-	gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
-	    .bufferDeviceAddress = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceBufferDeviceAddressFeatures,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES,
+	                         bufferDeviceAddress);
 
-	assert(gpu.get_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR)
-	           .rayTracingPipeline);
-	gpu.add_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR)
-	    .rayTracingPipeline = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceRayTracingPipelineFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR,
+	                         rayTracingPipeline);
 
-	assert(gpu.get_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR)
-	           .accelerationStructure);
-	gpu.add_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR)
-	    .accelerationStructure = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceAccelerationStructureFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR,
+	                         accelerationStructure);
 
-	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
-	           .shaderSampledImageArrayNonUniformIndexing);
-	gpu.add_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
-	    .shaderSampledImageArrayNonUniformIndexing = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDescriptorIndexingFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
+	                         shaderSampledImageArrayNonUniformIndexing);
 
 	if (gpu.get_features().samplerAnisotropy)
 	{

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -137,16 +137,25 @@ void RaytracingExtended::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable extension features required by this sample
 	// These are passed to device creation via a pNext structure chain
-	auto &requested_buffer_device_address_features                  = gpu.request_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES);
-	requested_buffer_device_address_features.bufferDeviceAddress    = VK_TRUE;
-	auto &requested_ray_tracing_features                            = gpu.request_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR);
-	requested_ray_tracing_features.rayTracingPipeline               = VK_TRUE;
-	auto &requested_acceleration_structure_features                 = gpu.request_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR);
-	requested_acceleration_structure_features.accelerationStructure = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
+	           .bufferDeviceAddress);
+	gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES)
+	    .bufferDeviceAddress = VK_TRUE;
 
-	auto &features = gpu.request_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(
-	    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT);
-	features.shaderSampledImageArrayNonUniformIndexing = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR)
+	           .rayTracingPipeline);
+	gpu.add_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR)
+	    .rayTracingPipeline = VK_TRUE;
+
+	assert(gpu.get_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR)
+	           .accelerationStructure);
+	gpu.add_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR)
+	    .accelerationStructure = VK_TRUE;
+
+	assert(gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
+	           .shaderSampledImageArrayNonUniformIndexing);
+	gpu.add_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT)
+	    .shaderSampledImageArrayNonUniformIndexing = VK_TRUE;
 
 	if (gpu.get_features().samplerAnisotropy)
 	{

--- a/samples/extensions/ray_tracing_position_fetch/ray_tracing_position_fetch.cpp
+++ b/samples/extensions/ray_tracing_position_fetch/ray_tracing_position_fetch.cpp
@@ -63,16 +63,18 @@ RayTracingPositionFetch::~RayTracingPositionFetch()
 void RayTracingPositionFetch::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Features required for ray tracing
-	auto &requested_buffer_device_address_features                  = gpu.request_extension_features<VkPhysicalDeviceBufferDeviceAddressFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES);
-	requested_buffer_device_address_features.bufferDeviceAddress    = VK_TRUE;
-	auto &requested_ray_tracing_features                            = gpu.request_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR);
-	requested_ray_tracing_features.rayTracingPipeline               = VK_TRUE;
-	auto &requested_acceleration_structure_features                 = gpu.request_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR);
-	requested_acceleration_structure_features.accelerationStructure = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(
+	    gpu, VkPhysicalDeviceBufferDeviceAddressFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES, bufferDeviceAddress);
+	REQUEST_REQUIRED_FEATURE(
+	    gpu, VkPhysicalDeviceRayTracingPipelineFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR, rayTracingPipeline);
+	REQUEST_REQUIRED_FEATURE(
+	    gpu, VkPhysicalDeviceAccelerationStructureFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR, accelerationStructure);
 
 	// Sample sepcific feature
-	auto &requested_ray_tracing_position_fetch_features                   = gpu.request_extension_features<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR);
-	requested_ray_tracing_position_fetch_features.rayTracingPositionFetch = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR,
+	                         rayTracingPositionFetch);
 }
 
 /*

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
@@ -134,11 +134,15 @@ RaytracingReflection::~RaytracingReflection()
 void RaytracingReflection::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// The request is filling with the capabilities (all on by default)
-	auto &vulkan12_features = gpu.request_extension_features<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES);
-	auto &vulkan11_features = gpu.request_extension_features<VkPhysicalDeviceVulkan11Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES);
+	gpu.add_extension_features<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES) =
+	    gpu.get_extension_features<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES);
+	gpu.add_extension_features<VkPhysicalDeviceVulkan11Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES) =
+	    gpu.get_extension_features<VkPhysicalDeviceVulkan11Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES);
 
-	auto &ray_tracing_features            = gpu.request_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR);
-	auto &acceleration_structure_features = gpu.request_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR);
+	gpu.add_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR) =
+	    gpu.get_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR);
+	gpu.add_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR) =
+	    gpu.get_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR);
 
 	// Enabling all Vulkan features (Int64)
 	gpu.get_mutable_requested_features() = gpu.get_features();

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
@@ -133,19 +133,18 @@ RaytracingReflection::~RaytracingReflection()
 */
 void RaytracingReflection::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	// The request is filling with the capabilities (all on by default)
-	gpu.add_extension_features<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES) =
-	    gpu.get_extension_features<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES);
-	gpu.add_extension_features<VkPhysicalDeviceVulkan11Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES) =
-	    gpu.get_extension_features<VkPhysicalDeviceVulkan11Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES);
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceVulkan12Features, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, bufferDeviceAddress);
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceAccelerationStructureFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR, accelerationStructure);
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceRayTracingPipelineFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR, rayTracingPipeline);
 
-	gpu.add_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR) =
-	    gpu.get_extension_features<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR);
-	gpu.add_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR) =
-	    gpu.get_extension_features<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR);
-
-	// Enabling all Vulkan features (Int64)
-	gpu.get_mutable_requested_features() = gpu.get_features();
+	if (gpu.get_features().shaderInt64)
+	{
+		gpu.get_mutable_requested_features().shaderInt64 = VK_TRUE;
+	}
+	else
+	{
+		throw std::runtime_error("Requested required feature <VkPhysicalDeviceFeatures::shaderInt64> is not supported");
+	}
 }
 
 /*

--- a/samples/extensions/shader_object/shader_object.cpp
+++ b/samples/extensions/shader_object/shader_object.cpp
@@ -330,10 +330,10 @@ void ShaderObject::request_gpu_features(vkb::PhysicalDevice &gpu)
 	}
 
 	// Enable Dynamic Rendering
-	assert(gpu.get_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR)
-	           .dynamicRendering);
-	gpu.add_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR).dynamicRendering =
-	    VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceDynamicRenderingFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR,
+	                         dynamicRendering);
 
 	// Enable Geometry Shaders
 	auto &requested_geometry_shader          = gpu.get_mutable_requested_features();

--- a/samples/extensions/shader_object/shader_object.cpp
+++ b/samples/extensions/shader_object/shader_object.cpp
@@ -313,8 +313,7 @@ void ShaderObject::create_default_sampler()
 void ShaderObject::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable Shader Object
-	assert(gpu.get_extension_features<VkPhysicalDeviceShaderObjectFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT).shaderObject);
-	gpu.add_extension_features<VkPhysicalDeviceShaderObjectFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT).shaderObject = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceShaderObjectFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT, shaderObject);
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)

--- a/samples/extensions/shader_object/shader_object.cpp
+++ b/samples/extensions/shader_object/shader_object.cpp
@@ -313,8 +313,8 @@ void ShaderObject::create_default_sampler()
 void ShaderObject::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Enable Shader Object
-	auto &requestedShaderObject        = gpu.request_extension_features<VkPhysicalDeviceShaderObjectFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT);
-	requestedShaderObject.shaderObject = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceShaderObjectFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT).shaderObject);
+	gpu.add_extension_features<VkPhysicalDeviceShaderObjectFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT).shaderObject = VK_TRUE;
 
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)
@@ -330,8 +330,10 @@ void ShaderObject::request_gpu_features(vkb::PhysicalDevice &gpu)
 	}
 
 	// Enable Dynamic Rendering
-	auto &requested_dynamic_rendering            = gpu.request_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR);
-	requested_dynamic_rendering.dynamicRendering = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR)
+	           .dynamicRendering);
+	gpu.add_extension_features<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR).dynamicRendering =
+	    VK_TRUE;
 
 	// Enable Geometry Shaders
 	auto &requested_geometry_shader          = gpu.get_mutable_requested_features();

--- a/samples/extensions/synchronization_2/synchronization_2.cpp
+++ b/samples/extensions/synchronization_2/synchronization_2.cpp
@@ -72,10 +72,10 @@ void Synchronization2::request_gpu_features(vkb::PhysicalDevice &gpu)
 	}
 
 	// Enable synchronization2 feature
-	assert(gpu.get_extension_features<VkPhysicalDeviceSynchronization2FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR)
-	           .synchronization2);
-	gpu.add_extension_features<VkPhysicalDeviceSynchronization2FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR).synchronization2 =
-	    VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceSynchronization2FeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR,
+	                         synchronization2);
 }
 
 void Synchronization2::load_assets()

--- a/samples/extensions/synchronization_2/synchronization_2.cpp
+++ b/samples/extensions/synchronization_2/synchronization_2.cpp
@@ -72,8 +72,10 @@ void Synchronization2::request_gpu_features(vkb::PhysicalDevice &gpu)
 	}
 
 	// Enable synchronization2 feature
-	auto &requested_synchronisation2_features            = gpu.request_extension_features<VkPhysicalDeviceSynchronization2FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR);
-	requested_synchronisation2_features.synchronization2 = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceSynchronization2FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR)
+	           .synchronization2);
+	gpu.add_extension_features<VkPhysicalDeviceSynchronization2FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR).synchronization2 =
+	    VK_TRUE;
 }
 
 void Synchronization2::load_assets()

--- a/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
+++ b/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
@@ -703,9 +703,10 @@ void TimelineSemaphore::render(float delta_time)
 void TimelineSemaphore::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Need to enable the timelineSemaphore feature.
-	auto &features = gpu.request_extension_features<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>(
-	    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR);
-	features.timelineSemaphore = VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR)
+	           .timelineSemaphore);
+	gpu.add_extension_features<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR)
+	    .timelineSemaphore = VK_TRUE;
 }
 
 std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_timeline_semaphore()

--- a/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
+++ b/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
@@ -703,10 +703,10 @@ void TimelineSemaphore::render(float delta_time)
 void TimelineSemaphore::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	// Need to enable the timelineSemaphore feature.
-	assert(gpu.get_extension_features<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR)
-	           .timelineSemaphore);
-	gpu.add_extension_features<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR)
-	    .timelineSemaphore = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceTimelineSemaphoreFeaturesKHR,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR,
+	                         timelineSemaphore);
 }
 
 std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_timeline_semaphore()

--- a/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.cpp
+++ b/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.cpp
@@ -449,11 +449,10 @@ void VertexDynamicState::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
-	assert(
-	    gpu.get_extension_features<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT)
-	        .vertexInputDynamicState);
-	gpu.add_extension_features<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT)
-	    .vertexInputDynamicState = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT,
+	                         vertexInputDynamicState);
 
 	if (gpu.get_features().samplerAnisotropy)
 	{

--- a/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.cpp
+++ b/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.cpp
@@ -449,8 +449,11 @@ void VertexDynamicState::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
-	auto &requested_vertex_input_features                   = gpu.request_extension_features<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT);
-	requested_vertex_input_features.vertexInputDynamicState = VK_TRUE;
+	assert(
+	    gpu.get_extension_features<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT)
+	        .vertexInputDynamicState);
+	gpu.add_extension_features<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT)
+	    .vertexInputDynamicState = VK_TRUE;
 
 	if (gpu.get_features().samplerAnisotropy)
 	{

--- a/samples/general/mobile_nerf/mobile_nerf.cpp
+++ b/samples/general/mobile_nerf/mobile_nerf.cpp
@@ -28,21 +28,6 @@
 namespace
 {
 constexpr uint32_t MIN_THREAD_COUNT = 1;
-struct RequestFeature
-{
-	vkb::PhysicalDevice &gpu;
-	explicit RequestFeature(vkb::PhysicalDevice &gpu) :
-	    gpu(gpu)
-	{}
-
-	template <typename T>
-	RequestFeature &request(VkStructureType s_type, VkBool32 T::*member)
-	{
-		assert(gpu.get_extension_features<T>(s_type).*member);
-		gpu.add_extension_features<T>(s_type).*member = VK_TRUE;
-		return *this;
-	}
-};
 
 template <typename T>
 struct CopyBuffer

--- a/samples/general/mobile_nerf/mobile_nerf.cpp
+++ b/samples/general/mobile_nerf/mobile_nerf.cpp
@@ -478,10 +478,9 @@ bool MobileNerf::resize(const uint32_t width, const uint32_t height)
 
 void MobileNerf::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	RequestFeature(gpu)
-	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT, &VkPhysicalDeviceDescriptorIndexingFeaturesEXT::shaderUniformBufferArrayNonUniformIndexing)
-	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT, &VkPhysicalDeviceDescriptorIndexingFeaturesEXT::runtimeDescriptorArray)
-	    .request(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT, &VkPhysicalDeviceDescriptorIndexingFeaturesEXT::descriptorBindingVariableDescriptorCount);
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceDescriptorIndexingFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT, shaderUniformBufferArrayNonUniformIndexing);
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceDescriptorIndexingFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT, runtimeDescriptorArray);
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceDescriptorIndexingFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT, descriptorBindingVariableDescriptorCount);
 }
 
 void MobileNerf::render(float delta_time)

--- a/samples/general/mobile_nerf/mobile_nerf.cpp
+++ b/samples/general/mobile_nerf/mobile_nerf.cpp
@@ -38,8 +38,8 @@ struct RequestFeature
 	template <typename T>
 	RequestFeature &request(VkStructureType s_type, VkBool32 T::*member)
 	{
-		auto &member_feature   = gpu.request_extension_features<T>(s_type);
-		member_feature.*member = VK_TRUE;
+		assert(gpu.get_extension_features<T>(s_type).*member);
+		gpu.add_extension_features<T>(s_type).*member = VK_TRUE;
 		return *this;
 	}
 };

--- a/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
+++ b/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
@@ -223,17 +223,27 @@ void KHR16BitArithmeticSample::VisualizationSubpass::prepare()
 
 void KHR16BitArithmeticSample::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	auto &storage_16bit_features =
-	    gpu.request_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES);
-	auto &arithmetic_16bit_8bit =
-	    gpu.request_extension_features<VkPhysicalDeviceFloat16Int8FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR);
+	auto storage_16bit_features = gpu.get_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES);
+	auto arithmetic_16bit_8bit =
+	    gpu.get_extension_features<VkPhysicalDeviceFloat16Int8FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR);
 
 	// Required features.
-	storage_16bit_features.storageBuffer16BitAccess = VK_TRUE;
+	assert(storage_16bit_features.storageBuffer16BitAccess);
+	gpu.add_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storageBuffer16BitAccess =
+	    VK_TRUE;
 
 	// Optional features.
-	supported_extensions     = arithmetic_16bit_8bit.shaderFloat16 == VK_TRUE;
+	supported_extensions = arithmetic_16bit_8bit.shaderFloat16 == VK_TRUE;
+	if (supported_extensions)
+	{
+		gpu.add_extension_features<VkPhysicalDeviceFloat16Int8FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR).shaderFloat16 = VK_TRUE;
+	}
 	supports_push_constant16 = storage_16bit_features.storagePushConstant16 == VK_TRUE;
+	if (supports_push_constant16)
+	{
+		gpu.add_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storagePushConstant16 =
+		    VK_TRUE;
+	}
 }
 
 void KHR16BitArithmeticSample::draw_renderpass(vkb::CommandBuffer &command_buffer, vkb::RenderTarget &render_target)

--- a/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
+++ b/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
@@ -228,6 +228,10 @@ void KHR16BitArithmeticSample::request_gpu_features(vkb::PhysicalDevice &gpu)
 	                         VkPhysicalDevice16BitStorageFeatures,
 	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES,
 	                         storageBuffer16BitAccess);
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDevice16BitStorageFeatures,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES,
+	                         uniformAndStorageBuffer16BitAccess);
 
 	// Optional features.
 	supported_extensions = REQUEST_OPTIONAL_FEATURE(gpu,
@@ -235,7 +239,8 @@ void KHR16BitArithmeticSample::request_gpu_features(vkb::PhysicalDevice &gpu)
 	                                                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR,
 	                                                shaderFloat16);
 
-	supports_push_constant16 = gpu.get_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storagePushConstant16;
+	supports_push_constant16 =
+	    REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDevice16BitStorageFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES, storagePushConstant16);
 }
 
 void KHR16BitArithmeticSample::draw_renderpass(vkb::CommandBuffer &command_buffer, vkb::RenderTarget &render_target)

--- a/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
+++ b/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
@@ -223,27 +223,19 @@ void KHR16BitArithmeticSample::VisualizationSubpass::prepare()
 
 void KHR16BitArithmeticSample::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	auto storage_16bit_features = gpu.get_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES);
-	auto arithmetic_16bit_8bit =
-	    gpu.get_extension_features<VkPhysicalDeviceFloat16Int8FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR);
-
 	// Required features.
-	assert(storage_16bit_features.storageBuffer16BitAccess);
-	gpu.add_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storageBuffer16BitAccess =
-	    VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDevice16BitStorageFeatures,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES,
+	                         storageBuffer16BitAccess);
 
 	// Optional features.
-	supported_extensions = arithmetic_16bit_8bit.shaderFloat16 == VK_TRUE;
-	if (supported_extensions)
-	{
-		gpu.add_extension_features<VkPhysicalDeviceFloat16Int8FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR).shaderFloat16 = VK_TRUE;
-	}
-	supports_push_constant16 = storage_16bit_features.storagePushConstant16 == VK_TRUE;
-	if (supports_push_constant16)
-	{
-		gpu.add_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storagePushConstant16 =
-		    VK_TRUE;
-	}
+	supported_extensions = REQUEST_OPTIONAL_FEATURE(gpu,
+	                                                VkPhysicalDeviceFloat16Int8FeaturesKHR,
+	                                                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR,
+	                                                shaderFloat16);
+
+	supports_push_constant16 = gpu.get_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storagePushConstant16;
 }
 
 void KHR16BitArithmeticSample::draw_renderpass(vkb::CommandBuffer &command_buffer, vkb::RenderTarget &render_target)

--- a/samples/performance/16bit_storage_input_output/16bit_storage_input_output.cpp
+++ b/samples/performance/16bit_storage_input_output/16bit_storage_input_output.cpp
@@ -194,8 +194,7 @@ bool KHR16BitStorageInputOutputSample::prepare(const vkb::ApplicationOptions &op
 
 void KHR16BitStorageInputOutputSample::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	assert(gpu.get_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storageInputOutput16);
-	gpu.add_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storageInputOutput16 = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDevice16BitStorageFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES, storageInputOutput16);
 }
 
 void KHR16BitStorageInputOutputSample::update(float delta_time)

--- a/samples/performance/16bit_storage_input_output/16bit_storage_input_output.cpp
+++ b/samples/performance/16bit_storage_input_output/16bit_storage_input_output.cpp
@@ -194,8 +194,8 @@ bool KHR16BitStorageInputOutputSample::prepare(const vkb::ApplicationOptions &op
 
 void KHR16BitStorageInputOutputSample::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	auto &features_16bit_storage = gpu.request_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES);
-	supports_16bit_storage       = features_16bit_storage.storageInputOutput16 == VK_TRUE;
+	assert(gpu.get_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storageInputOutput16);
+	gpu.add_extension_features<VkPhysicalDevice16BitStorageFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES).storageInputOutput16 = VK_TRUE;
 }
 
 void KHR16BitStorageInputOutputSample::update(float delta_time)

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -42,8 +42,8 @@ void AsyncComputeSample::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 #ifdef VKB_ENABLE_PORTABILITY
 	// Since sampler_info.compareEnable = VK_TRUE, must enable the mutableComparisonSamplers feature of VK_KHR_portability_subset
-	auto &requested_portability_subset_features                     = gpu.request_extension_features<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR);
-	requested_portability_subset_features.mutableComparisonSamplers = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(
+	    gpu, VkPhysicalDevicePortabilitySubsetFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR, mutableComparisonSamplers);
 #endif
 }
 

--- a/samples/performance/constant_data/constant_data.cpp
+++ b/samples/performance/constant_data/constant_data.cpp
@@ -125,9 +125,10 @@ void ConstantData::request_gpu_features(vkb::PhysicalDevice &gpu)
 	{
 		gpu.get_mutable_requested_features().vertexPipelineStoresAndAtomics = VK_TRUE;
 	}
-
-	gpu.add_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT) =
-	    gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT);
+	else
+	{
+		throw std::runtime_error("Requested required feature <VkPhysicalDeviceFeatures::vertexPipelineStoresAndAtomics> is not supported");
+	}
 }
 
 void ConstantData::draw_renderpass(vkb::CommandBuffer &command_buffer, vkb::RenderTarget &render_target)

--- a/samples/performance/constant_data/constant_data.cpp
+++ b/samples/performance/constant_data/constant_data.cpp
@@ -126,7 +126,8 @@ void ConstantData::request_gpu_features(vkb::PhysicalDevice &gpu)
 		gpu.get_mutable_requested_features().vertexPipelineStoresAndAtomics = VK_TRUE;
 	}
 
-	gpu.request_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT);
+	gpu.add_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT) =
+	    gpu.get_extension_features<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT);
 }
 
 void ConstantData::draw_renderpass(vkb::CommandBuffer &command_buffer, vkb::RenderTarget &render_target)

--- a/samples/performance/image_compression_control/image_compression_control.cpp
+++ b/samples/performance/image_compression_control/image_compression_control.cpp
@@ -46,23 +46,18 @@ void ImageCompressionControlSample::request_gpu_features(vkb::PhysicalDevice &gp
 {
 	if (gpu.is_extension_supported(VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME))
 	{
-		assert(
-		    gpu.get_extension_features<VkPhysicalDeviceImageCompressionControlFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT)
-		        .imageCompressionControl);
-		gpu.add_extension_features<VkPhysicalDeviceImageCompressionControlFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT)
-		    .imageCompressionControl = VK_TRUE;
+		REQUEST_REQUIRED_FEATURE(gpu,
+		                         VkPhysicalDeviceImageCompressionControlFeaturesEXT,
+		                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT,
+		                         imageCompressionControl);
 	}
 
 	if (gpu.is_extension_supported(VK_EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_EXTENSION_NAME))
 	{
-		assert(gpu
-		           .get_extension_features<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT>(
-		               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT)
-		           .imageCompressionControlSwapchain);
-		gpu
-		    .add_extension_features<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT>(
-		        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT)
-		    .imageCompressionControlSwapchain = VK_TRUE;
+		REQUEST_REQUIRED_FEATURE(gpu,
+		                         VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT,
+		                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT,
+		                         imageCompressionControlSwapchain);
 	}
 }
 

--- a/samples/performance/image_compression_control/image_compression_control.cpp
+++ b/samples/performance/image_compression_control/image_compression_control.cpp
@@ -46,16 +46,23 @@ void ImageCompressionControlSample::request_gpu_features(vkb::PhysicalDevice &gp
 {
 	if (gpu.is_extension_supported(VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME))
 	{
-		auto &compression_control_features = gpu.request_extension_features<VkPhysicalDeviceImageCompressionControlFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT);
-
-		compression_control_features.imageCompressionControl = VK_TRUE;
+		assert(
+		    gpu.get_extension_features<VkPhysicalDeviceImageCompressionControlFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT)
+		        .imageCompressionControl);
+		gpu.add_extension_features<VkPhysicalDeviceImageCompressionControlFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT)
+		    .imageCompressionControl = VK_TRUE;
 	}
 
 	if (gpu.is_extension_supported(VK_EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_EXTENSION_NAME))
 	{
-		auto &compression_control_swapchain_features = gpu.request_extension_features<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT);
-
-		compression_control_swapchain_features.imageCompressionControlSwapchain = VK_TRUE;
+		assert(gpu
+		           .get_extension_features<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT>(
+		               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT)
+		           .imageCompressionControlSwapchain);
+		gpu
+		    .add_extension_features<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT>(
+		        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT)
+		    .imageCompressionControlSwapchain = VK_TRUE;
 	}
 }
 

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -109,12 +109,7 @@ void MultiDrawIndirect::request_gpu_features(vkb::PhysicalDevice &gpu)
 
 	// Query whether the device supports buffer device addresses
 	m_supports_buffer_device =
-	    gpu.get_extension_features<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES).bufferDeviceAddress;
-	if (m_supports_buffer_device)
-	{
-		gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR)
-		    .bufferDeviceAddress = VK_TRUE;
-	}
+	    REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDeviceVulkan12Features, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, bufferDeviceAddress);
 
 	// This sample references 128 objects. We need to check whether this is supported by the device
 	VkPhysicalDeviceProperties physical_device_properties;

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -108,21 +108,12 @@ void MultiDrawIndirect::request_gpu_features(vkb::PhysicalDevice &gpu)
 	}
 
 	// Query whether the device supports buffer device addresses
-	VkPhysicalDeviceVulkan12Features features12;
-	features12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
-	features12.pNext = VK_NULL_HANDLE;
-	VkPhysicalDeviceFeatures2 features2;
-	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-	features2.pNext = &features12;
-	vkGetPhysicalDeviceFeatures2(gpu.get_handle(), &features2);
-
-	m_supports_buffer_device = features12.bufferDeviceAddress;
-
+	m_supports_buffer_device =
+	    gpu.get_extension_features<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES).bufferDeviceAddress;
 	if (m_supports_buffer_device)
 	{
-		auto &features = gpu.request_extension_features<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(
-		    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR);
-		features.bufferDeviceAddress = VK_TRUE;
+		gpu.add_extension_features<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR)
+		    .bufferDeviceAddress = VK_TRUE;
 	}
 
 	// This sample references 128 objects. We need to check whether this is supported by the device

--- a/samples/performance/multithreading_render_passes/multithreading_render_passes.cpp
+++ b/samples/performance/multithreading_render_passes/multithreading_render_passes.cpp
@@ -43,8 +43,8 @@ void MultithreadingRenderPasses::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
 #ifdef VKB_ENABLE_PORTABILITY
 	// Since shadowmap_sampler_create_info.compareEnable = VK_TRUE, must enable the mutableComparisonSamplers feature of VK_KHR_portability_subset
-	auto &requested_portability_subset_features                     = gpu.request_extension_features<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR);
-	requested_portability_subset_features.mutableComparisonSamplers = VK_TRUE;
+	REQUEST_REQUIRED_FEATURE(
+	    gpu, VkPhysicalDevicePortabilitySubsetFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR, mutableComparisonSamplers);
 #endif
 }
 


### PR DESCRIPTION
## Description

As described in #938, requesting and enabling extension features is currently incorrect. With this PR, this is done similar to how it's done for the simple PhysicalDeviceFeatures: one function to get the supported bits (`get_extension_features`) and one to actually set them into the structure chain (`add_extension_features`).
The perfect handling would look like this:
```
if (gpu.get_extension_features<VkExtensionFeaturesStruct>(VK_STRUCTURE_TYPE_EXTENSION_FEATURES_STRUCT).featureBit)
{
	gpu.add_extension_features<VkExtensionFeaturesStruct>(VK_STRUCTURE_TYPE_EXTENSION_FEATURES_STRUCT).featureBit = VK_TRUE;
}
else
{
	// some fallback or error handling!
}
```
To ease usage, `[HPP]PhysicalDevice` got two new template functions: `request_optional_feature` and `request_required_feature`, which log a message or throw an exception, respectively, if the requested feature is not supported.
Requesting a required feature would now look like
```
gpu.request_required_feature<VkExtensionFeaturesStruct>(VK_STRUCTURE_TYPE_EXTENSION_FEATURES_STRUCT,
                                                        &VkExtensionFeaturesStruct::featureBit,
                                                        "VkExtensionFeaturesStruct",
                                                        "featureBit");
```
Where the last two arguments to that functions are just for error reporting and maybe could omitted.

To ease usage even more, some macros have been added, so that requesting a required feature would now look like

`REQUEST_REQUIRED_FEATURE(gpu, VkExtensionFeaturesStruct, VK_STRUCTURE_TYPE_EXTENSION_FEATURES_STRUCT, featureBit);
`

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Fixes #938

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
