### PR TITLE
Fix screenshot path for dynamic primitive clipping sample

### DIFF
--- a/samples/extensions/dynamic_primitive_clipping/README.adoc
+++ b/samples/extensions/dynamic_primitive_clipping/README.adoc
@@ -23,7 +23,7 @@ ifdef::site-gen-antora[]
 TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/dynamic_primitive_clipping[Khronos Vulkan samples github repository].
 endif::[]
 
-image::screenshot.png[]
+image::./screenshot.png[]
 
 == Overview
 


### PR DESCRIPTION
Fix Antora build

## Description

Fixes the screenshot path for the dynamic primitive clipping sample which would result in an error when building the Antora site and a missing screenshot on the documentation site.

Note: This is a pure documentation fix.

Fixes #1028

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)