### PR TITLE
Add missing checks in ~ImageView() and ~RenderPass(); adjust loading in multi_draw_indirect

### DIFF
--- a/framework/core/image_view.cpp
+++ b/framework/core/image_view.cpp
@@ -82,7 +82,10 @@ ImageView::ImageView(ImageView &&other) :
 
 ImageView::~ImageView()
 {
-	vkDestroyImageView(get_device().get_handle(), get_handle(), nullptr);
+	if (has_device())
+	{
+		vkDestroyImageView(get_device().get_handle(), get_handle(), nullptr);
+	}
 }
 
 const Image &ImageView::get_image() const

--- a/framework/core/render_pass.cpp
+++ b/framework/core/render_pass.cpp
@@ -486,7 +486,10 @@ RenderPass::RenderPass(RenderPass &&other) :
 RenderPass::~RenderPass()
 {
 	// Destroy render pass
-	vkDestroyRenderPass(get_device().get_handle(), get_handle(), nullptr);
+	if (has_device())
+	{
+		vkDestroyRenderPass(get_device().get_handle(), get_handle(), nullptr);
+	}
 }
 
 const uint32_t RenderPass::get_color_output_count(uint32_t subpass_index) const

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -310,13 +310,11 @@ bool MultiDrawIndirect::prepare(const vkb::ApplicationOptions &options)
 
 void MultiDrawIndirect::load_scene()
 {
-	assert(has_device());
-	vkb::GLTFLoader   loader{get_device()};
 	const std::string scene_path = "scenes/vokselia/";
-	auto              scene      = loader.read_scene_from_file(scene_path + "vokselia.gltf");
+	ApiVulkanSample::load_scene(scene_path + "vokselia.gltf");
 
 	assert(has_scene());
-	for (auto &&mesh : scene->get_components<vkb::sg::Mesh>())
+	for (auto &&mesh : get_scene().get_components<vkb::sg::Mesh>())
 	{
 		const size_t texture_index = textures.size();
 		const auto  &short_name    = mesh->get_name();


### PR DESCRIPTION
## Description

Re-add checks in ImageView and RenderPass destructors;
Adjust scene loading sequence in sample multi_draw_indirect.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Fixes #1024

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
