### PR TITLE
Fix requested_stats_count value cause no performance counters working

### DIFF
--- a/framework/stats/hwcpipe_stats_provider.cpp
+++ b/framework/stats/hwcpipe_stats_provider.cpp
@@ -138,7 +138,7 @@ HWCPipeStatsProvider::HWCPipeStatsProvider(std::set<StatIndex> &requested_stats)
 		requested_stats.erase(iter.first);
 	}
 
-	requested_stats_count = requested_stats.size();
+	requested_stats_count = stat_data.size();
 
 	sampler = std::make_unique<hwcpipe::sampler<>>(config);
 

--- a/framework/stats/hwcpipe_stats_provider.cpp
+++ b/framework/stats/hwcpipe_stats_provider.cpp
@@ -138,11 +138,11 @@ HWCPipeStatsProvider::HWCPipeStatsProvider(std::set<StatIndex> &requested_stats)
 		requested_stats.erase(iter.first);
 	}
 
-	requested_stats_count = stat_data.size();
+	stat_data_count = stat_data.size();
 
 	sampler = std::make_unique<hwcpipe::sampler<>>(config);
 
-	if (requested_stats_count > 0)
+	if (stat_data_count > 0)
 	{
 		ec = sampler->start_sampling();
 		if (ec)
@@ -156,7 +156,7 @@ HWCPipeStatsProvider::~HWCPipeStatsProvider()
 {
 	std::error_code ec;
 
-	if (requested_stats_count > 0)
+	if (stat_data_count > 0)
 	{
 		ec = sampler->stop_sampling();
 		if (ec)
@@ -204,7 +204,7 @@ StatsProvider::Counters HWCPipeStatsProvider::sample(float delta_time)
 {
 	Counters res;
 
-	if (requested_stats_count < 1)
+	if (stat_data_count < 1)
 	{
 		return res;
 	}

--- a/framework/stats/hwcpipe_stats_provider.h
+++ b/framework/stats/hwcpipe_stats_provider.h
@@ -91,7 +91,7 @@ class HWCPipeStatsProvider : public StatsProvider
   private:
 	std::unique_ptr<hwcpipe::sampler<>> sampler;
 
-	size_t requested_stats_count{0};
+	size_t stat_data_count{0};
 
 	// Only stats which are available and were requested end up in stat_data
 	StatDataMap stat_data;


### PR DESCRIPTION
## Description

I found out that all HWCPipe counters not working when I downloaded the newest vulkan samples, and then i found out why and fixed it.
![wrong](https://github.com/KhronosGroup/Vulkan-Samples/assets/43629195/c3beda1d-f61f-46f9-9592-b8241c61164c)
![fixed](https://github.com/KhronosGroup/Vulkan-Samples/assets/43629195/41ffd6d4-f3ea-46b8-a30b-0f4d0cb51f68)

Fixes #1053

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
