### PR TITLE
Fix --data-path command line option and remove redundant path objects/methods from Platform::

### DIFF
--- a/app/plugins/data_path/data_path.cpp
+++ b/app/plugins/data_path/data_path.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, Arm Limited and Contributors
+/* Copyright (c) 2022-2024, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/app/plugins/data_path/data_path.cpp
+++ b/app/plugins/data_path/data_path.cpp
@@ -17,6 +17,8 @@
 
 #include "data_path.h"
 
+#include "filesystem/filesystem.hpp"
+
 namespace plugins
 {
 DataPath::DataPath() :
@@ -35,7 +37,8 @@ void DataPath::init(const vkb::CommandParser &parser)
 {
 	if (parser.contains(&data_path_flag))
 	{
-		vkb::Platform::set_external_storage_directory(parser.as<std::string>(&data_path_flag) + "/");
+		auto fs = vkb::filesystem::get();
+		fs->set_external_storage_directory(parser.as<std::string>(&data_path_flag) + "/");
 	}
 }
 

--- a/components/filesystem/include/filesystem/filesystem.hpp
+++ b/components/filesystem/include/filesystem/filesystem.hpp
@@ -54,8 +54,9 @@ class FileSystem
 	virtual void                 write_file(const Path &path, const std::vector<uint8_t> &data) = 0;
 	virtual void                 remove(const Path &path)                                       = 0;
 
-	virtual const Path &external_storage_directory() const = 0;
-	virtual const Path &temp_directory() const             = 0;
+	virtual void        set_external_storage_directory(const std::string &dir) = 0;
+	virtual const Path &external_storage_directory() const                     = 0;
+	virtual const Path &temp_directory() const                                 = 0;
 
 	void write_file(const Path &path, const std::string &data);
 

--- a/components/filesystem/src/std_filesystem.cpp
+++ b/components/filesystem/src/std_filesystem.cpp
@@ -140,6 +140,11 @@ void StdFileSystem::remove(const Path &path)
 	}
 }
 
+void StdFileSystem::set_external_storage_directory(const std::string &dir)
+{
+	_external_storage_directory = dir;
+}
+
 const Path &StdFileSystem::external_storage_directory() const
 {
 	return _external_storage_directory;

--- a/components/filesystem/src/std_filesystem.hpp
+++ b/components/filesystem/src/std_filesystem.hpp
@@ -49,6 +49,8 @@ class StdFileSystem final : public FileSystem
 
 	virtual void remove(const Path &path) override;
 
+	virtual void set_external_storage_directory(const std::string &dir) override;
+
 	const Path &external_storage_directory() const override;
 
 	const Path &temp_directory() const override;

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -29,7 +29,6 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 #include "core/util/logging.hpp"
-#include "filesystem/legacy.h"
 #include "force_close/force_close.h"
 #include "platform/parsers/CLI11.h"
 #include "platform/plugins/plugin.h"
@@ -40,16 +39,9 @@ namespace vkb
 const uint32_t Platform::MIN_WINDOW_WIDTH  = 420;
 const uint32_t Platform::MIN_WINDOW_HEIGHT = 320;
 
-std::string Platform::external_storage_directory = "";
-
-std::string Platform::temp_directory = "";
-
 Platform::Platform(const PlatformContext &context)
 {
 	arguments = context.arguments();
-
-	external_storage_directory = context.external_storage_directory();
-	temp_directory             = context.temp_directory();
 }
 
 ExitCode Platform::initialize(const std::vector<Plugin *> &plugins)
@@ -368,16 +360,6 @@ void Platform::set_window_properties(const Window::OptionalProperties &propertie
 	window_properties.extent.height = properties.extent.height.has_value() ? properties.extent.height.value() : window_properties.extent.height;
 }
 
-const std::string &Platform::get_external_storage_directory()
-{
-	return external_storage_directory;
-}
-
-const std::string &Platform::get_temp_directory()
-{
-	return temp_directory;
-}
-
 std::string &Platform::get_last_error()
 {
 	return last_error;
@@ -398,11 +380,6 @@ Application &Platform::get_app() const
 Window &Platform::get_window()
 {
 	return *window;
-}
-
-void Platform::set_external_storage_directory(const std::string &dir)
-{
-	external_storage_directory = dir;
 }
 
 void Platform::set_last_error(const std::string &error)

--- a/framework/platform/platform.h
+++ b/framework/platform/platform.h
@@ -28,7 +28,6 @@
 #include "common/optional.h"
 #include "common/utils.h"
 #include "common/vk_common.h"
-#include "filesystem/legacy.h"
 #include "platform/application.h"
 #include "platform/parser.h"
 #include "platform/plugins/plugin.h"
@@ -88,18 +87,6 @@ class Platform
 	 */
 	virtual void close();
 
-	/**
-	 * @brief Returns the working directory of the application set by the platform
-	 * @returns The path to the working directory
-	 */
-	static const std::string &get_external_storage_directory();
-
-	/**
-	 * @brief Returns the suitable directory for temporary files from the environment variables set in the system
-	 * @returns The path to the temp folder on the system
-	 */
-	static const std::string &get_temp_directory();
-
 	std::string &get_last_error();
 
 	virtual void resize(uint32_t width, uint32_t height);
@@ -111,8 +98,6 @@ class Platform
 	Application &get_app() const;
 
 	Application &get_app();
-
-	static void set_external_storage_directory(const std::string &dir);
 
 	void set_last_error(const std::string &error);
 
@@ -189,12 +174,6 @@ class Platform
 	std::vector<std::string> arguments;
 
 	std::string last_error;
-
-	// static so can be references from vkb::fs
-	static std::string external_storage_directory;
-
-	// static so can be references from vkb::fs
-	static std::string temp_directory;
 };
 
 template <class T>


### PR DESCRIPTION
## Description

1. Restores/Implements `--data-path` command line option to support running from an arbitrary working directory
2. Removes rendundant path objects/methods from `Platform::` - these were confusing and are no longer needed

Fixes #1056 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS ~~and Android~~. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

Can't test on Android.

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

Not applicable