### PR TITLE
Add note about documentation site, remove note on renaming master to …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,7 @@ endif::[]
 image::banner.jpg[Vulkan Samples banner]
 
 ifndef::site-gen-antora[]
-== Vulkan documentation site
+== Vulkan Documentation Site
 
 Documentation for the samples is best viewed at the new link:https://docs.vulkan.org/samples/latest/README.html[Vulkan Documentation Site]. The documentation uses AsciiDoc which isn't fully supported by github.
 

--- a/README.adoc
+++ b/README.adoc
@@ -26,15 +26,10 @@ endif::[]
 image::banner.jpg[Vulkan Samples banner]
 
 ifndef::site-gen-antora[]
-== Renaming Default Branch
+== Vulkan documentation site
 
-We have recently transitioned the repository to use the `main` branch by default.
-All remote git usage is handled automatically.
-To update your local repository to use main please use the following commands
+Documentation for the samples is best viewed at the new link:https://docs.vulkan.org/samples/latest/README.html[Vulkan Documentation Site]. The documentation uses AsciiDoc which isn't fully supported by github.
 
-----
-git branch -m master main && git fetch origin && git branch -u origin/main main && git remote set-head origin -a
-----
 endif::[]
 
 == Introduction


### PR DESCRIPTION
## Description

This PR makes some minor changes to the sample's main readme:

* It adds a note that the documentation is best viewed through docs.vulkan.org (see #1018). This note is only visible here on github, it's hidden when viewing the docs through Antora.
* It removes the note that we renamed the master branch to main. This has been there for ages and by now every contributor should've switched over to main.

**Note**: This is a pure documentation fix

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly