### PR TITLE
Fix pipeline stats in HPPTerrainTessellation

### DIFF
--- a/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
+++ b/samples/api/hpp_terrain_tessellation/hpp_terrain_tessellation.cpp
@@ -327,11 +327,13 @@ void HPPTerrainTessellation::draw()
 	if (statistics.query_supported)
 	{
 		// Read query results for displaying in next frame
-		statistics.results =
-		    get_device()
-		        .get_handle()
-		        .getQueryPoolResult<std::array<uint64_t, 2>>(statistics.query_pool, 0, 1, sizeof(statistics.results), vk::QueryResultFlagBits::e64)
-		        .value;
+		auto result = get_device()
+		                  .get_handle()
+		                  .getQueryPoolResult<std::array<uint64_t, 2>>(statistics.query_pool, 0, 1, sizeof(statistics.results), vk::QueryResultFlagBits::e64);
+		if (result.result == vk::Result::eSuccess)
+		{
+			statistics.results = result.value;
+		}
 	}
 
 	HPPApiVulkanSample::submit_frame();


### PR DESCRIPTION
## Description

Fixed pipeline stats in the hpp_terrain_tessellation sample.

The bug was caused by copying `result.value` when the query result was NotReady. The original C sample (`vkGetQueryPoolResults`) also generated NotReady, but since the result value was not written to the output pointer, the same problem as the HPP version did not occur.

The bug can also be fixed by setting the `VK_QUERY_RESULT_WAIT_BIT` flag, but to match the behavior of the original C sample, I modified it to only read the value if the result was Success.

- This PR has only been tested on Windows.
- Fixes #674 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
