### PR TITLE
single pass order-independent transparency (OIT)

### DIFF
--- a/samples/api/oit_linked_lists/oit_linked_lists.h
+++ b/samples/api/oit_linked_lists/oit_linked_lists.h
@@ -27,6 +27,7 @@ class OITLinkedLists : public ApiVulkanSample
 	OITLinkedLists();
 	~OITLinkedLists();
 
+	void setup_render_pass() override;
 	bool prepare(const vkb::ApplicationOptions &options) override;
 	bool resize(const uint32_t width, const uint32_t height) override;
 	void render(float delta_time) override;
@@ -94,9 +95,6 @@ class OITLinkedLists : public ApiVulkanSample
 	std::unique_ptr<vkb::core::Buffer>    fragment_buffer;
 	std::unique_ptr<vkb::core::Buffer>    fragment_counter;
 	glm::uint                             fragment_max_count = 0U;
-
-	VkRenderPass  gather_render_pass = VK_NULL_HANDLE;
-	VkFramebuffer gather_framebuffer = VK_NULL_HANDLE;
 
 	VkDescriptorSetLayout descriptor_set_layout = VK_NULL_HANDLE;
 	VkDescriptorPool      descriptor_pool       = VK_NULL_HANDLE;


### PR DESCRIPTION
## Description

Order-Independent Transparency example done in a single pass with a image memory barrier. Our use-case is that our scene-graph structure would greatly benefit from having the whole OIT scene rendered in a single rendergraph so we can overlay possibly transparent sub-scenes without holding on to temporary buffers and avoid the need of compositing these in yet another gather pass.

This required a subpass self-dependency declared when creating the render pass and matching dependency flags set in the VkImageMemoryBarrier (VK_DEPENDENCY_BY_REGION_BIT). While the render looks correct, there is still a validation error in the current version:

```
[error] 1306427741 - VUID-vkCmdPipelineBarrier-image-04073: 
Validation Error: [ VUID-vkCmdPipelineBarrier-image-04073 ] 
Object 0: handle = 0x290000000029, 
type = VK_OBJECT_TYPE_FRAMEBUFFER; 
| MessageID = 0x4dde815d 
| vkCmdPipelineBarrier(): 
pImageMemoryBarriers[0].image (VkImage 0x4c000000004c[]) does not match an image from the current 
VkFramebuffer 0x290000000029[]. The Vulkan spec states: If vkCmdPipelineBarrier is called within a render 
pass instance using a VkRenderPass object, the image member of any image memory barrier included in 
this command must be an attachment used in the current subpass both as an input attachment, and as 
either a color, color resolve, or depth/stencil attachment 
(https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdPipelineBarrier-image-04073)
```

This was tested on an AMD Radeon Pro W7900 with the mesa drivers on Linux Fedora 40.

## Note from the author: Do Not Merge

This PR modifies an existing example for a specific use-case. I did it this way to show how it differs from the original `oit_linked_lists` example and to spark a discussion on whether putting OIT into a single render pass is a good idea or not. It may end up being thrown out or accepted as an improvement to `oit_linked_lists` or split off into a new example like `oit_linked_lists_single_pass`.