### PR TITLE
Add availability checks for debug report extension usage

### DIFF
--- a/framework/core/hpp_instance.cpp
+++ b/framework/core/hpp_instance.cpp
@@ -316,7 +316,7 @@ HPPInstance::HPPInstance(const std::string                            &applicati
 
 		instance_info.pNext = &debug_utils_create_info;
 	}
-	else
+	else if (has_debug_report)
 	{
 		debug_report_create_info = vk::DebugReportCallbackCreateInfoEXT(
 		    vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning, debug_callback);
@@ -361,7 +361,7 @@ HPPInstance::HPPInstance(const std::string                            &applicati
 	{
 		debug_utils_messenger = handle.createDebugUtilsMessengerEXT(debug_utils_create_info);
 	}
-	else
+	else if (has_debug_report)
 	{
 		debug_report_callback = handle.createDebugReportCallbackEXT(debug_report_create_info);
 	}

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -340,7 +340,7 @@ Instance::Instance(const std::string                            &application_nam
 
 		instance_info.pNext = &debug_utils_create_info;
 	}
-	else
+	else if (has_debug_report)
 	{
 		debug_report_create_info.flags       = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
 		debug_report_create_info.pfnCallback = debug_callback;
@@ -395,7 +395,7 @@ Instance::Instance(const std::string                            &application_nam
 			throw VulkanException(result, "Could not create debug utils messenger");
 		}
 	}
-	else
+	else if (has_debug_report)
 	{
 		result = vkCreateDebugReportCallbackEXT(handle, &debug_report_create_info, nullptr, &debug_report_callback);
 		if (result != VK_SUCCESS)

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -162,10 +162,10 @@ void HelloTriangle::init_instance(Context                         &context,
 {
 	LOGI("Initializing vulkan instance.");
 
-    if (volkInitialize())
-    {
-        throw std::runtime_error("Failed to initialize volk.");
-    }
+	if (volkInitialize())
+	{
+		throw std::runtime_error("Failed to initialize volk.");
+	}
 
 	uint32_t instance_extension_count;
 	VK_CHECK(vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, nullptr));

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -265,9 +265,9 @@ void HelloTriangle::init_instance(Context                         &context,
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
 	VkDebugReportCallbackCreateInfoEXT debug_report_create_info = {VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT};
 	if (has_debug_report)
-    	{
-		debug_report_create_info.flags                          = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
-		debug_report_create_info.pfnCallback                    = debug_callback;
+	{
+		debug_report_create_info.flags       = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
+		debug_report_create_info.pfnCallback = debug_callback;
 
 		instance_info.pNext = &debug_report_create_info;
 	}

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -176,7 +176,23 @@ void HelloTriangle::init_instance(Context                         &context,
 	std::vector<const char *> active_instance_extensions(required_instance_extensions);
 
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	active_instance_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+	bool has_debug_report = false;
+	for (const auto &ext : instance_extensions)
+	{
+		if (strcmp(ext.extensionName, VK_EXT_DEBUG_REPORT_EXTENSION_NAME) == 0)
+		{
+			has_debug_report = true;
+			break;
+		}
+	}
+	if (has_debug_report)
+	{
+		active_instance_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+	}
+	else
+	{
+		LOGW("{} is not available; disabling debug reporting", VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+	}
 #endif
 
 #if (defined(VKB_ENABLE_PORTABILITY))
@@ -248,10 +264,13 @@ void HelloTriangle::init_instance(Context                         &context,
 
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
 	VkDebugReportCallbackCreateInfoEXT debug_report_create_info = {VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT};
-	debug_report_create_info.flags                              = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
-	debug_report_create_info.pfnCallback                        = debug_callback;
+	if (has_debug_report)
+    	{
+		debug_report_create_info.flags                          = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
+		debug_report_create_info.pfnCallback                    = debug_callback;
 
-	instance_info.pNext = &debug_report_create_info;
+		instance_info.pNext = &debug_report_create_info;
+	}
 #endif
 
 #if (defined(VKB_ENABLE_PORTABILITY))
@@ -264,7 +283,10 @@ void HelloTriangle::init_instance(Context                         &context,
 	volkLoadInstance(context.instance);
 
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	VK_CHECK(vkCreateDebugReportCallbackEXT(context.instance, &debug_report_create_info, nullptr, &context.debug_callback));
+	if (has_debug_report)
+	{
+		VK_CHECK(vkCreateDebugReportCallbackEXT(context.instance, &debug_report_create_info, nullptr, &context.debug_callback));
+	}
 #endif
 }
 


### PR DESCRIPTION
## Description

Adding the missing condition checks before using the structures and functions from the VK_EXT_debug_report extension in the samples.

Normal functionality should not change when the extension is supported, tested on a device where the extension is missing. 