### PR TITLE
Work-around macOS/iOS blank screen issues on swapchain recreation

### DIFF
--- a/framework/rendering/hpp_render_context.cpp
+++ b/framework/rendering/hpp_render_context.cpp
@@ -322,8 +322,7 @@ void HPPRenderContext::begin_frame()
 			}
 		}
 
-		// eSuboptimalKHR can legitimately occur in batch mode when exiting certain samples (e.g. afbc, msaa, surface_rotation, swapchain_images)
-		if (result != vk::Result::eSuccess && result != vk::Result::eSuboptimalKHR)
+		if (result != vk::Result::eSuccess)
 		{
 			prev_frame.reset();
 			return;

--- a/framework/rendering/hpp_render_context.cpp
+++ b/framework/rendering/hpp_render_context.cpp
@@ -119,6 +119,10 @@ void HPPRenderContext::update_swapchain(const uint32_t image_count)
 	device.get_handle().waitIdle();
 
 	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, image_count);
+#if defined(PLATFORM__MACOS)
+	// Workaround on macOS/iOS to avoid blank screen when only changing image_count
+	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, image_count);
+#endif
 
 	recreate();
 }
@@ -134,6 +138,10 @@ void HPPRenderContext::update_swapchain(const std::set<vk::ImageUsageFlagBits> &
 	device.get_resource_cache().clear_framebuffers();
 
 	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, image_usage_flags);
+#if defined(PLATFORM__MACOS)
+	// Workaround on macOS/iOS to avoid blank screen when only changing image_usage_flags
+	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, image_usage_flags);
+#endif
 
 	recreate();
 }
@@ -157,6 +165,10 @@ void HPPRenderContext::update_swapchain(const vk::Extent2D &extent, const vk::Su
 	}
 
 	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, vk::Extent2D{width, height}, transform);
+#if defined(PLATFORM__MACOS)
+	// Workaround on macOS/iOS to avoid blank screen when only changing transform
+	swapchain = std::make_unique<vkb::core::HPPSwapchain>(*swapchain, vk::Extent2D{width, height}, transform);
+#endif
 
 	// Save the preTransform attribute for future rotations
 	pre_transform = transform;

--- a/framework/rendering/hpp_render_context.cpp
+++ b/framework/rendering/hpp_render_context.cpp
@@ -312,6 +312,9 @@ void HPPRenderContext::begin_frame()
 
 			if (swapchain_updated)
 			{
+				// Need to destroy and reallocate acquired_semaphore since it may have already been signaled
+				device.get_handle().destroySemaphore(acquired_semaphore);
+				acquired_semaphore                   = prev_frame.request_semaphore_with_ownership();
 				std::tie(result, active_frame_index) = swapchain->acquire_next_image(acquired_semaphore);
 			}
 		}

--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -337,7 +337,10 @@ void RenderContext::begin_frame()
 
 			if (swapchain_updated)
 			{
-				result = swapchain->acquire_next_image(active_frame_index, acquired_semaphore, VK_NULL_HANDLE);
+				// Need to destroy and reallocate acquired_semaphore since it may have already been signaled
+				vkDestroySemaphore(device.get_handle(), acquired_semaphore, nullptr);
+				acquired_semaphore = prev_frame.request_semaphore_with_ownership();
+				result             = swapchain->acquire_next_image(active_frame_index, acquired_semaphore, VK_NULL_HANDLE);
 			}
 		}
 

--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -130,6 +130,10 @@ void RenderContext::update_swapchain(const uint32_t image_count)
 	device.wait_idle();
 
 	swapchain = std::make_unique<Swapchain>(*swapchain, image_count);
+#if defined(PLATFORM__MACOS)
+	// Workaround on macOS/iOS to avoid blank screen when only changing image_count
+	swapchain = std::make_unique<Swapchain>(*swapchain, image_count);
+#endif
 
 	recreate();
 }
@@ -145,6 +149,10 @@ void RenderContext::update_swapchain(const std::set<VkImageUsageFlagBits> &image
 	device.get_resource_cache().clear_framebuffers();
 
 	swapchain = std::make_unique<Swapchain>(*swapchain, image_usage_flags);
+#if defined(PLATFORM__MACOS)
+	// Workaround on macOS/iOS to avoid blank screen when only changing image_usage_flags
+	swapchain = std::make_unique<Swapchain>(*swapchain, image_usage_flags);
+#endif
 
 	recreate();
 }
@@ -168,6 +176,10 @@ void RenderContext::update_swapchain(const VkExtent2D &extent, const VkSurfaceTr
 	}
 
 	swapchain = std::make_unique<Swapchain>(*swapchain, VkExtent2D{width, height}, transform);
+#if defined(PLATFORM__MACOS)
+	// Workaround on macOS/iOS to avoid blank screen when only changing transform
+	swapchain = std::make_unique<Swapchain>(*swapchain, VkExtent2D{width, height}, transform);
+#endif
 
 	// Save the preTransform attribute for future rotations
 	pre_transform = transform;

--- a/framework/rendering/render_context.cpp
+++ b/framework/rendering/render_context.cpp
@@ -347,8 +347,7 @@ void RenderContext::begin_frame()
 			}
 		}
 
-		// VK_SUBOPTIMAL_KHR can legitimately occur in batch mode when exiting certain samples (e.g. afbc, msaa, surface_rotation, swapchain_images)
-		if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR)
+		if (result != VK_SUCCESS)
 		{
 			prev_frame.reset();
 			return;


### PR DESCRIPTION
## Description

This PR does ~~two~~ three things:

1. Adds workarounds on **macOS/iOS only** for swapchain recreation when only `image_count`, `image_usage_flags`, or `transform` parameters are changing (i.e. without resizing).  This workaround recreates the swapchain a second time within `[HPP]RenderContext::begin_frame()` specifically in cases when `vkAcquireNextImageKHR()` returns `VK_SUBOPTIMAL_KHR`. This fixes the blank screen problem when options are selected in certain samples (_afbc, msaa, swapchain_images, hpp_swapchain_images, and surface_rotation_).
2. Reverts the previous workarounds from PR #1084 which permitted `VK_SUBOPTIMAL_KHR` return codes within `[HPP]RenderContext::begin_frame()`.  These `VK_SUBOPTIMAL_KHR` return codes were due to swapchain recreation problems in item 1 above.  With these now addressed, the code allowing `VK_SUBOPTIMAL_KHR` is no longer needed.
3. **UPDATE**: Fixes a defect in the way `[HPP]RenderContext::begin_frame()` calls `swapchain->acquire_next_image()` a second time using the same semaphore from the first call. This is not correct since that semaphore will already be signaled and cannot be used again until cleared by a queue wait operation. To address this, I added code to destroy the semaphore and recreate it in a non-signaled state.

Fixes #1149 

Tested on macOS Ventura 13.6.6, iOS 17.6.1, and Windows 10 using an AMD 6600XT GPU.

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [X] I have tested every sample to ensure everything runs correctly
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [X] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [X] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
