### PR TITLE
Remove unavailable debug information for high level framework based samples

### DIFF
--- a/framework/scene_graph/hpp_scene.h
+++ b/framework/scene_graph/hpp_scene.h
@@ -62,7 +62,6 @@ class HPPScene : private vkb::sg::Scene
 		}
 		else
 		{
-			assert(false);        // path never passed -> Please add a type-check here!
 			return false;
 		}
 	}

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -1337,21 +1337,6 @@ inline void VulkanSample<bindingType>::update_debug_window()
 	                                                             to_string(render_context->get_swapchain().get_format()) + " (" +
 	                                                                 to_string(vkb::common::get_bits_per_pixel(render_context->get_swapchain().get_format())) +
 	                                                                 "bpp)");
-
-	if (scene != nullptr)
-	{
-		get_debug_info().template insert<field::Static, uint32_t>("mesh_count", to_u32(scene->get_components<sg::SubMesh>().size()));
-		get_debug_info().template insert<field::Static, uint32_t>("texture_count", to_u32(scene->get_components<sg::Texture>().size()));
-
-		if (auto camera = scene->get_components<vkb::sg::Camera>()[0])
-		{
-			if (auto camera_node = camera->get_node())
-			{
-				const glm::vec3 &pos = camera_node->get_transform().get_translation();
-				get_debug_info().template insert<field::Vector, float>("camera_pos", pos.x, pos.y, pos.z);
-			}
-		}
-	}
 }
 
 template <vkb::BindingType bindingType>


### PR DESCRIPTION
## Description

The high level framework based samples have a kinda hidden debug overlay activated with right click (on desktop). It shows some general debug information. This was broken (not sure when that did happen) and would crash every time you tried to toggle that debug overlay. This was caused by the scene graph not finding some components and also not checking if those are present. While fixing this, I noticed that those components weren't available in any of those samples so I simply removed the block. Also removed a wrong assert in the has_component check.

We may want to start thinking on how to simplify the high level framework. Debugging and fixing anything in that framework is tedious.

Fixes #1176

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly