### PR TITLE
Fix support for --headless.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -118,8 +118,12 @@ vulkan_samples sample swapchain_images
 # Run AFBC sample in benchmark mode for 5000 frames
 vulkan_samples sample afbc --benchmark --stop-after-frame 5000
 
-# Run bonza test offscreen
-vulkan_samples test bonza --headless
+# Run compute nbody using headless_surface and take a screenshot of frame 5 
+# Note: headless_surface uses VK_EXT_headless_surface.
+# This will create a surface and a Swapchain, but present will be a no op.
+# The extension is supported by Swiftshader(https://github.com/google/swiftshader).
+# It allows to quickly test content in environments without a GPU.
+vulkan_samples sample compute_nbody --headless_surface -screenshot 5
 
 # Run all the performance samples for 10 seconds in each configuration
 vulkan_samples batch --category performance --duration 10

--- a/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
+++ b/app/android/java/com/khronos/vulkan_samples/SampleLauncherActivity.java
@@ -292,7 +292,7 @@ public class SampleLauncherActivity extends AppCompatActivity {
             arguments.add("--benchmark");
         }
         if (isHeadless) {
-            arguments.add("--headless");
+            arguments.add("--headless_surface");
         }
         String[] argArray = new String[arguments.size()];
         sendArgumentsToPlatform(arguments.toArray(argArray));

--- a/app/plugins/window_options/window_options.h
+++ b/app/plugins/window_options/window_options.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2022, Arm Limited and Contributors
+/* Copyright (c) 2020-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -47,7 +47,7 @@ class WindowOptions : public WindowOptionsTags
 	vkb::FlagCommand width_flag      = {vkb::FlagType::OneValue, "width", "", "Initial window width"};
 	vkb::FlagCommand height_flag     = {vkb::FlagType::OneValue, "height", "", "Initial window height"};
 	vkb::FlagCommand fullscreen_flag = {vkb::FlagType::FlagOnly, "fullscreen", "", "Run in fullscreen mode"};
-	vkb::FlagCommand headless_flag   = {vkb::FlagType::FlagOnly, "headless", "", "Run in headless mode"};
+	vkb::FlagCommand headless_flag   = {vkb::FlagType::FlagOnly, "headless_surface", "", "Run in headless surface mode. A Surface and swap-chain is still created using VK_EXT_headless_surface."};
 	vkb::FlagCommand borderless_flag = {vkb::FlagType::FlagOnly, "borderless", "", "Run in borderless mode"};
 	vkb::FlagCommand stretch_flag    = {vkb::FlagType::FlagOnly, "stretch", "", "Stretch window to fullscreen (direct-to-display only)"};
 	vkb::FlagCommand vsync_flag      = {vkb::FlagType::OneValue, "vsync", "", "Force vsync {ON | OFF}. If not set samples decide how vsync is set"};

--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -1,4 +1,5 @@
 /* Copyright (c) 2019-2024, Sascha Willems
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -49,13 +50,10 @@ bool ApiVulkanSample::prepare(const vkb::ApplicationOptions &options)
 	submit_info                   = vkb::initializers::submit_info();
 	submit_info.pWaitDstStageMask = &submit_pipeline_stages;
 
-	if (window->get_window_mode() != vkb::Window::Mode::Headless)
-	{
-		submit_info.waitSemaphoreCount   = 1;
-		submit_info.pWaitSemaphores      = &semaphores.acquired_image_ready;
-		submit_info.signalSemaphoreCount = 1;
-		submit_info.pSignalSemaphores    = &semaphores.render_complete;
-	}
+	submit_info.waitSemaphoreCount   = 1;
+	submit_info.pWaitSemaphores      = &semaphores.acquired_image_ready;
+	submit_info.signalSemaphoreCount = 1;
+	submit_info.pSignalSemaphores    = &semaphores.render_complete;
 
 	queue = get_device().get_suitable_graphics_queue().get_handle();
 

--- a/framework/core/hpp_instance.cpp
+++ b/framework/core/hpp_instance.cpp
@@ -1,4 +1,5 @@
 /* Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -187,7 +188,6 @@ HPPInstance::HPPInstance(const std::string                            &applicati
                          const std::unordered_map<const char *, bool> &required_extensions,
                          const std::vector<const char *>              &required_validation_layers,
                          const std::vector<vk::LayerSettingEXT>       &required_layer_settings,
-                         bool                                          headless,
                          uint32_t                                      api_version)
 {
 	std::vector<vk::ExtensionProperties> available_instance_extensions = vk::enumerateInstanceExtensionProperties();
@@ -232,20 +232,11 @@ HPPInstance::HPPInstance(const std::string                            &applicati
 	}
 #endif
 
-	// Try to enable headless surface extension if it exists
-	if (headless)
-	{
-		const bool has_headless_surface = enable_extension(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME,
-		                                                   available_instance_extensions, enabled_extensions);
-		if (!has_headless_surface)
-		{
-			LOGW("{} is not available, disabling swapchain creation", VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME);
-		}
-	}
-	else
-	{
-		enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
-	}
+	// Specific surface extensions are obtained from  Window::get_required_surface_extensions
+	// They are already added to required_extensions by VulkanSample::prepare
+
+	// Even for a headless surface a swapchain is still required
+	enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
 
 	// VK_KHR_get_physical_device_properties2 is a prerequisite of VK_KHR_performance_query
 	// which will be used for stats gathering where available.

--- a/framework/core/hpp_instance.cpp
+++ b/framework/core/hpp_instance.cpp
@@ -235,7 +235,7 @@ HPPInstance::HPPInstance(const std::string                            &applicati
 	// Specific surface extensions are obtained from  Window::get_required_surface_extensions
 	// They are already added to required_extensions by VulkanSample::prepare
 
-	// Even for a headless surface a swapchain is still required
+	// If using VK_EXT_headless_surface, we still create and use a surface
 	enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
 
 	// VK_KHR_get_physical_device_properties2 is a prerequisite of VK_KHR_performance_query
@@ -436,7 +436,7 @@ vk::Instance HPPInstance::get_handle() const
 	return handle;
 }
 
-vkb::core::HPPPhysicalDevice &HPPInstance::get_suitable_gpu(vk::SurfaceKHR surface)
+vkb::core::HPPPhysicalDevice &HPPInstance::get_suitable_gpu(vk::SurfaceKHR surface, bool headless_surface)
 {
 	assert(!gpus.empty() && "No physical devices were found on the system.");
 
@@ -449,6 +449,10 @@ vkb::core::HPPPhysicalDevice &HPPInstance::get_suitable_gpu(vk::SurfaceKHR surfa
 			throw std::runtime_error("Selected GPU index is not within no. of available GPUs");
 		}
 		return *gpus[selected_gpu_index.value()];
+	}
+	if ( headless_surface )
+	{
+		LOGW("Using headless surface with multiple GPUs. Considered explicitly selecting the target GPU.")
 	}
 
 	// Find a discrete GPU

--- a/framework/core/hpp_instance.h
+++ b/framework/core/hpp_instance.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -54,7 +55,6 @@ class HPPInstance
 	 * @param required_extensions The extensions requested to be enabled
 	 * @param required_validation_layers The validation layers to be enabled
 	 * @param required_layer_settings The layer settings to be enabled
-	 * @param headless Whether the application is requesting a headless setup or not
 	 * @param api_version The Vulkan API version that the instance will be using
 	 * @throws runtime_error if the required extensions and validation layers are not found
 	 */
@@ -62,7 +62,6 @@ class HPPInstance
 	            const std::unordered_map<const char *, bool> &required_extensions        = {},
 	            const std::vector<const char *>              &required_validation_layers = {},
 	            const std::vector<vk::LayerSettingEXT>       &required_layer_settings    = {},
-	            bool                                          headless                   = false,
 	            uint32_t                                      api_version                = VK_API_VERSION_1_0);
 
 	/**

--- a/framework/core/hpp_instance.h
+++ b/framework/core/hpp_instance.h
@@ -93,9 +93,11 @@ class HPPInstance
 	/**
 	 * @brief Tries to find the first available discrete GPU that can render to the given surface
 	 * @param surface to test against
+	 * @param headless_surface Is surface created with VK_EXT_headless_surface
 	 * @returns A valid physical device
+
 	 */
-	HPPPhysicalDevice &get_suitable_gpu(vk::SurfaceKHR);
+	HPPPhysicalDevice &get_suitable_gpu(vk::SurfaceKHR surface, bool headless_surface);
 
 	/**
 	 * @brief Checks if the given extension is enabled in the vk::Instance

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -187,7 +187,6 @@ Instance::Instance(const std::string                            &application_nam
                    const std::unordered_map<const char *, bool> &required_extensions,
                    const std::vector<const char *>              &required_validation_layers,
                    const std::vector<VkLayerSettingEXT>         &required_layer_settings,
-                   bool                                          headless,
                    uint32_t                                      api_version)
 {
 	uint32_t instance_extension_count;
@@ -240,20 +239,11 @@ Instance::Instance(const std::string                            &application_nam
 	}
 #endif
 
-	// Try to enable headless surface extension if it exists
-	if (headless)
-	{
-		const bool has_headless_surface = enable_extension(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME,
-		                                                   available_instance_extensions, enabled_extensions);
-		if (!has_headless_surface)
-		{
-			LOGW("{} is not available, disabling swapchain creation", VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME);
-		}
-	}
-	else
-	{
-		enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
-	}
+	// Specific surface extensions are obtained from  Window::get_required_surface_extensions
+	// They are already added to required_extensions by VulkanSample::prepare
+
+	// Even for a headless surface a swapchain is still required
+	enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
 
 	// VK_KHR_get_physical_device_properties2 is a prerequisite of VK_KHR_performance_query
 	// which will be used for stats gathering where available.

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -493,7 +493,7 @@ PhysicalDevice &Instance::get_first_gpu()
 	return *gpus[0];
 }
 
-PhysicalDevice &Instance::get_suitable_gpu(VkSurfaceKHR surface)
+PhysicalDevice &Instance::get_suitable_gpu(VkSurfaceKHR surface, bool headless_surface)
 {
 	assert(!gpus.empty() && "No physical devices were found on the system.");
 
@@ -506,6 +506,10 @@ PhysicalDevice &Instance::get_suitable_gpu(VkSurfaceKHR surface)
 			throw std::runtime_error("Selected GPU index is not within no. of available GPUs");
 		}
 		return *gpus[selected_gpu_index.value()];
+	}
+	if (headless_surface)
+	{
+		LOGW("Using headless surface with multiple GPUs. Considered explicitly selecting the target GPU.")
 	}
 
 	// Find a discrete GPU

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -86,9 +86,10 @@ class Instance
 	/**
 	 * @brief Tries to find the first available discrete GPU that can render to the given surface
 	 * @param surface to test against
+	 * @param headless_surface Is surface created with VK_EXT_headless_surface
 	 * @returns A valid physical device
 	 */
-	PhysicalDevice &get_suitable_gpu(VkSurfaceKHR);
+	PhysicalDevice &get_suitable_gpu(VkSurfaceKHR surface, bool headless_surface);
 
 	/**
 	 * @brief Tries to find the first available discrete GPU

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -51,7 +51,6 @@ class Instance
 	 * @param required_extensions The extensions requested to be enabled
 	 * @param required_validation_layers The validation layers to be enabled
 	 * @param required_layer_settings The layer settings to be enabled
-	 * @param headless Whether the application is requesting a headless setup or not
 	 * @param api_version The Vulkan API version that the instance will be using
 	 * @throws runtime_error if the required extensions and validation layers are not found
 	 */
@@ -59,7 +58,6 @@ class Instance
 	         const std::unordered_map<const char *, bool> &required_extensions        = {},
 	         const std::vector<const char *>              &required_validation_layers = {},
 	         const std::vector<VkLayerSettingEXT>         &required_layer_settings    = {},
-	         bool                                          headless                   = false,
 	         uint32_t                                      api_version                = VK_API_VERSION_1_0);
 
 	/**

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -1,4 +1,5 @@
 /* Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -46,11 +47,8 @@ bool HPPApiVulkanSample::prepare(const vkb::ApplicationOptions &options)
 	submit_info                   = vk::SubmitInfo();
 	submit_info.pWaitDstStageMask = &submit_pipeline_stages;
 
-	if (window->get_window_mode() != vkb::Window::Mode::Headless)
-	{
-		submit_info.setWaitSemaphores(semaphores.acquired_image_ready);
-		submit_info.setSignalSemaphores(semaphores.render_complete);
-	}
+	submit_info.setWaitSemaphores(semaphores.acquired_image_ready);
+	submit_info.setSignalSemaphores(semaphores.render_complete);
 
 	queue = get_device().get_suitable_graphics_queue().get_handle();
 

--- a/framework/platform/headless_window.cpp
+++ b/framework/platform/headless_window.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2023, Arm Limited and Contributors
+/* Copyright (c) 2018-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,12 +26,22 @@ HeadlessWindow::HeadlessWindow(const Window::Properties &properties) :
 
 VkSurfaceKHR HeadlessWindow::create_surface(Instance &instance)
 {
-	return VK_NULL_HANDLE;
+	return create_surface(instance.get_handle(), VK_NULL_HANDLE);
 }
 
-VkSurfaceKHR HeadlessWindow::create_surface(VkInstance, VkPhysicalDevice)
+VkSurfaceKHR HeadlessWindow::create_surface(VkInstance instance, VkPhysicalDevice)
 {
-	return VK_NULL_HANDLE;
+	VkSurfaceKHR surface = VK_NULL_HANDLE;
+
+	if (instance)
+	{
+		VkHeadlessSurfaceCreateInfoEXT info{};
+		info.sType = VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT;
+
+		VK_CHECK(vkCreateHeadlessSurfaceEXT(instance, &info, VK_NULL_HANDLE, &surface));
+	}
+
+	return surface;
 }
 
 bool HeadlessWindow::should_close()
@@ -52,6 +62,6 @@ float HeadlessWindow::get_dpi_factor() const
 
 std::vector<const char *> HeadlessWindow::get_required_surface_extensions() const
 {
-	return {};
+	return {VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
 }
 }        // namespace vkb

--- a/framework/platform/headless_window.h
+++ b/framework/platform/headless_window.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2023, Arm Limited and Contributors
+/* Copyright (c) 2018-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,7 +22,9 @@
 namespace vkb
 {
 /**
- * @brief Surface-less implementation of a Window, for use in headless rendering
+ * @brief Surface-less implementation of a Window using VK_EXT_headless_surface.
+ * A surface and swapchain are still created but the the present operation resolves to a no op.
+ * Useful for testing and benchmarking in CI environments.
  */
 class HeadlessWindow : public Window
 {

--- a/framework/rendering/hpp_render_context.cpp
+++ b/framework/rendering/hpp_render_context.cpp
@@ -1,4 +1,5 @@
 /* Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -95,7 +96,7 @@ void HPPRenderContext::update_swapchain(const vk::Extent2D &extent)
 {
 	if (!swapchain)
 	{
-		LOGW("Can't update the swapchains extent in headless mode, skipping.");
+		LOGW("Can't update the swapchains extent. No swapchain, offscreen rendering detected, skipping.");
 		return;
 	}
 
@@ -110,7 +111,7 @@ void HPPRenderContext::update_swapchain(const uint32_t image_count)
 {
 	if (!swapchain)
 	{
-		LOGW("Can't update the swapchains image count in headless mode, skipping.");
+		LOGW("Can't update the swapchains image count. No swapchain, offscreen rendering detected, skipping.");
 		return;
 	}
 
@@ -127,7 +128,7 @@ void HPPRenderContext::update_swapchain(const std::set<vk::ImageUsageFlagBits> &
 {
 	if (!swapchain)
 	{
-		LOGW("Can't update the swapchains image usage in headless mode, skipping.");
+		LOGW("Can't update the swapchains image usage. No swapchain, offscreen rendering detected, skipping.");
 		return;
 	}
 
@@ -142,7 +143,7 @@ void HPPRenderContext::update_swapchain(const vk::Extent2D &extent, const vk::Su
 {
 	if (!swapchain)
 	{
-		LOGW("Can't update the swapchains extent and surface transform in headless mode, skipping.");
+		LOGW("Can't update the swapchains extent and surface transform. No swapchain, offscreen rendering detected, skipping.");
 		return;
 	}
 
@@ -199,7 +200,7 @@ bool HPPRenderContext::handle_surface_changes(bool force_update)
 {
 	if (!swapchain)
 	{
-		LOGW("Can't handle surface changes in headless mode, skipping.");
+		LOGW("Can't handle surface changes. No swapchain, offscreen rendering detected, skipping.");
 		return false;
 	}
 

--- a/framework/rendering/hpp_render_context.h
+++ b/framework/rendering/hpp_render_context.h
@@ -1,4 +1,5 @@
-/* Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -40,7 +41,7 @@ class HPPRenderContext
 	/**
 	 * @brief Constructor
 	 * @param device A valid device
-	 * @param surface A surface, nullptr if in headless mode
+	 * @param surface A surface, nullptr if in offscreen mode
 	 * @param window The window where the surface was created
 	 * @param present_mode Requests to set the present mode of the swapchain
 	 * @param present_mode_priority_list The order in which the swapchain prioritizes selecting its present mode

--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -106,7 +106,7 @@ void RenderContext::update_swapchain(const VkExtent2D &extent)
 {
 	if (!swapchain)
 	{
-		LOGW("Can't update the swapchains extent in headless mode, skipping.");
+		LOGW("Can't update the swapchains extent. No swapchain, offscreen rendering detected, skipping.");
 		return;
 	}
 
@@ -121,7 +121,7 @@ void RenderContext::update_swapchain(const uint32_t image_count)
 {
 	if (!swapchain)
 	{
-		LOGW("Can't update the swapchains image count in headless mode, skipping.");
+		LOGW("Can't update the swapchains image count. No swapchain, offscreen rendering detected, skipping.");
 		return;
 	}
 
@@ -138,7 +138,7 @@ void RenderContext::update_swapchain(const std::set<VkImageUsageFlagBits> &image
 {
 	if (!swapchain)
 	{
-		LOGW("Can't update the swapchains image usage in headless mode, skipping.");
+		LOGW("Can't update the swapchains image usage. No swapchain, offscreen rendering detected, skipping.");
 		return;
 	}
 
@@ -153,7 +153,7 @@ void RenderContext::update_swapchain(const VkExtent2D &extent, const VkSurfaceTr
 {
 	if (!swapchain)
 	{
-		LOGW("Can't update the swapchains extent and surface transform in headless mode, skipping.");
+		LOGW("Can't update the swapchains extent and surface transform. No swapchain, offscreen rendering detected, skipping.");
 		return;
 	}
 
@@ -179,7 +179,7 @@ void RenderContext::update_swapchain(const VkImageCompressionFlagsEXT compressio
 {
 	if (!swapchain)
 	{
-		LOGW("Can't update the swapchains compression in headless mode, skipping.");
+		LOGW("Can't update the swapchains compression. No swapchain, offscreen rendering detected, skipping.");
 		return;
 	}
 
@@ -228,7 +228,7 @@ bool RenderContext::handle_surface_changes(bool force_update)
 {
 	if (!swapchain)
 	{
-		LOGW("Can't handle surface changes in headless mode, skipping.");
+		LOGW("Can't handle surface changes. No swapchain, offscreen rendering detected, skipping.");
 		return false;
 	}
 

--- a/framework/rendering/render_context.h
+++ b/framework/rendering/render_context.h
@@ -51,7 +51,7 @@ class Window;
  * For normal rendering (using a swapchain), the RenderContext can be created by passing in a
  * swapchain. A RenderFrame will then be created for each Swapchain image.
  *
- * For headless rendering (no swapchain), the RenderContext can be given a valid Device, and
+ * For offscreen rendering (no swapchain), the RenderContext can be given a valid Device, and
  * a width and height. A single RenderFrame will then be created.
  */
 class RenderContext
@@ -63,7 +63,7 @@ class RenderContext
 	/**
 	 * @brief Constructor
 	 * @param device A valid device
-	 * @param surface A surface, VK_NULL_HANDLE if in headless mode
+	 * @param surface A surface, VK_NULL_HANDLE if in offscreen mode
 	 * @param window The window where the surface was created
 	 * @param present_mode Requests to set the present mode of the swapchain
 	 * @param present_mode_priority_list The order in which the swapchain prioritizes selecting its present mode

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -175,7 +175,7 @@ class VulkanSample : public vkb::Application
 	 * @brief Create the Vulkan instance used by this sample
 	 * @note Can be overridden to implement custom instance creation
 	 */
-	virtual std::unique_ptr<InstanceType> create_instance(bool headless);
+	virtual std::unique_ptr<InstanceType> create_instance();
 
 	/**
 	 * @brief Override this to customise the creation of the render_context
@@ -508,9 +508,9 @@ inline std::unique_ptr<typename VulkanSample<bindingType>::DeviceType> VulkanSam
 }
 
 template <vkb::BindingType bindingType>
-inline std::unique_ptr<typename VulkanSample<bindingType>::InstanceType> VulkanSample<bindingType>::create_instance(bool headless)
+inline std::unique_ptr<typename VulkanSample<bindingType>::InstanceType> VulkanSample<bindingType>::create_instance()
 {
-	return std::make_unique<InstanceType>(get_name(), get_instance_extensions(), get_validation_layers(), get_layer_settings(), headless, api_version);
+	return std::make_unique<InstanceType>(get_name(), get_instance_extensions(), get_validation_layers(), get_layer_settings(), api_version);
 }
 
 template <vkb::BindingType bindingType>
@@ -1049,11 +1049,11 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 
 	if constexpr (bindingType == BindingType::Cpp)
 	{
-		instance = create_instance(headless);
+		instance = create_instance();
 	}
 	else
 	{
-		instance.reset(reinterpret_cast<vkb::core::HPPInstance *>(create_instance(headless).release()));
+		instance.reset(reinterpret_cast<vkb::core::HPPInstance *>(create_instance().release()));
 	}
 
 	// initialize C++-Bindings default dispatcher, second step

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -1066,7 +1066,7 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 		throw std::runtime_error("Failed to create window surface.");
 	}
 
-	auto &gpu = instance->get_suitable_gpu(surface);
+	auto &gpu = instance->get_suitable_gpu(surface, headless);
 	gpu.set_high_priority_graphics_queue_enable(high_priority_graphics_queue);
 
 	// Request to enable ASTC
@@ -1086,7 +1086,7 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 	}
 
 	// Creating vulkan device, specifying the swapchain extension always
-	if (!headless || get_instance().is_enabled(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME))
+	// If using VK_EXT_headless_surface, we still create and use a swap-chain
 	{
 		add_device_extension(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -1080,7 +1080,9 @@ HelloTriangle::~HelloTriangle()
 
 bool HelloTriangle::prepare(const vkb::ApplicationOptions &options)
 {
+	// Headless is not supported to keep this sample as simple as possible
 	assert(options.window != nullptr);
+	assert(options.window->get_window_mode() != vkb::Window::Mode::Headless);
 
 	init_instance(context, {VK_KHR_SURFACE_EXTENSION_NAME}, {});
 

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -1,4 +1,5 @@
 /* Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -195,6 +196,10 @@ HPPHelloTriangle::~HPPHelloTriangle()
 
 bool HPPHelloTriangle::prepare(const vkb::ApplicationOptions &options)
 {
+	// Headless is not supported to keep this sample as simple as possible
+	assert(options.window != nullptr);
+	assert(options.window->get_window_mode() != vkb::Window::Mode::Headless);
+
 	if (Application::prepare(options))
 	{
 		instance = create_instance({VK_KHR_SURFACE_EXTENSION_NAME}, {});

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -1,4 +1,5 @@
 /* Copyright (c) 2024, Sascha Willems
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -431,7 +432,7 @@ const std::vector<const char *> ShaderDebugPrintf::get_validation_layers()
 }
 
 // This sample overrides the instance creation part of the framework to chain in additional structures
-std::unique_ptr<vkb::Instance> ShaderDebugPrintf::create_instance(bool headless)
+std::unique_ptr<vkb::Instance> ShaderDebugPrintf::create_instance()
 {
 	uint32_t instanceApiVersion;
 	VK_CHECK(vkEnumerateInstanceVersion(&instanceApiVersion));
@@ -452,7 +453,7 @@ std::unique_ptr<vkb::Instance> ShaderDebugPrintf::create_instance(bool headless)
 		set_api_version(instanceApiVersion <= VK_MAKE_API_VERSION(0, 1, 3, 290) ? VK_API_VERSION_1_2 : VK_API_VERSION_1_1);
 
 		// Run standard create_instance() from framework (with set_api_version and layer settings support) and return
-		return VulkanSample::create_instance(headless);
+		return VulkanSample::create_instance();
 	}
 
 	// Run remainder of this custom create_instance() (without layer settings support) and return

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.h
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2024, Sascha Willems
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -93,7 +94,7 @@ class ShaderDebugPrintf : public ApiVulkanSample
 	void                            draw();
 	bool                            prepare(const vkb::ApplicationOptions &options) override;
 	const std::vector<const char *> get_validation_layers() override;
-	std::unique_ptr<vkb::Instance>  create_instance(bool headless) override;
+	std::unique_ptr<vkb::Instance>  create_instance() override;
 	virtual void                    render(float delta_time) override;
 	virtual void                    on_update_ui_overlay(vkb::Drawer &drawer) override;
 	virtual bool                    resize(const uint32_t width, const uint32_t height) override;

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -1,4 +1,5 @@
 /* Copyright (c) 2022-2024, Sascha Willems
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -121,7 +122,7 @@ std::unique_ptr<vkb::Device> Profiles::create_device(vkb::PhysicalDevice &gpu)
 
 // This sample overrides the instance creation part of the framework
 // Instead of manually setting up all properties we use the Vulkan Profiles library to simplify instance setup
-std::unique_ptr<vkb::Instance> Profiles::create_instance(bool headless)
+std::unique_ptr<vkb::Instance> Profiles::create_instance()
 {
 	// Initialize Volk Vulkan Loader
 	VkResult result = volkInitialize();

--- a/samples/tooling/profiles/profiles.h
+++ b/samples/tooling/profiles/profiles.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2022-2024, Sascha Willems
+ * Copyright (c) 2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -80,7 +81,7 @@ class Profiles : public ApiVulkanSample
 	void                           render(float delta_time) override;
 	void                           view_changed() override;
 	std::unique_ptr<vkb::Device>   create_device(vkb::PhysicalDevice &gpu) override;
-	std::unique_ptr<vkb::Instance> create_instance(bool headless) override;
+	std::unique_ptr<vkb::Instance> create_instance() override;
 	virtual void                   on_update_ui_overlay(vkb::Drawer &drawer) override;
 };
 


### PR DESCRIPTION
## Description

The main objective of this PR is to fix the `--headless` flag. Currently it does not work in the framework, due to not requesting a surface and swap chain.

This PR reworks `HeadlessWindow` to make it more similar to the other window classes. This will allow us to enable `VK_EXT_headless_surface` in `HeadlessWindow::get_required_surface_extensions` like the other windows types. Now we can remove the `headless `paramater from `Instance::Instance` and `VulkanSample<>::create_instance` simplifying the framework.

To keep the samples `hello_world` and `hpp_hello_world` as simple as possible, I did not add support for headless. Instead, an assert is run to ensure the are not enabling with headless in those samples.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly
 
Fixes #830 
Fixes #314 

