### PR TITLE
Improve Filesystem error messages and add .idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ assets/scenes
 build
 .vs
 .vscode
+.idea
 imgui.ini
 doxygen/
 tests/system_test/artifacts

--- a/components/filesystem/src/std_filesystem.cpp
+++ b/components/filesystem/src/std_filesystem.cpp
@@ -79,7 +79,7 @@ bool StdFileSystem::create_directory(const Path &path)
 
 	if (ec)
 	{
-		throw std::runtime_error("Failed to create directory");
+		throw std::runtime_error("Failed to create directory at path: " + path.string());
 	}
 
 	return !ec;
@@ -91,7 +91,7 @@ std::vector<uint8_t> StdFileSystem::read_chunk(const Path &path, size_t offset, 
 
 	if (!file.is_open())
 	{
-		throw std::runtime_error("Failed to open file for reading");
+		throw std::runtime_error("Failed to open file for reading at path: " + path.string());
 	}
 
 	auto size = stat_file(path).size;
@@ -122,7 +122,7 @@ void StdFileSystem::write_file(const Path &path, const std::vector<uint8_t> &dat
 
 	if (!file.is_open())
 	{
-		throw std::runtime_error("Failed to open file for writing");
+		throw std::runtime_error("Failed to open file for writing at path: " + path.string());
 	}
 
 	file.write(reinterpret_cast<const char *>(data.data()), data.size());
@@ -136,7 +136,7 @@ void StdFileSystem::remove(const Path &path)
 
 	if (ec)
 	{
-		throw std::runtime_error("Failed to remove file");
+		throw std::runtime_error("Failed to remove file at path: " + path.string());
 	}
 }
 


### PR DESCRIPTION
## Description

Improve filesystem error messages by including path to the message.
Also add .idea folder to gitignore to exclude ide config files of jetbrains IDE s, similar to .vs and .vscode files

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly