### PR TITLE
Fix #1066: Fix OIT blending

### DIFF
--- a/samples/api/oit_linked_lists/oit_linked_lists.cpp
+++ b/samples/api/oit_linked_lists/oit_linked_lists.cpp
@@ -455,7 +455,7 @@ void OITLinkedLists::create_pipelines()
 			blend_attachment_state.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
 			blend_attachment_state.colorBlendOp        = VK_BLEND_OP_ADD;
 			blend_attachment_state.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-			blend_attachment_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+			blend_attachment_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
 			blend_attachment_state.alphaBlendOp        = VK_BLEND_OP_ADD;
 
 			shader_stages[0] = load_shader("oit_linked_lists/combine.vert", VK_SHADER_STAGE_VERTEX_BIT);

--- a/shaders/oit_linked_lists/combine.frag
+++ b/shaders/oit_linked_lists/combine.frag
@@ -1,5 +1,5 @@
 #version 450
-/* Copyright (c) 2023, Google
+/* Copyright (c) 2023-2024, Google
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/shaders/oit_linked_lists/combine.frag
+++ b/shaders/oit_linked_lists/combine.frag
@@ -54,9 +54,9 @@ layout (location = 0) out vec4 outFragColor;
 vec4 blendColors(uint packedSrcColor, vec4 dstColor)
 {
 	const vec4 srcColor = unpackUnorm4x8(packedSrcColor);
-	return vec4(
-		mix(dstColor.rgb, srcColor.rgb, srcColor.a),
-		dstColor.a * (1.0f - srcColor.a));
+	float alphaResult = srcColor.a + dstColor.a * (1.0f - srcColor.a);
+	vec3 rgbResult = (srcColor.rgb * srcColor.a + dstColor.rgb * dstColor.a * (1.0f - srcColor.a)) / alphaResult;
+	return vec4(rgbResult, alphaResult);
 }
 
 // Sort and blend fragments from the linked list.
@@ -70,7 +70,7 @@ vec4 mergeWithSort(uint firstFragmentIndex)
 	uint sortedFragmentCount = 0U;
 	const uint kSortedFragmentMaxCount = min(sceneConstants.sortedFragmentCount, SORTED_FRAGMENT_MAX_COUNT);
 
-	vec4 color = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+	vec4 color = vec4(0.0f);
 	uint fragmentIndex = firstFragmentIndex;
 	while(fragmentIndex != LINKED_LIST_END_SENTINEL)
 	{
@@ -123,14 +123,13 @@ vec4 mergeWithSort(uint firstFragmentIndex)
 	{
 		color = blendColors(sortedFragments[i].x, color);
 	}
-	color.a = 1.0f - color.a;
 	return color;
 }
 
 // Blend fragments from the linked list without sorting them.
 vec4 mergeWithoutSort(uint firstFragmentIndex)
 {
-	vec4 color = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+	vec4 color = vec4(0.0f);
 	uint fragmentIndex = firstFragmentIndex;
 	while(fragmentIndex != LINKED_LIST_END_SENTINEL)
 	{
@@ -138,7 +137,6 @@ vec4 mergeWithoutSort(uint firstFragmentIndex)
 		fragmentIndex = fragment.x;
 		color = blendColors(fragment.y, color);
 	}
-	color.a = 1.0f - color.a;
 	return color;
 }
 


### PR DESCRIPTION
Issue already reported what to fix in order to get the blending correct.

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc)

Fixes #1066

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
