### PR TITLE
Display actual sample name in UI instead of sample id

### DIFF
--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -445,13 +445,13 @@ bool Platform::start_app()
 
 	active_app = requested_app_info->create();
 
-	active_app->set_name(requested_app_info->id);
-
 	if (!active_app)
 	{
 		LOGE("Failed to create a valid vulkan app.");
 		return false;
 	}
+	auto sample_info = static_cast<const apps::SampleInfo *>(requested_app_info);
+	active_app->set_name(sample_info->name);
 
 	if (!active_app->prepare({false, window.get()}))
 	{


### PR DESCRIPTION
## Description

This PR changes the UI to display the actual name of the sample instead of it's internal id.

Before:

![image](https://github.com/KhronosGroup/Vulkan-Samples/assets/10283127/e84169fc-561f-4507-9466-b8b0aa941e29)

After:

![image](https://github.com/KhronosGroup/Vulkan-Samples/assets/10283127/b3b49624-43a0-4de9-b0a0-e41af56a42f4)

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly