### PR TITLE
Fix wrong swapchain creation in performance sample wait_idle

### DIFF
--- a/framework/core/hpp_swapchain.cpp
+++ b/framework/core/hpp_swapchain.cpp
@@ -309,15 +309,14 @@ HPPSwapchain::HPPSwapchain(HPPDevice                               &device,
 	// Chose best properties based on surface capabilities
 	vk::SurfaceCapabilitiesKHR const surface_capabilities = device.get_gpu().get_handle().getSurfaceCapabilitiesKHR(surface);
 
-	vk::FormatProperties const format_properties = device.get_gpu().get_handle().getFormatProperties(properties.surface_format.format);
-	this->image_usage_flags                      = choose_image_usage(image_usage_flags, surface_capabilities.supportedUsageFlags, format_properties.optimalTilingFeatures);
-
 	properties.image_count     = clamp(image_count,
 	                                   surface_capabilities.minImageCount,
                                    surface_capabilities.maxImageCount ? surface_capabilities.maxImageCount : std::numeric_limits<uint32_t>::max());
-	properties.extent          = choose_extent(extent, surface_capabilities.minImageExtent, surface_capabilities.maxImageExtent, surface_capabilities.currentExtent);
-	properties.array_layers    = 1;
-	properties.surface_format  = choose_surface_format(properties.surface_format, surface_formats, surface_format_priority_list);
+	properties.extent                            = choose_extent(extent, surface_capabilities.minImageExtent, surface_capabilities.maxImageExtent, surface_capabilities.currentExtent);
+	properties.array_layers                      = 1;
+	properties.surface_format                    = choose_surface_format(properties.surface_format, surface_formats, surface_format_priority_list);
+	vk::FormatProperties const format_properties = device.get_gpu().get_handle().getFormatProperties(properties.surface_format.format);
+	this->image_usage_flags                      = choose_image_usage(image_usage_flags, surface_capabilities.supportedUsageFlags, format_properties.optimalTilingFeatures);
 	properties.image_usage     = composite_image_flags(this->image_usage_flags);
 	properties.pre_transform   = choose_transform(transform, surface_capabilities.supportedTransforms, surface_capabilities.currentTransform);
 	properties.composite_alpha = choose_composite_alpha(vk::CompositeAlphaFlagBitsKHR::eInherit, surface_capabilities.supportedCompositeAlpha);

--- a/samples/performance/wait_idle/wait_idle.cpp
+++ b/samples/performance/wait_idle/wait_idle.cpp
@@ -62,10 +62,9 @@ bool WaitIdle::prepare(const vkb::ApplicationOptions &options)
 	return true;
 }
 
-void WaitIdle::prepare_render_context()
+void WaitIdle::create_render_context()
 {
 	set_render_context(std::make_unique<CustomRenderContext>(get_device(), get_surface(), *window, wait_idle_enabled));
-	VulkanSample::prepare_render_context();
 }
 
 WaitIdle::CustomRenderContext::CustomRenderContext(vkb::Device &device, VkSurfaceKHR surface, const vkb::Window &window, int &wait_idle_enabled) :

--- a/samples/performance/wait_idle/wait_idle.h
+++ b/samples/performance/wait_idle/wait_idle.h
@@ -46,7 +46,7 @@ class WaitIdle : public vkb::VulkanSample<vkb::BindingType::C>
 		int &wait_idle_enabled;
 	};
 
-	virtual void prepare_render_context() override;
+	virtual void create_render_context() override;
 
   private:
 	vkb::sg::PerspectiveCamera *camera{nullptr};


### PR DESCRIPTION
## Description

The fixed error consisted of two half-errors, one probably due to some defective rebasing of #703, which got visible with #910, where the new constructors of HPPSwapchain were actually used the first time.
The second part was a missing adjustment of the wait_idle sample itself to how a RenderContext is supposed to be created and prepared since #910.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Fixes #1033

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
