### PR TITLE
Fixed a validation error in the logic operations dynamic state sample

### DIFF
--- a/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
+++ b/samples/extensions/logic_op_dynamic_state/logic_op_dynamic_state.cpp
@@ -35,6 +35,7 @@ LogicOpDynamicState::LogicOpDynamicState()
 	add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	add_device_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
 	add_device_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
+	add_device_extension(VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_EXTENSION_NAME);
 }
 
 LogicOpDynamicState::~LogicOpDynamicState()
@@ -215,6 +216,11 @@ void LogicOpDynamicState::request_gpu_features(vkb::PhysicalDevice &gpu)
 	                         VkPhysicalDeviceExtendedDynamicStateFeaturesEXT,
 	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
 	                         extendedDynamicState);
+
+	REQUEST_REQUIRED_FEATURE(gpu,
+	                         VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT,
+	                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT,
+	                         primitiveTopologyListRestart);
 
 	if (gpu.get_features().samplerAnisotropy)
 	{


### PR DESCRIPTION
## Description

The following validation error was output in the logic operations dynamic state sample.

> vkCmdDrawIndexed():  the topology set is VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, the primitiveTopologyListRestart feature was not enabled, but vkCmdSetPrimitiveRestartEnable last set primitiveRestartEnable to VK_TRUE.

`VK_EXT_primitive_topology_list_restart` and `VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT` have been enabled.

- This PR has only been tested on Windows.
- There are no related issues.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
