### PR TITLE
Remove duplicate sentence at end of readme for timeline semaphre

### DIFF
--- a/samples/extensions/timeline_semaphore/README.adoc
+++ b/samples/extensions/timeline_semaphore/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2021-2023, Arm Limited and Contributors
+- Copyright (c) 2021-2024, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -364,10 +364,6 @@ ApiVulkanSample::submit_frame();
 
 Timeline semaphores grants a lot of flexibility to applications.
 With modern approaches of task graphs, many threads and free flowing synchronization, timeline semaphores simplify a lot of things and removes the need for emulating a similar concept with binary semaphores and fences.
-
-Be careful with out-of-order submissions.
-There are various pitfalls with this approach which have been outlined in this sample.
-s.
 
 Be careful with out-of-order submissions.
 There are various pitfalls with this approach which have been outlined in this sample.


### PR DESCRIPTION
## Description

The conclusion chapter of the timeline semaphore sample has a duplicate sentence at the very end (see https://docs.vulkan.org/samples/latest/samples/extensions/timeline_semaphore/README.html#_conclusion).

This PR removes that.

**Note: This is a pure documentation fix**

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly