### PR TITLE
Fixes to iOS render loop and HUD overlay.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,12 @@ tests/system_test/tmp
 output/*
 .mypy_cache
 tags
-.DS_Store
 
 # vim backup and temp files
 *~
 .*.sw*
 .sw*
 .tracy
+
+# macOS
+.DS_Store

--- a/app/ios/Storyboard.storyboard
+++ b/app/ios/Storyboard.storyboard
@@ -34,7 +34,7 @@ limitations under the License.
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                     <connections>
                         <outlet property="vulkan_view" destination="5EZ-qb-Rvc" id="XCX-oU-713"/>
@@ -45,9 +45,4 @@ limitations under the License.
             <point key="canvasLocation" x="-218" y="4"/>
         </scene>
     </scenes>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/framework/platform/ios/ios_window.mm
+++ b/framework/platform/ios/ios_window.mm
@@ -69,7 +69,7 @@ void IosWindow::close()
 
 float IosWindow::get_dpi_factor() const
 {
-    return [[UIScreen mainScreen] nativeScale] * (([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) ? 132 : 163);
+	return 1.0;
 }
 
 std::vector<const char *> IosWindow::get_required_surface_extensions() const

--- a/framework/platform/platform.h
+++ b/framework/platform/platform.h
@@ -64,11 +64,17 @@ class Platform
 	virtual ExitCode initialize(const std::vector<Plugin *> &plugins);
 
 	/**
-	 * @brief Handles the main loop of the platform
-	 * This should be overriden if a platform requires a specific main loop setup.
+	 * @brief Handles the main update and render loop
 	 * @return An exit code representing the outcome of the loop
 	 */
 	ExitCode main_loop();
+
+	/**
+	 * @brief Handles the update and render of a frame.
+	 * Called either from main_loop(), or from a platform-specific
+	 * frame-looping mechanism, typically tied to platform screen refeshes.
+	 * @return An exit code representing the outcome of the loop
+	 */
 	ExitCode main_loop_frame();
 
 	/**


### PR DESCRIPTION
* Refactor Platform::main_loop_frame() and main_loop(),
  to reduce fragility, and avoid unnecessary code duplication.

* Avoid initial app_requested() test in main_loop_frame(),
  as it was causing looping to stop after one frame.

* Since main_loop() is not a virtual function, remove
  declaration comment indicating it can be overridden.

* Set iOS view to have a black background, to ensure 
  transparency in HUD overlay displays in full on device.
  
* Fix rendering scaling in IosWindow::get_dpi_factor().
  Previous value was causing HUD overlay to render magnitudes too large.
  
* Add macOS files to .gitignore.

I created this from a branch on this repo instead of a separate fork, because I was not expecting to need to make a fix.

Fixes #1121
Fixes #1131

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
