### PR TITLE
Removed hard-coded swizzle hack in RayQueries sample

### DIFF
--- a/samples/extensions/ray_queries/ray_queries.cpp
+++ b/samples/extensions/ray_queries/ray_queries.cpp
@@ -286,9 +286,9 @@ void RayQueries::load_node(vkb::sg::Node &node)
 {
 	if (node.has_component<vkb::sg::Mesh>())
 	{
-		auto &mesh             = node.get_component<vkb::sg::Mesh>();
-		auto &transform_matrix = node.get_transform().get_world_matrix();
-		auto &normal_matrix    = glm::transpose(glm::inverse(glm::mat3(transform_matrix)));
+		auto     &mesh             = node.get_component<vkb::sg::Mesh>();
+		glm::mat4 transform_matrix = node.get_transform().get_world_matrix();
+		glm::mat3 normal_matrix    = glm::transpose(glm::inverse(glm::mat3(transform_matrix)));
 
 		for (auto &&sub_mesh : mesh.get_submeshes())
 		{

--- a/samples/extensions/ray_queries/ray_queries.cpp
+++ b/samples/extensions/ray_queries/ray_queries.cpp
@@ -186,8 +186,8 @@ bool RayQueries::prepare(const vkb::ApplicationOptions &options)
 
 	camera.type = vkb::CameraType::FirstPerson;
 	camera.set_perspective(60.0f, static_cast<float>(width) / static_cast<float>(height), 0.1f, 512.0f);
-	camera.set_rotation(glm::vec3(0.0f, 0.0f, 0.0f));
-	camera.set_translation(glm::vec3(0.0f, 1.5f, 0.f));
+	camera.set_rotation(glm::vec3(0.0f, 90.0f, 0.0f));
+	camera.set_translation(glm::vec3(0.0f, -2.0f, 0.f));
 
 	load_scene();
 	create_bottom_level_acceleration_structure();
@@ -282,16 +282,15 @@ void RayQueries::create_bottom_level_acceleration_structure()
 	bottom_level_acceleration_structure->build(queue, VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR, VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
 }
 
-void RayQueries::load_scene()
+void RayQueries::load_node(vkb::sg::Node &node)
 {
-	model = {};
-
-	vkb::GLTFLoader loader{get_device()};
-	auto            scene = loader.read_scene_from_file("scenes/sponza/Sponza01.gltf");
-
-	for (auto &&mesh : scene->get_components<vkb::sg::Mesh>())
+	if (node.has_component<vkb::sg::Mesh>())
 	{
-		for (auto &&sub_mesh : mesh->get_submeshes())
+		auto &mesh             = node.get_component<vkb::sg::Mesh>();
+		auto &transform_matrix = node.get_transform().get_world_matrix();
+		auto &normal_matrix    = glm::transpose(glm::inverse(glm::mat3(transform_matrix)));
+
+		for (auto &&sub_mesh : mesh.get_submeshes())
 		{
 			auto       pts_               = CopyBuffer<glm::vec3>{}(sub_mesh->vertex_buffers, "position");
 			const auto normals_           = CopyBuffer<glm::vec3>{}(sub_mesh->vertex_buffers, "normal");
@@ -303,8 +302,9 @@ void RayQueries::load_scene()
 				const float sponza_scale = 0.01f;
 				for (size_t i = 0; i < pts_.size(); ++i)
 				{
-					model.vertices[vertex_start_index + i].position = sponza_scale * pts_[i].yzx;
-					model.vertices[vertex_start_index + i].normal   = normals_[i].yzx;
+					// For simplicity, pre-multiply the transformation
+					model.vertices[vertex_start_index + i].position = transform_matrix * sponza_scale * glm::vec4(pts_[i], 1.0f);
+					model.vertices[vertex_start_index + i].normal   = normal_matrix * normals_[i];
 				}
 			}
 
@@ -332,6 +332,21 @@ void RayQueries::load_scene()
 			}
 		}
 	}
+
+	for (auto &child : node.get_children())
+	{
+		load_node(*child);
+	}
+}
+
+void RayQueries::load_scene()
+{
+	model = {};
+
+	vkb::GLTFLoader loader{get_device()};
+	auto            scene = loader.read_scene_from_file("scenes/sponza/Sponza01.gltf");
+
+	load_node(scene->get_root_node());
 }
 
 void RayQueries::create_descriptor_pool()
@@ -395,7 +410,7 @@ void RayQueries::prepare_pipelines()
 {
 	VkPipelineInputAssemblyStateCreateInfo input_assembly_state = vkb::initializers::pipeline_input_assembly_state_create_info(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, 0, VK_FALSE);
 
-	VkPipelineRasterizationStateCreateInfo rasterization_state = vkb::initializers::pipeline_rasterization_state_create_info(VK_POLYGON_MODE_FILL, VK_CULL_MODE_BACK_BIT, VK_FRONT_FACE_CLOCKWISE, 0);
+	VkPipelineRasterizationStateCreateInfo rasterization_state = vkb::initializers::pipeline_rasterization_state_create_info(VK_POLYGON_MODE_FILL, VK_CULL_MODE_BACK_BIT, VK_FRONT_FACE_COUNTER_CLOCKWISE, 0);
 
 	VkPipelineColorBlendAttachmentState blend_attachment_state = vkb::initializers::pipeline_color_blend_attachment_state(0xf, VK_FALSE);
 
@@ -488,13 +503,15 @@ void RayQueries::update_uniform_buffers()
 {
 	assert(!!uniform_buffer);
 	global_uniform.camera_position = camera.position;
-	global_uniform.proj            = camera.matrices.perspective;
+	global_uniform.proj            = vkb::rendering::vulkan_style_projection(camera.matrices.perspective);
 	global_uniform.view            = camera.matrices.view;
 
-	const float R                 = 1.f;
-	const float P                 = 2.f * 3.14159f / 5000.f;
-	const float t                 = static_cast<float>(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count()) / 1000.f;
-	global_uniform.light_position = glm::vec3(2 * R * cosf(t * P), R * sinf(t * P), -10.f);
+	const float PI                = 3.14159f;
+	const float radius            = 100.f;
+	const float speed             = 2.f * PI / 10000.f;
+	const float time              = static_cast<float>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count());
+	const float angle             = glm::mod(time * speed, PI);
+	global_uniform.light_position = glm::vec3(0.0f, radius * sinf(angle), radius * cosf(angle));
 
 	uniform_buffer->update(&global_uniform, sizeof(global_uniform));
 }

--- a/samples/extensions/ray_queries/ray_queries.h
+++ b/samples/extensions/ray_queries/ray_queries.h
@@ -88,6 +88,7 @@ class RayQueries : public ApiVulkanSample
 
 	void build_command_buffers() override;
 	void create_uniforms();
+	void load_node(vkb::sg::Node &node);
 	void load_scene();
 	void create_descriptor_pool();
 	void create_descriptor_sets();


### PR DESCRIPTION
## Description

Removed hard-coded swizzle of vertex positions.

https://github.com/KhronosGroup/Vulkan-Samples/blob/f7e97a19378255e01b51acc211bf6b31c849a34c/samples/extensions/ray_queries/ray_queries.cpp#L306-L307

Background:
* The Sponza includes rotation, but this is not taken into account when loading in this sample.
* Therefore, rotation is hard-coded by swizzling of the vertex positions.
* Furthermore, FrontFace is set to ClockWise to draw polygons that are inverted by this swizzling .

Fix:
* Load taking into account the scene rotation (for simplicity, pre-multiply the vertices by a transform matrix).
* Changed FrontFace to standard CounterClockWise.
* The projection matrix is ​​changed with `vkb::rendering::vulkan_style_projection()`.
* Adjusted the camera translation and rotation.

Bonus:
* Adjusted the light position to make the shadow effect easier to understand. (If it shouldn't be changed, please let me know and I'll revert it.)

Original lighting:

https://github.com/user-attachments/assets/fb04baa3-d38e-4698-8cf6-51be2dbad20d 

Updated lighting:

https://github.com/user-attachments/assets/7a01a96e-9640-4fc2-a471-ab83b4830f08

- This PR has only been tested on Windows.
- There are no related issues.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
