### PR TITLE
Fix profiles sample for Apple platforms

### DIFF
--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -160,7 +160,7 @@ std::unique_ptr<vkb::Instance> Profiles::create_instance(bool headless)
 	// If VK_KHR_portability_enumeration is available at runtime, enable the extension and flag for instance creation
 	if (std::any_of(available_instance_extensions.begin(),
 	                available_instance_extensions.end(),
-	                [](VkExtensionProperties extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
+	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
 	{
 		enabled_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 		create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
@@ -174,7 +174,7 @@ std::unique_ptr<vkb::Instance> Profiles::create_instance(bool headless)
 
 	if (std::any_of(available_instance_extensions.begin(),
 	                available_instance_extensions.end(),
-	                [](VkExtensionProperties extension) { return strcmp(extension.extensionName, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0; }))
+	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0; }))
 	{
 		enabled_extensions.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
 

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -30,9 +30,14 @@
 // The Vulkan Profiles library is part of the SDK and has been copied to the sample's folder for convenience
 #include "vulkan_profiles.hpp"
 
-// This sample uses the VP_LUNARG_desktop_portability_2021 profile that defines feature sets for common desktop platforms with drivers supporting Vulkan 1.1 on Windows and Linux
-#define PROFILE_NAME VP_LUNARG_DESKTOP_PORTABILITY_2021_NAME
-#define PROFILE_SPEC_VERSION VP_LUNARG_DESKTOP_PORTABILITY_2021_SPEC_VERSION
+// This sample uses the VP_LUNARG_desktop_portability_2021 profile that defines feature sets for common desktop platforms with drivers supporting Vulkan 1.1 on Windows and Linux, and the VP_LUNARG_desktop_portability_2021_subset profile on portability platforms like macOS
+#if (defined(VKB_ENABLE_PORTABILITY))
+#	define PROFILE_NAME VP_LUNARG_DESKTOP_PORTABILITY_2021_SUBSET_NAME
+#	define PROFILE_SPEC_VERSION VP_LUNARG_DESKTOP_PORTABILITY_2021_SUBSET_SPEC_VERSION
+#else
+#	define PROFILE_NAME VP_LUNARG_DESKTOP_PORTABILITY_2021_NAME
+#	define PROFILE_SPEC_VERSION VP_LUNARG_DESKTOP_PORTABILITY_2021_SPEC_VERSION
+#endif
 
 Profiles::Profiles()
 {

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -31,7 +31,7 @@
 #include "vulkan_profiles.hpp"
 
 // This sample uses the VP_LUNARG_desktop_portability_2021 profile that defines feature sets for common desktop platforms with drivers supporting Vulkan 1.1 on Windows and Linux, and the VP_LUNARG_desktop_portability_2021_subset profile on portability platforms like macOS
-#if (defined(VKB_ENABLE_PORTABILITY))
+#if (defined(VKB_ENABLE_PORTABILITY) && defined(VP_LUNARG_desktop_portability_2021_subset))
 #	define PROFILE_NAME VP_LUNARG_DESKTOP_PORTABILITY_2021_SUBSET_NAME
 #	define PROFILE_SPEC_VERSION VP_LUNARG_DESKTOP_PORTABILITY_2021_SUBSET_SPEC_VERSION
 #else


### PR DESCRIPTION
## Description

This PR fixes the _profiles_ sample on Apple platforms by doing the following:
1. Enabling the `VK_KHR_portability_enumeration` extension and flag during instance creation.
2. Enabling MoltenVK's Metal Argument Buffer feature on macOS.  This uses the layer settings capability (note this does **_not_** depend on my pending layer settings framework PR), and falls back to an environment variable if layer settings is not available at runtime for older SDKs.
3. Using the `VP_LUNARG_desktop_portability_2021_subset` profile on portability platforms.  In addition to the standard desktop capabilities, this also checks the platform's portability subset features.  **UPDATE**: Added an additional #ifdef guard to prevent build failures on iOS for current build configs (i.e. prior to merging my pending framework PR).  This defensive check may become redundant in the future, but at least will be compatible and will not cause problems.
4. **UPDATE**: Even though iOS will support Metal Argument Buffers staring with MoltenVK 1.2.10 and later (expected in the next Vulkan SDK following 1.3.290), that device platform does not support all features required for the selected Vulkan profile.  For instance on iPhone 15, the following device features are missing: `fragmentStoresAndAtomics`,   `shaderStorageImageArrayDynamicIndexing`, `textureCompressionBC`, and `vertexPipelineStoresAndAtomics`.  In addition, some limits are lower than required: `maxPerStageDescriptorSampledImages = 96`, `maxPerStageResources = 127`, and `maxPerStageDescriptorUpdateAfterBindInputAttachments = 96`, and finally some image formats and/or tiling capabilities are not supported (e.g. all `VK_FORMAT_<*>_BLOCK` formats and some tiling features of `VK_FORMAT_R32G32B32A32_SFLOAT`, `VK_FORMAT_R32G32_SFLOAT`, `VK_FORMAT_R32_SFLOAT`).

Note that all code changes are guarded by `VKB_ENABLE_PORTABILITY`, so it will only affect portability platforms.

Fixes #1118

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly.  _Not applicable_.
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [X] I have tested the sample on at least one compliant Vulkan implementation
- [X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms.  _Tested on macOS Ventura 13.6.6 with Vulkan SDK 1.3.290/MoltenVK 1.2.9 as well as with MoltenVK 1.2.10 standalone (i.e. no Vulkan loader)._