### PR TITLE
Remove duplicate text from buffer_device_address

### DIFF
--- a/samples/extensions/buffer_device_address/README.adoc
+++ b/samples/extensions/buffer_device_address/README.adoc
@@ -299,4 +299,3 @@ If the `bufferDeviceAddressCaptureReplay` is not present however, tools like Ren
 == Conclusion
 
 Buffer device address is an extremely powerful feature which enables various use cases which were either impossible or very impractical before.
-e cases which were either impossible or very impractical before.

--- a/samples/extensions/buffer_device_address/README.adoc
+++ b/samples/extensions/buffer_device_address/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2021-2023, Arm Limited and Contributors
+- Copyright (c) 2021-2024, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -


### PR DESCRIPTION
## Description

Simple documentation change to remove text which appears to be accidentally duplicated.

Edit: Similar but different to PR #1098 