### PR TITLE
Use Vulkan API 1.0 support funcs for Vulkan API 1.0 samples memory_budget & dynamic_blending

### DIFF
--- a/framework/stats/vulkan_stats_provider.cpp
+++ b/framework/stats/vulkan_stats_provider.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2023, Broadcom Inc. and Contributors
+/* Copyright (c) 2020-2024, Broadcom Inc. and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/stats/vulkan_stats_provider.cpp
+++ b/framework/stats/vulkan_stats_provider.cpp
@@ -308,7 +308,7 @@ bool VulkanStatsProvider::is_supported(const CounterSamplingConfig &sampling_con
 	device_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
 	device_features.pNext = &perf_query_features;
 
-	vkGetPhysicalDeviceFeatures2(device.get_gpu().get_handle(), &device_features);
+	vkGetPhysicalDeviceFeatures2KHR(device.get_gpu().get_handle(), &device_features);
 	if (!perf_query_features.performanceCounterQueryPools)
 	{
 		return false;

--- a/samples/extensions/dynamic_blending/dynamic_blending.cpp
+++ b/samples/extensions/dynamic_blending/dynamic_blending.cpp
@@ -153,10 +153,10 @@ void DynamicBlending::request_gpu_features(vkb::PhysicalDevice &gpu)
 	eds_feature_support       = {};
 	eds_feature_support.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT;
 
-	VkPhysicalDeviceFeatures2 features2{};
-	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+	VkPhysicalDeviceFeatures2KHR features2{};
+	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
 	features2.pNext = &eds_feature_support;
-	vkGetPhysicalDeviceFeatures2(gpu.get_handle(), &features2);
+	vkGetPhysicalDeviceFeatures2KHR(gpu.get_handle(), &features2);
 
 	{
 		// Only request the features that we support

--- a/samples/extensions/memory_budget/memory_budget.cpp
+++ b/samples/extensions/memory_budget/memory_budget.cpp
@@ -147,7 +147,7 @@ void MemoryBudget::initialize_device_memory_properties()
 	physical_device_memory_budget_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT;
 	physical_device_memory_budget_properties.pNext = nullptr;
 	// Initialize physical device memory properties structure variables
-	device_memory_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
+	device_memory_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR;
 	device_memory_properties.pNext = &physical_device_memory_budget_properties;
 }
 
@@ -197,7 +197,7 @@ std::string MemoryBudget::read_memoryHeap_flags(VkMemoryHeapFlags inputVkMemoryH
 
 void MemoryBudget::update_device_memory_properties()
 {
-	vkGetPhysicalDeviceMemoryProperties2(get_device().get_gpu().get_handle(), &device_memory_properties);
+	vkGetPhysicalDeviceMemoryProperties2KHR(get_device().get_gpu().get_handle(), &device_memory_properties);
 	device_memory_heap_count = device_memory_properties.memoryProperties.memoryHeapCount;
 
 	device_memory_total_usage  = 0;

--- a/samples/extensions/memory_budget/memory_budget.h
+++ b/samples/extensions/memory_budget/memory_budget.h
@@ -33,7 +33,7 @@ class MemoryBudget : public ApiVulkanSample
   private:
 	// Memory budget extension related variables
 	VkPhysicalDeviceMemoryBudgetPropertiesEXT physical_device_memory_budget_properties{};
-	VkPhysicalDeviceMemoryProperties2         device_memory_properties{};
+	VkPhysicalDeviceMemoryProperties2KHR      device_memory_properties{};
 
 	struct ConvertedMemory
 	{

--- a/samples/extensions/memory_budget/memory_budget.h
+++ b/samples/extensions/memory_budget/memory_budget.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019-2023, Sascha Willems
- * Copyright (c) 2023, Holochip Corporation
+/* Copyright (c) 2019-2024, Sascha Willems
+ * Copyright (c) 2023-2024, Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
## Description

This PR replaces Vulkan 1.1 API support functions with Vulkan 1.0 equivalents within samples that specify Vulkan API 1.0: _memory_budget_ and _dynamic_blending_.  It also does the same within `VulkanStatsProvider::is_supported()`, which is a utility that can be used with any Vulkan sample.  This prevents runtime failures (undefined functions) on Vulkan drivers that enforce the specified API version.

I did not up-version the 2 samples to Vulkan API 1.1 since it appears that Vulkan API 1.0 was the intended API version, with extensions enabled by `VK_KHR_get_physical_device_properties2`.

Fixes #1123

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [X] I have tested every sample to ensure everything runs correctly.
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [X] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [X] I have tested the sample on at least one compliant Vulkan implementation
- [X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms.  _Tested on macOS Ventura 13.6.6 with Vulkan SDK 1.3.290 and MoltenVK 1.2.10 standalone._