### PR TITLE
Transcoded version of performance sample texture_compression_comparison based on Vulkan-Hpp

### DIFF
--- a/antora/modules/ROOT/nav.adoc
+++ b/antora/modules/ROOT/nav.adoc
@@ -110,6 +110,7 @@
 *** xref:samples/performance/hpp_swapchain_images/README.adoc[Swapchain images (Vulkan-Hpp)]
 ** xref:samples/performance/texture_compression_basisu/README.adoc[Texture compression basisu]
 ** xref:samples/performance/texture_compression_comparison/README.adoc[Texture compression comparison]
+*** xref:samples/performance/hpp_texture_compression_comparison/README.adoc[Texture compression comparison (Vulkan-Hpp)]
 ** xref:samples/performance/wait_idle/README.adoc[Wait idle]
 * xref:samples/tooling/README.adoc[Tooling samples]
 ** xref:samples/tooling/profiles/README.adoc[Profiles]

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -150,6 +150,7 @@ set(SCENE_GRAPH_FILES
     scene_graph/node.h
     scene_graph/scene.h
     scene_graph/script.h
+    scene_graph/hpp_scene.h
     # Source Files
     scene_graph/component.cpp
     scene_graph/node.cpp
@@ -175,7 +176,10 @@ set(SCENE_GRAPH_COMPONENT_FILES
     scene_graph/components/image/ktx.h
     scene_graph/components/image/stb.h
     scene_graph/components/hpp_image.h
+    scene_graph/components/hpp_material.h
+    scene_graph/components/hpp_mesh.h
     scene_graph/components/hpp_sub_mesh.h
+    scene_graph/components/hpp_texture.h
     # Source Files
     scene_graph/components/aabb.cpp
     scene_graph/components/camera.cpp

--- a/framework/common/hpp_utils.h
+++ b/framework/common/hpp_utils.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -20,6 +20,7 @@
 #include <common/utils.h>
 
 #include <rendering/hpp_render_context.h>
+#include <scene_graph/hpp_scene.h>
 
 /**
  * @brief facade helper functions around the functions in common/utils.h, providing a vulkan.hpp-based interface
@@ -28,9 +29,9 @@ namespace vkb
 {
 namespace common
 {
-inline sg::Node &add_free_camera(sg::Scene &scene, const std::string &node_name, vk::Extent2D const &extent)
+inline sg::Node &add_free_camera(vkb::scene_graph::HPPScene &scene, const std::string &node_name, vk::Extent2D const &extent)
 {
-	return vkb::add_free_camera(scene, node_name, static_cast<VkExtent2D>(extent));
+	return vkb::add_free_camera(reinterpret_cast<vkb::sg::Scene &>(scene), node_name, static_cast<VkExtent2D>(extent));
 }
 
 inline void screenshot(vkb::rendering::HPPRenderContext &render_context, const std::string &filename)

--- a/framework/hpp_gltf_loader.h
+++ b/framework/hpp_gltf_loader.h
@@ -21,6 +21,7 @@
 
 #include <core/hpp_device.h>
 #include <scene_graph/components/hpp_sub_mesh.h>
+#include <scene_graph/hpp_scene.h>
 
 namespace vkb
 {
@@ -32,8 +33,6 @@ namespace vkb
 class HPPGLTFLoader : private vkb::GLTFLoader
 {
   public:
-	using vkb::GLTFLoader::read_scene_from_file;
-
 	HPPGLTFLoader(vkb::core::HPPDevice &device) :
 	    GLTFLoader(reinterpret_cast<vkb::Device &>(device))
 	{}
@@ -43,6 +42,11 @@ class HPPGLTFLoader : private vkb::GLTFLoader
 		return std::unique_ptr<vkb::scene_graph::components::HPPSubMesh>(
 		    reinterpret_cast<vkb::scene_graph::components::HPPSubMesh *>(
 		        vkb::GLTFLoader::read_model_from_file(file_name, index).release()));
+	}
+
+	std::unique_ptr<vkb::scene_graph::HPPScene> read_scene_from_file(const std::string &file_name, int scene_index = -1)
+	{
+		return std::unique_ptr<vkb::scene_graph::HPPScene>(reinterpret_cast<vkb::scene_graph::HPPScene *>(vkb::GLTFLoader::read_scene_from_file(file_name, scene_index).release()));
 	}
 };
 }        // namespace vkb

--- a/framework/rendering/subpasses/hpp_forward_subpass.h
+++ b/framework/rendering/subpasses/hpp_forward_subpass.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -36,14 +36,14 @@ class HPPForwardSubpass : public vkb::ForwardSubpass
 {
   public:
 	HPPForwardSubpass(vkb::rendering::HPPRenderContext &render_context,
-	                  vkb::ShaderSource &&              vertex_shader,
-	                  vkb::ShaderSource &&              fragment_shader,
-	                  vkb::sg::Scene &                  scene,
-	                  vkb::sg::Camera &                 camera) :
+	                  vkb::ShaderSource               &&vertex_shader,
+	                  vkb::ShaderSource               &&fragment_shader,
+	                  vkb::scene_graph::HPPScene       &scene,
+	                  vkb::sg::Camera                  &camera) :
 	    vkb::ForwardSubpass(reinterpret_cast<vkb::RenderContext &>(render_context),
 	                        std::forward<ShaderSource>(vertex_shader),
 	                        std::forward<ShaderSource>(fragment_shader),
-	                        scene,
+	                        reinterpret_cast<vkb::sg::Scene &>(scene),
 	                        camera)
 	{}
 };

--- a/framework/scene_graph/components/hpp_material.h
+++ b/framework/scene_graph/components/hpp_material.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "hpp_texture.h"
+#include "material.h"
+
+namespace vkb
+{
+namespace scene_graph
+{
+namespace components
+{
+/**
+ * @brief facade class around vkb::sg::Material, providing a vulkan.hpp-based interface
+ *
+ * See vkb::sb::Material for documentation
+ */
+class HPPMaterial : private vkb::sg::Material
+{
+  public:
+	std::unordered_map<std::string, vkb::scene_graph::components::HPPTexture *> const &get_textures() const
+	{
+		return reinterpret_cast<std::unordered_map<std::string, vkb::scene_graph::components::HPPTexture *> const &>(vkb::sg::Material::textures);
+	}
+};
+}        // namespace components
+}        // namespace scene_graph
+}        // namespace vkb

--- a/framework/scene_graph/components/hpp_mesh.h
+++ b/framework/scene_graph/components/hpp_mesh.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "hpp_sub_mesh.h"
+#include "mesh.h"
+
+namespace vkb
+{
+namespace scene_graph
+{
+namespace components
+{
+/**
+ * @brief facade class around vkb::sg::Mesh, providing a vulkan.hpp-based interface
+ *
+ * See vkb::sb::Mesh for documentation
+ */
+class HPPMesh : private vkb::sg::Mesh
+{
+  public:
+	std::vector<vkb::scene_graph::components::HPPSubMesh *> const &get_submeshes() const
+	{
+		return reinterpret_cast<std::vector<vkb::scene_graph::components::HPPSubMesh *> const &>(vkb::sg::Mesh::get_submeshes());
+	}
+};
+}        // namespace components
+}        // namespace scene_graph
+}        // namespace vkb

--- a/framework/scene_graph/components/hpp_sub_mesh.h
+++ b/framework/scene_graph/components/hpp_sub_mesh.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <core/hpp_buffer.h>
+#include <scene_graph/components/hpp_material.h>
 #include <scene_graph/components/sub_mesh.h>
 
 namespace vkb
@@ -44,6 +45,11 @@ class HPPSubMesh : private vkb::sg::SubMesh
 	vk::IndexType get_index_type() const
 	{
 		return static_cast<vk::IndexType>(vkb::sg::SubMesh::index_type);
+	}
+
+	vkb::scene_graph::components::HPPMaterial const *get_material() const
+	{
+		return reinterpret_cast<vkb::scene_graph::components::HPPMaterial const *>(vkb::sg::SubMesh::get_material());
 	}
 
 	vkb::core::HPPBuffer const &get_vertex_buffer(std::string const &name) const

--- a/framework/scene_graph/components/hpp_texture.h
+++ b/framework/scene_graph/components/hpp_texture.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "hpp_image.h"
+#include "texture.h"
+
+namespace vkb
+{
+namespace scene_graph
+{
+namespace components
+{
+/**
+ * @brief facade class around vkb::sg::Texture, providing a vulkan.hpp-based interface
+ *
+ * See vkb::sb::Texture for documentation
+ */
+class HPPTexture : private vkb::sg::Texture
+{
+  public:
+	vkb::scene_graph::components::HPPImage *get_image()
+	{
+		return reinterpret_cast<vkb::scene_graph::components::HPPImage *>(vkb::sg::Texture::get_image());
+	}
+
+	void set_image(vkb::scene_graph::components::HPPImage &image)
+	{
+		vkb::sg::Texture::set_image(reinterpret_cast<vkb::sg::Image &>(image));
+	}
+};
+}        // namespace components
+}        // namespace scene_graph
+}        // namespace vkb

--- a/framework/scene_graph/hpp_scene.h
+++ b/framework/scene_graph/hpp_scene.h
@@ -1,0 +1,71 @@
+/* Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "components/hpp_mesh.h"
+#include "scene.h"
+#include "scene_graph/script.h"
+#include "scene_graph/scripts/animation.h"
+
+namespace vkb
+{
+namespace scene_graph
+{
+/**
+ * @brief facade class around vkb::sg::Scene, providing a vulkan.hpp-based interface
+ *
+ * See vkb::sb::Scene for documentation
+ */
+class HPPScene : private vkb::sg::Scene
+{
+  public:
+	template <class T>
+	std::vector<T *> get_components() const
+	{
+		if constexpr (std::is_same<T, vkb::sg::Script>::value)
+		{
+			return vkb::sg::Scene::get_components<T>();
+		}
+		else if constexpr (std::is_same<T, vkb::scene_graph::components::HPPMesh>::value)
+		{
+			std::vector<vkb::sg::Mesh *> meshes = vkb::sg::Scene::get_components<vkb::sg::Mesh>();
+			return *reinterpret_cast<std::vector<T *> *>(&meshes);
+		}
+		else
+		{
+			assert(false);        // path never passed -> Please add a type-check here!
+			return {};
+		}
+	}
+
+	template <class T>
+	bool has_component() const
+	{
+		if constexpr (std::is_same<T, vkb::sg::Animation>::value || std::is_same<T, vkb::sg::Script>::value)
+		{
+			return vkb::sg::Scene::has_component(typeid(T));
+		}
+		else
+		{
+			assert(false);        // path never passed -> Please add a type-check here!
+			return false;
+		}
+	}
+};
+}        // namespace scene_graph
+}        // namespace vkb

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -137,6 +137,7 @@ set(ORDER_LIST
     #HPP Performance Samples
     "hpp_pipeline_cache"
     "hpp_swapchain_images"
+	"hpp_texture_compression_comparison"
     
     #General Samples
     "mobile_nerf")

--- a/samples/performance/README.adoc
+++ b/samples/performance/README.adoc
@@ -49,9 +49,17 @@ The most straightforward and flexible approach is to re-create them for each fra
 The problem of descriptor management is intertwined with that of buffer management, that is choosing how to pack data in `VkBuffer` objects.
 This sample will explore a few options to improve both descriptor and buffer management.
 
+=== xref:./{performance_samplespath}hpp_pipeline_cache/README.adoc[HPP Pipeline cache]
+
+A transcoded version of the Performance sample <<pipeline_cache,Pipeline cache>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+
 === xref:./{performance_samplespath}hpp_swapchain_images/README.adoc[HPP Swapchain images]
 
 A transcoded version of the Performance sample <<swapchain_images,Swapchain images>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+
+=== xref:./{performance_samplespath}hpp_texture_compression_comparison/README.adoc[HPP Texture compression comparison]
+
+A transcoded version of the Performance sample <<texture_compression_comparison,Texture compression comparison>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./{performance_samplespath}image_compression_control/README.adoc[Image compression control]
 

--- a/samples/performance/hpp_texture_compression_comparison/CMakeLists.txt
+++ b/samples/performance/hpp_texture_compression_comparison/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) 2021-2024, Holochip
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+get_filename_component(FOLDER_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+get_filename_component(PARENT_DIR ${CMAKE_CURRENT_LIST_DIR} PATH)
+get_filename_component(CATEGORY_NAME ${PARENT_DIR} NAME)
+
+add_sample_with_tags(
+    ID ${FOLDER_NAME}
+    CATEGORY ${CATEGORY_NAME}
+    AUTHOR "Holochip"
+    NAME "HPP Texture compression comparison"
+    DESCRIPTION "Compare the performance of different texture formats (ASTC, BC[x], ETC2, and PVRTC), using Vulkan-Hpp")

--- a/samples/performance/hpp_texture_compression_comparison/README.adoc
+++ b/samples/performance/hpp_texture_compression_comparison/README.adoc
@@ -1,0 +1,27 @@
+////
+- Copyright (c) 2024, The Khronos Group
+-
+- SPDX-License-Identifier: Apache-2.0
+-
+- Licensed under the Apache License, Version 2.0 the "License";
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-
+////
+
+= Texture compression comparison using Vulkan-Hpp
+
+ifdef::site-gen-antora[]
+TIP: The source for this sample can be found in the https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/hpp_texture_compression_comparison[Khronos Vulkan samples github repository].
+endif::[]
+
+
+This sample demonstrates how to use different types of compressed GPU textures in a Vulkan application, and shows the timing benefits of each, using Vulkan-Hpp.

--- a/samples/performance/hpp_texture_compression_comparison/hpp_texture_compression_comparison.cpp
+++ b/samples/performance/hpp_texture_compression_comparison/hpp_texture_compression_comparison.cpp
@@ -1,0 +1,324 @@
+/* Copyright (c) 2021-2024, Holochip
+ * Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hpp_texture_compression_comparison.h"
+#include "scene_graph/components/hpp_image.h"
+#include "scene_graph/components/hpp_mesh.h"
+#include "scene_graph/components/material.h"
+
+namespace
+{
+constexpr std::array<const char *, 19> error_codes = {
+    "KTX_SUCCESS",
+    "KTX_FILE_DATA_ERROR",
+    "KTX_FILE_ISPIPE",
+    "KTX_FILE_OPEN_FAILED",
+    "KTX_FILE_OVERFLOW",
+    "KTX_FILE_READ_ERROR",
+    "KTX_FILE_SEEK_ERROR",
+    "KTX_FILE_UNEXPECTED_EOF",
+    "KTX_FILE_WRITE_ERROR",
+    "KTX_GL_ERROR",
+    "KTX_INVALID_OPERATION",
+    "KTX_INVALID_VALUE",
+    "KTX_NOT_FOUND",
+    "KTX_OUT_OF_MEMORY",
+    "KTX_TRANSCODE_FAILED",
+    "KTX_UNKNOWN_FILE_FORMAT",
+    "KTX_UNSUPPORTED_TEXTURE_TYPE",
+    "KTX_UNSUPPORTED_FEATURE",
+    "KTX_LIBRARY_NOT_LINKED",
+};
+
+std::string get_sponza_texture_filename(const std::string &short_name)
+{
+	return vkb::fs::path::get(vkb::fs::path::Type::Assets) + "scenes/sponza/ktx2/" + short_name + "2";
+}
+
+class HPPCompressedImage : public vkb::scene_graph::components::HPPImage
+{
+  public:
+	HPPCompressedImage(vkb::core::HPPDevice                                  &device,
+	                   const std::string                                     &name,
+	                   std::vector<vkb::scene_graph::components::HPPMipmap> &&mipmaps,
+	                   vk::Format                                             format) :
+	    vkb::scene_graph::components::HPPImage(name, std::vector<uint8_t>{}, std::move(mipmaps))
+	{
+		vkb::scene_graph::components::HPPImage::set_format(format);
+		vkb::scene_graph::components::HPPImage::create_vk_image(device);
+	}
+};
+}        // namespace
+
+#define KTX_CHECK(x)                                                                              \
+	do                                                                                            \
+	{                                                                                             \
+		KTX_error_code err = x;                                                                   \
+		if (err != KTX_SUCCESS)                                                                   \
+		{                                                                                         \
+			auto index = static_cast<uint32_t>(err);                                              \
+			LOGE("Detected KTX error: {}", index < error_codes.size() ? error_codes[index] : ""); \
+			abort();                                                                              \
+		}                                                                                         \
+	} while (0)
+
+HPPTextureCompressionComparison::HPPTextureCompressionComparison()
+{
+	texture_compression_data = {
+	    {nullptr, "", vk::Format::eR8G8B8A8Srgb, KTX_TTF_RGBA32, "KTX_TTF_RGBA32", "RGBA 32", true},
+	    {&vk::PhysicalDeviceFeatures::textureCompressionBC, "", vk::Format::eBc7SrgbBlock, KTX_TTF_BC7_RGBA, "KTX_TTF_BC7_RGBA", "BC7"},
+	    {&vk::PhysicalDeviceFeatures::textureCompressionBC, "", vk::Format::eBc3SrgbBlock, KTX_TTF_BC3_RGBA, "KTX_TTF_BC3_RGBA", "BC3"},
+	    {&vk::PhysicalDeviceFeatures::textureCompressionASTC_LDR, "", vk::Format::eAstc4x4SrgbBlock, KTX_TTF_ASTC_4x4_RGBA, "KTX_TTF_ASTC_4x4_RGBA", "ASTC 4x4"},
+	    {&vk::PhysicalDeviceFeatures::textureCompressionETC2, "", vk::Format::eEtc2R8G8B8A8SrgbBlock, KTX_TTF_ETC2_RGBA, "KTX_TTF_ETC2_RGBA", "ETC2"},
+	    {nullptr, VK_IMG_FORMAT_PVRTC_EXTENSION_NAME, vk::Format::ePvrtc14BppSrgbBlockIMG, KTX_TTF_PVRTC1_4_RGBA, "KTX_TTF_PVRTC1_4_RGBA", "PVRTC1 4"}};
+
+	add_device_extension(VK_IMG_FORMAT_PVRTC_EXTENSION_NAME, true);
+}
+
+void HPPTextureCompressionComparison::draw_gui()
+{
+	get_gui().show_options_window(
+	    [this]() {
+		    if (ImGui::Combo(
+		            "Compressed Format",
+		            &current_gui_format,
+		            [](void *user_data, int idx) -> char const * { return reinterpret_cast<HPPTextureCompressionData *>(user_data)[idx].gui_name.c_str(); },
+		            texture_compression_data.data(),
+		            static_cast<int>(texture_compression_data.size())))
+		    {
+			    require_redraw = true;
+			    if (texture_compression_data[current_gui_format].is_supported)
+			    {
+				    current_format = current_gui_format;
+			    }
+		    }
+		    const auto &current_gui_tc = texture_compression_data[current_gui_format];
+		    if (current_gui_tc.is_supported)
+		    {
+			    ImGui::Text("Format name: %s", current_gui_tc.format_name.c_str());
+			    ImGui::Text("Bytes: %f MB", static_cast<float>(current_benchmark.total_bytes) / 1024.f / 1024.f);
+			    ImGui::Text("Compression Time: %f (ms)", current_benchmark.compress_time_ms);
+		    }
+		    else
+		    {
+			    ImGui::Text("%s not supported on this GPU.", current_gui_tc.short_name.c_str());
+		    }
+	    });
+}
+
+bool HPPTextureCompressionComparison::prepare(const vkb::ApplicationOptions &options)
+{
+	if (vkb::VulkanSample<vkb::BindingType::Cpp>::prepare(options))
+	{
+		load_assets();
+
+		auto &camera_node = vkb::common::add_free_camera(get_scene(), "main_camera", get_render_context().get_surface_extent());
+		camera            = &camera_node.get_component<vkb::sg::Camera>();
+
+		create_subpass();
+
+		get_stats().request_stats({vkb::StatIndex::frame_times, vkb::StatIndex::gpu_ext_read_bytes});
+		create_gui(*window, &get_stats());
+		prepare_gui();
+
+		return true;
+	}
+	return false;
+}
+
+void HPPTextureCompressionComparison::update(float delta_time)
+{
+	if (require_redraw)
+	{
+		require_redraw = false;
+		assert(current_format >= 0 && static_cast<size_t>(current_format) < texture_compression_data.size());
+		current_benchmark = update_textures(texture_compression_data[current_format]);
+	}
+	VulkanSample<vkb::BindingType::Cpp>::update(delta_time);
+}
+
+std::pair<std::unique_ptr<vkb::scene_graph::components::HPPImage>, HPPTextureCompressionComparison::HPPTextureBenchmark>
+    HPPTextureCompressionComparison::compress(const std::string                                         &filename,
+                                              HPPTextureCompressionComparison::HPPTextureCompressionData texture_format,
+                                              const std::string                                         &name)
+{
+	ktxTexture2 *ktx_texture{nullptr};
+	KTX_CHECK(ktxTexture2_CreateFromNamedFile(filename.c_str(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, &ktx_texture));
+
+	HPPTextureBenchmark benchmark;
+	{
+		const auto start = std::chrono::high_resolution_clock::now();
+		KTX_CHECK(ktxTexture2_TranscodeBasis(ktx_texture, texture_format.ktx_format, 0));
+		const auto end             = std::chrono::high_resolution_clock::now();
+		benchmark.compress_time_ms = static_cast<float>(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) / 1000.f;
+	}
+	benchmark.total_bytes = ktx_texture->dataSize;
+	auto image            = create_image(ktx_texture, name);
+	ktxTexture_Destroy((ktxTexture *) ktx_texture);
+
+	return {std::move(image), benchmark};
+}
+
+std::unique_ptr<vkb::scene_graph::components::HPPImage> HPPTextureCompressionComparison::create_image(ktxTexture2 *ktx_texture, const std::string &name)
+{
+	std::unique_ptr<vkb::core::HPPBuffer> staging_buffer =
+	    std::make_unique<vkb::core::HPPBuffer>(get_device(), ktx_texture->dataSize, vk::BufferUsageFlagBits::eTransferSrc, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	memcpy(staging_buffer->map(), ktx_texture->pData, ktx_texture->dataSize);
+
+	const auto vk_format = static_cast<vk::Format>(ktx_texture->vkFormat);
+
+	vk::Extent3D extent(ktx_texture->baseWidth, ktx_texture->baseHeight, 1);
+
+	std::vector<vk::BufferImageCopy>                        buffer_copies;
+	std::unique_ptr<vkb::scene_graph::components::HPPImage> image_out;
+	{
+		std::vector<vkb::scene_graph::components::HPPMipmap> mip_maps;
+		for (uint32_t mip_level = 0; mip_level < ktx_texture->numLevels; ++mip_level)
+		{
+			vk::Extent3D mip_extent(extent.width >> mip_level, extent.height >> mip_level, 1);
+			if (!mip_extent.width || !mip_extent.height)
+			{
+				break;
+			}
+
+			ktx_size_t offset{0};
+			KTX_CHECK(ktxTexture_GetImageOffset((ktxTexture *) ktx_texture, mip_level, 0, 0, &offset));
+			vk::BufferImageCopy buffer_image_copy = {};
+			buffer_image_copy.imageSubresource    = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, mip_level, 0, 1);
+			buffer_image_copy.imageExtent         = mip_extent;
+			buffer_image_copy.bufferOffset        = static_cast<uint32_t>(offset);
+			buffer_copies.push_back(buffer_image_copy);
+
+			vkb::scene_graph::components::HPPMipmap mip_map;
+			mip_map.extent = buffer_image_copy.imageExtent;
+			mip_map.level  = mip_level;
+			mip_map.offset = static_cast<uint32_t>(offset);
+			mip_maps.push_back(mip_map);
+		}
+
+		image_out = std::make_unique<HPPCompressedImage>(get_device(), name, std::move(mip_maps), vk_format);
+	}
+	auto &vkb_image = image_out->get_vk_image();
+	auto  image     = vkb_image.get_handle();
+
+	vk::ImageSubresourceRange subresource_range(vk::ImageAspectFlagBits::eColor, 0, static_cast<uint32_t>(buffer_copies.size()), 0, 1);
+
+	vk::CommandBuffer command_buffer = get_device().create_command_buffer(vk::CommandBufferLevel::ePrimary, true);
+
+	vkb::common::image_layout_transition(command_buffer, image, vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, subresource_range);
+
+	command_buffer.copyBufferToImage(staging_buffer->get_handle(), image, vk::ImageLayout::eTransferDstOptimal, buffer_copies);
+
+	vkb::common::image_layout_transition(
+	    command_buffer, image, vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal, subresource_range);
+
+	get_device().flush_command_buffer(command_buffer, get_device().get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0).get_handle(), true);
+
+	return image_out;
+}
+
+void HPPTextureCompressionComparison::create_subpass()
+{
+	vkb::ShaderSource vert_shader("base.vert");
+	vkb::ShaderSource frag_shader("base.frag");
+	auto              scene_sub_pass = std::make_unique<vkb::rendering::subpasses::HPPForwardSubpass>(
+        get_render_context(), std::move(vert_shader), std::move(frag_shader), get_scene(), *camera);
+
+	auto render_pipeline = std::make_unique<vkb::rendering::HPPRenderPipeline>();
+	render_pipeline->add_subpass(std::move(scene_sub_pass));
+
+	set_render_pipeline(std::move(render_pipeline));
+}
+
+bool HPPTextureCompressionComparison::is_texture_format_supported(const HPPTextureCompressionData &tcd, vk::PhysicalDeviceFeatures const &device_features)
+{
+	const bool supported_by_feature   = tcd.feature_ptr && device_features.*tcd.feature_ptr;
+	const bool supported_by_extension = tcd.extension_name.length() && get_device().is_extension_supported(tcd.extension_name);
+	const bool supported_by_default   = tcd.always_supported;
+
+	return supported_by_default || supported_by_feature || supported_by_extension;
+}
+
+void HPPTextureCompressionComparison::load_assets()
+{
+	load_scene("scenes/sponza/Sponza01.gltf");
+	if (!has_scene())
+	{
+		throw std::runtime_error("Unable to load Sponza scene");
+	}
+
+	for (auto &&mesh : get_scene().get_components<vkb::scene_graph::components::HPPMesh>())
+	{
+		for (auto &&sub_mesh : mesh->get_submeshes())
+		{
+			auto material = sub_mesh->get_material();
+			for (auto &name_texture : material->get_textures())
+			{
+				vkb::scene_graph::components::HPPTexture *texture = name_texture.second;
+				auto                                      image   = texture->get_image();
+				textures.emplace_back(texture, image->get_name());
+			}
+		}
+	}
+}
+
+void HPPTextureCompressionComparison::prepare_gui()
+{
+	const auto device_features = get_device().get_gpu().get_features();
+
+	for (auto &tc : texture_compression_data)
+	{
+		tc.is_supported = is_texture_format_supported(tc, device_features);
+		tc.gui_name     = fmt::format(FMT_STRING("{:s} {:s}"), tc.short_name, tc.is_supported ? "" : "(not supported)");
+	}
+}
+
+HPPTextureCompressionComparison::HPPTextureBenchmark HPPTextureCompressionComparison::update_textures(const HPPTextureCompressionData &new_format)
+{
+	HPPTextureBenchmark             benchmark;
+	std::unordered_set<std::string> visited;
+	for (auto &&texture_filename : textures)
+	{
+		vkb::scene_graph::components::HPPTexture *texture = texture_filename.first;
+		assert(!!texture);
+		auto &internal_name = texture_filename.second;
+		if (!visited.count(internal_name))
+		{
+			auto filename                             = get_sponza_texture_filename(internal_name);
+			auto new_image                            = compress(filename, new_format, "");
+			texture_raw_data[internal_name].image     = std::move(new_image.first);
+			texture_raw_data[internal_name].benchmark = new_image.second;
+			benchmark += new_image.second;
+		}
+
+		vkb::scene_graph::components::HPPImage *image = texture_raw_data[internal_name].image.get();
+		assert(image);
+		texture->set_image(*image);
+		visited.insert(internal_name);
+	}
+
+	// update the forward subpass to use the new textures
+	create_subpass();
+
+	return benchmark;
+}
+
+std::unique_ptr<HPPTextureCompressionComparison> create_hpp_texture_compression_comparison()
+{
+	return std::make_unique<HPPTextureCompressionComparison>();
+}

--- a/samples/performance/hpp_texture_compression_comparison/hpp_texture_compression_comparison.h
+++ b/samples/performance/hpp_texture_compression_comparison/hpp_texture_compression_comparison.h
@@ -1,0 +1,91 @@
+/* Copyright (c) 2021-2024, Holochip
+ * Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "ktx.h"
+#include "vulkan_sample.h"
+
+class HPPTextureCompressionComparison : public vkb::VulkanSample<vkb::BindingType::Cpp>
+{
+  public:
+	HPPTextureCompressionComparison();
+
+  private:
+	// from vkb::VulkanSample
+	void draw_gui() override;
+	bool prepare(const vkb::ApplicationOptions &options) override;
+	void update(float delta_time) override;
+
+  private:
+	struct HPPTextureCompressionData
+	{
+		vk::Bool32 vk::PhysicalDeviceFeatures::*feature_ptr      = nullptr;
+		std::string                             extension_name   = {};
+		vk::Format                              format           = {};
+		ktx_transcode_fmt_e                     ktx_format       = KTX_TTF_NOSELECTION;
+		std::string                             format_name      = {};
+		std::string                             short_name       = {};
+		bool                                    always_supported = false;
+		std::string                             gui_name         = {};
+		bool                                    is_supported     = {};
+	};
+
+	struct HPPTextureBenchmark
+	{
+		HPPTextureBenchmark &operator+=(const HPPTextureBenchmark &other)
+		{
+			total_bytes += other.total_bytes;
+			compress_time_ms += other.compress_time_ms;
+			frame_time_ms += other.frame_time_ms;
+			return *this;
+		}
+		vk::DeviceSize total_bytes      = 0;
+		float          compress_time_ms = 0.f;
+		float          frame_time_ms    = 0.f;
+	};
+
+	struct HPPSampleTexture
+	{
+		std::vector<uint8_t>                                    raw_bytes;
+		std::unique_ptr<vkb::scene_graph::components::HPPImage> image;
+		HPPTextureBenchmark                                     benchmark;
+	};
+
+  private:
+	std::pair<std::unique_ptr<vkb::scene_graph::components::HPPImage>, HPPTextureBenchmark> compress(
+	    const std::string &filename, HPPTextureCompressionData texture_format, const std::string &name);
+	std::unique_ptr<vkb::scene_graph::components::HPPImage> create_image(ktxTexture2 *ktx_texture, const std::string &name);
+	void                                                    create_subpass();
+	bool                                                    is_texture_format_supported(const HPPTextureCompressionData &tcd, vk::PhysicalDeviceFeatures const &device_features);
+	void                                                    load_assets();
+	void                                                    prepare_gui();
+	HPPTextureBenchmark                                     update_textures(const HPPTextureCompressionData &new_format);
+
+  private:
+	vkb::sg::Camera                                                                *camera             = nullptr;
+	HPPTextureBenchmark                                                             current_benchmark  = {};
+	int                                                                             current_gui_format = 0;
+	int                                                                             current_format     = 0;
+	bool                                                                            require_redraw     = true;
+	std::vector<HPPTextureCompressionData>                                          texture_compression_data;
+	std::unordered_map<std::string, HPPSampleTexture>                               texture_raw_data;
+	std::vector<std::pair<vkb::scene_graph::components::HPPTexture *, std::string>> textures;
+};
+
+std::unique_ptr<HPPTextureCompressionComparison> create_hpp_texture_compression_comparison();

--- a/samples/performance/texture_compression_comparison/texture_compression_comparison.cpp
+++ b/samples/performance/texture_compression_comparison/texture_compression_comparison.cpp
@@ -190,21 +190,8 @@ bool TextureCompressionComparison::is_texture_format_supported(const TextureComp
 	return supported_by_default || supported_by_feature || supported_by_extension;
 }
 
-void TextureCompressionComparison::get_available_texture_formats()
-{
-	available_texture_formats.clear();
-
-	const auto all_formats = get_texture_formats();
-
-	// Determine which formats are supported by this device
-	std::copy_if(all_formats.cbegin(), all_formats.cend(), std::back_inserter(available_texture_formats), [this](const auto &texture_format) {
-		return is_texture_format_supported(texture_format);
-	});
-}
-
 void TextureCompressionComparison::load_assets()
 {
-	get_available_texture_formats();
 	load_scene("scenes/sponza/Sponza01.gltf");
 	if (!has_scene())
 	{
@@ -336,18 +323,6 @@ std::unique_ptr<vkb::sg::Image> TextureCompressionComparison::create_image(ktxTe
 	get_device().flush_command_buffer(command_buffer, get_device().get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0).get_handle(), true);
 
 	return image_out;
-}
-
-std::vector<uint8_t> TextureCompressionComparison::get_raw_image(const std::string &filename)
-{
-	if (filename.empty())
-	{
-		return {};
-	}
-
-	std::ifstream                  is(filename, std::ios::binary);
-	std::istream_iterator<uint8_t> start(is), end;
-	return {start, end};
 }
 
 std::pair<std::unique_ptr<vkb::sg::Image>, TextureCompressionComparison::TextureBenchmark> TextureCompressionComparison::compress(const std::string &filename, TextureCompressionComparison::CompressedTexture_t texture_format, const std::string &name)

--- a/samples/performance/texture_compression_comparison/texture_compression_comparison.h
+++ b/samples/performance/texture_compression_comparison/texture_compression_comparison.h
@@ -67,15 +67,12 @@ class TextureCompressionComparison : public vkb::VulkanSample<vkb::BindingType::
   private:
 	static const std::vector<CompressedTexture_t>               &get_texture_formats();
 	bool                                                         is_texture_format_supported(const CompressedTexture_t &format);
-	void                                                         get_available_texture_formats();
 	void                                                         load_assets();
 	void                                                         create_subpass();
 	TextureBenchmark                                             update_textures(const CompressedTexture_t &new_format);
 	std::unique_ptr<vkb::sg::Image>                              create_image(ktxTexture2 *ktx_texture, const std::string &name);
-	static std::vector<uint8_t>                                  get_raw_image(const std::string &filename);
 	std::pair<std::unique_ptr<vkb::sg::Image>, TextureBenchmark> compress(const std::string &filename, CompressedTexture_t texture_format, const std::string &name);
 	std::vector<std::string>                                     gui_texture_names;
-	std::vector<CompressedTexture_t>                             available_texture_formats = {};
 	std::unordered_map<std::string, SampleTexture>               texture_raw_data;
 	std::vector<std::pair<vkb::sg::Texture *, std::string>>      textures;
 	vkb::sg::Camera                                             *camera{VK_NULL_HANDLE};


### PR DESCRIPTION
## Description

Introduces a new Vulkan-Hpp-based sample, which is a transcoded version of the performance sample `texture_compression_comparison`.

In addition to the new sample, this PR
- introduces new facade classes `scene_graph::components::HPPMaterial`, `scene_graph::components::HPPMesh`, `scene_graph::components::HPPTexture`, and `scene_graph::HPPScene`
- adjusts `common/hpp_utils.h`, `hpp_gltf_loader.h`, `rendering/subpasses/hpp_forward_subpass.h`, `scene_graph/components/hpp_sub_mesh.h`, and `vulkan_sample.h`
- removes some dead code from the performance sample `texture_compression_comparison`.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
