### PR TITLE
Fix build of samples dynamic rendering local read and host image copy

### DIFF
--- a/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
+++ b/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
@@ -432,8 +432,8 @@ void DynamicRenderingLocalRead::create_attachments()
 
 void DynamicRenderingLocalRead::prepare_buffers()
 {
-	buffers.ubo_vs      = std::make_unique<vkb::core::Buffer>(get_device(), sizeof(shader_data_vs), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
-	buffers.ssbo_lights = std::make_unique<vkb::core::Buffer>(get_device(), lights.size() * sizeof(Light), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	buffers.ubo_vs      = std::make_unique<vkb::core::BufferC>(get_device(), sizeof(shader_data_vs), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	buffers.ssbo_lights = std::make_unique<vkb::core::BufferC>(get_device(), lights.size() * sizeof(Light), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
 
 	update_uniform_buffer();
 	update_lights_buffer();

--- a/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.h
+++ b/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.h
@@ -65,8 +65,8 @@ class DynamicRenderingLocalRead : public ApiVulkanSample
 
 	struct
 	{
-		std::unique_ptr<vkb::core::Buffer> ubo_vs;
-		std::unique_ptr<vkb::core::Buffer> ssbo_lights;
+		std::unique_ptr<vkb::core::BufferC> ubo_vs;
+		std::unique_ptr<vkb::core::BufferC> ssbo_lights;
 	} buffers;
 
 	struct PushConstantSceneNode

--- a/samples/extensions/host_image_copy/host_image_copy.cpp
+++ b/samples/extensions/host_image_copy/host_image_copy.cpp
@@ -429,7 +429,7 @@ void HostImageCopy::prepare_pipelines()
 void HostImageCopy::prepare_uniform_buffers()
 {
 	// Vertex shader uniform buffer block
-	uniform_buffer_vs = std::make_unique<vkb::core::Buffer>(get_device(),
+	uniform_buffer_vs = std::make_unique<vkb::core::BufferC>(get_device(),
 	                                                        sizeof(ubo_vs),
 	                                                        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
 	                                                        VMA_MEMORY_USAGE_CPU_TO_GPU);

--- a/samples/extensions/host_image_copy/host_image_copy.cpp
+++ b/samples/extensions/host_image_copy/host_image_copy.cpp
@@ -430,9 +430,9 @@ void HostImageCopy::prepare_uniform_buffers()
 {
 	// Vertex shader uniform buffer block
 	uniform_buffer_vs = std::make_unique<vkb::core::BufferC>(get_device(),
-	                                                        sizeof(ubo_vs),
-	                                                        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-	                                                        VMA_MEMORY_USAGE_CPU_TO_GPU);
+	                                                         sizeof(ubo_vs),
+	                                                         VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+	                                                         VMA_MEMORY_USAGE_CPU_TO_GPU);
 
 	update_uniform_buffers();
 }

--- a/samples/extensions/host_image_copy/host_image_copy.h
+++ b/samples/extensions/host_image_copy/host_image_copy.h
@@ -46,7 +46,7 @@ class HostImageCopy : public ApiVulkanSample
 		float     lod_bias = 0.0f;
 	} ubo_vs;
 
-	std::unique_ptr<vkb::core::Buffer> uniform_buffer_vs;
+	std::unique_ptr<vkb::core::BufferC> uniform_buffer_vs;
 
 	VkPipeline            pipeline{VK_NULL_HANDLE};
 	VkPipelineLayout      pipeline_layout{VK_NULL_HANDLE};


### PR DESCRIPTION
## Description

PR #887 predated vkb::core::CppBuffer merge, change type used to BufferC in samples dynamic rendering local read and host image copy.

Fixes #1154.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
