### PR TITLE
Introduce type aliases for vkb::VulkanSample and vkb::core::VulkanResource.

### DIFF
--- a/app/plugins/batch_mode/batch_mode.cpp
+++ b/app/plugins/batch_mode/batch_mode.cpp
@@ -116,7 +116,7 @@ void BatchMode::on_update(float delta_time)
 		elapsed_time = 0.0f;
 
 		// Only check and advance the config if the application is a vulkan sample
-		if (auto *vulkan_app = dynamic_cast<vkb::VulkanSample<vkb::BindingType::C> *>(&platform->get_app()))
+		if (auto *vulkan_app = dynamic_cast<vkb::VulkanSampleC *>(&platform->get_app()))
 		{
 			auto &configuration = vulkan_app->get_configuration();
 

--- a/bldsys/cmake/template/sample/sample.cpp.in
+++ b/bldsys/cmake/template/sample/sample.cpp.in
@@ -58,7 +58,7 @@ bool @SAMPLE_NAME@::prepare(const vkb::ApplicationOptions &options)
 	return true;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_@SAMPLE_NAME_FILE@()
+std::unique_ptr<vkb::VulkanSampleC> create_@SAMPLE_NAME_FILE@()
 {
 	return std::make_unique<@SAMPLE_NAME@>();
 }

--- a/bldsys/cmake/template/sample/sample.h.in
+++ b/bldsys/cmake/template/sample/sample.h.in
@@ -21,7 +21,7 @@
 #include "scene_graph/components/camera.h"
 #include "vulkan_sample.h"
 
-class @SAMPLE_NAME@ : public vkb::VulkanSample<vkb::BindingType::C>
+class @SAMPLE_NAME@ : public vkb::VulkanSampleC
 {
   public:
 	@SAMPLE_NAME@();
@@ -31,4 +31,4 @@ class @SAMPLE_NAME@ : public vkb::VulkanSample<vkb::BindingType::C>
 	virtual ~@SAMPLE_NAME@() = default;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_@SAMPLE_NAME_FILE@();
+std::unique_ptr<vkb::VulkanSampleC> create_@SAMPLE_NAME_FILE@();

--- a/bldsys/cmake/template/sample_api/sample.cpp.in
+++ b/bldsys/cmake/template/sample_api/sample.cpp.in
@@ -168,7 +168,7 @@ void @SAMPLE_NAME@::render(float delta_time)
 	ApiVulkanSample::submit_frame();
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_@SAMPLE_NAME_FILE@()
+std::unique_ptr<vkb::VulkanSampleC> create_@SAMPLE_NAME_FILE@()
 {
 	return std::make_unique<@SAMPLE_NAME@>();
 }

--- a/bldsys/cmake/template/sample_api/sample.h.in
+++ b/bldsys/cmake/template/sample_api/sample.h.in
@@ -39,4 +39,4 @@ class @SAMPLE_NAME@ : public ApiVulkanSample
 	VkPipelineLayout sample_pipeline_layout{};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_@SAMPLE_NAME_FILE@();
+std::unique_ptr<vkb::VulkanSampleC> create_@SAMPLE_NAME_FILE@();

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -99,7 +99,7 @@ struct Meshlet
  *
  * See vkb::VulkanSample for documentation
  */
-class ApiVulkanSample : public vkb::VulkanSample<vkb::BindingType::C>
+class ApiVulkanSample : public vkb::VulkanSampleC
 {
   public:
 	ApiVulkanSample() = default;

--- a/framework/common/hpp_resource_caching.h
+++ b/framework/common/hpp_resource_caching.h
@@ -134,7 +134,7 @@ struct hash<vkb::core::HPPImageView>
 {
 	size_t operator()(const vkb::core::HPPImageView &image_view) const
 	{
-		size_t result = std::hash<vkb::core::VulkanResource<vkb::BindingType::Cpp, vk::ImageView>>()(image_view);
+		size_t result = std::hash<vkb::core::VulkanResourceCpp<vk::ImageView>>()(image_view);
 		vkb::hash_combine(result, image_view.get_image());
 		vkb::hash_combine(result, image_view.get_format());
 		vkb::hash_combine(result, image_view.get_subresource_range());

--- a/framework/core/allocated.h
+++ b/framework/core/allocated.h
@@ -275,7 +275,7 @@ class AllocatedBase
 template <
     typename HandleType,
     typename MemoryType = VkDeviceMemory,
-    typename ParentType = vkb::core::VulkanResource<vkb::BindingType::C, HandleType>>
+    typename ParentType = vkb::core::VulkanResourceC<HandleType>>
 class Allocated : public ParentType, public AllocatedBase
 {
   public:

--- a/framework/core/command_buffer.h
+++ b/framework/core/command_buffer.h
@@ -57,7 +57,7 @@ using SubpassC = Subpass<vkb::BindingType::C>;
  * @brief Helper class to manage and record a command buffer, building and
  *        keeping track of pipeline state and resource bindings
  */
-class CommandBuffer : public vkb::core::VulkanResource<vkb::BindingType::C, VkCommandBuffer>
+class CommandBuffer : public vkb::core::VulkanResourceC<VkCommandBuffer>
 {
   public:
 	enum class ResetMode

--- a/framework/core/device.cpp
+++ b/framework/core/device.cpp
@@ -27,7 +27,7 @@ Device::Device(PhysicalDevice                        &gpu,
                VkSurfaceKHR                           surface,
                std::unique_ptr<DebugUtils>          &&debug_utils,
                std::unordered_map<const char *, bool> requested_extensions) :
-    vkb::core::VulkanResource<vkb::BindingType::C, VkDevice>{VK_NULL_HANDLE, this},        // Recursive, but valid
+    vkb::core::VulkanResourceC<VkDevice>{VK_NULL_HANDLE, this},        // Recursive, but valid
     debug_utils{std::move(debug_utils)},
     gpu{gpu},
     resource_cache{*this}

--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -50,7 +50,7 @@ struct DriverVersion
 	uint16_t patch;
 };
 
-class Device : public vkb::core::VulkanResource<vkb::BindingType::C, VkDevice>
+class Device : public vkb::core::VulkanResourceC<VkDevice>
 {
   public:
 	/**

--- a/framework/core/hpp_allocated.h
+++ b/framework/core/hpp_allocated.h
@@ -65,9 +65,9 @@ template <typename HandleType>
 class HPPAllocated : public Allocated<
                          HandleType,
                          vk::DeviceMemory,
-                         vkb::core::VulkanResource<vkb::BindingType::Cpp, HandleType>>
+                         vkb::core::VulkanResourceCpp<HandleType>>
 {
-	using Parent = Allocated<HandleType, vk::DeviceMemory, vkb::core::VulkanResource<vkb::BindingType::Cpp, HandleType>>;
+	using Parent = Allocated<HandleType, vk::DeviceMemory, vkb::core::VulkanResourceCpp<HandleType>>;
 
   public:
 	using Parent::get_handle;

--- a/framework/core/hpp_command_buffer.h
+++ b/framework/core/hpp_command_buffer.h
@@ -45,7 +45,7 @@ class HPPDescriptorSetLayout;
  * @brief Helper class to manage and record a command buffer, building and
  *        keeping track of pipeline state and resource bindings
  */
-class HPPCommandBuffer : public vkb::core::VulkanResource<vkb::BindingType::Cpp, vk::CommandBuffer>
+class HPPCommandBuffer : public vkb::core::VulkanResourceCpp<vk::CommandBuffer>
 {
   public:
 	struct RenderPassBinding

--- a/framework/core/hpp_device.h
+++ b/framework/core/hpp_device.h
@@ -33,7 +33,7 @@ namespace core
 {
 class HPPBuffer;
 
-class HPPDevice : public vkb::core::VulkanResource<vkb::BindingType::Cpp, vk::Device>
+class HPPDevice : public vkb::core::VulkanResourceCpp<vk::Device>
 {
   public:
 	/**

--- a/framework/core/hpp_image_view.h
+++ b/framework/core/hpp_image_view.h
@@ -24,7 +24,7 @@ namespace vkb
 {
 namespace core
 {
-class HPPImageView : public vkb::core::VulkanResource<vkb::BindingType::Cpp, vk::ImageView>
+class HPPImageView : public vkb::core::VulkanResourceCpp<vk::ImageView>
 {
   public:
 	HPPImageView(vkb::core::HPPImage &image,

--- a/framework/core/hpp_sampler.cpp
+++ b/framework/core/hpp_sampler.cpp
@@ -24,7 +24,7 @@ namespace vkb
 namespace core
 {
 HPPSampler::HPPSampler(vkb::core::HPPDevice &device, const vk::SamplerCreateInfo &info) :
-    vkb::core::VulkanResource<vkb::BindingType::Cpp, vk::Sampler>{device.get_handle().createSampler(info), &device}
+    vkb::core::VulkanResourceCpp<vk::Sampler>{device.get_handle().createSampler(info), &device}
 {}
 
 HPPSampler::HPPSampler(HPPSampler &&other) :

--- a/framework/core/hpp_sampler.h
+++ b/framework/core/hpp_sampler.h
@@ -26,7 +26,7 @@ namespace core
 /**
  * @brief Represents a Vulkan Sampler, using Vulkan-Hpp
  */
-class HPPSampler : public vkb::core::VulkanResource<vkb::BindingType::Cpp, vk::Sampler>
+class HPPSampler : public vkb::core::VulkanResourceCpp<vk::Sampler>
 {
   public:
 	/**

--- a/framework/core/image_view.h
+++ b/framework/core/image_view.h
@@ -26,7 +26,7 @@ namespace vkb
 {
 namespace core
 {
-class ImageView : public vkb::core::VulkanResource<vkb::BindingType::C, VkImageView>
+class ImageView : public vkb::core::VulkanResourceC<VkImageView>
 {
   public:
 	ImageView(Image &image, VkImageViewType view_type, VkFormat format = VK_FORMAT_UNDEFINED,

--- a/framework/core/render_pass.h
+++ b/framework/core/render_pass.h
@@ -43,7 +43,7 @@ struct SubpassInfo
 	std::string debug_name;
 };
 
-class RenderPass : public vkb::core::VulkanResource<vkb::BindingType::C, VkRenderPass>
+class RenderPass : public vkb::core::VulkanResourceC<VkRenderPass>
 {
   public:
 	RenderPass(Device                           &device,

--- a/framework/core/sampler.h
+++ b/framework/core/sampler.h
@@ -30,7 +30,7 @@ namespace core
 /**
  * @brief Represents a Vulkan Sampler
  */
-class Sampler : public VulkanResource<vkb::BindingType::C, VkSampler>
+class Sampler : public VulkanResourceC<VkSampler>
 {
   public:
 	/**

--- a/framework/core/vulkan_resource.h
+++ b/framework/core/vulkan_resource.h
@@ -280,5 +280,10 @@ inline void VulkanResource<bindingType, Handle>::set_handle(Handle hdl)
 {
 	handle = hdl;
 }
+
+template <typename Handle>
+using VulkanResourceC = VulkanResource<vkb::BindingType::C, Handle>;
+template <typename Handle>
+using VulkanResourceCpp = VulkanResource<vkb::BindingType::Cpp, Handle>;
 }        // namespace core
 }        // namespace vkb

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -93,7 +93,7 @@ const ImGuiWindowFlags Gui::options_flags = Gui::common_flags;
 
 const ImGuiWindowFlags Gui::info_flags = Gui::common_flags | ImGuiWindowFlags_NoInputs;
 
-Gui::Gui(VulkanSample<vkb::BindingType::C> &sample_, const Window &window, const Stats *stats, const float font_size, bool explicit_update) :
+Gui::Gui(VulkanSampleC &sample_, const Window &window, const Stats *stats, const float font_size, bool explicit_update) :
     sample{sample_},
     content_scale_factor{window.get_content_scale_factor()},
     dpi_factor{window.get_dpi_factor() * content_scale_factor},

--- a/framework/gui.h
+++ b/framework/gui.h
@@ -148,7 +148,7 @@ class Gui
 	 * @param font_size The font size
 	 * @param explicit_update If true, update buffers every frame
 	 */
-	Gui(VulkanSample<vkb::BindingType::C> &sample, const Window &window, const Stats *stats = nullptr, const float font_size = 21.0f, bool explicit_update = false);
+	Gui(VulkanSampleC &sample, const Window &window, const Stats *stats = nullptr, const float font_size = 21.0f, bool explicit_update = false);
 
 	/**
 	 * @brief Destroys the Gui
@@ -270,7 +270,7 @@ class Gui
 
 	static const ImGuiWindowFlags info_flags;
 
-	VulkanSample<vkb::BindingType::C> &sample;
+	VulkanSampleC &sample;
 
 	std::unique_ptr<core::Buffer> vertex_buffer;
 

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -26,7 +26,7 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 
 bool HPPApiVulkanSample::prepare(const vkb::ApplicationOptions &options)
 {
-	if (!VulkanSample<vkb::BindingType::Cpp>::prepare(options))
+	if (!vkb::VulkanSampleCpp::prepare(options))
 	{
 		return false;
 	}
@@ -160,17 +160,17 @@ void HPPApiVulkanSample::create_render_context()
 	auto surface_priority_list = std::vector<vk::SurfaceFormatKHR>{{vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
 	                                                               {vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}};
 
-	VulkanSample<vkb::BindingType::Cpp>::create_render_context(surface_priority_list);
+	vkb::VulkanSampleCpp::create_render_context(surface_priority_list);
 }
 
 void HPPApiVulkanSample::prepare_render_context()
 {
-	VulkanSample<vkb::BindingType::Cpp>::prepare_render_context();
+	vkb::VulkanSampleCpp::prepare_render_context();
 }
 
 void HPPApiVulkanSample::input_event(const vkb::InputEvent &input_event)
 {
-	VulkanSample<vkb::BindingType::Cpp>::input_event(input_event);
+	vkb::VulkanSampleCpp::input_event(input_event);
 
 	bool gui_captures_event = false;
 

--- a/framework/hpp_api_vulkan_sample.h
+++ b/framework/hpp_api_vulkan_sample.h
@@ -60,7 +60,7 @@ struct HPPVertex
  *
  * See vkb::ApiVulkanSample for documentation
  */
-class HPPApiVulkanSample : public vkb::VulkanSample<vkb::BindingType::Cpp>
+class HPPApiVulkanSample : public vkb::VulkanSampleCpp
 {
   public:
 	HPPApiVulkanSample() = default;

--- a/framework/hpp_gui.cpp
+++ b/framework/hpp_gui.cpp
@@ -68,7 +68,7 @@ const ImGuiWindowFlags HPPGui::common_flags  = ImGuiWindowFlags_NoMove |
 const ImGuiWindowFlags HPPGui::options_flags = HPPGui::common_flags;
 const ImGuiWindowFlags HPPGui::info_flags    = HPPGui::common_flags | ImGuiWindowFlags_NoInputs;
 
-HPPGui::HPPGui(VulkanSample<BindingType::Cpp> &sample_, const vkb::Window &window, const vkb::stats::HPPStats *stats, float font_size, bool explicit_update) :
+HPPGui::HPPGui(VulkanSampleCpp &sample_, const vkb::Window &window, const vkb::stats::HPPStats *stats, float font_size, bool explicit_update) :
     sample{sample_}, content_scale_factor{window.get_content_scale_factor()}, dpi_factor{window.get_dpi_factor() * content_scale_factor}, explicit_update{explicit_update}, stats_view(stats)
 {
 	ImGui::CreateContext();

--- a/framework/hpp_gui.h
+++ b/framework/hpp_gui.h
@@ -32,6 +32,7 @@ namespace vkb
 {
 template <vkb::BindingType bindingType>
 class VulkanSample;
+using VulkanSampleCpp = VulkanSample<vkb::BindingType::Cpp>;
 
 /**
  * @brief Helper structure for fonts loaded from TTF
@@ -62,7 +63,7 @@ struct HPPFont
 	}
 
 	std::vector<uint8_t> data;
-	ImFont	          *handle = nullptr;
+	ImFont              *handle = nullptr;
 	std::string          name;
 	float                size = 0.0f;
 };
@@ -117,11 +118,11 @@ class HPPGui
 	 * @param font_size The font size
 	 * @param explicit_update If true, update buffers every frame
 	 */
-	HPPGui(VulkanSample<vkb::BindingType::Cpp> &sample,
-	       const vkb::Window                   &window,
-	       const vkb::stats::HPPStats          *stats           = nullptr,
-	       float                                font_size       = 21.0f,
-	       bool                                 explicit_update = false);
+	HPPGui(VulkanSampleCpp            &sample,
+	       const vkb::Window          &window,
+	       const vkb::stats::HPPStats *stats           = nullptr,
+	       float                       font_size       = 21.0f,
+	       bool                        explicit_update = false);
 
 	/**
 	 * @brief Destroys the HPPGui
@@ -258,7 +259,7 @@ class HPPGui
 
   private:
 	PushConstBlock                           push_const_block;
-	VulkanSample<vkb::BindingType::Cpp>     &sample;
+	VulkanSampleCpp                         &sample;
 	std::unique_ptr<vkb::core::HPPBuffer>    vertex_buffer;
 	std::unique_ptr<vkb::core::HPPBuffer>    index_buffer;
 	size_t                                   last_vertex_buffer_size = 0;

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -260,14 +260,14 @@ void Platform::update()
 		});
 		active_app->update(delta_time);
 
-		if (auto *app = dynamic_cast<VulkanSample<vkb::BindingType::Cpp> *>(active_app.get()))
+		if (auto *app = dynamic_cast<VulkanSampleCpp *>(active_app.get()))
 		{
 			if (app->has_render_context())
 			{
 				on_post_draw(reinterpret_cast<vkb::RenderContext &>(app->get_render_context()));
 			}
 		}
-		else if (auto *app = dynamic_cast<VulkanSample<vkb::BindingType::C> *>(active_app.get()))
+		else if (auto *app = dynamic_cast<VulkanSampleC *>(active_app.get()))
 		{
 			if (app->has_render_context())
 			{

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -1105,7 +1105,7 @@ inline void VulkanSample<bindingType>::create_gui(const Window &window, StatsTyp
 	else
 	{
 		gui = std::make_unique<vkb::HPPGui>(
-		    *reinterpret_cast<VulkanSample<vkb::BindingType::Cpp> *>(this), window, reinterpret_cast<vkb::stats::HPPStats const *>(stats), font_size, explicit_update);
+		    *reinterpret_cast<VulkanSampleCpp *>(this), window, reinterpret_cast<vkb::stats::HPPStats const *>(stats), font_size, explicit_update);
 	}
 }
 
@@ -1365,5 +1365,8 @@ inline void VulkanSample<bindingType>::update_stats(float delta_time)
 		}
 	}
 }
+
+using VulkanSampleC   = VulkanSample<vkb::BindingType::C>;
+using VulkanSampleCpp = VulkanSample<vkb::BindingType::Cpp>;
 
 }        // namespace vkb

--- a/samples/api/hpp_oit_depth_peeling/hpp_oit_depth_peeling.cpp
+++ b/samples/api/hpp_oit_depth_peeling/hpp_oit_depth_peeling.cpp
@@ -553,7 +553,7 @@ void HPPOITDepthPeeling::update_scene_constants()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::Cpp>> create_hpp_oit_depth_peeling()
+std::unique_ptr<vkb::VulkanSampleCpp> create_hpp_oit_depth_peeling()
 {
 	return std::make_unique<HPPOITDepthPeeling>();
 }

--- a/samples/api/hpp_oit_depth_peeling/hpp_oit_depth_peeling.h
+++ b/samples/api/hpp_oit_depth_peeling/hpp_oit_depth_peeling.h
@@ -184,4 +184,4 @@ class HPPOITDepthPeeling : public HPPApiVulkanSample
 	std::unique_ptr<vkb::core::HPPBuffer>                     scene_constants = {};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::Cpp>> create_hpp_oit_depth_peeling();
+std::unique_ptr<vkb::VulkanSampleCpp> create_hpp_oit_depth_peeling();

--- a/samples/api/oit_depth_peeling/oit_depth_peeling.cpp
+++ b/samples/api/oit_depth_peeling/oit_depth_peeling.cpp
@@ -572,7 +572,7 @@ void OITDepthPeeling::update_scene_constants()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_oit_depth_peeling()
+std::unique_ptr<vkb::VulkanSampleC> create_oit_depth_peeling()
 {
 	return std::make_unique<OITDepthPeeling>();
 }

--- a/samples/api/oit_depth_peeling/oit_depth_peeling.h
+++ b/samples/api/oit_depth_peeling/oit_depth_peeling.h
@@ -107,4 +107,4 @@ class OITDepthPeeling : public ApiVulkanSample
 	int32_t back_layer_index     = kLayerMaxCount - 1;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_oit_depth_peeling();
+std::unique_ptr<vkb::VulkanSampleC> create_oit_depth_peeling();

--- a/samples/api/oit_linked_lists/oit_linked_lists.cpp
+++ b/samples/api/oit_linked_lists/oit_linked_lists.cpp
@@ -518,7 +518,7 @@ void OITLinkedLists::fill_instance_data()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_oit_linked_lists()
+std::unique_ptr<vkb::VulkanSampleC> create_oit_linked_lists()
 {
 	return std::make_unique<OITLinkedLists>();
 }

--- a/samples/api/oit_linked_lists/oit_linked_lists.h
+++ b/samples/api/oit_linked_lists/oit_linked_lists.h
@@ -113,4 +113,4 @@ class OITLinkedLists : public ApiVulkanSample
 	float   background_grayscale  = 0.3f;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_oit_linked_lists();
+std::unique_ptr<vkb::VulkanSampleC> create_oit_linked_lists();

--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -975,7 +975,7 @@ SwapchainRecreation::~SwapchainRecreation()
 
 std::unique_ptr<vkb::Device> SwapchainRecreation::create_device(vkb::PhysicalDevice &gpu)
 {
-	std::unique_ptr<vkb::Device> device = vkb::VulkanSample<vkb::BindingType::C>::create_device(gpu);
+	std::unique_ptr<vkb::Device> device = vkb::VulkanSampleC::create_device(gpu);
 
 	has_maintenance1 = get_instance().is_enabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME) &&
 	                   get_instance().is_enabled(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME) &&

--- a/samples/api/swapchain_recreation/swapchain_recreation.h
+++ b/samples/api/swapchain_recreation/swapchain_recreation.h
@@ -25,7 +25,7 @@
  * @brief A sample that implements best practices in handling present resources and swapchain
  * recreation, for example due to window resizing or present mode changes.
  */
-class SwapchainRecreation : public vkb::VulkanSample<vkb::BindingType::C>
+class SwapchainRecreation : public vkb::VulkanSampleC
 {
 	struct SwapchainObjects
 	{

--- a/samples/extensions/buffer_device_address/buffer_device_address.cpp
+++ b/samples/extensions/buffer_device_address/buffer_device_address.cpp
@@ -433,7 +433,7 @@ void BufferDeviceAddress::request_gpu_features(vkb::PhysicalDevice &gpu)
 	features.bufferDeviceAddress = VK_TRUE;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_buffer_device_address()
+std::unique_ptr<vkb::VulkanSampleC> create_buffer_device_address()
 {
 	return std::make_unique<BufferDeviceAddress>();
 }

--- a/samples/extensions/buffer_device_address/buffer_device_address.h
+++ b/samples/extensions/buffer_device_address/buffer_device_address.h
@@ -72,4 +72,4 @@ class BufferDeviceAddress : public ApiVulkanSample
 	uint32_t                              num_indices_per_mesh{};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_buffer_device_address();
+std::unique_ptr<vkb::VulkanSampleC> create_buffer_device_address();

--- a/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
+++ b/samples/extensions/conservative_rasterization/conservative_rasterization.cpp
@@ -632,7 +632,7 @@ void ConservativeRasterization::on_update_ui_overlay(vkb::Drawer &drawer)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_conservative_rasterization()
+std::unique_ptr<vkb::VulkanSampleC> create_conservative_rasterization()
 {
 	return std::make_unique<ConservativeRasterization>();
 }

--- a/samples/extensions/conservative_rasterization/conservative_rasterization.h
+++ b/samples/extensions/conservative_rasterization/conservative_rasterization.h
@@ -125,4 +125,4 @@ class ConservativeRasterization : public ApiVulkanSample
 	virtual void on_update_ui_overlay(vkb::Drawer &drawer) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_conservative_rasterization();
+std::unique_ptr<vkb::VulkanSampleC> create_conservative_rasterization();

--- a/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
+++ b/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.cpp
@@ -470,7 +470,7 @@ void DescriptorBufferBasic::on_update_ui_overlay(vkb::Drawer &drawer)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_descriptor_buffer_basic()
+std::unique_ptr<vkb::VulkanSampleC> create_descriptor_buffer_basic()
 {
 	return std::make_unique<DescriptorBufferBasic>();
 }

--- a/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.h
+++ b/samples/extensions/descriptor_buffer_basic/descriptor_buffer_basic.h
@@ -87,4 +87,4 @@ class DescriptorBufferBasic : public ApiVulkanSample
 	void         on_update_ui_overlay(vkb::Drawer &drawer) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_descriptor_buffer_basic();
+std::unique_ptr<vkb::VulkanSampleC> create_descriptor_buffer_basic();

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -529,7 +529,7 @@ void DescriptorIndexing::request_gpu_features(vkb::PhysicalDevice &gpu)
 	vkGetPhysicalDeviceProperties2KHR(gpu.get_handle(), &device_properties);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_descriptor_indexing()
+std::unique_ptr<vkb::VulkanSampleC> create_descriptor_indexing()
 {
 	return std::make_unique<DescriptorIndexing>();
 }

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.h
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.h
@@ -79,4 +79,4 @@ class DescriptorIndexing : public ApiVulkanSample
 	const VkFormat                                  format = VK_FORMAT_R8G8B8A8_UNORM;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_descriptor_indexing();
+std::unique_ptr<vkb::VulkanSampleC> create_descriptor_indexing();

--- a/samples/extensions/dynamic_blending/dynamic_blending.cpp
+++ b/samples/extensions/dynamic_blending/dynamic_blending.cpp
@@ -684,7 +684,7 @@ bool DynamicBlending::resize(const uint32_t width, const uint32_t height)
 	return true;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_dynamic_blending()
+std::unique_ptr<vkb::VulkanSampleC> create_dynamic_blending()
 {
 	return std::make_unique<DynamicBlending>();
 }

--- a/samples/extensions/dynamic_blending/dynamic_blending.h
+++ b/samples/extensions/dynamic_blending/dynamic_blending.h
@@ -143,4 +143,4 @@ class DynamicBlending : public ApiVulkanSample
 	void randomize_color(std::array<float, 4> &color, bool alpha = false);
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_dynamic_blending();
+std::unique_ptr<vkb::VulkanSampleC> create_dynamic_blending();

--- a/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.cpp
+++ b/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.cpp
@@ -522,7 +522,7 @@ bool DynamicLineRasterization::resize(const uint32_t width, const uint32_t heigh
 	return true;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_dynamic_line_rasterization()
+std::unique_ptr<vkb::VulkanSampleC> create_dynamic_line_rasterization()
 {
 	return std::make_unique<DynamicLineRasterization>();
 }

--- a/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.h
+++ b/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.h
@@ -89,4 +89,4 @@ class DynamicLineRasterization : public ApiVulkanSample
 	static uint16_t array_to_uint16(const std::array<bool, 16> &array);
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_dynamic_line_rasterization();
+std::unique_ptr<vkb::VulkanSampleC> create_dynamic_line_rasterization();

--- a/samples/extensions/dynamic_primitive_clipping/dynamic_primitive_clipping.cpp
+++ b/samples/extensions/dynamic_primitive_clipping/dynamic_primitive_clipping.cpp
@@ -387,7 +387,7 @@ void DynamicPrimitiveClipping::setup_descriptor_sets()
 	vkUpdateDescriptorSets(get_device().get_handle(), static_cast<uint32_t>(write_descriptor_sets.size()), write_descriptor_sets.data(), 0, NULL);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_dynamic_primitive_clipping()
+std::unique_ptr<vkb::VulkanSampleC> create_dynamic_primitive_clipping()
 {
 	return std::make_unique<DynamicPrimitiveClipping>();
 }

--- a/samples/extensions/dynamic_primitive_clipping/dynamic_primitive_clipping.h
+++ b/samples/extensions/dynamic_primitive_clipping/dynamic_primitive_clipping.h
@@ -103,4 +103,4 @@ class DynamicPrimitiveClipping : public ApiVulkanSample
 	VkPipeline sample_pipeline{};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_dynamic_primitive_clipping();
+std::unique_ptr<vkb::VulkanSampleC> create_dynamic_primitive_clipping();

--- a/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
+++ b/samples/extensions/dynamic_rendering/dynamic_rendering.cpp
@@ -460,7 +460,7 @@ void DynamicRendering::on_update_ui_overlay(vkb::Drawer &drawer)
 {
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_dynamic_rendering()
+std::unique_ptr<vkb::VulkanSampleC> create_dynamic_rendering()
 {
 	return std::make_unique<DynamicRendering>();
 }

--- a/samples/extensions/dynamic_rendering/dynamic_rendering.h
+++ b/samples/extensions/dynamic_rendering/dynamic_rendering.h
@@ -77,4 +77,4 @@ class DynamicRendering : public ApiVulkanSample
 	bool enable_dynamic;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_dynamic_rendering();
+std::unique_ptr<vkb::VulkanSampleC> create_dynamic_rendering();

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -1115,7 +1115,7 @@ void ExtendedDynamicState2::cube_animation(float delta_time)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_extended_dynamic_state2()
+std::unique_ptr<vkb::VulkanSampleC> create_extended_dynamic_state2()
 {
 	return std::make_unique<ExtendedDynamicState2>();
 }

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.h
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.h
@@ -157,4 +157,4 @@ class ExtendedDynamicState2 : public ApiVulkanSample
 	void      cube_animation(float delta_time);
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_extended_dynamic_state2();
+std::unique_ptr<vkb::VulkanSampleC> create_extended_dynamic_state2();

--- a/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.cpp
+++ b/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.cpp
@@ -398,7 +398,7 @@ void FragmentShaderBarycentric::request_gpu_features(vkb::PhysicalDevice &gpu)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_fragment_shader_barycentric()
+std::unique_ptr<vkb::VulkanSampleC> create_fragment_shader_barycentric()
 {
 	return std::make_unique<FragmentShaderBarycentric>();
 }

--- a/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.h
+++ b/samples/extensions/fragment_shader_barycentric/fragment_shader_barycentric.h
@@ -85,4 +85,4 @@ class FragmentShaderBarycentric : public ApiVulkanSample
 	void draw();
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_fragment_shader_barycentric();
+std::unique_ptr<vkb::VulkanSampleC> create_fragment_shader_barycentric();

--- a/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
+++ b/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
@@ -740,7 +740,7 @@ bool FragmentShadingRate::resize(const uint32_t width, const uint32_t height)
 	return true;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_fragment_shading_rate()
+std::unique_ptr<vkb::VulkanSampleC> create_fragment_shading_rate()
 {
 	return std::make_unique<FragmentShadingRate>();
 }

--- a/samples/extensions/fragment_shading_rate/fragment_shading_rate.h
+++ b/samples/extensions/fragment_shading_rate/fragment_shading_rate.h
@@ -104,4 +104,4 @@ class FragmentShadingRate : public ApiVulkanSample
 	virtual bool resize(const uint32_t width, const uint32_t height) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_fragment_shading_rate();
+std::unique_ptr<vkb::VulkanSampleC> create_fragment_shading_rate();

--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -1205,7 +1205,7 @@ bool FragmentShadingRateDynamic::resize(const uint32_t new_width, const uint32_t
 	return true;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_fragment_shading_rate_dynamic()
+std::unique_ptr<vkb::VulkanSampleC> create_fragment_shading_rate_dynamic()
 {
 	return std::make_unique<FragmentShadingRateDynamic>();
 }

--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.h
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.h
@@ -149,4 +149,4 @@ class FragmentShadingRateDynamic : public ApiVulkanSample
 	} push_const_block;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_fragment_shading_rate_dynamic();
+std::unique_ptr<vkb::VulkanSampleC> create_fragment_shading_rate_dynamic();

--- a/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.cpp
+++ b/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.cpp
@@ -193,7 +193,7 @@ void HPPMeshShading::draw()
 	HPPApiVulkanSample::submit_frame();
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::Cpp>> create_hpp_mesh_shading()
+std::unique_ptr<vkb::VulkanSampleCpp> create_hpp_mesh_shading()
 {
 	return std::make_unique<HPPMeshShading>();
 }

--- a/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.h
+++ b/samples/extensions/hpp_mesh_shading/hpp_mesh_shading.h
@@ -54,4 +54,4 @@ class HPPMeshShading : public HPPApiVulkanSample
 	vk::DescriptorSetLayout descriptor_set_layout = nullptr;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::Cpp>> create_hpp_mesh_shading();
+std::unique_ptr<vkb::VulkanSampleCpp> create_hpp_mesh_shading();

--- a/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
+++ b/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
@@ -689,7 +689,7 @@ void LogicOpDynamicState::on_update_ui_overlay(vkb::Drawer &drawer)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_logic_op_dynamic_state()
+std::unique_ptr<vkb::VulkanSampleC> create_logic_op_dynamic_state()
 {
 	return std::make_unique<LogicOpDynamicState>();
 }

--- a/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.h
+++ b/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.h
@@ -140,4 +140,4 @@ class LogicOpDynamicState : public ApiVulkanSample
 	void create_render_context() override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_logic_op_dynamic_state();
+std::unique_ptr<vkb::VulkanSampleC> create_logic_op_dynamic_state();

--- a/samples/extensions/mesh_shader_culling/mesh_shader_culling.cpp
+++ b/samples/extensions/mesh_shader_culling/mesh_shader_culling.cpp
@@ -377,7 +377,7 @@ bool MeshShaderCulling::resize(uint32_t width, uint32_t height)
 	return true;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_mesh_shader_culling()
+std::unique_ptr<vkb::VulkanSampleC> create_mesh_shader_culling()
 {
 	return std::make_unique<MeshShaderCulling>();
 }

--- a/samples/extensions/mesh_shader_culling/mesh_shader_culling.h
+++ b/samples/extensions/mesh_shader_culling/mesh_shader_culling.h
@@ -70,4 +70,4 @@ class MeshShaderCulling : public ApiVulkanSample
 	void get_query_results();
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_mesh_shader_culling();
+std::unique_ptr<vkb::VulkanSampleC> create_mesh_shader_culling();

--- a/samples/extensions/mesh_shading/mesh_shading.cpp
+++ b/samples/extensions/mesh_shading/mesh_shading.cpp
@@ -240,7 +240,7 @@ void MeshShading::render(float delta_time)
 	draw();
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_mesh_shading()
+std::unique_ptr<vkb::VulkanSampleC> create_mesh_shading()
 {
 	return std::make_unique<MeshShading>();
 }

--- a/samples/extensions/mesh_shading/mesh_shading.h
+++ b/samples/extensions/mesh_shading/mesh_shading.h
@@ -45,4 +45,4 @@ class MeshShading : public ApiVulkanSample
 	void render(float delta_time) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_mesh_shading();
+std::unique_ptr<vkb::VulkanSampleC> create_mesh_shading();

--- a/samples/extensions/open_cl_interop/open_cl_interop.cpp
+++ b/samples/extensions/open_cl_interop/open_cl_interop.cpp
@@ -908,7 +908,7 @@ bool OpenCLInterop::prepare(const vkb::ApplicationOptions &options)
 	return true;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_open_cl_interop()
+std::unique_ptr<vkb::VulkanSampleC> create_open_cl_interop()
 {
 	return std::make_unique<OpenCLInterop>();
 }

--- a/samples/extensions/open_cl_interop/open_cl_interop.h
+++ b/samples/extensions/open_cl_interop/open_cl_interop.h
@@ -129,4 +129,4 @@ class OpenCLInterop : public ApiVulkanSample
 	float total_time_passed{0};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_open_cl_interop();
+std::unique_ptr<vkb::VulkanSampleC> create_open_cl_interop();

--- a/samples/extensions/open_gl_interop/open_gl_interop.cpp
+++ b/samples/extensions/open_gl_interop/open_gl_interop.cpp
@@ -761,7 +761,7 @@ OpenGLInterop::~OpenGLInterop()
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_open_gl_interop()
+std::unique_ptr<vkb::VulkanSampleC> create_open_gl_interop()
 {
 	return std::make_unique<OpenGLInterop>();
 }

--- a/samples/extensions/open_gl_interop/open_gl_interop.h
+++ b/samples/extensions/open_gl_interop/open_gl_interop.h
@@ -113,4 +113,4 @@ class OpenGLInterop : public ApiVulkanSample
 	VkDescriptorSetLayout descriptor_set_layout{VK_NULL_HANDLE};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_open_gl_interop();
+std::unique_ptr<vkb::VulkanSampleC> create_open_gl_interop();

--- a/samples/extensions/patch_control_points/patch_control_points.cpp
+++ b/samples/extensions/patch_control_points/patch_control_points.cpp
@@ -603,7 +603,7 @@ void PatchControlPoints::on_update_ui_overlay(vkb::Drawer &drawer)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_patch_control_points()
+std::unique_ptr<vkb::VulkanSampleC> create_patch_control_points()
 {
 	return std::make_unique<PatchControlPoints>();
 }

--- a/samples/extensions/patch_control_points/patch_control_points.h
+++ b/samples/extensions/patch_control_points/patch_control_points.h
@@ -105,4 +105,4 @@ class PatchControlPoints : public ApiVulkanSample
 	void create_descriptor_sets();
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_patch_control_points();
+std::unique_ptr<vkb::VulkanSampleC> create_patch_control_points();

--- a/samples/extensions/push_descriptors/push_descriptors.cpp
+++ b/samples/extensions/push_descriptors/push_descriptors.cpp
@@ -391,7 +391,7 @@ void PushDescriptors::on_update_ui_overlay(vkb::Drawer &drawer)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_push_descriptors()
+std::unique_ptr<vkb::VulkanSampleC> create_push_descriptors()
 {
 	return std::make_unique<PushDescriptors>();
 }

--- a/samples/extensions/push_descriptors/push_descriptors.h
+++ b/samples/extensions/push_descriptors/push_descriptors.h
@@ -83,4 +83,4 @@ class PushDescriptors : public ApiVulkanSample
 	virtual void on_update_ui_overlay(vkb::Drawer &drawer) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_push_descriptors();
+std::unique_ptr<vkb::VulkanSampleC> create_push_descriptors();

--- a/samples/extensions/ray_queries/ray_queries.cpp
+++ b/samples/extensions/ray_queries/ray_queries.cpp
@@ -518,7 +518,7 @@ void RayQueries::draw()
 	ApiVulkanSample::submit_frame();
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_ray_queries()
+std::unique_ptr<vkb::VulkanSampleC> create_ray_queries()
 {
 	return std::make_unique<RayQueries>();
 }

--- a/samples/extensions/ray_queries/ray_queries.h
+++ b/samples/extensions/ray_queries/ray_queries.h
@@ -96,4 +96,4 @@ class RayQueries : public ApiVulkanSample
 	void draw();
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_ray_queries();
+std::unique_ptr<vkb::VulkanSampleC> create_ray_queries();

--- a/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
+++ b/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
@@ -885,7 +885,7 @@ void RaytracingBasic::render(float delta_time)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_ray_tracing_basic()
+std::unique_ptr<vkb::VulkanSampleC> create_ray_tracing_basic()
 {
 	return std::make_unique<RaytracingBasic>();
 }

--- a/samples/extensions/ray_tracing_basic/ray_tracing_basic.h
+++ b/samples/extensions/ray_tracing_basic/ray_tracing_basic.h
@@ -103,4 +103,4 @@ class RaytracingBasic : public ApiVulkanSample
 	virtual void  render(float delta_time) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_ray_tracing_basic();
+std::unique_ptr<vkb::VulkanSampleC> create_ray_tracing_basic();

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -1478,7 +1478,7 @@ void RaytracingExtended::render(float delta_time)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_ray_tracing_extended()
+std::unique_ptr<vkb::VulkanSampleC> create_ray_tracing_extended()
 {
 	return std::make_unique<RaytracingExtended>();
 }

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.h
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.h
@@ -286,4 +286,4 @@ class RaytracingExtended : public ApiVulkanSample
 	void render(float delta_time) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_ray_tracing_extended();
+std::unique_ptr<vkb::VulkanSampleC> create_ray_tracing_extended();

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
@@ -1008,7 +1008,7 @@ void RaytracingReflection::render(float delta_time)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_ray_tracing_reflection()
+std::unique_ptr<vkb::VulkanSampleC> create_ray_tracing_reflection()
 {
 	return std::make_unique<RaytracingReflection>();
 }

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.h
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.h
@@ -136,4 +136,4 @@ class RaytracingReflection : public ApiVulkanSample
 	void render(float delta_time) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_ray_tracing_reflection();
+std::unique_ptr<vkb::VulkanSampleC> create_ray_tracing_reflection();

--- a/samples/extensions/shader_object/shader_object.cpp
+++ b/samples/extensions/shader_object/shader_object.cpp
@@ -2024,7 +2024,7 @@ void ShaderObject::Shader::destroy(VkDevice device)
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_shader_object()
+std::unique_ptr<vkb::VulkanSampleC> create_shader_object()
 {
 	return std::make_unique<ShaderObject>();
 }

--- a/samples/extensions/shader_object/shader_object.h
+++ b/samples/extensions/shader_object/shader_object.h
@@ -288,4 +288,4 @@ class ShaderObject : public ApiVulkanSample
 	std::default_random_engine rng;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_shader_object();
+std::unique_ptr<vkb::VulkanSampleC> create_shader_object();

--- a/samples/extensions/sparse_image/sparse_image.cpp
+++ b/samples/extensions/sparse_image/sparse_image.cpp
@@ -940,7 +940,7 @@ void SparseImage::render(float delta_time)
 	draw();
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_sparse_image()
+std::unique_ptr<vkb::VulkanSampleC> create_sparse_image()
 {
 	return std::make_unique<SparseImage>();
 }

--- a/samples/extensions/sparse_image/sparse_image.h
+++ b/samples/extensions/sparse_image/sparse_image.h
@@ -396,4 +396,4 @@ class SparseImage : public ApiVulkanSample
 	virtual void on_update_ui_overlay(vkb::Drawer &drawer) override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_sparse_image();
+std::unique_ptr<vkb::VulkanSampleC> create_sparse_image();

--- a/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.cpp
+++ b/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.cpp
@@ -569,7 +569,7 @@ void VertexDynamicState::model_data_creation()
 	get_device().flush_command_buffer(copy_command, queue, true);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_vertex_dynamic_state()
+std::unique_ptr<vkb::VulkanSampleC> create_vertex_dynamic_state()
 {
 	return std::make_unique<VertexDynamicState>();
 }

--- a/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.h
+++ b/samples/extensions/vertex_dynamic_state/vertex_dynamic_state.h
@@ -86,4 +86,4 @@ class VertexDynamicState : public ApiVulkanSample
 	void draw_created_model(VkCommandBuffer commandBuffer);
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_vertex_dynamic_state();
+std::unique_ptr<vkb::VulkanSampleC> create_vertex_dynamic_state();

--- a/samples/general/mobile_nerf/mobile_nerf.cpp
+++ b/samples/general/mobile_nerf/mobile_nerf.cpp
@@ -1691,7 +1691,7 @@ void MobileNerf::update_render_pass_nerf_baseline()
 	VK_CHECK(vkCreateRenderPass(get_device().get_handle(), &render_pass_create_info, nullptr, &render_pass_nerf));
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_mobile_nerf()
+std::unique_ptr<vkb::VulkanSampleC> create_mobile_nerf()
 {
 	return std::make_unique<MobileNerf>();
 }

--- a/samples/general/mobile_nerf/mobile_nerf.h
+++ b/samples/general/mobile_nerf/mobile_nerf.h
@@ -226,4 +226,4 @@ class MobileNerf : public ApiVulkanSample
 	bool     use_native_screen_size = false;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_mobile_nerf();
+std::unique_ptr<vkb::VulkanSampleC> create_mobile_nerf();

--- a/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
+++ b/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
@@ -348,7 +348,7 @@ void KHR16BitArithmeticSample::draw_gui()
 	    /* lines = */ 1);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_16bit_arithmetic()
+std::unique_ptr<vkb::VulkanSampleC> create_16bit_arithmetic()
 {
 	return std::make_unique<KHR16BitArithmeticSample>();
 }

--- a/samples/performance/16bit_arithmetic/16bit_arithmetic.h
+++ b/samples/performance/16bit_arithmetic/16bit_arithmetic.h
@@ -23,7 +23,7 @@
 /**
  * @brief Using 16-bit arithmetic extension to improve arithmetic throughput
  */
-class KHR16BitArithmeticSample : public vkb::VulkanSample<vkb::BindingType::C>
+class KHR16BitArithmeticSample : public vkb::VulkanSampleC
 {
   public:
 	KHR16BitArithmeticSample();
@@ -69,4 +69,4 @@ class KHR16BitArithmeticSample : public vkb::VulkanSample<vkb::BindingType::C>
 	};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_16bit_arithmetic();
+std::unique_ptr<vkb::VulkanSampleC> create_16bit_arithmetic();

--- a/samples/performance/16bit_storage_input_output/16bit_storage_input_output.cpp
+++ b/samples/performance/16bit_storage_input_output/16bit_storage_input_output.cpp
@@ -246,7 +246,7 @@ void KHR16BitStorageInputOutputSample::recreate_swapchain()
 	get_render_context().update_swapchain(image_usage_flags);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_16bit_storage_input_output()
+std::unique_ptr<vkb::VulkanSampleC> create_16bit_storage_input_output()
 {
 	return std::make_unique<KHR16BitStorageInputOutputSample>();
 }

--- a/samples/performance/16bit_storage_input_output/16bit_storage_input_output.h
+++ b/samples/performance/16bit_storage_input_output/16bit_storage_input_output.h
@@ -22,7 +22,7 @@
 /**
  * @brief Using 16-bit storage features to reduce bandwidth for input-output data between vertex and fragment shaders.
  */
-class KHR16BitStorageInputOutputSample : public vkb::VulkanSample<vkb::BindingType::C>
+class KHR16BitStorageInputOutputSample : public vkb::VulkanSampleC
 {
   public:
 	KHR16BitStorageInputOutputSample();
@@ -60,4 +60,4 @@ class KHR16BitStorageInputOutputSample : public vkb::VulkanSample<vkb::BindingTy
 	bool supports_16bit_storage{false};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_16bit_storage_input_output();
+std::unique_ptr<vkb::VulkanSampleC> create_16bit_storage_input_output();

--- a/samples/performance/afbc/afbc.cpp
+++ b/samples/performance/afbc/afbc.cpp
@@ -130,7 +130,7 @@ void AFBCSample::draw_gui()
 	    /* lines = */ 1);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_afbc()
+std::unique_ptr<vkb::VulkanSampleC> create_afbc()
 {
 	return std::make_unique<AFBCSample>();
 }

--- a/samples/performance/afbc/afbc.h
+++ b/samples/performance/afbc/afbc.h
@@ -25,7 +25,7 @@
 /**
  * @brief Using framebuffer compression to reduce bandwidth
  */
-class AFBCSample : public vkb::VulkanSample<vkb::BindingType::C>
+class AFBCSample : public vkb::VulkanSampleC
 {
   public:
 	AFBCSample();
@@ -50,4 +50,4 @@ class AFBCSample : public vkb::VulkanSample<vkb::BindingType::C>
 	std::chrono::system_clock::time_point start_time;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_afbc();
+std::unique_ptr<vkb::VulkanSampleC> create_afbc();

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -732,7 +732,7 @@ void AsyncComputeSample::finish()
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_async_compute()
+std::unique_ptr<vkb::VulkanSampleC> create_async_compute()
 {
 	return std::make_unique<AsyncComputeSample>();
 }

--- a/samples/performance/async_compute/async_compute.h
+++ b/samples/performance/async_compute/async_compute.h
@@ -26,7 +26,7 @@
 /**
  * @brief Using multiple queues to achieve more parallelism on the GPU
  */
-class AsyncComputeSample : public vkb::VulkanSample<vkb::BindingType::C>
+class AsyncComputeSample : public vkb::VulkanSampleC
 {
   public:
 	AsyncComputeSample();
@@ -118,4 +118,4 @@ class AsyncComputeSample : public vkb::VulkanSample<vkb::BindingType::C>
 	vkb::RenderTarget &get_current_forward_render_target();
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_async_compute();
+std::unique_ptr<vkb::VulkanSampleC> create_async_compute();

--- a/samples/performance/command_buffer_usage/command_buffer_usage.cpp
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.cpp
@@ -427,7 +427,7 @@ CommandBufferUsage::ForwardSubpassSecondaryState &CommandBufferUsage::ForwardSub
 	return state;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_command_buffer_usage()
+std::unique_ptr<vkb::VulkanSampleC> create_command_buffer_usage()
 {
 	return std::make_unique<CommandBufferUsage>();
 }

--- a/samples/performance/command_buffer_usage/command_buffer_usage.h
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.h
@@ -33,7 +33,7 @@
  *        multi-threaded recording, as well as the different
  *        strategies for recycling command buffers every frame
  */
-class CommandBufferUsage : public vkb::VulkanSample<vkb::BindingType::C>
+class CommandBufferUsage : public vkb::VulkanSampleC
 {
   public:
 	CommandBufferUsage();
@@ -147,4 +147,4 @@ class CommandBufferUsage : public vkb::VulkanSample<vkb::BindingType::C>
 	uint32_t max_thread_count{0};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_command_buffer_usage();
+std::unique_ptr<vkb::VulkanSampleC> create_command_buffer_usage();

--- a/samples/performance/constant_data/constant_data.cpp
+++ b/samples/performance/constant_data/constant_data.cpp
@@ -276,7 +276,7 @@ void ConstantData::draw_gui()
 	    /* lines = */ vkb::to_u32(lines));
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_constant_data()
+std::unique_ptr<vkb::VulkanSampleC> create_constant_data()
 {
 	return std::make_unique<ConstantData>();
 }

--- a/samples/performance/constant_data/constant_data.h
+++ b/samples/performance/constant_data/constant_data.h
@@ -67,7 +67,7 @@ struct alignas(16) MVPUniform
  *
  * The shaders will be compiled with a definition to handle this difference.
  */
-class ConstantData : public vkb::VulkanSample<vkb::BindingType::C>
+class ConstantData : public vkb::VulkanSampleC
 {
   public:
 	/**
@@ -274,4 +274,4 @@ class ConstantData : public vkb::VulkanSample<vkb::BindingType::C>
 	int last_gui_method_value{static_cast<int>(Method::PushConstants)};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_constant_data();
+std::unique_ptr<vkb::VulkanSampleC> create_constant_data();

--- a/samples/performance/descriptor_management/descriptor_management.cpp
+++ b/samples/performance/descriptor_management/descriptor_management.cpp
@@ -144,7 +144,7 @@ void DescriptorManagement::draw_gui()
 	    /* lines = */ vkb::to_u32(lines));
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_descriptor_management()
+std::unique_ptr<vkb::VulkanSampleC> create_descriptor_management()
 {
 	return std::make_unique<DescriptorManagement>();
 }

--- a/samples/performance/descriptor_management/descriptor_management.h
+++ b/samples/performance/descriptor_management/descriptor_management.h
@@ -21,7 +21,7 @@
 #include "scene_graph/components/perspective_camera.h"
 #include "vulkan_sample.h"
 
-class DescriptorManagement : public vkb::VulkanSample<vkb::BindingType::C>
+class DescriptorManagement : public vkb::VulkanSampleC
 {
   public:
 	DescriptorManagement();
@@ -61,4 +61,4 @@ class DescriptorManagement : public vkb::VulkanSample<vkb::BindingType::C>
 	virtual void draw_gui() override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_descriptor_management();
+std::unique_ptr<vkb::VulkanSampleC> create_descriptor_management();

--- a/samples/performance/hpp_pipeline_cache/hpp_pipeline_cache.cpp
+++ b/samples/performance/hpp_pipeline_cache/hpp_pipeline_cache.cpp
@@ -48,7 +48,7 @@ HPPPipelineCache::~HPPPipelineCache()
 
 bool HPPPipelineCache::prepare(const vkb::ApplicationOptions &options)
 {
-	if (!VulkanSample<vkb::BindingType::Cpp>::prepare(options))
+	if (!vkb::VulkanSampleCpp::prepare(options))
 	{
 		return false;
 	}
@@ -158,10 +158,10 @@ void HPPPipelineCache::update(float delta_time)
 		record_frame_time_next_frame    = false;
 	}
 
-	VulkanSample<vkb::BindingType::Cpp>::update(delta_time);
+	vkb::VulkanSampleCpp::update(delta_time);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::Cpp>> create_hpp_pipeline_cache()
+std::unique_ptr<vkb::VulkanSampleCpp> create_hpp_pipeline_cache()
 {
 	return std::make_unique<HPPPipelineCache>();
 }

--- a/samples/performance/hpp_pipeline_cache/hpp_pipeline_cache.h
+++ b/samples/performance/hpp_pipeline_cache/hpp_pipeline_cache.h
@@ -24,7 +24,7 @@
 /**
  * @brief Pipeline creation and caching
  */
-class HPPPipelineCache : public vkb::VulkanSample<vkb::BindingType::Cpp>
+class HPPPipelineCache : public vkb::VulkanSampleCpp
 {
   public:
 	HPPPipelineCache();
@@ -45,4 +45,4 @@ class HPPPipelineCache : public vkb::VulkanSample<vkb::BindingType::Cpp>
 	bool              record_frame_time_next_frame    = false;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::Cpp>> create_hpp_pipeline_cache();
+std::unique_ptr<vkb::VulkanSampleCpp> create_hpp_pipeline_cache();

--- a/samples/performance/hpp_swapchain_images/hpp_swapchain_images.cpp
+++ b/samples/performance/hpp_swapchain_images/hpp_swapchain_images.cpp
@@ -31,7 +31,7 @@ HPPSwapchainImages::HPPSwapchainImages()
 
 bool HPPSwapchainImages::prepare(const vkb::ApplicationOptions &options)
 {
-	if (!VulkanSample<vkb::BindingType::Cpp>::prepare(options))
+	if (!vkb::VulkanSampleCpp::prepare(options))
 	{
 		return false;
 	}
@@ -70,7 +70,7 @@ void HPPSwapchainImages::update(float delta_time)
 		last_swapchain_image_count = swapchain_image_count;
 	}
 
-	VulkanSample<vkb::BindingType::Cpp>::update(delta_time);
+	vkb::VulkanSampleCpp::update(delta_time);
 }
 
 void HPPSwapchainImages::draw_gui()

--- a/samples/performance/hpp_swapchain_images/hpp_swapchain_images.h
+++ b/samples/performance/hpp_swapchain_images/hpp_swapchain_images.h
@@ -23,7 +23,7 @@
 /**
  * @brief Using triple buffering over double buffering, using Vulkan-Hpp
  */
-class HPPSwapchainImages : public vkb::VulkanSample<vkb::BindingType::Cpp>
+class HPPSwapchainImages : public vkb::VulkanSampleCpp
 {
   public:
 	HPPSwapchainImages();

--- a/samples/performance/image_compression_control/image_compression_control.cpp
+++ b/samples/performance/image_compression_control/image_compression_control.cpp
@@ -172,7 +172,7 @@ void ImageCompressionControlSample::create_render_context()
 			new_surface_priority_list.push_back(remaining_format);
 		}
 
-		VulkanSample<vkb::BindingType::C>::create_render_context(new_surface_priority_list);
+		vkb::VulkanSampleC::create_render_context(new_surface_priority_list);
 	}
 
 	/**
@@ -576,7 +576,7 @@ void ImageCompressionControlSample::draw_gui()
 	    lines);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_image_compression_control()
+std::unique_ptr<vkb::VulkanSampleC> create_image_compression_control()
 {
 	return std::make_unique<ImageCompressionControlSample>();
 }

--- a/samples/performance/image_compression_control/image_compression_control.h
+++ b/samples/performance/image_compression_control/image_compression_control.h
@@ -33,7 +33,7 @@
  * The UI shows the impact compression has on image size and bandwidth,
  * illustrating the benefits of fixed-rate (visually lossless) compression.
  */
-class ImageCompressionControlSample : public vkb::VulkanSample<vkb::BindingType::C>
+class ImageCompressionControlSample : public vkb::VulkanSampleC
 {
   public:
 	ImageCompressionControlSample();
@@ -186,4 +186,4 @@ class ImageCompressionControlSample : public vkb::VulkanSample<vkb::BindingType:
 	FixedRateCompressionLevel last_gui_fixed_rate_compression_level{gui_fixed_rate_compression_level};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_image_compression_control();
+std::unique_ptr<vkb::VulkanSampleC> create_image_compression_control();

--- a/samples/performance/layout_transitions/layout_transitions.cpp
+++ b/samples/performance/layout_transitions/layout_transitions.cpp
@@ -255,7 +255,7 @@ void LayoutTransitions::draw_gui()
 	    /* lines = */ 2);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_layout_transitions()
+std::unique_ptr<vkb::VulkanSampleC> create_layout_transitions()
 {
 	return std::make_unique<LayoutTransitions>();
 }

--- a/samples/performance/layout_transitions/layout_transitions.h
+++ b/samples/performance/layout_transitions/layout_transitions.h
@@ -25,7 +25,7 @@
 /**
  * @brief Transitioning images from UNDEFINED vs last known layout
  */
-class LayoutTransitions : public vkb::VulkanSample<vkb::BindingType::C>
+class LayoutTransitions : public vkb::VulkanSampleC
 {
   public:
 	LayoutTransitions();
@@ -60,4 +60,4 @@ class LayoutTransitions : public vkb::VulkanSample<vkb::BindingType::C>
 	LayoutTransitionType layout_transition_type{LayoutTransitionType::UNDEFINED};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_layout_transitions();
+std::unique_ptr<vkb::VulkanSampleC> create_layout_transitions();

--- a/samples/performance/msaa/msaa.cpp
+++ b/samples/performance/msaa/msaa.cpp
@@ -850,7 +850,7 @@ void MSAASample::draw_gui()
 	    lines);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_msaa()
+std::unique_ptr<vkb::VulkanSampleC> create_msaa()
 {
 	return std::make_unique<MSAASample>();
 }

--- a/samples/performance/msaa/msaa.h
+++ b/samples/performance/msaa/msaa.h
@@ -60,7 +60,7 @@
  * This sample shows how to use the extension to also resolve the depth
  * attachment on writeback and use it in a simple postprocessing pass.
  */
-class MSAASample : public vkb::VulkanSample<vkb::BindingType::C>
+class MSAASample : public vkb::VulkanSampleC
 {
   public:
 	MSAASample();
@@ -272,4 +272,4 @@ class MSAASample : public vkb::VulkanSample<vkb::BindingType::C>
 	VkResolveModeFlagBits last_gui_depth_resolve_mode{VK_RESOLVE_MODE_NONE};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_msaa();
+std::unique_ptr<vkb::VulkanSampleC> create_msaa();

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -948,7 +948,7 @@ void MultiDrawIndirect::cpu_cull()
 	get_device().get_fence_pool().wait();
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_multi_draw_indirect()
+std::unique_ptr<vkb::VulkanSampleC> create_multi_draw_indirect()
 {
 	return std::make_unique<MultiDrawIndirect>();
 }

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.h
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.h
@@ -150,4 +150,4 @@ class MultiDrawIndirect : public ApiVulkanSample
 	bool m_supports_buffer_device  = false;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_multi_draw_indirect();
+std::unique_ptr<vkb::VulkanSampleC> create_multi_draw_indirect();

--- a/samples/performance/multithreading_render_passes/multithreading_render_passes.cpp
+++ b/samples/performance/multithreading_render_passes/multithreading_render_passes.cpp
@@ -542,7 +542,7 @@ void MultithreadingRenderPasses::ShadowSubpass::prepare_push_constants(vkb::Comm
 	return;
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_multithreading_render_passes()
+std::unique_ptr<vkb::VulkanSampleC> create_multithreading_render_passes()
 {
 	return std::make_unique<MultithreadingRenderPasses>();
 }

--- a/samples/performance/multithreading_render_passes/multithreading_render_passes.h
+++ b/samples/performance/multithreading_render_passes/multithreading_render_passes.h
@@ -35,7 +35,7 @@ struct alignas(16) ShadowUniform
  * This sample shows performance improvement when using multithreading with
  * multiple render passes and primary level command buffers.
  */
-class MultithreadingRenderPasses : public vkb::VulkanSample<vkb::BindingType::C>
+class MultithreadingRenderPasses : public vkb::VulkanSampleC
 {
   public:
 	enum class MultithreadingMode
@@ -178,4 +178,4 @@ class MultithreadingRenderPasses : public vkb::VulkanSample<vkb::BindingType::C>
 	void draw_main_pass(vkb::CommandBuffer &command_buffer);
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_multithreading_render_passes();
+std::unique_ptr<vkb::VulkanSampleC> create_multithreading_render_passes();

--- a/samples/performance/pipeline_barriers/pipeline_barriers.cpp
+++ b/samples/performance/pipeline_barriers/pipeline_barriers.cpp
@@ -344,7 +344,7 @@ void PipelineBarriers::draw_gui()
 	    /* lines = */ lines);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_pipeline_barriers()
+std::unique_ptr<vkb::VulkanSampleC> create_pipeline_barriers()
 {
 	return std::make_unique<PipelineBarriers>();
 }

--- a/samples/performance/pipeline_barriers/pipeline_barriers.h
+++ b/samples/performance/pipeline_barriers/pipeline_barriers.h
@@ -25,7 +25,7 @@
 /**
  * @brief Using pipeline barriers efficiently
  */
-class PipelineBarriers : public vkb::VulkanSample<vkb::BindingType::C>
+class PipelineBarriers : public vkb::VulkanSampleC
 {
   public:
 	PipelineBarriers();
@@ -59,4 +59,4 @@ class PipelineBarriers : public vkb::VulkanSample<vkb::BindingType::C>
 	DependencyType dependency_type{DependencyType::BOTTOM_TO_TOP};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_pipeline_barriers();
+std::unique_ptr<vkb::VulkanSampleC> create_pipeline_barriers();

--- a/samples/performance/pipeline_cache/pipeline_cache.cpp
+++ b/samples/performance/pipeline_cache/pipeline_cache.cpp
@@ -183,7 +183,7 @@ void PipelineCache::update(float delta_time)
 	VulkanSample::update(delta_time);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_pipeline_cache()
+std::unique_ptr<vkb::VulkanSampleC> create_pipeline_cache()
 {
 	return std::make_unique<PipelineCache>();
 }

--- a/samples/performance/pipeline_cache/pipeline_cache.h
+++ b/samples/performance/pipeline_cache/pipeline_cache.h
@@ -26,7 +26,7 @@
 /**
  * @brief Pipeline creation and caching
  */
-class PipelineCache : public vkb::VulkanSample<vkb::BindingType::C>
+class PipelineCache : public vkb::VulkanSampleC
 {
   public:
 	PipelineCache();
@@ -53,4 +53,4 @@ class PipelineCache : public vkb::VulkanSample<vkb::BindingType::C>
 	virtual void draw_gui() override;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_pipeline_cache();
+std::unique_ptr<vkb::VulkanSampleC> create_pipeline_cache();

--- a/samples/performance/render_passes/render_passes.cpp
+++ b/samples/performance/render_passes/render_passes.cpp
@@ -173,7 +173,7 @@ void RenderPassesSample::draw_renderpass(vkb::CommandBuffer &command_buffer, vkb
 	command_buffer.end_render_pass();
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_render_passes()
+std::unique_ptr<vkb::VulkanSampleC> create_render_passes()
 {
 	return std::make_unique<RenderPassesSample>();
 }

--- a/samples/performance/render_passes/render_passes.h
+++ b/samples/performance/render_passes/render_passes.h
@@ -26,7 +26,7 @@
 /**
  * @brief Appropriate use of render pass attachment operations
  */
-class RenderPassesSample : public vkb::VulkanSample<vkb::BindingType::C>
+class RenderPassesSample : public vkb::VulkanSampleC
 {
   public:
 	RenderPassesSample();
@@ -80,4 +80,4 @@ class RenderPassesSample : public vkb::VulkanSample<vkb::BindingType::C>
 	float frame_rate;
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_render_passes();
+std::unique_ptr<vkb::VulkanSampleC> create_render_passes();

--- a/samples/performance/specialization_constants/specialization_constants.cpp
+++ b/samples/performance/specialization_constants/specialization_constants.cpp
@@ -162,7 +162,7 @@ void SpecializationConstants::draw_gui()
 	    /* lines = */ lines);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_specialization_constants()
+std::unique_ptr<vkb::VulkanSampleC> create_specialization_constants()
 {
 	return std::make_unique<SpecializationConstants>();
 }

--- a/samples/performance/specialization_constants/specialization_constants.h
+++ b/samples/performance/specialization_constants/specialization_constants.h
@@ -36,7 +36,7 @@ struct alignas(16) CustomForwardLights
 /**
  * @brief Using specialization constants
  */
-class SpecializationConstants : public vkb::VulkanSample<vkb::BindingType::C>
+class SpecializationConstants : public vkb::VulkanSampleC
 {
   public:
 	SpecializationConstants();
@@ -121,4 +121,4 @@ class SpecializationConstants : public vkb::VulkanSample<vkb::BindingType::C>
 	int specialization_constants_enabled{0};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_specialization_constants();
+std::unique_ptr<vkb::VulkanSampleC> create_specialization_constants();

--- a/samples/performance/subpasses/subpasses.cpp
+++ b/samples/performance/subpasses/subpasses.cpp
@@ -441,7 +441,7 @@ void Subpasses::draw_renderpass(vkb::CommandBuffer &command_buffer, vkb::RenderT
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_subpasses()
+std::unique_ptr<vkb::VulkanSampleC> create_subpasses()
 {
 	return std::make_unique<Subpasses>();
 }

--- a/samples/performance/subpasses/subpasses.h
+++ b/samples/performance/subpasses/subpasses.h
@@ -28,7 +28,7 @@
  *        implements deferred rendering with and without sub-passes, giving the
  *        user the possibility to change some key settings.
  */
-class Subpasses : public vkb::VulkanSample<vkb::BindingType::C>
+class Subpasses : public vkb::VulkanSampleC
 {
   public:
 	Subpasses();
@@ -137,4 +137,4 @@ class Subpasses : public vkb::VulkanSample<vkb::BindingType::C>
 	     /* value       = */ 0}};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_subpasses();
+std::unique_ptr<vkb::VulkanSampleC> create_subpasses();

--- a/samples/performance/surface_rotation/surface_rotation.cpp
+++ b/samples/performance/surface_rotation/surface_rotation.cpp
@@ -212,7 +212,7 @@ void SurfaceRotation::recreate_swapchain()
 	}
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_surface_rotation()
+std::unique_ptr<vkb::VulkanSampleC> create_surface_rotation()
 {
 	return std::make_unique<SurfaceRotation>();
 }

--- a/samples/performance/surface_rotation/surface_rotation.h
+++ b/samples/performance/surface_rotation/surface_rotation.h
@@ -28,7 +28,7 @@
 /**
  * @brief Appropriate use of surface rotation
  */
-class SurfaceRotation : public vkb::VulkanSample<vkb::BindingType::C>
+class SurfaceRotation : public vkb::VulkanSampleC
 {
   public:
 	SurfaceRotation();
@@ -65,4 +65,4 @@ class SurfaceRotation : public vkb::VulkanSample<vkb::BindingType::C>
 	void handle_no_resize_rotations();
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_surface_rotation();
+std::unique_ptr<vkb::VulkanSampleC> create_surface_rotation();

--- a/samples/performance/swapchain_images/swapchain_images.cpp
+++ b/samples/performance/swapchain_images/swapchain_images.cpp
@@ -39,7 +39,7 @@ SwapchainImages::SwapchainImages()
 
 bool SwapchainImages::prepare(const vkb::ApplicationOptions &options)
 {
-	if (!VulkanSample<vkb::BindingType::C>::prepare(options))
+	if (!vkb::VulkanSampleC::prepare(options))
 	{
 		return false;
 	}
@@ -92,7 +92,7 @@ void SwapchainImages::draw_gui()
 	    /* lines = */ 1);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_swapchain_images()
+std::unique_ptr<vkb::VulkanSampleC> create_swapchain_images()
 {
 	return std::make_unique<SwapchainImages>();
 }

--- a/samples/performance/swapchain_images/swapchain_images.h
+++ b/samples/performance/swapchain_images/swapchain_images.h
@@ -25,7 +25,7 @@
 /**
  * @brief Using triple buffering over double buffering
  */
-class SwapchainImages : public vkb::VulkanSample<vkb::BindingType::C>
+class SwapchainImages : public vkb::VulkanSampleC
 {
   public:
 	SwapchainImages();
@@ -46,4 +46,4 @@ class SwapchainImages : public vkb::VulkanSample<vkb::BindingType::C>
 	int last_swapchain_image_count{3};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_swapchain_images();
+std::unique_ptr<vkb::VulkanSampleC> create_swapchain_images();

--- a/samples/performance/texture_compression_comparison/texture_compression_comparison.h
+++ b/samples/performance/texture_compression_comparison/texture_compression_comparison.h
@@ -22,7 +22,7 @@
 #include "api_vulkan_sample.h"
 #include "scene_graph/components/camera.h"
 
-class TextureCompressionComparison : public vkb::VulkanSample<vkb::BindingType::C>
+class TextureCompressionComparison : public vkb::VulkanSampleC
 {
   public:
 	TextureCompressionComparison()           = default;

--- a/samples/performance/wait_idle/wait_idle.cpp
+++ b/samples/performance/wait_idle/wait_idle.cpp
@@ -105,7 +105,7 @@ void WaitIdle::draw_gui()
 	    /* lines = */ lines);
 }
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_wait_idle()
+std::unique_ptr<vkb::VulkanSampleC> create_wait_idle()
 {
 	return std::make_unique<WaitIdle>();
 }

--- a/samples/performance/wait_idle/wait_idle.h
+++ b/samples/performance/wait_idle/wait_idle.h
@@ -22,7 +22,7 @@
 #include "scene_graph/components/perspective_camera.h"
 #include "vulkan_sample.h"
 
-class WaitIdle : public vkb::VulkanSample<vkb::BindingType::C>
+class WaitIdle : public vkb::VulkanSampleC
 {
   public:
 	WaitIdle();
@@ -56,4 +56,4 @@ class WaitIdle : public vkb::VulkanSample<vkb::BindingType::C>
 	int wait_idle_enabled{0};
 };
 
-std::unique_ptr<vkb::VulkanSample<vkb::BindingType::C>> create_wait_idle();
+std::unique_ptr<vkb::VulkanSampleC> create_wait_idle();


### PR DESCRIPTION
## Description

Introduces type aliases VulkanSample[C|Cpp] and VulkanResource[C|Cpp].

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
