### PR TITLE
FindVulkan fixes. Bump CMake minimum version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(NOT DEFINED CMAKE_C_COMPILER_LAUNCHER AND NOT DEFINED CMAKE_CXX_COMPILER_LAUN
     endif()
 endif()
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 
 # search for Vulkan SDK
 find_package(Vulkan)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(NOT DEFINED CMAKE_C_COMPILER_LAUNCHER AND NOT DEFINED CMAKE_CXX_COMPILER_LAUN
     endif()
 endif()
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 # search for Vulkan SDK
 find_package(Vulkan)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -15,11 +15,15 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 include(android_package)
 
 # create sample app project
 project(vulkan_samples LANGUAGES C CXX)
+
+if(IOS AND CMAKE_VERSION VERSION_LESS 3.20)
+    message(FATAL_ERROR "Configuring iOS apps requires a minimum CMake version of 3.20")
+endif()
 
 add_subdirectory(plugins)
 add_subdirectory(apps)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 include(android_package)
 
 # create sample app project

--- a/bldsys/cmake/module/FindVulkan.cmake
+++ b/bldsys/cmake/module/FindVulkan.cmake
@@ -287,7 +287,7 @@ else()
             "$ENV{VULKAN_SDK}/lib"
     )
 endif()
-if(APPLE AND DEFINED ENV{VULKAN_SDK})
+if(APPLE AND DEFINED Vulkan_Target_SDK)
     list(APPEND _Vulkan_hint_include_search_paths
             "${Vulkan_Target_SDK}/macOS/include"
     )
@@ -301,7 +301,7 @@ if(APPLE AND DEFINED ENV{VULKAN_SDK})
         )
     else()
         list(APPEND _Vulkan_hint_library_search_paths
-                "${Vulkan_Target_SDK}}/lib"
+                "${Vulkan_Target_SDK}/lib"
         )
     endif()
 endif()

--- a/bldsys/cmake/module/FindVulkan.cmake
+++ b/bldsys/cmake/module/FindVulkan.cmake
@@ -668,7 +668,7 @@ find_package_handle_standard_args(Vulkan
 
 if(Vulkan_FOUND AND NOT TARGET Vulkan::Vulkan)
     add_library(Vulkan::Vulkan UNKNOWN IMPORTED)
-    cmake_path(GET Vulkan_LIBRARIES EXTENSION _Vulkan_lib_extension)
+    get_filename_component(_Vulkan_lib_extension ${Vulkan_LIBRARIES} LAST_EXT)
     if(_Vulkan_lib_extension STREQUAL ".framework" AND CMAKE_VERSION VERSION_LESS 3.28)
         set_target_properties(Vulkan::Vulkan PROPERTIES
                 # Prior to 3.28 must reference library just inside the framework.

--- a/bldsys/cmake/module/FindVulkan.cmake
+++ b/bldsys/cmake/module/FindVulkan.cmake
@@ -536,8 +536,6 @@ endif()
 if(DEFINED _Vulkan_saved_cmake_find_framework)
     set(CMAKE_FIND_FRAMEWORK ${_Vulkan_saved_cmake_find_framework})
     unset(_Vulkan_saved_cmake_find_framework)
-else()
-    unset(CMAKE_FIND_FRAMEWORK)
 endif()
 
 if(Vulkan_GLSLC_EXECUTABLE)

--- a/bldsys/cmake/module/FindVulkan.cmake
+++ b/bldsys/cmake/module/FindVulkan.cmake
@@ -240,9 +240,9 @@ endif()
 # are ever included in the SDK for macOS, the search mechanism will need
 # revisiting.
 if(DEFINED CMAKE_FIND_FRAMEWORK)
-    set( _Vulkan_saved_cmake_find_framework ${CMAKE_FIND_FRAMEWORK} )
+    set(_Vulkan_saved_cmake_find_framework ${CMAKE_FIND_FRAMEWORK})
+    set(CMAKE_FIND_FRAMEWORK FIRST)
 endif()
-set( CMAKE_FIND_FRAMEWORK FIRST )
 
 if(IOS)
     get_filename_component(Vulkan_Target_SDK "$ENV{VULKAN_SDK}/.." REALPATH)
@@ -534,7 +534,7 @@ if (dxc IN_LIST Vulkan_FIND_COMPONENTS)
 endif()
 
 if(DEFINED _Vulkan_saved_cmake_find_framework)
-    set(CMAKE_FIND_FRAMEWORK ${saved_cmake_find_framework})
+    set(CMAKE_FIND_FRAMEWORK ${_Vulkan_saved_cmake_find_framework})
     unset(_Vulkan_saved_cmake_find_framework)
 else()
     unset(CMAKE_FIND_FRAMEWORK)

--- a/bldsys/cmake/module/FindVulkan.cmake
+++ b/bldsys/cmake/module/FindVulkan.cmake
@@ -318,7 +318,7 @@ find_library(Vulkan_LIBRARY
         HINTS
         ${_Vulkan_hint_library_search_paths}
 )
-message(STATUS vulkan_library ${Vulkan_LIBRARY} search paths ${_Vulkan_hint_library_search_paths})
+message(STATUS "vulkan_library ${Vulkan_LIBRARY} search paths ${_Vulkan_hint_library_search_paths}")
 mark_as_advanced(Vulkan_LIBRARY)
 
 find_library(Vulkan_Layer_API_DUMP
@@ -652,9 +652,18 @@ find_package_handle_standard_args(Vulkan
 
 if(Vulkan_FOUND AND NOT TARGET Vulkan::Vulkan)
     add_library(Vulkan::Vulkan UNKNOWN IMPORTED)
+    cmake_path(GET Vulkan_LIBRARIES EXTENSION _Vulkan_lib_extension)
+    if(_Vulkan_lib_extension STREQUAL ".framework" AND CMAKE_VERSION VERSION_LESS 3.28)
+        set_target_properties(Vulkan::Vulkan PROPERTIES
+                # Prior to 3.28 must reference library just inside the framework.
+                IMPORTED_LOCATION "${Vulkan_LIBRARIES}/vulkan")
+    else()
+        set_target_properties(Vulkan::Vulkan PROPERTIES
+                IMPORTED_LOCATION "${Vulkan_LIBRARIES}")
+    endif()
     set_target_properties(Vulkan::Vulkan PROPERTIES
-            IMPORTED_LOCATION "${Vulkan_LIBRARIES}"
             INTERFACE_INCLUDE_DIRECTORIES "${Vulkan_INCLUDE_DIRS}")
+    unset(_Vulkan_lib_extension)
 endif()
 
 if(Vulkan_FOUND AND NOT TARGET Vulkan::Headers)

--- a/bldsys/cmake/module/FindVulkan.cmake
+++ b/bldsys/cmake/module/FindVulkan.cmake
@@ -233,6 +233,17 @@ if("FATAL_ERROR" IN_LIST Vulkan_FIND_COMPONENTS)
     list(REMOVE_ITEM Vulkan_FIND_COMPONENTS "FATAL_ERROR")
 endif()
 
+# FindVulkan only works correctly with the default CMAKE_FIND_FRAMEWORK
+# value: FIRST. If LAST it will find the macOS dylibs instead of the iOS
+# frameworks when IOS is true. If ALWAYS it will fail to find the macOS
+# dylibs. If NEVER it will fail to find the iOS frameworks. If frameworks
+# are ever included in the SDK for macOS, the search mechanism will need
+# revisiting.
+if(DEFINED CMAKE_FIND_FRAMEWORK)
+    set( _Vulkan_saved_cmake_find_framework ${CMAKE_FIND_FRAMEWORK} )
+endif()
+set( CMAKE_FIND_FRAMEWORK FIRST )
+
 if(IOS)
     get_filename_component(Vulkan_Target_SDK "$ENV{VULKAN_SDK}/.." REALPATH)
     list(APPEND CMAKE_FRAMEWORK_PATH "${Vulkan_Target_SDK}/iOS/lib")
@@ -520,6 +531,13 @@ if (dxc IN_LIST Vulkan_FIND_COMPONENTS)
             HINTS
             ${_Vulkan_hint_executable_search_paths})
     mark_as_advanced(Vulkan_dxc_EXECUTABLE)
+endif()
+
+if(DEFINED _Vulkan_saved_cmake_find_framework)
+    set(CMAKE_FIND_FRAMEWORK ${saved_cmake_find_framework})
+    unset(_Vulkan_saved_cmake_find_framework)
+else()
+    unset(CMAKE_FIND_FRAMEWORK)
 endif()
 
 if(Vulkan_GLSLC_EXECUTABLE)


### PR DESCRIPTION
## Description

Fixes 4 issues with FindVulkan:
1. Make it work with CMake 3.20+ as well as the currently required 3.28.
2. Set `CMAKE_FIND_FRAMEWORK` to `FIRST`, the only value for which the searches work.
3. Fix if() to prevent use of a variable that is undefined when seeking for macOS.
4. Remove an errant closing brace.

Bumps the minimum cmake version for `CMakeLists.txt` and `app/CMakeLists.txt` consistent with the CMake features used. In the case of `CMakeLists.txt `the version is bumped to 3.20 for consistency with app and to support use of `cmake_path` which is used in the accompanying fix to `FindVulkan.cmake` to support versions earlier than 3.28.

Fixes 1, 3 and 4 are useful to this project. All fixes are useful to people who are copying FindVulkan into their own projects. No. 2 is especially important to those using building for iOS using vcpkg which sets `CMAKE_FIND_FRAMEWORK` to `LAST`.

Fixes #1100

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

_I have left unchecked items which are not relevant to this change._

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
