### PR TITLE
Fix some minor issues with the api samples base class

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -304,6 +304,7 @@ void ApiVulkanSample::input_event(const vkb::InputEvent &input_event)
 						{
 							get_gui().visible = !get_gui().visible;
 						}
+						break;
 					default:
 						break;
 				}
@@ -703,7 +704,7 @@ void ApiVulkanSample::setup_depth_stencil()
 
 void ApiVulkanSample::setup_framebuffer()
 {
-	VkImageView attachments[2];
+	VkImageView attachments[2]{};
 
 	// Depth/Stencil attachment is the same for all frame buffers
 	attachments[1] = depth_stencil.view;
@@ -781,7 +782,7 @@ void ApiVulkanSample::setup_render_pass()
 	subpass_description.pResolveAttachments     = nullptr;
 
 	// Subpass dependencies for layout transitions
-	std::array<VkSubpassDependency, 2> dependencies;
+	std::array<VkSubpassDependency, 2> dependencies{};
 
 	dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
 	dependencies[0].dstSubpass      = 0;
@@ -866,7 +867,7 @@ void ApiVulkanSample::update_render_pass_flags(uint32_t flags)
 	subpass_description.pResolveAttachments     = nullptr;
 
 	// Subpass dependencies for layout transitions
-	std::array<VkSubpassDependency, 2> dependencies;
+	std::array<VkSubpassDependency, 2> dependencies{};
 
 	dependencies[0].srcSubpass      = VK_SUBPASS_EXTERNAL;
 	dependencies[0].dstSubpass      = 0;

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -361,6 +361,7 @@ class ApiVulkanSample : public vkb::VulkanSampleC
 	/**
 	 * @brief Updates the overlay
 	 * @param delta_time The time taken since the last frame
+	 * @param additional_ui Function that implements an additional Gui
 	 */
 	void update_overlay(float delta_time, const std::function<void()> &additional_ui) override;
 

--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -113,8 +113,6 @@ class ApiVulkanSample : public vkb::VulkanSampleC
 
 	virtual void update(float delta_time) override;
 
-	virtual void update_overlay(float delta_time, const std::function<void()> &additional_ui) override;
-
 	virtual bool resize(const uint32_t width, const uint32_t height) override;
 
 	virtual void render(float delta_time) = 0;
@@ -364,7 +362,7 @@ class ApiVulkanSample : public vkb::VulkanSampleC
 	 * @brief Updates the overlay
 	 * @param delta_time The time taken since the last frame
 	 */
-	void update_overlay(float delta_time);
+	void update_overlay(float delta_time, const std::function<void()> &additional_ui) override;
 
 	/**
 	 * @brief If the gui is enabled, then record the drawing commands to a command buffer

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -300,6 +300,7 @@ void HPPApiVulkanSample::input_event(const vkb::InputEvent &input_event)
 						{
 							get_gui().visible = !get_gui().visible;
 						}
+						break;
 					default:
 						break;
 				}


### PR DESCRIPTION
## Description

This PR fixes some minor issues I noticed in the api sample base class. E.g. a duplicate function declaration that triggered a compiler warning and some non-initialized values that triggered the linter.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly
