### PR TITLE
Fixes for timeline semaphore

### DIFF
--- a/samples/extensions/timeline_semaphore/CMakeLists.txt
+++ b/samples/extensions/timeline_semaphore/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Arm Limited and Contributors
+# Copyright (c) 2021-2024, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -15,24 +15,19 @@
 # limitations under the License.
 #
 
-if (NOT WIN32)
-    # Not enabled on Windows at this time due to bugs.
-    # Out-of-order submission in presentation causes kernel level issues,
-    # and need to be figured out before this sample can be enabled on Windows.
-    get_filename_component(FOLDER_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
-    get_filename_component(PARENT_DIR ${CMAKE_CURRENT_LIST_DIR} PATH)
-    get_filename_component(CATEGORY_NAME ${PARENT_DIR} NAME)
+get_filename_component(FOLDER_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+get_filename_component(PARENT_DIR ${CMAKE_CURRENT_LIST_DIR} PATH)
+get_filename_component(CATEGORY_NAME ${PARENT_DIR} NAME)
 
-    add_sample_with_tags(
-            ID ${FOLDER_NAME}
-            CATEGORY ${CATEGORY_NAME}
-            AUTHOR "Hans-Kristian Arntzen"
-            NAME "Timeline semaphore"
-            DESCRIPTION "Demonstrates use of timeline semaphores to express complex queue dependency graphs"
-            SHADER_FILES_GLSL            
-                "timeline_semaphore/game_of_life_update.comp"
-                "timeline_semaphore/game_of_life_mutate.comp"
-                "timeline_semaphore/game_of_life_init.comp"
-                "timeline_semaphore/render.vert"
-                "timeline_semaphore/render.frag")
-endif()
+add_sample_with_tags(
+        ID ${FOLDER_NAME}
+        CATEGORY ${CATEGORY_NAME}
+        AUTHOR "Hans-Kristian Arntzen"
+        NAME "Timeline semaphore"
+        DESCRIPTION "Demonstrates use of timeline semaphores to express complex queue dependency graphs"
+        SHADER_FILES_GLSL
+            "timeline_semaphore/game_of_life_update.comp"
+            "timeline_semaphore/game_of_life_mutate.comp"
+            "timeline_semaphore/game_of_life_init.comp"
+            "timeline_semaphore/render.vert"
+            "timeline_semaphore/render.frag")

--- a/samples/extensions/timeline_semaphore/README.adoc
+++ b/samples/extensions/timeline_semaphore/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2021-2023, Arm Limited and Contributors
+- Copyright (c) 2021-2024, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -189,69 +189,63 @@ This sample could trivially be done with binary semaphores of course, so in this
 
 === Async worker thread - out-of-order submission
 
-The key aspect we use to demonstrate out of order submission is a dedicated worker thread which does all work related to simulation on the async compute queue.
-It never synchronizes with the main thread except at teardown, so the only way it synchronizes is through timeline semaphores.
-Submission order is completely out-of-order in this case and forward progress in the async queue is generally blocked by the main thread submitting more work.
+The key aspects we use to demonstrate out of order submission are dedicated workers thread which perform all work related to simulation on the async compute queue, and drawing on the graphics queue.
+They never synchronize with the main thread except at teardown, so the only way to synchronize them is through timeline semaphores.
+To avoid issues when running the sample on Windows platforms (particularly when resizing the window), forward progress in the queues is throttled by the main thread (i.e. only allowing the timeline to advance
+when a render call is active).
+
 
 === Data flow
 
 To simulate "Game of Life", we allocate two images of 64x64 RGBA8.
 First, one image is initialized with initial state, and from here there is a ping-pong where image N is updated, while reading from image 1 - N.
-
 After updating image N, the main thread will sample from image N.
-Before async compute updates the same image index N again, it must wait for graphics queue to complete.
-With the double buffer in play, the async queue can run ahead for a little while and it will be mostly stalled by graphics queue.
 
-The sequential flow of the rendering is something like, assuming two timeline semaphores A and G:
+The sequential flow of the rendering is something like:
 
-* Async compute write image 1.
-* Async compute signal A = 1.
-* Graphics wait A = 1.
-* Graphics read image 1.
-* Graphics signal G = 1.
-* Async compute wait A = 1.
-(Could use pipeline barrier of course, but hey!)
-* Async compute write image 0.
-* Async compute signal A = 2.
-* Graphics wait A = 2.
-* Graphics read image 0.
-* Graphics signal G = 2.
-* Async compute wait G = 1.
-(Resolve write-after-read hazard)
-* Async compute wait A = 2.
-(Could use pipeline barrier of course, but hey!)
-* Async compute wait host A = 1.
-(Wait for command buffer to retire so we can re-record it!)
-* Async compute write image 1.
-* Async compute signal A = 3.
-* Graphics wait A = 3.
-* Graphics read image 1.
-* Graphics signal G = 3.
+* Compute thread waits for "prepare"
+* Graphics thread waits for prepare
+* Main thread signals "prepare"
+* Main thread acquires the next swapchain image
+* Compute thread prepares command buffer
+* Compute thread waits on "submit"
+* Graphics thread prepares command buffer
+* Graphics thread waits on "submit"
+* Main thread signals "submit"
+* Main thread waits for "present"
+* Compute thread writes image
+* Compute thread signals "draw"
+* Compute thread waits for next frame
+* Graphics thread reads image
+* Graphics thread signals "present"
+* Graphics thread waits for next frame
+* Main thread presents swapchain
+* Main thread signals "end of frame"
+* Compute thread waits for "prepare"
+* Graphics thread waits for prepare
 
 And so on ...
 With out of order signal, we can end up observing this order of submissions instead.
 
-* Async compute write image 1.
-* Async compute signal A = 1.
-* Async compute wait A = 1.
-* Async compute write image 0.
-* Async compute signal A = 2.
-* Async compute wait G = 1.
-(Out of order submission, queue progress is stalled, but we can keep recording)
-* Async compute wait A = 2.
-* Async compute wait host A = 1.
-* Async compute write image 1.
-* Async compute signal A = 3.
-* Graphics wait A = 1.
-* Graphics read image 1.
-* Graphics signal G = 1.
-(Unblocks queue forward progress)
-* Graphics wait A = 2.
-* Graphics read image 0.
-* Graphics signal G = 2.
-* Graphics wait A = 3.
-* Graphics read image 1.
-* Graphics signal G = 3.
+* Main thread signals "prepare"
+* Main thread acquires the next swapchain image
+* Main signals "submit"
+* Compute thread waits for "prepare"
+* Compute thread prepares command buffer
+* Compute thread writes image
+* Compute thread signals "draw"
+* Compute thread waits for next frame
+* Graphics thread waits for "prepare"
+* Graphics thread prepares command buffer
+* Graphics thread waits on "submit"
+* Graphics thread reads image
+* Graphics thread signals present
+* Graphics thread waits for next frame
+* Main thread presents swapchain
+* Main thread signals end of frame
+* Main thread signals "prepare"
+* Compute thread waits for "prepare"
+* Graphics thread waits for prepare
 
 When submitting out of order, it is important that you don't just submit work way ahead of where the GPU actually is, since the latency becomes extremely large.
 The natural place to keep submission explosion under control here is the place where we wait for the timeline on host, since we need to re-record command buffers anyways.
@@ -269,37 +263,44 @@ Instead, just wait for timeline semaphores on host to "drain" the GPU, or if you
 Similar to `vkDeviceWaitIdle`, when tearing down the application, an out-of-order submission might be waiting on work which never comes, and that queue becomes deadlocked.
 To alleviate this, we can make use of host signalling of timeline semaphores to unblock everything in one fell swoop.
 
-From `TimelineSemaphore::finish()`:
+From `TimelineSemaphore::finish_timeline_workers()`:
 
 [,cpp]
 ----
-// Draining queues which submit out-of-order can be quite tricky, since QueueWaitIdle can deadlock for threads which want to run ahead.
-// If we call Submit waiting for a semaphore which is yet to be signalled,
-// QueueWaitIdle will not finish until a signal in another thread happens.
-// Here's an approach we can use to safely tear down the queue.
+	graphics_worker.alive = false;
+	compute_worker.alive  = false;
 
-// Drain the main thread timeline.
-// The async queue might be stalled waiting on the main queue to finish rendering a future frame which it never completes,
-// but we might never hit that count, since we're tearing down the application now.
-wait_timeline_cpu(main_thread_timeline);
+	signal_timeline(Timeline::MAX_STAGES);
 
-// Now we're guaranteed that the graphics timeline is at N and the async compute queue is blocked at N + num_frames + 1, waiting for N + 1 to finish.
-// Since we're not reading any more in graphics queue, we can jump bump the timeline on CPU towards infinity.
-// On the next loop iteration, we will exit the rendering loop and QueueWaitIdle will not be blocked on async thread anymore.
-// Just bump the timeline by INT32_MAX which is min-spec for maxTimelineSemaphoreValueDifference.
-// This is a useful way to mark a timeline semaphore as "permanently" signalled.
-main_thread_timeline.timeline += std::numeric_limits<int32_t>::max();
+	if (graphics_worker.thread.joinable())
+	{
+		graphics_worker.thread.join();
+	}
 
-// Order matters here, this works kinda like a condition variable.
-// If the timeline update is observed, we should see that the worker is not alive anymore.
-async_compute_worker.alive = false;
-signal_timeline_cpu(main_thread_timeline, main_thread_timeline_lock);
+	if (compute_worker.thread.joinable())
+	{
+		compute_worker.thread.join();
+	}
+----
 
-// This will now complete in finite time.
-if (async_compute_worker.thread.joinable())
-{
-    async_compute_worker.thread.join();
-}
+From `TimelineSemaphore::finish_timeline_workers()`:
+
+[,cpp]
+----
+	graphics_worker.alive = false;
+	compute_worker.alive  = false;
+
+	signal_timeline(Timeline::MAX_STAGES);
+
+	if (graphics_worker.thread.joinable())
+	{
+		graphics_worker.thread.join();
+	}
+
+	if (compute_worker.thread.joinable())
+	{
+		compute_worker.thread.join();
+	}
 ----
 
 === Out-of-order submission fallbacks for single queue implementations

--- a/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
+++ b/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
@@ -17,63 +17,157 @@
 
 #include "timeline_semaphore.h"
 
+// What we're trying to demonstrate here is:
+// - Out-of-order submission using threads which synchronize GPU work with each other using timeline semaphores.
+//   In this sample we have a dedicated worker threads for submitting work to the compute and graphics pipelines respectively,
+//   and the only synchronization with main thread happens via timeline semaphores.
+// - Waiting for timeline semaphore on CPU to replace redundant fence objects.
+// - Multiple waits on the same timeline. We don't need to worry about allocating and managing binary semaphores in complex scenarios.
+//   We can wait on the same timeline values as many times as we want, and we avoid all resource management problems that binary semaphores have.
+
+namespace
+{
 static constexpr unsigned grid_width  = 64;
 static constexpr unsigned grid_height = 64;
 
-// A simple variant of std::lock_guard which takes a condition for when to lock.
-// We need this since we will only lock vkQueueSubmit when the worker thread needs to submit to the main thread as well.
-// Otherwise, we will submit lock-free since we only need to externally synchronize the same VkQueue.
-class ConditionalLockGuard
+VkTimelineSemaphoreSubmitInfo create_timeline_submit_info(uint32_t waitValueCount, uint64_t *waitValue, uint32_t signalValueCount, uint64_t *signalValue)
 {
-  public:
-	ConditionalLockGuard(std::mutex &lock_, bool cond_) :
-	    lock(lock_), cond(cond_)
-	{
-		if (cond)
-		{
-			lock.lock();
-		}
-	}
+	return VkTimelineSemaphoreSubmitInfo{
+	    VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO,
+	    NULL,
+	    waitValueCount,
+	    waitValue,
+	    signalValueCount,
+	    signalValue};
+}
 
-	~ConditionalLockGuard()
-	{
-		if (cond)
-		{
-			lock.unlock();
-		}
-	}
-
-  private:
-	std::mutex &lock;
-	bool        cond;
-};
+}        // namespace
 
 TimelineSemaphore::TimelineSemaphore()
 {
-	title = "Timeline semaphore";
+	title = "Timeline Semaphore";
 
-	// Need to enable timeline semaphore extension.
-	add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	add_device_extension(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
+	add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 }
 
 TimelineSemaphore::~TimelineSemaphore()
 {
+	if (prepared)
+	{
+		finish_timeline_workers();
+	}
+
 	if (has_device())
 	{
 		VkDevice vk_device = get_device().get_handle();
-		vkDestroyPipelineLayout(vk_device, pipelines.compute_pipeline_layout, nullptr);
-		vkDestroyPipelineLayout(vk_device, pipelines.graphics_pipeline_layout, nullptr);
-		vkDestroyPipeline(vk_device, pipelines.visualize_pipeline, nullptr);
-		vkDestroyPipeline(vk_device, pipelines.compute_update_pipeline, nullptr);
-		vkDestroyPipeline(vk_device, pipelines.compute_mutate_pipeline, nullptr);
-		vkDestroyPipeline(vk_device, pipelines.compute_init_pipeline, nullptr);
-		vkDestroyDescriptorSetLayout(vk_device, descriptors.sampled_layout, nullptr);
-		vkDestroyDescriptorSetLayout(vk_device, descriptors.storage_layout, nullptr);
-		vkDestroyDescriptorPool(vk_device, descriptors.descriptor_pool, nullptr);
+		vkDestroyCommandPool(vk_device, graphics.command_pool, nullptr);
+		vkDestroyPipelineLayout(vk_device, graphics.pipeline_layout, nullptr);
+		vkDestroyPipeline(vk_device, graphics.pipeline, nullptr);
 
-		vkDestroySemaphore(vk_device, main_thread_timeline.semaphore, nullptr);
-		vkDestroySemaphore(vk_device, async_compute_timeline.semaphore, nullptr);
+		vkDestroyCommandPool(vk_device, compute.command_pool, nullptr);
+		vkDestroyPipelineLayout(vk_device, compute.pipeline_layout, nullptr);
+		vkDestroyPipeline(vk_device, compute.update_pipeline, nullptr);
+		vkDestroyPipeline(vk_device, compute.mutate_pipeline, nullptr);
+		vkDestroyPipeline(vk_device, compute.init_pipeline, nullptr);
+
+		vkDestroyDescriptorSetLayout(vk_device, shared.storage_layout, nullptr);
+		vkDestroyDescriptorSetLayout(vk_device, shared.sampled_layout, nullptr);
+
+		vkDestroySemaphore(vk_device, timeline.semaphore, nullptr);
+	}
+}
+
+void TimelineSemaphore::setup_shared_resources()
+{
+	// Descriptor pool
+	{
+		VkDescriptorPoolSize pool_sizes[2] = {
+		    {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, NumAsyncFrames},
+		    {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, NumAsyncFrames},
+		};
+
+		VkDescriptorPoolCreateInfo pool_info = vkb::initializers::descriptor_pool_create_info(2, pool_sizes, 2 * NumAsyncFrames);
+		VK_CHECK(vkCreateDescriptorPool(get_device().get_handle(), &pool_info, nullptr, &shared.descriptor_pool));
+	}
+
+	// Sampler
+	{
+		auto sampler_create_info         = vkb::initializers::sampler_create_info();
+		sampler_create_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+		sampler_create_info.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+		sampler_create_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+		sampler_create_info.minFilter    = VK_FILTER_NEAREST;
+		sampler_create_info.magFilter    = VK_FILTER_NEAREST;
+		sampler_create_info.maxLod       = VK_LOD_CLAMP_NONE;
+		sampler_create_info.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+		shared.immutable_sampler         = std::make_unique<vkb::core::Sampler>(get_device(), sampler_create_info);
+	}
+
+	// Images and image views
+	{
+		uint32_t queue_families[2]{};
+		uint32_t num_queue_families{};
+
+		// Need CONCURRENT usage here since we will sample from the image
+		// in both graphics and compute queues.
+		if (get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT) !=
+		    get_device().get_queue_by_present(0).get_family_index())
+		{
+			queue_families[0]  = get_device().get_queue_by_present(0).get_family_index();
+			queue_families[1]  = get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT);
+			num_queue_families = 2;
+		}
+
+		for (int i = 0; i < NumAsyncFrames; ++i)
+		{
+			shared.images[i] = std::make_unique<vkb::core::Image>(get_device(), VkExtent3D{grid_width, grid_height, 1},
+			                                                      VK_FORMAT_R8G8B8A8_UNORM,
+			                                                      VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+			                                                      VMA_MEMORY_USAGE_GPU_ONLY,
+			                                                      VK_SAMPLE_COUNT_1_BIT,
+			                                                      1, 1, VK_IMAGE_TILING_OPTIMAL,
+			                                                      0, num_queue_families, queue_families);
+
+			shared.image_views[i] = std::make_unique<vkb::core::ImageView>(*shared.images[i], VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM);
+		}
+	}
+
+	// Descriptor layouts
+	{
+		VkDescriptorSetLayoutBinding storage_binding = vkb::initializers::descriptor_set_layout_binding(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_SHADER_STAGE_COMPUTE_BIT, 0);
+		VkDescriptorSetLayoutBinding sampled_binding = vkb::initializers::descriptor_set_layout_binding(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_ALL, 0);
+
+		VkSampler vk_immutable_sampler     = shared.immutable_sampler->get_handle();
+		sampled_binding.pImmutableSamplers = &vk_immutable_sampler;
+
+		VkDescriptorSetLayoutCreateInfo storage_set_layout_info = vkb::initializers::descriptor_set_layout_create_info(&storage_binding, 1);
+		VkDescriptorSetLayoutCreateInfo sampled_set_layout_info = vkb::initializers::descriptor_set_layout_create_info(&sampled_binding, 1);
+
+		VK_CHECK(vkCreateDescriptorSetLayout(get_device().get_handle(), &storage_set_layout_info, nullptr, &shared.storage_layout));
+		VK_CHECK(vkCreateDescriptorSetLayout(get_device().get_handle(), &sampled_set_layout_info, nullptr, &shared.sampled_layout));
+	}
+
+	// Descriptor sets
+	{
+		VkDescriptorSetAllocateInfo storage_alloc_info = vkb::initializers::descriptor_set_allocate_info(shared.descriptor_pool, &shared.storage_layout, 1);
+		VkDescriptorSetAllocateInfo sampled_alloc_info = vkb::initializers::descriptor_set_allocate_info(shared.descriptor_pool, &shared.sampled_layout, 1);
+
+		for (int i = 0; i < NumAsyncFrames; ++i)
+		{
+			VK_CHECK(vkAllocateDescriptorSets(get_device().get_handle(), &storage_alloc_info, &shared.storage_images[i]));
+			VK_CHECK(vkAllocateDescriptorSets(get_device().get_handle(), &sampled_alloc_info, &shared.sampled_images[i]));
+
+			auto general_info  = vkb::initializers::descriptor_image_info(VK_NULL_HANDLE, shared.image_views[i]->get_handle(), VK_IMAGE_LAYOUT_GENERAL);
+			auto readonly_info = vkb::initializers::descriptor_image_info(VK_NULL_HANDLE, shared.image_views[i]->get_handle(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+			const VkWriteDescriptorSet writes[2] = {
+			    vkb::initializers::write_descriptor_set(shared.storage_images[i], VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 0, &general_info),
+			    vkb::initializers::write_descriptor_set(shared.sampled_images[i], VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 0, &readonly_info),
+			};
+
+			vkUpdateDescriptorSets(get_device().get_handle(), 2, writes, 0, nullptr);
+		}
 	}
 }
 
@@ -81,47 +175,7 @@ void TimelineSemaphore::build_command_buffers()
 {
 }
 
-void TimelineSemaphore::on_update_ui_overlay(vkb::Drawer &)
-{
-}
-
-void TimelineSemaphore::finish()
-{
-	if (!has_device())
-	{
-		return;
-	}
-
-	// Draining queues which submit out-of-order can be quite tricky, since QueueWaitIdle can deadlock for threads which want to run ahead.
-	// If we call Submit waiting for a semaphore which is yet to be signalled,
-	// QueueWaitIdle will not finish until a signal in another thread happens.
-	// Here's an approach we can use to safely tear down the queue.
-
-	// Drain the main thread timeline.
-	// The async queue might be stalled waiting on the main queue to finish rendering a future frame which it never completes,
-	// but we might never hit that count, since we're tearing down the application now.
-	wait_timeline_cpu(main_thread_timeline);
-
-	// Now we're guaranteed that the graphics timeline is at N and the async compute queue is blocked at N + num_frames + 1, waiting for N + 1 to finish.
-	// Since we're not reading any more in graphics queue, we can bump the timeline on CPU towards infinity.
-	// On the next loop iteration, we will exit the rendering loop and QueueWaitIdle will not be blocked on async thread anymore.
-	// Just bump the timeline by INT32_MAX which is min-spec for maxTimelineSemaphoreValueDifference.
-	// This is a useful way to mark a timeline semaphore as "permanently" signalled.
-	main_thread_timeline.timeline += std::numeric_limits<int32_t>::max();
-
-	// Order matters here, this works kinda like a condition variable.
-	// If the timeline update is observed, we should see that the worker is not alive anymore.
-	async_compute_worker.alive = false;
-	signal_timeline_cpu(main_thread_timeline, main_thread_timeline_lock);
-
-	// This will now complete in finite time.
-	if (async_compute_worker.thread.joinable())
-	{
-		async_compute_worker.thread.join();
-	}
-}
-
-void TimelineSemaphore::create_timeline_semaphore(Timeline &timeline)
+void TimelineSemaphore::create_timeline_semaphore()
 {
 	// A timeline semaphore is still a semaphore, but it is of TIMELINE type rather than BINARY.
 	VkSemaphoreCreateInfo        create_info = vkb::initializers::semaphore_create_info();
@@ -133,431 +187,319 @@ void TimelineSemaphore::create_timeline_semaphore(Timeline &timeline)
 
 	VK_CHECK(vkCreateSemaphore(get_device().get_handle(), &create_info, nullptr, &timeline.semaphore));
 
-	timeline.timeline = 0;
+	timeline.frame = 0;
 }
 
-void TimelineSemaphore::create_timeline_semaphores()
+void TimelineSemaphore::start_timeline_workers()
 {
-	create_timeline_semaphore(main_thread_timeline);
-	create_timeline_semaphore(async_compute_timeline);
+	graphics_worker.alive  = true;
+	graphics_worker.thread = std::thread([this]() { do_graphics_work(); });
+
+	compute_worker.alive  = true;
+	compute_worker.thread = std::thread([this]() { do_compute_work(); });
 }
 
-void TimelineSemaphore::create_timeline_worker(TimelineWorker &worker, std::function<void()> thread_func)
+void TimelineSemaphore::finish_timeline_workers()
 {
-	worker.alive  = true;
-	worker.thread = std::thread(std::move(thread_func));
-}
+	graphics_worker.alive = false;
+	compute_worker.alive  = false;
 
-// Normally, signal and wait would be merged into a single submit info,
-// but this would have made the sample a bit harder to read and reason about.
-// For this reason, we split up signals, waits and executions.
-void TimelineSemaphore::signal_timeline_gpu(VkQueue signal_queue, const Timeline &timeline, TimelineLock &lock)
-{
-	VkSubmitInfo submit         = vkb::initializers::submit_info();
-	submit.pSignalSemaphores    = &timeline.semaphore;
-	submit.signalSemaphoreCount = 1;
+	// The MAX_STAGES value is used to unblock all threads that are waiting on a timeline stage
+	signal_timeline(Timeline::MAX_STAGES);
 
-	// When N semaphores are provided and at least one of them is a timeline semaphore,
-	// we must pass an auxillary pNext struct which provides which timeline values to use.
-	VkTimelineSemaphoreSubmitInfoKHR timeline_info{VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR};
-	timeline_info.signalSemaphoreValueCount = 1;
-	timeline_info.pSignalSemaphoreValues    = &timeline.timeline;
-
-	submit.pNext = &timeline_info;
-
-	// VkQueue needs to be externally synchronized in vkQueueSubmit if async_queue == queue.
+	if (graphics_worker.thread.joinable())
 	{
-		ConditionalLockGuard holder{submission_lock, async_queue == queue};
-		VK_CHECK(vkQueueSubmit(signal_queue, 1, &submit, VK_NULL_HANDLE));
+		graphics_worker.thread.join();
 	}
 
-	// This is a special case to handle a scenario where async_queue == queue as well.
-	// Out-of-order submit is not possible with a single queue since the queue will deadlock itself.
-	// Very few implementations only support one queue, but the sample should run on all implementations.
-	// We also need this to handle the fact that we currently cannot use out-of-order submissions with swapchain.
-	update_pending(lock, timeline.timeline);
-}
-
-void TimelineSemaphore::wait_timeline_gpu(VkQueue wait_queue, const Timeline &timeline, TimelineLock &lock)
-{
-	if (timeline.timeline == 0)
+	if (compute_worker.thread.joinable())
 	{
-		// No-op.
-		return;
-	}
-
-	// This is a special case to handle a scenario where async_queue == queue as well.
-	// Out-of-order submit is not possible with a single queue since the queue will deadlock itself.
-	// Very few implementations only support one queue, but the sample should run on all implementations.
-	wait_pending_in_order_queue(lock, timeline.timeline);
-
-	const VkPipelineStageFlags wait_stages = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-
-	VkSubmitInfo submit       = vkb::initializers::submit_info();
-	submit.pWaitSemaphores    = &timeline.semaphore;
-	submit.pWaitDstStageMask  = &wait_stages;
-	submit.waitSemaphoreCount = 1;
-
-	VkTimelineSemaphoreSubmitInfoKHR timeline_info{VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR};
-	timeline_info.waitSemaphoreValueCount = 1;
-	timeline_info.pWaitSemaphoreValues    = &timeline.timeline;
-
-	submit.pNext = &timeline_info;
-
-	// VkQueue needs to be externally synchronized in vkQueueSubmit if async_queue == queue.
-	{
-		ConditionalLockGuard holder{submission_lock, async_queue == queue};
-		VK_CHECK(vkQueueSubmit(wait_queue, 1, &submit, VK_NULL_HANDLE));
+		compute_worker.thread.join();
 	}
 }
 
-void TimelineSemaphore::wait_timeline_cpu(const Timeline &timeline)
+// Signal the timeline from the host.
+void TimelineSemaphore::signal_timeline(Timeline::Stages stage)
 {
-	// There is no distinction between fences and semaphores anymore.
-	// We can freely wait for a timeline semaphore on host.
-	// There is also no external synchronization requirement like with VkFence!
-	// This allows for a free flowing synchronization implementation which makes multithreading even nicer.
+	VkSemaphoreSignalInfo signalInfo;
+	signalInfo.sType     = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
+	signalInfo.pNext     = NULL;
+	signalInfo.semaphore = timeline.semaphore;
+	signalInfo.value     = get_timeline_stage_value(stage);
 
-	VkSemaphoreWaitInfoKHR wait_info{VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO_KHR};
-	wait_info.pSemaphores    = &timeline.semaphore;
-	wait_info.semaphoreCount = 1;
-	wait_info.pValues        = &timeline.timeline;
-	VK_CHECK(vkWaitSemaphoresKHR(get_device().get_handle(), &wait_info, UINT64_MAX));
+	VK_CHECK(vkSignalSemaphoreKHR(get_device().get_handle(), &signalInfo));
 }
 
-void TimelineSemaphore::signal_timeline_cpu(const Timeline &timeline, TimelineLock &lock)
+// Wait on the timeline from the host.
+void TimelineSemaphore::wait_on_timeline(Timeline::Stages stage)
 {
-	VkSemaphoreSignalInfoKHR signal_info{VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO_KHR};
-	signal_info.semaphore = timeline.semaphore;
-	signal_info.value     = timeline.timeline;
-	VK_CHECK(vkSignalSemaphoreKHR(get_device().get_handle(), &signal_info));
+	const uint64_t waitValue = get_timeline_stage_value(stage);
 
-	// This is a special case to handle a scenario where async_queue == queue as well.
-	// Out-of-order submit is not possible with a single queue since the queue will deadlock itself.
-	// Very few implementations only support one queue, but the sample should run on all implementations.
-	update_pending(lock, timeline.timeline);
+	VkSemaphoreWaitInfo waitInfo;
+	waitInfo.sType          = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
+	waitInfo.pNext          = NULL;
+	waitInfo.flags          = 0;
+	waitInfo.semaphoreCount = 1;
+	waitInfo.pSemaphores    = &timeline.semaphore;
+	waitInfo.pValues        = &waitValue;
+
+	VK_CHECK(vkWaitSemaphoresKHR(get_device().get_handle(), &waitInfo, UINT64_MAX));
 }
 
-void TimelineSemaphore::update_pending(TimelineLock &lock, uint64_t timeline)
+// Sends the MAX_STAGES signal for the current frame, then increments the frame counter
+void TimelineSemaphore::signal_next_frame()
 {
-	// To support out-of-order signal and wait with a single queue we must do some workarounds.
-	// Normally, an application should not bother with multiple async queues
-	// if they have to be hammered onto one VkQueue in the end,
-	// but it can be useful to know about these problem scenarios up front.
-	//
-	// The other case where we need to ensure some kind of ordering is when waiting on a binary semaphore.
-	// Binary semaphores still have the requirement that all dependencies must already have been submitted,
-	// and we must still use binary semaphores for swapchain.
-	//
-	// To make the single queue scenario work, we must be able to guarantee that a wait is submitted after a signal,
-	// since we cannot signal on a queue once it is blocked by a wait.
-	// The only way to do this is to hold back submissions and ensure submissions happen in a forward-progress order.
-	//
-	// In this sample, we can achieve this with a condition variable where we wait until
-	// a pending signal has been submitted, but this approach does not work in all cases.
-	// It works here since we have a dedicated submission thread.
-	// It is always possible to add submission threads which may or may not be practical.
-	//
-	// This is called after signalling the timeline, which lets other submission threads know that it is safe to wait on
-	// any timeline value that is <= pending_timeline.
-	std::lock_guard<std::mutex> holder{lock.lock};
-	lock.pending_timeline = timeline;
-	lock.cond.notify_one();
+	VkSemaphoreSignalInfo signalInfo;
+	signalInfo.sType     = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
+	signalInfo.pNext     = NULL;
+	signalInfo.semaphore = timeline.semaphore;
+	signalInfo.value     = get_timeline_stage_value(Timeline::MAX_STAGES);
+
+	timeline.frame++;
+
+	VK_CHECK(vkSignalSemaphoreKHR(get_device().get_handle(), &signalInfo));
 }
 
-void TimelineSemaphore::wait_pending(TimelineLock &lock, uint64_t timeline)
+// Waits for the timeline to reach MAX_STAGES for the current frame
+void TimelineSemaphore::wait_for_next_frame()
 {
-	// See update_pending(). This is called before submitting a wait to the single VkQueue.
-	std::unique_lock<std::mutex> holder{lock.lock};
-	lock.cond.wait(holder, [&lock, timeline]() -> bool {
-		return lock.pending_timeline >= timeline;
-	});
+	// MAX_STAGES is used as it provides a boundary value between the stages of this frame and the next
+	const uint64_t waitValue = (timeline.frame + 1) * Timeline::MAX_STAGES;
+
+	VkSemaphoreWaitInfo waitInfo;
+	waitInfo.sType          = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
+	waitInfo.pNext          = NULL;
+	waitInfo.flags          = 0;
+	waitInfo.semaphoreCount = 1;
+	waitInfo.pSemaphores    = &timeline.semaphore;
+	waitInfo.pValues        = &waitValue;
+
+	VK_CHECK(vkWaitSemaphoresKHR(get_device().get_handle(), &waitInfo, UINT64_MAX));
 }
 
-void TimelineSemaphore::wait_pending_in_order_queue(TimelineLock &lock, uint64_t timeline)
+// Calculates the timeline value for the specified stage in the current frame
+uint64_t TimelineSemaphore::get_timeline_stage_value(Timeline::Stages stage)
 {
-	if (async_queue == queue)
+	return (timeline.frame * Timeline::MAX_STAGES) + stage;
+}
+
+void TimelineSemaphore::do_compute_work()
+{
+	setup_compute_resources();
+	setup_compute_pipeline();
+
+	compute.timer.start();
+	while (compute_worker.alive)
 	{
-		wait_pending(lock, timeline);
-	}
-}
+		wait_on_timeline(Timeline::prepare);
 
-// We want to achieve a pipeline where we're doing these in a double-buffered fashion:
-// - Do async compute work, write buffer frame % 2, read buffer (frame - 1) % 2.
-// - Blit results in main thread, read buffer frame % 2, write swapchain.
-
-// What we're trying to demonstrate here is:
-// - Out-of-order submission using threads which synchronize GPU work with each other using timeline semaphores.
-//   In this sample we have a dedicated worker thread which submits work to async compute,
-//   and the only synchronization with main thread happens via timeline semaphores.
-// - Waiting for timeline semaphore on CPU to replace redundant fence objects.
-// - Multiple waits on the same timeline. We don't need to worry about allocating and managing binary semaphores in complex scenarios.
-//   We can wait on the same timeline values as many times as we want, and we avoid all resource management problems that binary semaphores have.
-
-void TimelineSemaphore::async_compute_loop()
-{
-	uint64_t iteration = 0;
-
-	vkb::Timer timer;
-	timer.start();
-
-	// We're going to be recording commands on a thread, so make sure we have our own command pool.
-	VkCommandPool pool = get_device().create_command_pool(get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT),
-	                                                      VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-
-	// Pre-allocate N command buffers. We will however re-record them every iteration.
-	VkCommandBufferAllocateInfo alloc_info =
-	    vkb::initializers::command_buffer_allocate_info(pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, NumAsyncFrames);
-	VkCommandBuffer cmds[NumAsyncFrames];
-	VK_CHECK(vkAllocateCommandBuffers(get_device().get_handle(), &alloc_info, cmds));
-
-	while (async_compute_worker.alive)
-	{
-		iteration++;
-		unsigned        frame_index = iteration % NumAsyncFrames;
-		VkCommandBuffer cmd         = cmds[frame_index];
-
-		if (iteration >= NumAsyncFrames)
+		if (timeline.frame == 0)
 		{
-			// Wait for main thread to be done reading from the buffer, before we clobber it.
-			wait_timeline_gpu(async_queue, {main_thread_timeline.semaphore, iteration - NumAsyncFrames}, main_thread_timeline_lock);
-
-			// We're going to re-record command buffers, wait on host here. This also ensures we don't endlessly submit commands to the async queues.
-			// The signalling of async compute timeline is gated somewhat on the main thread submitting work to the swapchain.
-			wait_timeline_cpu({async_compute_timeline.semaphore, iteration - NumAsyncFrames});
-		}
-
-		// Wait for last iteration to complete since we're going to read from the results.
-		// Could use pipeline barrier here certainly, but this is a sample
-		// where we can show how free-flowing queue synchronization can be.
-		wait_timeline_gpu(async_queue, async_compute_timeline, async_compute_timeline_lock);
-
-		auto begin_info  = vkb::initializers::command_buffer_begin_info();
-		begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-		VK_CHECK(vkResetCommandBuffer(cmd, 0));
-		VK_CHECK(vkBeginCommandBuffer(cmd, &begin_info));
-
-		vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipelines.compute_pipeline_layout, 0, 1,
-		                        &descriptors.storage_images[frame_index],
-		                        0, nullptr);
-
-		if (iteration == 1)
-		{
-			// On the first iteration, we initialize the game of life.
-			vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipelines.compute_init_pipeline);
+			// Initialise the game of life on the first frame
+			build_compute_command_buffers(ComputeResources::init);
 		}
 		else
 		{
-			auto elapsed = static_cast<float>(timer.elapsed());
+			auto elapsed      = static_cast<float>(compute.timer.elapsed());
+			auto command_type = (elapsed > 1.0f) ? ComputeResources::update : ComputeResources::mutate;
 
-			// Either we iterate the game every second, or we mutate it by changing colors gradually
-			// to make something more aesthetically interesting.
-			if (elapsed > 1.0f)
-			{
-				vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipelines.compute_update_pipeline);
-				timer.lap();
-			}
-			else
-			{
-				vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipelines.compute_mutate_pipeline);
-				vkCmdPushConstants(cmd, pipelines.compute_pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT,
-				                   0, sizeof(elapsed), &elapsed);
-			}
-
-			// Bind previous iteration's texture.
-			vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipelines.compute_pipeline_layout, 1, 1,
-			                        &descriptors.sampled_images[(frame_index + (NumAsyncFrames - 1)) % NumAsyncFrames],
-			                        0, nullptr);
+			build_compute_command_buffers(command_type, elapsed);
 		}
 
-		VkImageMemoryBarrier image_barrier = vkb::initializers::image_memory_barrier();
-		image_barrier.srcAccessMask        = 0;
-		image_barrier.dstAccessMask        = VK_ACCESS_SHADER_WRITE_BIT;
-		image_barrier.image                = images[frame_index]->get_handle();
-		image_barrier.subresourceRange     = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-		image_barrier.oldLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
-		image_barrier.newLayout            = VK_IMAGE_LAYOUT_GENERAL;
+		uint64_t                      signal_value  = get_timeline_stage_value(Timeline::draw);
+		VkTimelineSemaphoreSubmitInfo timeline_info = create_timeline_submit_info(0, nullptr, 1, &signal_value);
 
-		// The semaphore takes care of srcStageMask.
-		vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-		                     0, 0, nullptr, 0, nullptr, 1, &image_barrier);
+		VkSubmitInfo submit_info         = vkb::initializers::submit_info();
+		submit_info.pNext                = &timeline_info;
+		submit_info.commandBufferCount   = 1;
+		submit_info.pCommandBuffers      = &compute.command_buffer;
+		submit_info.signalSemaphoreCount = 1;
+		submit_info.pSignalSemaphores    = &timeline.semaphore;
 
-		vkCmdDispatch(cmd, grid_width / 8, grid_height / 8, 1);
+		// Wait for the main thread to signal that the workers can submit to their queues
+		wait_on_timeline(Timeline::submit);
 
-		image_barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-		image_barrier.dstAccessMask = 0;
-		image_barrier.oldLayout     = VK_IMAGE_LAYOUT_GENERAL;
-		image_barrier.newLayout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-		// The semaphore takes care of dstStageMask.
-		vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-		                     0, 0, nullptr, 0, nullptr, 1, &image_barrier);
-
-		VK_CHECK(vkEndCommandBuffer(cmd));
-
-		auto submit_info               = vkb::initializers::submit_info();
-		submit_info.commandBufferCount = 1;
-		submit_info.pCommandBuffers    = &cmd;
-
-		// VkQueue needs to be externally synchronized in vkQueueSubmit if async_queue == queue.
+		// If the threads are being killed, we need to skip the queue submission to allow the program to exit gracefully
+		if (compute_worker.alive)
 		{
-			ConditionalLockGuard holder{submission_lock, async_queue == queue};
-			VK_CHECK(vkQueueSubmit(async_queue, 1, &submit_info, VK_NULL_HANDLE));
+			VK_CHECK(vkQueueSubmit(compute.queue, 1, &submit_info, VK_NULL_HANDLE));
 		}
 
-		// Kicks shading work in main queue.
-		async_compute_timeline.timeline = iteration;
-		signal_timeline_gpu(async_queue, async_compute_timeline, async_compute_timeline_lock);
-	}
-
-	// This QueueWaitIdle can be precarious.
-	// See TimelineSemaphore::finish() comments for why this is the case.
-	{
-		ConditionalLockGuard holder{submission_lock, async_queue == queue};
-		vkQueueWaitIdle(async_queue);
-	}
-
-	// This also frees command buffers allocated from the pool.
-	vkDestroyCommandPool(get_device().get_handle(), pool, nullptr);
-}
-
-void TimelineSemaphore::create_timeline_workers()
-{
-	create_timeline_worker(async_compute_worker, [this]() { async_compute_loop(); });
-}
-
-void TimelineSemaphore::prepare_queue()
-{
-	// Attempt to find a queue which is async compute.
-	// If we cannot find that queue family, at least try to find a queue which is not the "main" queue.
-	// If we have different queues we can safely use out of order signal and wait which is a core part of this sample.
-
-	auto    &device       = get_device();
-	uint32_t family_index = device.get_queue_family_index(VK_QUEUE_COMPUTE_BIT);
-	uint32_t num_queues   = device.get_num_queues_for_queue_family(family_index);
-
-	for (uint32_t i = 0; i < num_queues; i++)
-	{
-		auto &candidate = device.get_queue(family_index, i);
-		if (candidate.get_handle() != queue)
-		{
-			async_queue = candidate.get_handle();
-			break;
-		}
-	}
-
-	if (!async_queue)
-	{
-		// Fallback path. Cannot use out-of-order signal and wait here since the queue will deadlock itself.
-		// If this happens we need to add some locks and condition variables to make things work.
-		// See comments in TimelineSemaphore::update_pending().
-		async_queue = queue;
+		wait_for_next_frame();
 	}
 }
 
-void TimelineSemaphore::create_resources()
+void TimelineSemaphore::setup_compute_pipeline()
 {
-	uint32_t queue_families[2]{};
-	uint32_t num_queue_families{};
-
-	// Need CONCURRENT usage here since we will sample from the image
-	// in both graphics and compute queues.
-	if (get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT) !=
-	    get_device().get_queue_by_present(0).get_family_index())
-	{
-		queue_families[0]  = get_device().get_queue_by_present(0).get_family_index();
-		queue_families[1]  = get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT);
-		num_queue_families = 2;
-	}
-
-	for (int i = 0; i < NumAsyncFrames; i++)
-	{
-		images[i] = std::make_unique<vkb::core::Image>(get_device(), VkExtent3D{grid_width, grid_height, 1},
-		                                               VK_FORMAT_R8G8B8A8_UNORM,
-		                                               VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-		                                               VMA_MEMORY_USAGE_GPU_ONLY,
-		                                               VK_SAMPLE_COUNT_1_BIT,
-		                                               1, 1, VK_IMAGE_TILING_OPTIMAL,
-		                                               0, num_queue_families, queue_families);
-
-		image_views[i] = std::make_unique<vkb::core::ImageView>(*images[i], VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM);
-	}
-
-	// Boilerplate where we create a STORAGE_IMAGE descriptor set and SAMPLED_IMAGE descriptor set.
-
-	auto sampler_create_info         = vkb::initializers::sampler_create_info();
-	sampler_create_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-	sampler_create_info.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-	sampler_create_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-	sampler_create_info.minFilter    = VK_FILTER_NEAREST;
-	sampler_create_info.magFilter    = VK_FILTER_NEAREST;
-	sampler_create_info.maxLod       = VK_LOD_CLAMP_NONE;
-	sampler_create_info.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-	immutable_sampler                = std::make_unique<vkb::core::Sampler>(get_device(), sampler_create_info);
-	VkSampler vk_immutable_sampler   = immutable_sampler->get_handle();
-
-	VkDescriptorSetLayoutBinding storage_binding            = vkb::initializers::descriptor_set_layout_binding(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_SHADER_STAGE_COMPUTE_BIT, 0);
-	VkDescriptorSetLayoutBinding sampled_binding            = vkb::initializers::descriptor_set_layout_binding(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_ALL, 0);
-	sampled_binding.pImmutableSamplers                      = &vk_immutable_sampler;
-	VkDescriptorSetLayoutCreateInfo storage_set_layout_info = vkb::initializers::descriptor_set_layout_create_info(&storage_binding, 1);
-	VkDescriptorSetLayoutCreateInfo sampled_set_layout_info = vkb::initializers::descriptor_set_layout_create_info(&sampled_binding, 1);
-
-	VK_CHECK(vkCreateDescriptorSetLayout(get_device().get_handle(), &storage_set_layout_info, nullptr, &descriptors.storage_layout));
-	VK_CHECK(vkCreateDescriptorSetLayout(get_device().get_handle(), &sampled_set_layout_info, nullptr, &descriptors.sampled_layout));
-
-	VkDescriptorPoolSize pool_sizes[2] = {
-	    {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, NumAsyncFrames},
-	    {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, NumAsyncFrames},
-	};
-	VkDescriptorPoolCreateInfo pool_info = vkb::initializers::descriptor_pool_create_info(2, pool_sizes, NumAsyncFrames * 2);
-	VK_CHECK(vkCreateDescriptorPool(get_device().get_handle(), &pool_info, nullptr, &descriptors.descriptor_pool));
-
-	VkDescriptorSetAllocateInfo storage_alloc_info = vkb::initializers::descriptor_set_allocate_info(descriptors.descriptor_pool, &descriptors.storage_layout, 1);
-	VkDescriptorSetAllocateInfo sampled_alloc_info = vkb::initializers::descriptor_set_allocate_info(descriptors.descriptor_pool, &descriptors.sampled_layout, 1);
-	for (int i = 0; i < NumAsyncFrames; i++)
-	{
-		VK_CHECK(vkAllocateDescriptorSets(get_device().get_handle(), &storage_alloc_info, &descriptors.storage_images[i]));
-		VK_CHECK(vkAllocateDescriptorSets(get_device().get_handle(), &sampled_alloc_info, &descriptors.sampled_images[i]));
-
-		auto general_info  = vkb::initializers::descriptor_image_info(VK_NULL_HANDLE, image_views[i]->get_handle(), VK_IMAGE_LAYOUT_GENERAL);
-		auto readonly_info = vkb::initializers::descriptor_image_info(VK_NULL_HANDLE, image_views[i]->get_handle(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-
-		const VkWriteDescriptorSet writes[2] = {
-		    vkb::initializers::write_descriptor_set(descriptors.storage_images[i], VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 0, &general_info),
-		    vkb::initializers::write_descriptor_set(descriptors.sampled_images[i], VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 0, &readonly_info),
-		};
-		vkUpdateDescriptorSets(get_device().get_handle(), 2, writes, 0, nullptr);
-	}
-}
-
-void TimelineSemaphore::create_compute_pipeline()
-{
-	VkDescriptorSetLayout layouts[2]  = {descriptors.storage_layout, descriptors.sampled_layout};
+	VkDescriptorSetLayout layouts[2]  = {shared.storage_layout, shared.sampled_layout};
 	auto                  layout_info = vkb::initializers::pipeline_layout_create_info(layouts, 2);
 
 	VkPushConstantRange range          = vkb::initializers::push_constant_range(VK_SHADER_STAGE_COMPUTE_BIT, sizeof(float), 0);
 	layout_info.pushConstantRangeCount = 1;
 	layout_info.pPushConstantRanges    = &range;
 
-	VK_CHECK(vkCreatePipelineLayout(get_device().get_handle(), &layout_info, nullptr, &pipelines.compute_pipeline_layout));
-	VkComputePipelineCreateInfo info = vkb::initializers::compute_pipeline_create_info(pipelines.compute_pipeline_layout);
+	VK_CHECK(vkCreatePipelineLayout(get_device().get_handle(), &layout_info, nullptr, &compute.pipeline_layout));
+	VkComputePipelineCreateInfo info = vkb::initializers::compute_pipeline_create_info(compute.pipeline_layout);
 
 	info.stage = load_shader("timeline_semaphore/game_of_life_update.comp", VK_SHADER_STAGE_COMPUTE_BIT);
-	VK_CHECK(vkCreateComputePipelines(get_device().get_handle(), VK_NULL_HANDLE, 1, &info, nullptr, &pipelines.compute_update_pipeline));
+	VK_CHECK(vkCreateComputePipelines(get_device().get_handle(), VK_NULL_HANDLE, 1, &info, nullptr, &compute.update_pipeline));
 
 	info.stage = load_shader("timeline_semaphore/game_of_life_mutate.comp", VK_SHADER_STAGE_COMPUTE_BIT);
-	VK_CHECK(vkCreateComputePipelines(get_device().get_handle(), VK_NULL_HANDLE, 1, &info, nullptr, &pipelines.compute_mutate_pipeline));
+	VK_CHECK(vkCreateComputePipelines(get_device().get_handle(), VK_NULL_HANDLE, 1, &info, nullptr, &compute.mutate_pipeline));
 
 	info.stage = load_shader("timeline_semaphore/game_of_life_init.comp", VK_SHADER_STAGE_COMPUTE_BIT);
-	VK_CHECK(vkCreateComputePipelines(get_device().get_handle(), VK_NULL_HANDLE, 1, &info, nullptr, &pipelines.compute_init_pipeline));
+	VK_CHECK(vkCreateComputePipelines(get_device().get_handle(), VK_NULL_HANDLE, 1, &info, nullptr, &compute.init_pipeline));
 }
 
-void TimelineSemaphore::create_graphics_pipeline()
+void TimelineSemaphore::setup_compute_resources()
 {
-	auto layout_info = vkb::initializers::pipeline_layout_create_info(&descriptors.sampled_layout, 1);
-	VK_CHECK(vkCreatePipelineLayout(get_device().get_handle(), &layout_info, nullptr, &pipelines.graphics_pipeline_layout));
+	// Get compute queue
+	compute.queue_family_index = get_device().get_queue_family_index(VK_QUEUE_COMPUTE_BIT);
+	vkGetDeviceQueue(get_device().get_handle(), compute.queue_family_index, 0, &compute.queue);
 
-	VkGraphicsPipelineCreateInfo info = vkb::initializers::pipeline_create_info(pipelines.graphics_pipeline_layout, render_pass);
+	compute.command_pool = get_device().create_command_pool(compute.queue_family_index, VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+
+	VkCommandBufferAllocateInfo alloc_info =
+	    vkb::initializers::command_buffer_allocate_info(compute.command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1);
+
+	VK_CHECK(vkAllocateCommandBuffers(get_device().get_handle(), &alloc_info, &compute.command_buffer));
+}
+
+void TimelineSemaphore::build_compute_command_buffers(const ComputeResources::CommandType type, float elapsed)
+{
+	auto begin_info  = vkb::initializers::command_buffer_begin_info();
+	begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+	VK_CHECK(vkResetCommandBuffer(compute.command_buffer, 0));
+	VK_CHECK(vkBeginCommandBuffer(compute.command_buffer, &begin_info));
+
+	auto frame_index = timeline.frame % NumAsyncFrames;
+	auto prev_index  = (timeline.frame - 1) % NumAsyncFrames;
+
+	vkCmdBindDescriptorSets(compute.command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.pipeline_layout, 0, 1, &shared.storage_images[frame_index], 0, nullptr);
+
+	switch (type)
+	{
+		case ComputeResources::init:
+		{
+			//  On the first iteration, we initialize the game of life.
+			vkCmdBindPipeline(compute.command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.init_pipeline);
+		}
+		break;
+
+		case ComputeResources::update:
+		{
+			vkCmdBindPipeline(compute.command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.update_pipeline);
+			compute.timer.lap();
+
+			// Bind previous iteration's texture.
+			vkCmdBindDescriptorSets(compute.command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.pipeline_layout, 1, 1, &shared.sampled_images[prev_index], 0, nullptr);
+		}
+		break;
+
+		case ComputeResources::mutate:
+		{
+			vkCmdBindPipeline(compute.command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.mutate_pipeline);
+			vkCmdPushConstants(compute.command_buffer, compute.pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT,
+			                   0, sizeof(elapsed), &elapsed);
+
+			// Bind previous iteration's texture.
+			vkCmdBindDescriptorSets(compute.command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.pipeline_layout, 1, 1, &shared.sampled_images[prev_index], 0, nullptr);
+		}
+		break;
+	}
+
+	VkImageMemoryBarrier image_barrier = vkb::initializers::image_memory_barrier();
+	image_barrier.srcAccessMask        = 0;
+	image_barrier.dstAccessMask        = VK_ACCESS_SHADER_WRITE_BIT;
+	image_barrier.image                = shared.images[frame_index]->get_handle();
+	image_barrier.subresourceRange     = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+	image_barrier.oldLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
+	image_barrier.newLayout            = VK_IMAGE_LAYOUT_GENERAL;
+
+	// The semaphore takes care of srcStageMask.
+	vkCmdPipelineBarrier(compute.command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &image_barrier);
+
+	vkCmdDispatch(compute.command_buffer, grid_width / 8, grid_height / 8, 1);
+
+	image_barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+	image_barrier.dstAccessMask = 0;
+	image_barrier.oldLayout     = VK_IMAGE_LAYOUT_GENERAL;
+	image_barrier.newLayout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+	// The semaphore takes care of dstStageMask.
+	vkCmdPipelineBarrier(compute.command_buffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 1, &image_barrier);
+
+	VK_CHECK(vkEndCommandBuffer(compute.command_buffer));
+}
+
+void TimelineSemaphore::do_graphics_work()
+{
+	setup_graphics_resources();
+	setup_graphics_pipeline();
+
+	while (graphics_worker.alive)
+	{
+		wait_on_timeline(Timeline::prepare);
+
+		build_graphics_command_buffer();
+
+		uint64_t                      wait_values[]       = {0, get_timeline_stage_value(Timeline::draw)};
+		VkPipelineStageFlags          wait_stage_masks[]  = {VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT};
+		VkSemaphore                   wait_semaphores[]   = {semaphores.acquired_image_ready, timeline.semaphore};
+		uint64_t                      signal_values[]     = {get_timeline_stage_value(Timeline::present), 0};
+		VkSemaphore                   signal_semaphores[] = {timeline.semaphore, semaphores.render_complete};
+		VkTimelineSemaphoreSubmitInfo timeline_info       = create_timeline_submit_info(2, wait_values, 2, signal_values);
+
+		VkSubmitInfo submit_info         = vkb::initializers::submit_info();
+		submit_info.pNext                = &timeline_info;
+		submit_info.waitSemaphoreCount   = 2;
+		submit_info.pWaitSemaphores      = wait_semaphores;
+		submit_info.pWaitDstStageMask    = wait_stage_masks;
+		submit_info.signalSemaphoreCount = 2;
+		submit_info.pSignalSemaphores    = signal_semaphores;
+		submit_info.commandBufferCount   = 1;
+		submit_info.pCommandBuffers      = &graphics.command_buffer;
+
+		// Wait for the main thread to signal that the workers can submit to their queues
+		wait_on_timeline(Timeline::submit);
+
+		if (compute.queue == graphics.queue)
+		{
+			// If compute.queue == queue, we need synchronise access to the queue AND ensure that submissions are made in order
+			// (otherwise the queue will deadlock itself). So we wait for the "draw" stage to be signalled on the host, before
+			// submitting the work.
+			wait_on_timeline(Timeline::draw);
+		}
+
+		// If the threads are being killed, we need to skip the queue submission to allow the program to exit gracefully
+		if (graphics_worker.alive)
+		{
+			VK_CHECK(vkQueueSubmit(graphics.queue, 1, &submit_info, VK_NULL_HANDLE));
+		}
+
+		wait_for_next_frame();
+	}
+}
+
+void TimelineSemaphore::setup_graphics_resources()
+{
+	graphics.queue_family_index = get_device().get_queue_family_index(VK_QUEUE_GRAPHICS_BIT);
+	graphics.queue              = queue;
+
+	graphics.command_pool = get_device().create_command_pool(graphics.queue_family_index, VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+
+	VkCommandBufferAllocateInfo alloc_info =
+	    vkb::initializers::command_buffer_allocate_info(graphics.command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1);
+
+	VK_CHECK(vkAllocateCommandBuffers(get_device().get_handle(), &alloc_info, &graphics.command_buffer));
+}
+
+void TimelineSemaphore::setup_graphics_pipeline()
+{
+	auto layout_info = vkb::initializers::pipeline_layout_create_info(&shared.sampled_layout, 1);
+	VK_CHECK(vkCreatePipelineLayout(get_device().get_handle(), &layout_info, nullptr, &graphics.pipeline_layout));
+
+	VkGraphicsPipelineCreateInfo info = vkb::initializers::pipeline_create_info(graphics.pipeline_layout, render_pass);
 
 	VkPipelineVertexInputStateCreateInfo vertex_input_state = vkb::initializers::pipeline_vertex_input_state_create_info();
 
@@ -595,41 +537,14 @@ void TimelineSemaphore::create_graphics_pipeline()
 
 	stages[0] = load_shader("timeline_semaphore/render.vert", VK_SHADER_STAGE_VERTEX_BIT);
 	stages[1] = load_shader("timeline_semaphore/render.frag", VK_SHADER_STAGE_FRAGMENT_BIT);
-	VK_CHECK(vkCreateGraphicsPipelines(get_device().get_handle(), VK_NULL_HANDLE, 1, &info, nullptr, &pipelines.visualize_pipeline));
+	VK_CHECK(vkCreateGraphicsPipelines(get_device().get_handle(), VK_NULL_HANDLE, 1, &info, nullptr, &graphics.pipeline));
 }
 
-void TimelineSemaphore::create_pipelines()
+void TimelineSemaphore::build_graphics_command_buffer()
 {
-	create_compute_pipeline();
-	create_graphics_pipeline();
-}
-
-bool TimelineSemaphore::prepare(const vkb::ApplicationOptions &options)
-{
-	if (!ApiVulkanSample::prepare(options))
-	{
-		return false;
-	}
-
-	create_resources();
-	create_pipelines();
-	prepare_queue();
-	create_timeline_semaphores();
-	create_timeline_workers();
-
-	prepared = true;
-	return true;
-}
-
-void TimelineSemaphore::render(float delta_time)
-{
-	ApiVulkanSample::prepare_frame();
-
-	VK_CHECK(vkWaitForFences(get_device().get_handle(), 1, &wait_fences[current_buffer], VK_TRUE, UINT64_MAX));
-	VK_CHECK(vkResetFences(get_device().get_handle(), 1, &wait_fences[current_buffer]));
-
-	VkViewport viewport = {0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f};
-	VkRect2D   scissor  = {{0, 0}, {width, height}};
+	auto       frame_index = timeline.frame % NumAsyncFrames;
+	VkViewport viewport    = {0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f};
+	VkRect2D   scissor     = {{0, 0}, {width, height}};
 
 	// Simple fix for 1:1 pixel aspect ratio.
 	if (viewport.width > viewport.height)
@@ -643,11 +558,10 @@ void TimelineSemaphore::render(float delta_time)
 		viewport.height = viewport.width;
 	}
 
-	recreate_current_command_buffer();
-	auto cmd         = draw_cmd_buffers[current_buffer];
 	auto begin_info  = vkb::initializers::command_buffer_begin_info();
 	begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-	vkBeginCommandBuffer(cmd, &begin_info);
+	VK_CHECK(vkResetCommandBuffer(graphics.command_buffer, 0));
+	VK_CHECK(vkBeginCommandBuffer(graphics.command_buffer, &begin_info));
 
 	VkRenderPassBeginInfo render_pass_begin    = vkb::initializers::render_pass_begin_info();
 	render_pass_begin.renderPass               = render_pass;
@@ -661,43 +575,20 @@ void TimelineSemaphore::render(float delta_time)
 	render_pass_begin.pClearValues             = clears;
 	render_pass_begin.framebuffer              = framebuffers[current_buffer];
 
-	vkCmdBeginRenderPass(cmd, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+	vkCmdBeginRenderPass(graphics.command_buffer, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
 
-	vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines.visualize_pipeline);
-	vkCmdSetViewport(cmd, 0, 1, &viewport);
-	vkCmdSetScissor(cmd, 0, 1, &scissor);
+	vkCmdBindPipeline(graphics.command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, graphics.pipeline);
+	vkCmdSetViewport(graphics.command_buffer, 0, 1, &viewport);
+	vkCmdSetScissor(graphics.command_buffer, 0, 1, &scissor);
 
-	main_thread_timeline.timeline++;
-	uint32_t frame_index = main_thread_timeline.timeline % NumAsyncFrames;
-	vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines.graphics_pipeline_layout,
-	                        0, 1, &descriptors.sampled_images[frame_index], 0, nullptr);
-	vkCmdDraw(cmd, 3, 1, 0, 0);
+	vkCmdBindDescriptorSets(graphics.command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, graphics.pipeline_layout, 0, 1, &shared.sampled_images[frame_index], 0, nullptr);
+	vkCmdDraw(graphics.command_buffer, 3, 1, 0, 0);
 
-	draw_ui(cmd);
+	draw_ui(graphics.command_buffer);
 
-	vkCmdEndRenderPass(cmd);
+	vkCmdEndRenderPass(graphics.command_buffer);
 
-	VK_CHECK(vkEndCommandBuffer(cmd));
-	submit_info.commandBufferCount = 1;
-	submit_info.pCommandBuffers    = &draw_cmd_buffers[current_buffer];
-
-	// Wait for the async queue to have completed rendering.
-	wait_timeline_gpu(queue, {async_compute_timeline.semaphore, main_thread_timeline.timeline}, async_compute_timeline_lock);
-
-	// Need to hold the conditional lock during submit_frame as well since vkQueuePresentKHR uses the main queue as well.
-	{
-		ConditionalLockGuard holder{submission_lock, async_queue == queue};
-		VK_CHECK(vkQueueSubmit(queue, 1, &submit_info, wait_fences[current_buffer]));
-
-		// Before we call present, which uses a binary semaphore, we must ensure that all dependent submissions
-		// have been submitted, so that the presenting queue is unblocked at the time of calling.
-		wait_pending(async_compute_timeline_lock, main_thread_timeline.timeline);
-
-		ApiVulkanSample::submit_frame();
-	}
-
-	// Let async queue know it is safe to clobber the image since main queue is done reading it.
-	signal_timeline_gpu(queue, main_thread_timeline, main_thread_timeline_lock);
+	VK_CHECK(vkEndCommandBuffer(graphics.command_buffer));
 }
 
 void TimelineSemaphore::request_gpu_features(vkb::PhysicalDevice &gpu)
@@ -708,7 +599,52 @@ void TimelineSemaphore::request_gpu_features(vkb::PhysicalDevice &gpu)
 	features.timelineSemaphore = VK_TRUE;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_timeline_semaphore()
+bool TimelineSemaphore::prepare(const vkb::ApplicationOptions &options)
+{
+	if (!ApiVulkanSample::prepare(options))
+	{
+		return false;
+	}
+
+	setup_shared_resources();
+	create_timeline_semaphore();
+
+	start_timeline_workers();
+
+	prepared = true;
+	return true;
+}
+
+void TimelineSemaphore::render(float delta_time)
+{
+	if (!prepared)
+	{
+		return;
+	}
+
+	// Signal to the worker threads that they can prepare their command buffers
+	signal_timeline(Timeline::prepare);
+
+	ApiVulkanSample::prepare_frame();
+
+	// Signal to the worker threads that they can submit their work, then wait for the work to complete
+	signal_timeline(Timeline::submit);
+
+	// Wait for the worker threads to signal that the frame is ready to present
+	wait_on_timeline(Timeline::present);
+
+	ApiVulkanSample::submit_frame();
+
+	// Signal to the worker threads that they can proceed to the next frame's work
+	signal_next_frame();
+}
+
+bool TimelineSemaphore::resize(const uint32_t width, const uint32_t height)
+{
+	return ApiVulkanSample::resize(width, height);
+}
+
+std::unique_ptr<vkb::Application> create_timeline_semaphore()
 {
 	return std::make_unique<TimelineSemaphore>();
 }

--- a/samples/extensions/timeline_semaphore/timeline_semaphore.h
+++ b/samples/extensions/timeline_semaphore/timeline_semaphore.h
@@ -18,98 +18,119 @@
 #pragma once
 
 #include "api_vulkan_sample.h"
-#include <memory>
-#include <mutex>
-#include <thread>
-#include <vector>
 
 class TimelineSemaphore : public ApiVulkanSample
 {
   public:
-	TimelineSemaphore();
-	~TimelineSemaphore();
+	static const uint32_t NumAsyncFrames = 2;
 
-  private:
-	virtual void request_gpu_features(vkb::PhysicalDevice &gpu) override;
-	virtual void render(float delta_time) override;
-	virtual void build_command_buffers() override;
-	virtual void on_update_ui_overlay(vkb::Drawer &drawer) override;
-	virtual bool prepare(const vkb::ApplicationOptions &options) override;
-	virtual void finish() override;
-
-	void create_resources();
-	void create_pipelines();
-	void create_compute_pipeline();
-	void create_graphics_pipeline();
-
-	struct Pipelines
+	// Resources for the graphics worker
+	struct GraphicsResources
 	{
-		VkPipelineLayout compute_pipeline_layout{};
-		VkPipelineLayout graphics_pipeline_layout{};
-		VkPipeline       visualize_pipeline{};
-		VkPipeline       compute_update_pipeline{};
-		VkPipeline       compute_mutate_pipeline{};
-		VkPipeline       compute_init_pipeline{};
-	} pipelines;
+		VkQueue         queue;
+		VkCommandPool   command_pool;
+		VkCommandBuffer command_buffer;
 
-	enum
+		VkPipelineLayout pipeline_layout;
+		VkPipeline       pipeline;
+
+		uint32_t queue_family_index;
+	} graphics;
+
+	// Resources for the compute worker
+	struct ComputeResources
 	{
-		NumAsyncFrames = 2
-	};
+		VkQueue         queue;
+		VkCommandPool   command_pool;
+		VkCommandBuffer command_buffer;
 
-	struct Descriptors
+		VkPipelineLayout pipeline_layout;
+		VkPipeline       init_pipeline;
+		VkPipeline       update_pipeline;
+		VkPipeline       mutate_pipeline;
+
+		vkb::Timer timer;
+		uint32_t   queue_family_index;
+
+		enum CommandType
+		{
+			init,
+			update,
+			mutate
+		};
+	} compute;
+
+	// Resources used by both workers for storing/sampling images
+	struct SharedResources
 	{
 		VkDescriptorSetLayout storage_layout;
 		VkDescriptorSetLayout sampled_layout;
 		VkDescriptorSet       storage_images[NumAsyncFrames];
 		VkDescriptorSet       sampled_images[NumAsyncFrames];
 		VkDescriptorPool      descriptor_pool;
-	} descriptors{};
 
-	std::unique_ptr<vkb::core::Sampler>   immutable_sampler;
-	std::unique_ptr<vkb::core::Image>     images[NumAsyncFrames];
-	std::unique_ptr<vkb::core::ImageView> image_views[NumAsyncFrames];
-
-	VkQueue    async_queue{VK_NULL_HANDLE};
-	void       prepare_queue();
-	std::mutex submission_lock;
+		std::unique_ptr<vkb::core::Sampler>   immutable_sampler;
+		std::unique_ptr<vkb::core::Image>     images[NumAsyncFrames];
+		std::unique_ptr<vkb::core::ImageView> image_views[NumAsyncFrames];
+	} shared;
 
 	struct Timeline
 	{
-		VkSemaphore semaphore;
-		uint64_t    timeline;
-	};
-	Timeline main_thread_timeline{}, async_compute_timeline{};
+		// The stages of the timeline are enumerated, to make it easier to read which stage we are signalling/waiting on, and to allow
+		// the stages to be reused without needing to recreate the semaphore.
+		enum Stages
+		{
+			prepare = 1,        // Worker threads can begin preparing command buffers for submission
+			submit,             // Worker threads can submit their command buffers,
+			draw,               // The graphics worker can draw the current frame
+			present,            // The main thread can present the frame to the display
+			MAX_STAGES
+		};
 
-	struct TimelineLock
-	{
-		std::condition_variable cond;
-		std::mutex              lock;
-		uint64_t                pending_timeline;
-	};
-	TimelineLock main_thread_timeline_lock{}, async_compute_timeline_lock{};
+		VkSemaphore semaphore;
+		uint64_t    frame;        // Number of iterations through the timeline stages
+	} timeline;
 
 	struct TimelineWorker
 	{
 		std::thread      thread;
 		std::atomic_bool alive;
 	};
-	TimelineWorker async_compute_worker;
-	void           create_timeline_semaphores();
-	void           create_timeline_semaphore(Timeline &timeline);
 
-	void        create_timeline_workers();
-	static void create_timeline_worker(TimelineWorker &worker, std::function<void()> thread_func);
+	TimelineWorker graphics_worker, compute_worker;
 
-	void async_compute_loop();
+	TimelineSemaphore();
+	~TimelineSemaphore();
 
-	void signal_timeline_gpu(VkQueue queue, const Timeline &timeline, TimelineLock &lock);
-	void wait_timeline_gpu(VkQueue queue, const Timeline &timeline, TimelineLock &lock);
-	void wait_timeline_cpu(const Timeline &timeline);
-	void signal_timeline_cpu(const Timeline &timeline, TimelineLock &lock);
-	void update_pending(TimelineLock &lock, uint64_t timeline);
-	void wait_pending_in_order_queue(TimelineLock &lock, uint64_t timeline);
-	void wait_pending(TimelineLock &lock, uint64_t timeline);
+	void setup_shared_resources();
+	void build_command_buffers() override;
+
+	// Timeline operations
+	void     create_timeline_semaphore();
+	void     start_timeline_workers();
+	void     finish_timeline_workers();
+	void     signal_next_frame();
+	void     wait_for_next_frame();
+	void     signal_timeline(Timeline::Stages stage);
+	void     wait_on_timeline(Timeline::Stages stage);
+	uint64_t get_timeline_stage_value(Timeline::Stages stage);
+
+	// Compute Work
+	void do_compute_work();
+	void setup_compute_pipeline();
+	void setup_compute_resources();
+	void build_compute_command_buffers(const ComputeResources::CommandType type, const float elapsed = 0.0f);
+
+	// Graphics Work
+	void do_graphics_work();
+	void setup_graphics_resources();
+	void setup_graphics_pipeline();
+	void build_graphics_command_buffer();
+
+	virtual void request_gpu_features(vkb::PhysicalDevice &gpu) override;
+	virtual bool prepare(const vkb::ApplicationOptions &options) override;
+	virtual void render(float delta_time) override;
+	virtual bool resize(const uint32_t width, const uint32_t height) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_timeline_semaphore();
+std::unique_ptr<vkb::Application> create_timeline_semaphore();

--- a/samples/extensions/timeline_semaphore/timeline_semaphore.h
+++ b/samples/extensions/timeline_semaphore/timeline_semaphore.h
@@ -109,16 +109,17 @@ class TimelineSemaphore : public ApiVulkanSample
 	void     create_timeline_semaphore();
 	void     start_timeline_workers();
 	void     finish_timeline_workers();
-	void     signal_next_frame();
-	void     wait_for_next_frame();
 	void     signal_timeline(Timeline::Stages stage);
 	void     wait_on_timeline(Timeline::Stages stage);
+	void     signal_next_frame();
+	void     wait_for_next_frame();
 	uint64_t get_timeline_stage_value(Timeline::Stages stage);
 
 	// Compute Work
 	void do_compute_work();
 	void setup_compute_pipeline();
 	void setup_compute_resources();
+	void setup_game_of_life();
 	void build_compute_command_buffers(const ComputeResources::CommandType type, const float elapsed = 0.0f);
 
 	// Graphics Work


### PR DESCRIPTION
## Description
Reworked the timeline semaphore sample to prevent it crashing on Windows. 

The only obvious trigger for the crash that I could observe was the main thread calling "vkDeviceWaitIdle" whilst the compute thread was in "wait_timeline_gpu". To avoid this, I removed the "wait/signal_timeline_gpu" calls (opting to attach the "VkTimelineSemaphoreSubmitInfo" to the queue submissions instead), and restructured the compute/graphics work stages to prevent the compute thread running ahead and submitting (potentially blocking) work.

- Replaced the "wait/signal_timeline_gpu" calls with "VkTimelineSemaphoreSubmitInfo" added to the queue submissions
- Added an enum for identifying the timeline stages, to make it easier to read and debug the signals/waits
- Moved the rendering work to a seperate thread, leaving the main thread responsible for acquiring and presenting the swapchain image, and signalling the timeline semaphore.

Fixes #588

Tested on Windows
Tested with shared queue for compute and graphics
## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [X] I have tested every sample to ensure everything runs correctly
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [X] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [X] I have tested the sample on at least one compliant Vulkan implementation
- [X] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [X] Any dependent assets have been merged and published in downstream modules
- [X] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [X] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [X] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
