### PR TITLE
Workaround on feature requesting for extension sample gshader_to_mshader.

### DIFF
--- a/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
+++ b/samples/extensions/gshader_to_mshader/gshader_to_mshader.cpp
@@ -430,6 +430,10 @@ void GshaderToMshader::request_gpu_features(vkb::PhysicalDevice &gpu)
 	auto &requested_vertex_input_features      = gpu.request_extension_features<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT);
 	requested_vertex_input_features.meshShader = VK_TRUE;
 
+	// we explicitly don't want those features!!
+	requested_vertex_input_features.multiviewMeshShader                    = VK_FALSE;
+	requested_vertex_input_features.primitiveFragmentShadingRateMeshShader = VK_FALSE;
+
 	if (gpu.get_features().geometryShader)
 	{
 		gpu.get_mutable_requested_features().geometryShader = VK_TRUE;


### PR DESCRIPTION
## Description

With the current approach to request features, each and every available feature is requested. In the gshader_to_mshader, that approach leads to some validation layer errors, because some features need some other stuff to be enabled as well.
This workaround explicitly does not request some features to resolve the validation layer errors.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Note: this needs to be adjusted, when #1013 (or something similar) is in.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
