### PR TITLE
Make sampler creation optional when loading textures

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -976,7 +976,7 @@ VkDescriptorImageInfo ApiVulkanSample::create_descriptor(Texture &texture, VkDes
 	return descriptor;
 }
 
-Texture ApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler = true)
+Texture ApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler)
 {
 	Texture texture{};
 
@@ -1075,7 +1075,7 @@ Texture ApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::C
 	return texture;
 }
 
-Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler = true)
+Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler)
 {
 	Texture texture{};
 
@@ -1177,7 +1177,7 @@ Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Im
 	return texture;
 }
 
-Texture ApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler = true)
+Texture ApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler)
 {
 	Texture texture{};
 

--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -976,7 +976,7 @@ VkDescriptorImageInfo ApiVulkanSample::create_descriptor(Texture &texture, VkDes
 	return descriptor;
 }
 
-Texture ApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::ContentType content_type)
+Texture ApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler = true)
 {
 	Texture texture{};
 
@@ -1046,33 +1046,36 @@ Texture ApiVulkanSample::load_texture(const std::string &file, vkb::sg::Image::C
 	VkSamplerMipmapMode mipmap_mode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
 	vkb::make_filters_valid(get_device().get_gpu().get_handle(), texture.image->get_format(), &filter, &mipmap_mode);
 
-	// Create a defaultsampler
-	VkSamplerCreateInfo sampler_create_info = {};
-	sampler_create_info.sType               = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-	sampler_create_info.magFilter           = filter;
-	sampler_create_info.minFilter           = filter;
-	sampler_create_info.mipmapMode          = mipmap_mode;
-	sampler_create_info.addressModeU        = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-	sampler_create_info.addressModeV        = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-	sampler_create_info.addressModeW        = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-	sampler_create_info.mipLodBias          = 0.0f;
-	sampler_create_info.compareOp           = VK_COMPARE_OP_NEVER;
-	sampler_create_info.minLod              = 0.0f;
-	// Max level-of-detail should match mip level count
-	sampler_create_info.maxLod = static_cast<float>(mipmaps.size());
-	// Only enable anisotropic filtering if enabled on the device
-	// Note that for simplicity, we will always be using max. available anisotropy level for the current device
-	// This may have an impact on performance, esp. on lower-specced devices
-	// In a real-world scenario the level of anisotropy should be a user setting or e.g. lowered for mobile devices by default
-	sampler_create_info.maxAnisotropy    = get_device().get_gpu().get_requested_features().samplerAnisotropy ? (get_device().get_gpu().get_properties().limits.maxSamplerAnisotropy) : 1.0f;
-	sampler_create_info.anisotropyEnable = get_device().get_gpu().get_requested_features().samplerAnisotropy;
-	sampler_create_info.borderColor      = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-	VK_CHECK(vkCreateSampler(get_device().get_handle(), &sampler_create_info, nullptr, &texture.sampler));
+	if (create_sampler)
+	{
+		// Create a default sampler
+		VkSamplerCreateInfo sampler_create_info = {};
+		sampler_create_info.sType               = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+		sampler_create_info.magFilter           = filter;
+		sampler_create_info.minFilter           = filter;
+		sampler_create_info.mipmapMode          = mipmap_mode;
+		sampler_create_info.addressModeU        = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+		sampler_create_info.addressModeV        = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+		sampler_create_info.addressModeW        = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+		sampler_create_info.mipLodBias          = 0.0f;
+		sampler_create_info.compareOp           = VK_COMPARE_OP_NEVER;
+		sampler_create_info.minLod              = 0.0f;
+		// Max level-of-detail should match mip level count
+		sampler_create_info.maxLod = static_cast<float>(mipmaps.size());
+		// Only enable anisotropic filtering if enabled on the device
+		// Note that for simplicity, we will always be using max. available anisotropy level for the current device
+		// This may have an impact on performance, esp. on lower-specced devices
+		// In a real-world scenario the level of anisotropy should be a user setting or e.g. lowered for mobile devices by default
+		sampler_create_info.maxAnisotropy    = get_device().get_gpu().get_requested_features().samplerAnisotropy ? (get_device().get_gpu().get_properties().limits.maxSamplerAnisotropy) : 1.0f;
+		sampler_create_info.anisotropyEnable = get_device().get_gpu().get_requested_features().samplerAnisotropy;
+		sampler_create_info.borderColor      = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+		VK_CHECK(vkCreateSampler(get_device().get_handle(), &sampler_create_info, nullptr, &texture.sampler));
+	}
 
 	return texture;
 }
 
-Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type)
+Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler = true)
 {
 	Texture texture{};
 
@@ -1148,30 +1151,33 @@ Texture ApiVulkanSample::load_texture_array(const std::string &file, vkb::sg::Im
 	VkSamplerMipmapMode mipmap_mode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
 	vkb::make_filters_valid(get_device().get_gpu().get_handle(), texture.image->get_format(), &filter, &mipmap_mode);
 
-	// Create a defaultsampler
-	VkSamplerCreateInfo sampler_create_info = {};
-	sampler_create_info.sType               = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-	sampler_create_info.magFilter           = filter;
-	sampler_create_info.minFilter           = filter;
-	sampler_create_info.mipmapMode          = mipmap_mode;
-	sampler_create_info.addressModeU        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	sampler_create_info.addressModeV        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	sampler_create_info.addressModeW        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	sampler_create_info.mipLodBias          = 0.0f;
-	sampler_create_info.compareOp           = VK_COMPARE_OP_NEVER;
-	sampler_create_info.minLod              = 0.0f;
-	// Max level-of-detail should match mip level count
-	sampler_create_info.maxLod = static_cast<float>(mipmaps.size());
-	// Only enable anisotropic filtering if enabled on the devicec
-	sampler_create_info.maxAnisotropy    = get_device().get_gpu().get_features().samplerAnisotropy ? get_device().get_gpu().get_properties().limits.maxSamplerAnisotropy : 1.0f;
-	sampler_create_info.anisotropyEnable = get_device().get_gpu().get_features().samplerAnisotropy;
-	sampler_create_info.borderColor      = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-	VK_CHECK(vkCreateSampler(get_device().get_handle(), &sampler_create_info, nullptr, &texture.sampler));
+	if (create_sampler)
+	{
+		// Create a default sampler
+		VkSamplerCreateInfo sampler_create_info = {};
+		sampler_create_info.sType               = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+		sampler_create_info.magFilter           = filter;
+		sampler_create_info.minFilter           = filter;
+		sampler_create_info.mipmapMode          = mipmap_mode;
+		sampler_create_info.addressModeU        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampler_create_info.addressModeV        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampler_create_info.addressModeW        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampler_create_info.mipLodBias          = 0.0f;
+		sampler_create_info.compareOp           = VK_COMPARE_OP_NEVER;
+		sampler_create_info.minLod              = 0.0f;
+		// Max level-of-detail should match mip level count
+		sampler_create_info.maxLod = static_cast<float>(mipmaps.size());
+		// Only enable anisotropic filtering if enabled on the devicec
+		sampler_create_info.maxAnisotropy    = get_device().get_gpu().get_features().samplerAnisotropy ? get_device().get_gpu().get_properties().limits.maxSamplerAnisotropy : 1.0f;
+		sampler_create_info.anisotropyEnable = get_device().get_gpu().get_features().samplerAnisotropy;
+		sampler_create_info.borderColor      = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+		VK_CHECK(vkCreateSampler(get_device().get_handle(), &sampler_create_info, nullptr, &texture.sampler));
+	}
 
 	return texture;
 }
 
-Texture ApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type)
+Texture ApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler = true)
 {
 	Texture texture{};
 
@@ -1247,25 +1253,28 @@ Texture ApiVulkanSample::load_texture_cubemap(const std::string &file, vkb::sg::
 	VkSamplerMipmapMode mipmap_mode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
 	vkb::make_filters_valid(get_device().get_gpu().get_handle(), texture.image->get_format(), &filter, &mipmap_mode);
 
-	// Create a defaultsampler
-	VkSamplerCreateInfo sampler_create_info = {};
-	sampler_create_info.sType               = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-	sampler_create_info.magFilter           = filter;
-	sampler_create_info.minFilter           = filter;
-	sampler_create_info.mipmapMode          = mipmap_mode;
-	sampler_create_info.addressModeU        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	sampler_create_info.addressModeV        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	sampler_create_info.addressModeW        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	sampler_create_info.mipLodBias          = 0.0f;
-	sampler_create_info.compareOp           = VK_COMPARE_OP_NEVER;
-	sampler_create_info.minLod              = 0.0f;
-	// Max level-of-detail should match mip level count
-	sampler_create_info.maxLod = static_cast<float>(mipmaps.size());
-	// Only enable anisotropic filtering if enabled on the devicec
-	sampler_create_info.maxAnisotropy    = get_device().get_gpu().get_features().samplerAnisotropy ? get_device().get_gpu().get_properties().limits.maxSamplerAnisotropy : 1.0f;
-	sampler_create_info.anisotropyEnable = get_device().get_gpu().get_features().samplerAnisotropy;
-	sampler_create_info.borderColor      = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-	VK_CHECK(vkCreateSampler(get_device().get_handle(), &sampler_create_info, nullptr, &texture.sampler));
+	if (create_sampler)
+	{
+		// Create a default sampler
+		VkSamplerCreateInfo sampler_create_info = {};
+		sampler_create_info.sType               = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+		sampler_create_info.magFilter           = filter;
+		sampler_create_info.minFilter           = filter;
+		sampler_create_info.mipmapMode          = mipmap_mode;
+		sampler_create_info.addressModeU        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampler_create_info.addressModeV        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampler_create_info.addressModeW        = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampler_create_info.mipLodBias          = 0.0f;
+		sampler_create_info.compareOp           = VK_COMPARE_OP_NEVER;
+		sampler_create_info.minLod              = 0.0f;
+		// Max level-of-detail should match mip level count
+		sampler_create_info.maxLod = static_cast<float>(mipmaps.size());
+		// Only enable anisotropic filtering if enabled on the devicec
+		sampler_create_info.maxAnisotropy    = get_device().get_gpu().get_features().samplerAnisotropy ? get_device().get_gpu().get_properties().limits.maxSamplerAnisotropy : 1.0f;
+		sampler_create_info.anisotropyEnable = get_device().get_gpu().get_features().samplerAnisotropy;
+		sampler_create_info.borderColor      = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+		VK_CHECK(vkCreateSampler(get_device().get_handle(), &sampler_create_info, nullptr, &texture.sampler));
+	}
 
 	return texture;
 }

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -58,7 +58,7 @@ struct SwapchainBuffer
 struct Texture
 {
 	std::unique_ptr<vkb::sg::Image> image;
-	VkSampler                       sampler;
+	VkSampler                       sampler{VK_NULL_HANDLE};
 };
 
 /**
@@ -213,22 +213,25 @@ class ApiVulkanSample : public vkb::VulkanSample<vkb::BindingType::C>
 	 * @brief Loads in a ktx 2D texture
 	 * @param file The filename of the texture to load
 	 * @param content_type The type of content in the image file
+	 * @param create_sampler If true, a default sampler for this image is created
 	 */
-	Texture load_texture(const std::string &file, vkb::sg::Image::ContentType content_type);
+	Texture load_texture(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler = true);
 
 	/**
 	 * @brief Loads in a ktx 2D texture array
 	 * @param file The filename of the texture to load
 	 * @param content_type The type of content in the image file
+	 * @param create_sampler If true, a default sampler for this image is created
 	 */
-	Texture load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type);
+	Texture load_texture_array(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler = true);
 
 	/**
 	 * @brief Loads in a ktx 2D texture cubemap
 	 * @param file The filename of the texture to load
 	 * @param content_type The type of content in the image file
+	 * @param create_sampler If true, a default sampler for this image is created
 	 */
-	Texture load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type);
+	Texture load_texture_cubemap(const std::string &file, vkb::sg::Image::ContentType content_type, bool create_sampler = true);
 
 	/**
 	 * @brief Loads in a single model from a GLTF file

--- a/samples/api/terrain_tessellation/terrain_tessellation.cpp
+++ b/samples/api/terrain_tessellation/terrain_tessellation.cpp
@@ -148,7 +148,6 @@ void TerrainTessellation::load_assets()
 	vkb::make_filters_valid(get_device().get_gpu().get_handle(), textures.heightmap.image->get_format(), &filter, &mipmap_mode);
 
 	// Setup a mirroring sampler for the height map
-	vkDestroySampler(get_device().get_handle(), textures.heightmap.sampler, nullptr);
 	sampler_create_info.magFilter    = filter;
 	sampler_create_info.minFilter    = filter;
 	sampler_create_info.mipmapMode   = mipmap_mode;
@@ -166,7 +165,6 @@ void TerrainTessellation::load_assets()
 	vkb::make_filters_valid(get_device().get_gpu().get_handle(), textures.terrain_array.image->get_format(), &filter, &mipmap_mode);
 
 	// Setup a repeating sampler for the terrain texture layers
-	vkDestroySampler(get_device().get_handle(), textures.terrain_array.sampler, nullptr);
 	sampler_create_info              = vkb::initializers::sampler_create_info();
 	sampler_create_info.magFilter    = filter;
 	sampler_create_info.minFilter    = filter;

--- a/samples/extensions/shader_object/shader_object.cpp
+++ b/samples/extensions/shader_object/shader_object.cpp
@@ -402,10 +402,10 @@ void ShaderObject::load_assets()
 	checkerboard_texture = load_texture("textures/checkerboard_rgba.ktx", vkb::sg::Image::Color);
 
 	// Terrain textures are stored in a texture array with layers corresponding to terrain height
-	terrain_array_textures = load_texture_array("textures/terrain_texturearray_rgba.ktx", vkb::sg::Image::Color);
+	terrain_array_textures = load_texture_array("textures/terrain_texturearray_rgba.ktx", vkb::sg::Image::Color, false);
 
 	// Height data is stored in a one-channel texture
-	heightmap_texture = load_texture("textures/terrain_heightmap_r16.ktx", vkb::sg::Image::Other);
+	heightmap_texture = load_texture("textures/terrain_heightmap_r16.ktx", vkb::sg::Image::Other, false);
 
 	// Calculate valid filter and mipmap modes
 	VkFilter            filter      = VK_FILTER_LINEAR;
@@ -415,7 +415,6 @@ void ShaderObject::load_assets()
 	VkSamplerCreateInfo sampler_create_info = vkb::initializers::sampler_create_info();
 
 	// Setup a mirroring sampler for the height map
-	vkDestroySampler(get_device().get_handle(), heightmap_texture.sampler, nullptr);
 	sampler_create_info.magFilter    = filter;
 	sampler_create_info.minFilter    = filter;
 	sampler_create_info.mipmapMode   = mipmap_mode;
@@ -433,7 +432,6 @@ void ShaderObject::load_assets()
 	vkb::make_filters_valid(get_device().get_gpu().get_handle(), terrain_array_textures.image->get_format(), &filter, &mipmap_mode);
 
 	// Setup a repeating sampler for the terrain texture layers
-	vkDestroySampler(get_device().get_handle(), terrain_array_textures.sampler, nullptr);
 	sampler_create_info              = vkb::initializers::sampler_create_info();
 	sampler_create_info.magFilter    = filter;
 	sampler_create_info.minFilter    = filter;


### PR DESCRIPTION
## Description

This PR adds a new argument to the texture loading functions of the api samples base class that allows to skip default sampler creation. With this change samples that use custom samplers for certain textures (shader object, terrain tessellation) no longer need to delete the sampler that would've been implicitly created when loading the texture. This results in cleaner, easier to understand code.

Fixes #866

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)