### PR TITLE
Fix two more bugs introduced by unifying vkb::core::[HPP]Buffer

### DIFF
--- a/framework/core/acceleration_structure.cpp
+++ b/framework/core/acceleration_structure.cpp
@@ -41,12 +41,16 @@ AccelerationStructure::~AccelerationStructure()
 uint64_t AccelerationStructure::add_triangle_geometry(vkb::core::BufferC &vertex_buffer,
                                                       vkb::core::BufferC &index_buffer,
                                                       vkb::core::BufferC &transform_buffer,
-                                                      uint32_t triangle_count, uint32_t max_vertex,
-                                                      VkDeviceSize vertex_stride, uint32_t transform_offset,
-                                                      VkFormat vertex_format, VkGeometryFlagsKHR flags,
-                                                      uint64_t vertex_buffer_data_address,
-                                                      uint64_t index_buffer_data_address,
-                                                      uint64_t transform_buffer_data_address)
+                                                      uint32_t            triangle_count,
+                                                      uint32_t            max_vertex,
+                                                      VkDeviceSize        vertex_stride,
+                                                      uint32_t            transform_offset,
+                                                      VkFormat            vertex_format,
+                                                      VkIndexType         index_type,
+                                                      VkGeometryFlagsKHR  flags,
+                                                      uint64_t            vertex_buffer_data_address,
+                                                      uint64_t            index_buffer_data_address,
+                                                      uint64_t            transform_buffer_data_address)
 {
 	VkAccelerationStructureGeometryKHR geometry{};
 	geometry.sType                                          = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
@@ -56,7 +60,7 @@ uint64_t AccelerationStructure::add_triangle_geometry(vkb::core::BufferC &vertex
 	geometry.geometry.triangles.vertexFormat                = vertex_format;
 	geometry.geometry.triangles.maxVertex                   = max_vertex;
 	geometry.geometry.triangles.vertexStride                = vertex_stride;
-	geometry.geometry.triangles.indexType                   = VK_INDEX_TYPE_UINT32;
+	geometry.geometry.triangles.indexType                   = index_type;
 	geometry.geometry.triangles.vertexData.deviceAddress    = vertex_buffer_data_address == 0 ? vertex_buffer.get_device_address() : vertex_buffer_data_address;
 	geometry.geometry.triangles.indexData.deviceAddress     = index_buffer_data_address == 0 ? index_buffer.get_device_address() : index_buffer_data_address;
 	geometry.geometry.triangles.transformData.deviceAddress = transform_buffer_data_address == 0 ? transform_buffer.get_device_address() : transform_buffer_data_address;

--- a/framework/core/acceleration_structure.h
+++ b/framework/core/acceleration_structure.h
@@ -54,6 +54,7 @@ class AccelerationStructure
 	 * @param vertex_stride Stride of the vertex structure
 	 * @param transform_offset Offset of this geometry in the transform data buffer
 	 * @param vertex_format Format of the vertex structure
+	 * @param index_type Type of the indices
 	 * @param flags Ray tracing geometry flags
 	 * @param vertex_buffer_data_address set this if don't want the vertex_buffer data_address
 	 * @param index_buffer_data_address set this if don't want the index_buffer data_address
@@ -67,6 +68,7 @@ class AccelerationStructure
 	                               VkDeviceSize        vertex_stride,
 	                               uint32_t            transform_offset              = 0,
 	                               VkFormat            vertex_format                 = VK_FORMAT_R32G32B32_SFLOAT,
+	                               VkIndexType         index_type                    = VK_INDEX_TYPE_UINT32,
 	                               VkGeometryFlagsKHR  flags                         = VK_GEOMETRY_OPAQUE_BIT_KHR,
 	                               uint64_t            vertex_buffer_data_address    = 0,
 	                               uint64_t            index_buffer_data_address     = 0,

--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -761,7 +761,7 @@ sg::Scene GLTFLoader::load_scene(int scene_index, VkBufferUsageFlags additional_
 
 				vkb::core::BufferC buffer{device,
 				                          vertex_data.size(),
-				                          VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+				                          VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | additional_buffer_usage_flags,
 				                          VMA_MEMORY_USAGE_CPU_TO_GPU};
 				buffer.update(vertex_data);
 				buffer.set_debug_name(fmt::format("'{}' mesh, primitive #{}: '{}' vertex buffer",
@@ -804,7 +804,7 @@ sg::Scene GLTFLoader::load_scene(int scene_index, VkBufferUsageFlags additional_
 
 				submesh->index_buffer = std::make_unique<vkb::core::BufferC>(device,
 				                                                             index_data.size(),
-				                                                             VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+				                                                             VK_BUFFER_USAGE_INDEX_BUFFER_BIT | additional_buffer_usage_flags,
 				                                                             VMA_MEMORY_USAGE_GPU_TO_CPU);
 				submesh->index_buffer->set_debug_name(fmt::format("'{}' mesh, primitive #{}: index buffer",
 				                                                  gltf_mesh.name, i_primitive));

--- a/samples/extensions/ray_queries/ray_queries.cpp
+++ b/samples/extensions/ray_queries/ray_queries.cpp
@@ -273,16 +273,18 @@ void RayQueries::create_bottom_level_acceleration_structure()
 	{
 		bottom_level_acceleration_structure = std::make_unique<vkb::core::AccelerationStructure>(
 		    get_device(), VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR);
-		bottom_level_acceleration_structure->add_triangle_geometry(
-		    *vertex_buffer,
-		    *index_buffer,
-		    *transform_matrix_buffer,
-		    static_cast<uint32_t>(model.indices.size()),
-		    static_cast<uint32_t>(model.vertices.size()) - 1,
-		    sizeof(Vertex),
-		    0, VK_FORMAT_R32G32B32_SFLOAT, VK_GEOMETRY_OPAQUE_BIT_KHR,
-		    get_buffer_device_address(vertex_buffer->get_handle()),
-		    get_buffer_device_address(index_buffer->get_handle()));
+		bottom_level_acceleration_structure->add_triangle_geometry(*vertex_buffer,
+		                                                           *index_buffer,
+		                                                           *transform_matrix_buffer,
+		                                                           static_cast<uint32_t>(model.indices.size()),
+		                                                           static_cast<uint32_t>(model.vertices.size()) - 1,
+		                                                           sizeof(Vertex),
+		                                                           0,
+		                                                           VK_FORMAT_R32G32B32_SFLOAT,
+		                                                           VK_INDEX_TYPE_UINT32,
+		                                                           VK_GEOMETRY_OPAQUE_BIT_KHR,
+		                                                           get_buffer_device_address(vertex_buffer->get_handle()),
+		                                                           get_buffer_device_address(index_buffer->get_handle()));
 	}
 	bottom_level_acceleration_structure->build(queue, VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR, VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
 }

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -387,7 +387,10 @@ void RaytracingExtended::create_bottom_level_acceleration_structure(bool is_upda
 			    static_cast<uint32_t>(model_buffer.num_triangles),
 			    static_cast<uint32_t>(model_buffer.num_vertices) - 1,
 			    sizeof(NewVertex),
-			    0, VK_FORMAT_R32G32B32_SFLOAT, VK_GEOMETRY_OPAQUE_BIT_KHR,
+			    0,
+			    VK_FORMAT_R32G32B32_SFLOAT,
+			    VK_INDEX_TYPE_UINT32,
+			    VK_GEOMETRY_OPAQUE_BIT_KHR,
 			    model_buffer.vertex_offset + (model_buffer.is_static ? static_vertex_handle : dynamic_vertex_handle),
 			    model_buffer.index_offset + (model_buffer.is_static ? static_index_handle : dynamic_index_handle));
 		}


### PR DESCRIPTION
## Description

- While combining the two versions of AccelerationStructure::add_triangle_geometry, one argument of one of those versions got lost
- In the gltf_loader, the additional_buffer_usage_flags to be used for the vertex and index buffers got lost

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Fixes #1146

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [(x)] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
