### PR TITLE
Update Image Compression Control sample tutorial

### DIFF
--- a/samples/performance/image_compression_control/README.adoc
+++ b/samples/performance/image_compression_control/README.adoc
@@ -131,7 +131,7 @@ To query if a particular image supports fixed-rate compression, add a https://re
 VkImageCompressionPropertiesEXT supported_compression_properties{VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT};
 
 VkImageCompressionControlEXT compression_control{VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_CONTROL_EXT};
-compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT;
+compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT;
 
 VkPhysicalDeviceImageFormatInfo2 image_format_info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2};
 image_format_info.format = VK_FORMAT_R8G8B8_UNORM;


### PR DESCRIPTION
## Description

_**Documentation change only**_

When querying for image compression support, `VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT` should be used, as shown in the [extension proposal](https://docs.vulkan.org/features/latest/features/proposals/VK_EXT_image_compression_control.html#_examples), otherwise the returned `imageCompressionFixedRateFlags` might be `0`.

This is correct in the framework/sample, but was copied incorrectly in the tutorial.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [n/a] I did a full batch run using the `batch` command line argument to make sure all samples still work properly