### PR TITLE
Use Vulkan API 1.0 support funcs for Vulkan API 1.0 sample host_image_copy

### DIFF
--- a/samples/extensions/host_image_copy/host_image_copy.cpp
+++ b/samples/extensions/host_image_copy/host_image_copy.cpp
@@ -93,11 +93,11 @@ void HostImageCopy::load_texture()
 	// Note: All formats that support sampling are required to support this flag
 	// So for the format used here (R8G8B8A8_UNORM) we could skip this check
 	// The flag we need to check is an extension flag, so we need to go through VkFormatProperties3
-	VkFormatProperties3 format_properties_3{};
+	VkFormatProperties3KHR format_properties_3{};
 	format_properties_3.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3_KHR;
 	// Properties3 need to be chained into Properties2
-	VkFormatProperties2 format_properties_2{};
-	format_properties_2.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+	VkFormatProperties2KHR format_properties_2{};
+	format_properties_2.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR;
 	format_properties_2.pNext = &format_properties_3;
 	vkGetPhysicalDeviceFormatProperties2KHR(get_device().get_gpu().get_handle(), image_format, &format_properties_2);
 

--- a/samples/extensions/host_image_copy/host_image_copy.cpp
+++ b/samples/extensions/host_image_copy/host_image_copy.cpp
@@ -99,7 +99,7 @@ void HostImageCopy::load_texture()
 	VkFormatProperties2 format_properties_2{};
 	format_properties_2.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
 	format_properties_2.pNext = &format_properties_3;
-	vkGetPhysicalDeviceFormatProperties2(get_device().get_gpu().get_handle(), image_format, &format_properties_2);
+	vkGetPhysicalDeviceFormatProperties2KHR(get_device().get_gpu().get_handle(), image_format, &format_properties_2);
 
 	if ((format_properties_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT) == 0)
 	{


### PR DESCRIPTION
## Description

This PR replaces Vulkan 1.1 API support function `vkGetPhysicalDeviceFormatProperties2()` with Vulkan 1.0 equivalent `vkGetPhysicalDeviceFormatProperties2KHR()` for Vulkan API 1.0 sample _host_image_copy_. This prevents runtime failures (undefined functions) on Vulkan drivers that enforce the specified API version.

I did not up-version the sample to Vulkan API 1.1 since it appears that Vulkan API 1.0 was the intended API version, with extensions enabled by `VK_KHR_get_physical_device_properties2`.

Tested on macOS Ventura and iOS 17 using both the Vulkan loader and MoltenVK standalone.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
