### PR TITLE
Add missing buffer usage flags to ray tracing acceleration structures

### DIFF
--- a/framework/core/acceleration_structure.cpp
+++ b/framework/core/acceleration_structure.cpp
@@ -179,7 +179,7 @@ void AccelerationStructure::build(VkQueue queue, VkBuildAccelerationStructureFla
 		buffer = std::make_unique<vkb::core::Buffer>(
 		    device,
 		    build_sizes_info.accelerationStructureSize,
-		    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+		    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 		    VMA_MEMORY_USAGE_GPU_ONLY);
 
 		VkAccelerationStructureCreateInfoKHR acceleration_structure_create_info{};

--- a/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
+++ b/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
@@ -272,7 +272,7 @@ void RaytracingBasic::create_bottom_level_acceleration_structure()
 	bottom_level_acceleration_structure.buffer = std::make_unique<vkb::core::Buffer>(
 	    get_device(),
 	    acceleration_structure_build_sizes_info.accelerationStructureSize,
-	    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+	    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 	    VMA_MEMORY_USAGE_GPU_ONLY);
 
 	// Create the acceleration structure
@@ -383,7 +383,7 @@ void RaytracingBasic::create_top_level_acceleration_structure()
 	top_level_acceleration_structure.buffer = std::make_unique<vkb::core::Buffer>(
 	    get_device(),
 	    acceleration_structure_build_sizes_info.accelerationStructureSize,
-	    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+	    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 	    VMA_MEMORY_USAGE_GPU_ONLY);
 
 	// Create the acceleration structure

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -473,7 +473,7 @@ void RaytracingExtended::create_bottom_level_acceleration_structure(bool is_upda
 			bottom_level_acceleration_structure.buffer = std::make_unique<vkb::core::Buffer>(
 			    get_device(),
 			    model_buffer.buildSize.accelerationStructureSize,
-			    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+			    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 			    VMA_MEMORY_USAGE_GPU_ONLY);
 		}
 		if (!is_update && bottom_level_acceleration_structure.handle == nullptr)
@@ -698,7 +698,7 @@ void RaytracingExtended::create_top_level_acceleration_structure(bool print_time
 		top_level_acceleration_structure.buffer = std::make_unique<vkb::core::Buffer>(
 		    get_device(),
 		    acceleration_structure_build_sizes_info.accelerationStructureSize,
-		    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+		    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 		    VMA_MEMORY_USAGE_GPU_ONLY);
 	}
 

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
@@ -257,7 +257,7 @@ void RaytracingReflection::create_bottom_level_acceleration_structure(ObjModelGp
 
 	// Create a buffer to hold the acceleration structure
 	AccelerationStructure blas;
-	blas.buffer = std::make_unique<vkb::core::Buffer>(get_device(), acceleration_structure_build_sizes_info.accelerationStructureSize, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR, VMA_MEMORY_USAGE_GPU_ONLY);
+	blas.buffer = std::make_unique<vkb::core::Buffer>(get_device(), acceleration_structure_build_sizes_info.accelerationStructureSize, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VMA_MEMORY_USAGE_GPU_ONLY);
 
 	// Create the acceleration structure
 	VkAccelerationStructureCreateInfoKHR acceleration_structure_create_info{VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR};
@@ -348,7 +348,7 @@ void RaytracingReflection::create_top_level_acceleration_structure(std::vector<V
 	top_level_acceleration_structure.buffer = std::make_unique<vkb::core::Buffer>(
 	    get_device(),
 	    acceleration_structure_build_sizes_info.accelerationStructureSize,
-	    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+	    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 	    VMA_MEMORY_USAGE_GPU_ONLY);
 
 	// Create the acceleration structure


### PR DESCRIPTION
## Description

The ray tracing samples were missing the `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` for the bottom/top level acceleration structures. This resulted in validation layer errors for all ray tracing samples. This PR adds that missing flag, cleaning up validation.

Tested on Windows 11 with an NVIDIDA RTX 4070

Fixes #948

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)