### PR TITLE
Fix folder creation on Android

### DIFF
--- a/components/filesystem/src/legacy.cpp
+++ b/components/filesystem/src/legacy.cpp
@@ -99,7 +99,7 @@ void create_path(const std::string &root, const std::string &path)
 	for (auto it = path.begin(); it != path.end(); ++it)
 	{
 		it = std::find(it, path.end(), '/');
-		create_directory(root + std::string(path.begin(), it));
+		create_directory(root + '/' + std::string(path.begin(), it));
 	}
 }
 


### PR DESCRIPTION
## Description

`root` doesn't has a trailing slash, so on Android a folder named `filesoutput/` was created instead of `files/output/`.
This PR adds the missing directory separator when creating folders.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly
