### PR TITLE
Reduce updating frequency for fps in GUI.

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -441,7 +441,16 @@ void ApiVulkanSample::update_overlay(float delta_time, const std::function<void(
 {
 	if (has_gui())
 	{
-		get_gui().show_simple_window(get_name(), vkb::to_u32(1.0f / delta_time), [this, additional_ui]() {
+		frame_count++;
+		accumulated_time += delta_time;
+		if (0.5f < accumulated_time)
+		{
+			fps              = static_cast<uint32_t>(frame_count / accumulated_time);
+			frame_count      = 0;
+			accumulated_time = 0.0f;
+		}
+
+		get_gui().show_simple_window(get_name(), fps, [this, additional_ui]() {
 			on_update_ui_overlay(get_gui().get_drawer());
 			additional_ui();
 		});

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -451,4 +451,8 @@ class ApiVulkanSample : public vkb::VulkanSample<vkb::BindingType::C>
 	} touch_pos;
 	bool   touch_down  = false;
 	double touch_timer = 0.0;
+
+	uint32_t frame_count      = 0;
+	float    accumulated_time = 0.0f;
+	uint32_t fps              = 1;        // to prevent division by zero on first frame
 };

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -417,7 +417,16 @@ void HPPApiVulkanSample::update_overlay(float delta_time, const std::function<vo
 {
 	if (has_gui())
 	{
-		get_gui().show_simple_window(get_name(), vkb::to_u32(1.0f / delta_time), [this, additional_ui]() { on_update_ui_overlay(get_gui().get_drawer()); });
+		frame_count++;
+		accumulated_time += delta_time;
+		if (0.5f < accumulated_time)
+		{
+			fps              = static_cast<uint32_t>(frame_count / accumulated_time);
+			frame_count      = 0;
+			accumulated_time = 0.0f;
+		}
+
+		get_gui().show_simple_window(get_name(), fps, [this, additional_ui]() { on_update_ui_overlay(get_gui().get_drawer()); });
 
 		get_gui().update(delta_time);
 

--- a/framework/hpp_api_vulkan_sample.h
+++ b/framework/hpp_api_vulkan_sample.h
@@ -406,4 +406,8 @@ class HPPApiVulkanSample : public vkb::VulkanSample<vkb::BindingType::Cpp>
 	} touch_pos;
 	bool   touch_down  = false;
 	double touch_timer = 0.0;
+
+	uint32_t frame_count      = 0;
+	float    accumulated_time = 0.0f;
+	uint32_t fps              = 1;        // to prevent division by zero on first frame
 };


### PR DESCRIPTION
## Description

Currently, the fps information in the GUI is hard to read, as it's changing to often.
With this change, the fps is updated only after at least half a second.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
