### PR TITLE
Don't implicitly enable dedicated memory allocation

### DIFF
--- a/framework/core/allocated.h
+++ b/framework/core/allocated.h
@@ -141,7 +141,7 @@ void init(const DeviceType &device)
 
 	bool can_get_memory_requirements = device.is_extension_supported(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
 	bool has_dedicated_allocation    = device.is_extension_supported(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
-	if (can_get_memory_requirements && has_dedicated_allocation)
+	if (can_get_memory_requirements && has_dedicated_allocation && device.is_enabled(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME))
 	{
 		allocator_info.flags |= VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
 	}

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -112,8 +112,6 @@ std::unique_ptr<vkb::Device> Profiles::create_device(vkb::PhysicalDevice &gpu)
 	device->create_internal_fence_pool();
 
 	return device;
-
-	return device;
 }
 
 // This sample overrides the instance creation part of the framework


### PR DESCRIPTION
## Description

For whatever reason the framework **implicitly** enables dedicated memory allocation if the extension is present.  It's the only memory related feature that we implicitly enabled, unlike all other features that are only enabled if the required extension is actually requested by the sample. see https://github.com/KhronosGroup/Vulkan-Samples/blob/main/framework/core/allocated.h#L144

This seems to have been introduced recently and broke the profiles sample.

This PR changes this behavior and enables dedicated memory allocations only if the extension is actually requested (which isn't the case for any samples btw). In general I'm not a fan of implicitly enabled things for samples that show how to use an explicit api like Vulkan.

This fixes the profiles sample.

Fixes #1008

Did a batch run on Windows 11 with an RTX 4070 and saw no errors. Sadly batch run failed at some point as some samples on main are simply broken.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)