### PR TITLE
Apply recent framework changes to sample templates

### DIFF
--- a/bldsys/cmake/template/sample/sample.cpp.in
+++ b/bldsys/cmake/template/sample/sample.cpp.in
@@ -40,25 +40,25 @@ bool @SAMPLE_NAME@::prepare(const vkb::ApplicationOptions &options)
 	load_scene("scenes/sponza/Sponza01.gltf");
 
 	// Attach a move script to the camera component in the scene
-	auto &camera_node = vkb::add_free_camera(*scene, "main_camera", get_render_context().get_surface_extent());
+	auto &camera_node = vkb::add_free_camera(get_scene(), "main_camera", get_render_context().get_surface_extent());
 	auto camera       = &camera_node.get_component<vkb::sg::Camera>();
 
 	// Example Scene Render Pipeline
 	vkb::ShaderSource vert_shader("base.vert");
 	vkb::ShaderSource frag_shader("base.frag");
-	auto              scene_subpass   = std::make_unique<vkb::ForwardSubpass>(get_render_context(), std::move(vert_shader), std::move(frag_shader), *scene, *camera);
-	auto              render_pipeline = vkb::RenderPipeline();
-	render_pipeline.add_subpass(std::move(scene_subpass));
+	auto              scene_subpass   = std::make_unique<vkb::ForwardSubpass>(get_render_context(), std::move(vert_shader), std::move(frag_shader), get_scene(), *camera);
+	auto              render_pipeline = std::make_unique<vkb::RenderPipeline>();
+	render_pipeline->add_subpass(std::move(scene_subpass));
 	set_render_pipeline(std::move(render_pipeline));
 
 	// Add a GUI with the stats you want to monitor
-	stats->request_stats({/*stats you require*/});
-	gui = std::make_unique<vkb::Gui>(*this, *window, stats.get());
+	get_stats().request_stats({/*stats you require*/});
+	create_gui(*window, &get_stats());
 
 	return true;
 }
 
-std::unique_ptr<vkb::VulkanSample> create_@SAMPLE_NAME_FILE@()
+std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_@SAMPLE_NAME_FILE@()
 {
 	return std::make_unique<@SAMPLE_NAME@>();
 }

--- a/bldsys/cmake/template/sample/sample.h.in
+++ b/bldsys/cmake/template/sample/sample.h.in
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2023, Arm Limited and Contributors
+/* Copyright (c) 2019-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,7 +21,7 @@
 #include "scene_graph/components/camera.h"
 #include "vulkan_sample.h"
 
-class @SAMPLE_NAME@ : public vkb::VulkanSample
+class @SAMPLE_NAME@ : public vkb::VulkanSample<vkb::BindingType::C>
 {
   public:
 	@SAMPLE_NAME@();
@@ -31,4 +31,4 @@ class @SAMPLE_NAME@ : public vkb::VulkanSample
 	virtual ~@SAMPLE_NAME@() = default;
 };
 
-std::unique_ptr<vkb::VulkanSample> create_@SAMPLE_NAME_FILE@();
+std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_@SAMPLE_NAME_FILE@();

--- a/bldsys/cmake/template/sample_api/sample.cpp.in
+++ b/bldsys/cmake/template/sample_api/sample.cpp.in
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, Arm Limited and Contributors
+/* Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -23,7 +23,7 @@
 
 @SAMPLE_NAME@::~@SAMPLE_NAME@()
 {
-	if (device)
+	if (has_device())
 	{
 		vkDestroyPipeline(get_device().get_handle(), sample_pipeline, nullptr);
 		vkDestroyPipelineLayout(get_device().get_handle(), sample_pipeline_layout, nullptr);
@@ -168,7 +168,7 @@ void @SAMPLE_NAME@::render(float delta_time)
 	ApiVulkanSample::submit_frame();
 }
 
-std::unique_ptr<vkb::VulkanSample> create_@SAMPLE_NAME_FILE@()
+std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_@SAMPLE_NAME_FILE@()
 {
 	return std::make_unique<@SAMPLE_NAME@>();
 }

--- a/bldsys/cmake/template/sample_api/sample.h.in
+++ b/bldsys/cmake/template/sample_api/sample.h.in
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, Arm Limited and Contributors
+/* Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -39,4 +39,4 @@ class @SAMPLE_NAME@ : public ApiVulkanSample
 	VkPipelineLayout sample_pipeline_layout{};
 };
 
-std::unique_ptr<vkb::VulkanSample> create_@SAMPLE_NAME_FILE@();
+std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_@SAMPLE_NAME_FILE@();


### PR DESCRIPTION
## Description

This PR updates both sample templates (framework and api) that can be used to generate new samples via a script. Recent framework changes made those no longer work, with people having to manually fix them.

If we do any additional fundamental changes to the framework in the future, we always need to make sure the templates are updated accordingly.

Fixes #1062

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly