### PR TITLE
Fixes command buffer used for blit command

### DIFF
--- a/samples/api/hpp_texture_mipmap_generation/hpp_texture_mipmap_generation.cpp
+++ b/samples/api/hpp_texture_mipmap_generation/hpp_texture_mipmap_generation.cpp
@@ -313,18 +313,18 @@ void HPPTextureMipMapGeneration::load_assets()
 		// Prepare current mip level as image blit destination
 		vk::ImageSubresourceRange image_subresource_range(vk::ImageAspectFlagBits::eColor, i, 1, 0, 1);
 		vkb::common::image_layout_transition(
-		    copy_command, texture.image, vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, image_subresource_range);
+		    blit_command, texture.image, vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, image_subresource_range);
 
 		// Blit from previous level
 		blit_command.blitImage(texture.image, vk::ImageLayout::eTransferSrcOptimal, texture.image, vk::ImageLayout::eTransferDstOptimal, image_blit, vk::Filter::eLinear);
 
 		// Prepare current mip level as image blit source for next level
 		vkb::common::image_layout_transition(
-		    copy_command, texture.image, vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eTransferSrcOptimal, image_subresource_range);
+		    blit_command, texture.image, vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eTransferSrcOptimal, image_subresource_range);
 	}
 
 	// After the loop, all mip layers are in TRANSFER_SRC layout, so transition all to SHADER_READ
-	vkb::common::image_layout_transition(copy_command,
+	vkb::common::image_layout_transition(blit_command,
 	                                     texture.image,
 	                                     vk::ImageLayout::eTransferSrcOptimal,
 	                                     vk::ImageLayout::eShaderReadOnlyOptimal,


### PR DESCRIPTION
## Description

Command buffer being used was already freed, in the hpp_texture_mipmap_generation sample.
Change to use the probably intended command buffer target instead.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
