### PR TITLE
Check dynamic state / line rasterization feature support during sample init

### DIFF
--- a/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.h
+++ b/samples/extensions/dynamic_line_rasterization/dynamic_line_rasterization.h
@@ -67,6 +67,7 @@ class DynamicLineRasterization : public ApiVulkanSample
 
 		int                      selected_rasterization_mode = 0;
 		std::vector<std::string> rasterization_mode_names    = {"DEFAULT", "RECT", "BRESENHAM", "SMOOTH"};
+		std::vector<bool>        rasterization_mode_support  = {true, true, true, true};
 
 		bool  stipple_enabled = true;
 		float line_width      = 1.0f;

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -32,7 +32,7 @@ ExtendedDynamicState2::ExtendedDynamicState2()
 	add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	add_device_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
 	add_device_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-	add_device_extension(VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_EXTENSION_NAME);
+	add_device_extension(VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_EXTENSION_NAME, /* optional = */ true);
 }
 
 ExtendedDynamicState2::~ExtendedDynamicState2()
@@ -737,6 +737,20 @@ void ExtendedDynamicState2::create_descriptor_sets()
  */
 void ExtendedDynamicState2::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
+	// Check whether the device supports extended dynamic state2 features
+	VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features;
+	extended_dynamic_state2_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT;
+	extended_dynamic_state2_features.pNext = VK_NULL_HANDLE;
+	VkPhysicalDeviceFeatures2 features2;
+	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+	features2.pNext = &extended_dynamic_state2_features;
+	vkGetPhysicalDeviceFeatures2(gpu.get_handle(), &features2);
+
+	if (!extended_dynamic_state2_features.extendedDynamicState2 || !extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints)
+	{
+		throw vkb::VulkanException(VK_ERROR_FEATURE_NOT_PRESENT, "Selected GPU does not support required extended dynamic state2 features!");
+	}
+
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
 	auto &requested_extended_dynamic_state2_features =

--- a/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
+++ b/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
@@ -200,6 +200,20 @@ void LogicOpDynamicState::build_command_buffers()
  */
 void LogicOpDynamicState::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
+	// Check whether the device supports extended dynamic state2 features
+	VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features;
+	extended_dynamic_state2_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT;
+	extended_dynamic_state2_features.pNext = VK_NULL_HANDLE;
+	VkPhysicalDeviceFeatures2 features2;
+	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+	features2.pNext = &extended_dynamic_state2_features;
+	vkGetPhysicalDeviceFeatures2(gpu.get_handle(), &features2);
+
+	if (!extended_dynamic_state2_features.extendedDynamicState2 || !extended_dynamic_state2_features.extendedDynamicState2LogicOp)
+	{
+		throw vkb::VulkanException(VK_ERROR_FEATURE_NOT_PRESENT, "Selected GPU does not support required extended dynamic state2 features!");
+	}
+
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
 	auto &requested_extended_dynamic_state2_features =

--- a/samples/extensions/patch_control_points/patch_control_points.cpp
+++ b/samples/extensions/patch_control_points/patch_control_points.cpp
@@ -549,6 +549,20 @@ void PatchControlPoints::create_descriptor_sets()
  */
 void PatchControlPoints::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
+	// Check whether the device supports extended dynamic state2 features
+	VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features;
+	extended_dynamic_state2_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT;
+	extended_dynamic_state2_features.pNext = VK_NULL_HANDLE;
+	VkPhysicalDeviceFeatures2 features2;
+	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+	features2.pNext = &extended_dynamic_state2_features;
+	vkGetPhysicalDeviceFeatures2(gpu.get_handle(), &features2);
+
+	if (!extended_dynamic_state2_features.extendedDynamicState2 || !extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints)
+	{
+		throw vkb::VulkanException(VK_ERROR_FEATURE_NOT_PRESENT, "Selected GPU does not support required extended dynamic state2 features!");
+	}
+
 	/* Enable extension features required by this sample
 	   These are passed to device creation via a pNext structure chain */
 	auto &requested_extended_dynamic_state2_features =


### PR DESCRIPTION
## Description

This PR adds feature checks to the following samples prior to Vulkan device creation:

1. _dynamic_line_rasterization_ : `rectangularLines`, `bresenhamLines`, and `smoothLines` features
2. _extended_dynamic_state2_: `extendedDynamicState2` and `extendedDynamicState2PatchControlPoints` features
3. _logic_op_dynamic_state_: `extendedDynamicState2` and `extendedDynamicState2LogicOp` features
4. _patch_control_points_: `extendedDynamicState2` and `extendedDynamicState2PatchControlPoints` features

In addition, for _dynamic_line_rasterization_, the sample now enables line types individually, and provides feedback to users regarding which types are supported.

Also, for _extended_dynamic_state2_, the `VK_EXT_primitive_topology_list_restart` extension has been made optional to allow the sample to mostly work on macOS.

Tested on Windows 10 and macOS Ventura using an AMD 6600XT GPU with lastest AMD drivers and SDK 1.3.290.  The samples **no longer crash on Windows 10** when using AMD drivers, and run as per the following:

Windows 10: _dynamic_line_rasterization_ runs with partial lines support; _extended_dynamic_state2_, _logic_op_dynamic_state_, and _patch_control_points_ do not run based on lack of feature support, but exit cleanly.

macOS Ventura: _extended_dynamic_state2_ and _patch_control_points_ run; _dynamic_line_rasterization_ and _logic_op_dynamic_state_ do not run based on lack of feature support, but exit cleanly.

Fixes #1144 

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [X] I have tested every sample to ensure everything runs correctly
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [X] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [X] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [X] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
