### PR TITLE
shader_debugprintf: Use API 1.2 for SDKs <= 1.3.290, API 1.1 for SDKs > 1.3.290

### DIFF
--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -433,6 +433,9 @@ const std::vector<const char *> ShaderDebugPrintf::get_validation_layers()
 // This sample overrides the instance creation part of the framework to chain in additional structures
 std::unique_ptr<vkb::Instance> ShaderDebugPrintf::create_instance(bool headless)
 {
+	uint32_t instanceApiVersion;
+	VK_CHECK(vkEnumerateInstanceVersion(&instanceApiVersion));
+
 	uint32_t instance_extension_count;
 	VK_CHECK(vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, nullptr));
 	std::vector<VkExtensionProperties> available_instance_extensions(instance_extension_count);
@@ -444,9 +447,9 @@ std::unique_ptr<vkb::Instance> ShaderDebugPrintf::create_instance(bool headless)
 	                available_instance_extensions.end(),
 	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0; }))
 	{
-		// debugPrintfEXT layer feature requires Vulkan API 1.1, but has performance issues due to VVL defect in SDKs <= 1.3.290
+		// debugPrintfEXT layer feature requires Vulkan API 1.1, but use API 1.2 until VVL performance fix is available in SDKs > 1.3.290
 		// See VVL issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7562 for defect and fix information
-		set_api_version(VK_API_VERSION_1_1);
+		set_api_version(instanceApiVersion <= VK_MAKE_API_VERSION(0, 1, 3, 290) ? VK_API_VERSION_1_2 : VK_API_VERSION_1_1);
 
 		// Run standard create_instance() from framework (with set_api_version and layer settings support) and return
 		return VulkanSample::create_instance(headless);
@@ -477,7 +480,7 @@ std::unique_ptr<vkb::Instance> ShaderDebugPrintf::create_instance(bool headless)
 	VkApplicationInfo app_info{VK_STRUCTURE_TYPE_APPLICATION_INFO};
 	app_info.pApplicationName = "Shader debugprintf";
 	app_info.pEngineName      = "Vulkan Samples";
-	app_info.apiVersion       = VK_API_VERSION_1_1;
+	app_info.apiVersion       = instanceApiVersion <= VK_MAKE_API_VERSION(0, 1, 3, 290) ? VK_API_VERSION_1_2 : VK_API_VERSION_1_1;
 
 	// Shader printf is a feature of the validation layers that needs to be enabled
 	std::vector<VkValidationFeatureEnableEXT> validation_feature_enables = {VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT};


### PR DESCRIPTION
## Description

This fixes the _shader_debugprintf_ sample to work correctly with Vulkan SDKs >= 1.3.290 where the Validation Layer requires Vulkan API >= 1.1 to enable the `debugPrintfEXT`feature.  Earlier SDKs with older Validation Layers did not enforce this and could run with Vulkan API 1.0.  This change also respects the upcoming Validation Layer performance fix for issue [7562](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7562) which caused slowdowns on SDKs <= 1.3.290 when using the `debugPrintfEXT` feature with the correct APi 1.1 version. VVL fix [8323](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8323) will be available in Vulkan SDKs > 1.3.290 and thus Vulkan API 1.1 can be used by this sample for these future SDKs without performance problems.

**UPDATE**: This PR also contains a workaround for SDKs not yet containing the VVL performance fix above.  For SDKs <= 1.3.290, this sample will now use Vulkan API 1.2 which does not exhibit the performance problem, and also satisfies the `debugPrintfEXT` layer feature which requires Vulkan API level >= 1.1 to function.

Tested on macOS Ventura using: a) Vulkan SDKs 1.3.283 and 1.3.290 with their stock Validation Layers, and b) using a private build of the most recent Validation Layer containing the fix above.

Fixes #1132

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly.  _Not applicable._
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
