### PR TITLE
Fix barrier setting in async compute sample

### DIFF
--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -532,7 +532,7 @@ VkSemaphore AsyncComputeSample::render_compute_post(VkSemaphore wait_graphics_se
 	if (early_graphics_queue->get_family_index() != post_compute_queue->get_family_index())
 	{
 		vkb::ImageMemoryBarrier memory_barrier{};
-		memory_barrier.old_layout      = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		memory_barrier.old_layout      = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		memory_barrier.new_layout      = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		memory_barrier.src_access_mask = 0;
 		memory_barrier.dst_access_mask = VK_ACCESS_SHADER_READ_BIT;

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -82,6 +82,8 @@ void AsyncComputeSample::prepare_render_targets()
 	     VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
 	     VMA_MEMORY_USAGE_GPU_ONLY},
 	};
+	color_targets[0].set_debug_name("color_targets[0]");
+	color_targets[1].set_debug_name("color_targets[1]");
 
 	// Should only really need one depth target, but vkb::RenderTarget needs to own the resource.
 	vkb::core::Image depth_targets[2]{
@@ -92,6 +94,8 @@ void AsyncComputeSample::prepare_render_targets()
 	     VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
 	     VMA_MEMORY_USAGE_GPU_ONLY},
 	};
+	depth_targets[0].set_debug_name("depth_targets[0]");
+	depth_targets[1].set_debug_name("depth_targets[1]");
 
 	// 8K shadow-map overkill to stress devices.
 	// Min-spec is 4K however, so clamp to that if required.
@@ -108,6 +112,7 @@ void AsyncComputeSample::prepare_render_targets()
 	vkb::core::Image shadow_target{get_device(), shadow_resolution, VK_FORMAT_D16_UNORM,
 	                               VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
 	                               VMA_MEMORY_USAGE_GPU_ONLY};
+	shadow_target.set_debug_name("shadow_target");
 
 	// Create a simple mip-chain used for bloom blur.
 	// Could technically mip-map the HDR target,
@@ -202,7 +207,7 @@ void AsyncComputeSample::setup_queues()
 
 		if (graphics_family_index == compute_family_index)
 		{
-			LOGI("Device has does not have a dedicated compute queue family.");
+			LOGI("Device does not have a dedicated compute queue family.");
 			post_compute_queue = early_graphics_queue;
 		}
 		else
@@ -324,6 +329,7 @@ void AsyncComputeSample::render_shadow_pass()
 {
 	auto &queue          = *early_graphics_queue;
 	auto &command_buffer = get_render_context().get_active_frame().request_command_buffer(queue);
+	command_buffer.set_debug_name("shadow_pass");
 	command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
 	auto &views = shadow_render_target->get_views();
@@ -370,6 +376,7 @@ VkSemaphore AsyncComputeSample::render_forward_offscreen_pass(VkSemaphore hdr_wa
 {
 	auto &queue          = *early_graphics_queue;
 	auto &command_buffer = get_render_context().get_active_frame().request_command_buffer(queue);
+	command_buffer.set_debug_name("forward_offscreen_pass");
 
 	command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
@@ -447,6 +454,7 @@ VkSemaphore AsyncComputeSample::render_swapchain(VkSemaphore post_semaphore)
 {
 	auto &queue          = *present_graphics_queue;
 	auto &command_buffer = get_render_context().get_active_frame().request_command_buffer(queue);
+	command_buffer.set_debug_name("swapchain");
 
 	command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
@@ -514,6 +522,7 @@ VkSemaphore AsyncComputeSample::render_compute_post(VkSemaphore wait_graphics_se
 {
 	auto &queue          = *post_compute_queue;
 	auto &command_buffer = get_render_context().get_active_frame().request_command_buffer(queue);
+	command_buffer.set_debug_name("compute_post");
 
 	command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 


### PR DESCRIPTION
## Description

In the async compute sample, when "Enable async queue" is checked in the GUI, the following validation error is output.

![image](https://github.com/user-attachments/assets/4cd24941-30a1-41fc-8bbd-93ee7abe97f0)

> Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout ] 
> Object 0: handle = 0x18b310c3570, type = VK_OBJECT_TYPE_COMMAND_BUFFER; 
> Object 1: handle = 0x1ff0c40000000a81, type = > VK_OBJECT_TYPE_IMAGE; | 
> MessageID = 0x4dae5635 | 
> vkQueueSubmit(): pSubmits[0].pCommandBuffers[0] command buffer VkCommandBuffer 0x18b310c3570[] expects VkImage 0x1ff0c40000000a81[] (subresource: aspectMask 0x1 array layer 0, mip level 0) to be in layout VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL--instead, current layout is VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL.

> [!NOTE]
> If you get output different from the one below when you check the checkbox, the error may not be reproducible in your environment.
> ```
> [info] Device has 2 or more graphics queues.
> [info] Device has async compute queue.
> ```

Since the sample contains multiple images and command buffers, I added `set_debug_name()` to make the error more understandable, as shown below.

> Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout ] 
> Object 0: handle = 0x24dda4ae730, name = compute_post, type = VK_OBJECT_TYPE_COMMAND_BUFFER; 
> Object 1: handle = 0xdd5f6f0000000a82, name = color_targets[0], type = VK_OBJECT_TYPE_IMAGE; | 
> MessageID = 0x4dae5635 | 
> vkQueueSubmit(): pSubmits[0].pCommandBuffers[0] command buffer VkCommandBuffer 0x24dda4ae730[compute_post] expects VkImage 0xdd5f6f0000000a82[color_targets[0]] (subresource: aspectMask 0x1 array layer 0, mip level 0) to be in layout VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL--instead, current layout is VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL.

This shows that the barrier setting for `color_targets[0]` in `compute_post` is incorrect. The code is as follows:

https://github.com/KhronosGroup/Vulkan-Samples/blob/f7e97a19378255e01b51acc211bf6b31c849a34c/samples/performance/async_compute/async_compute.cpp#L526-L527

In the previous `forward_offscreen_pass`, the layout already transitioned to `SHADER_READ_ONLY_OPTIMAL` after drawing. This means that the current code is performing the same image layout transition twice (However, both barriers are required for queue transitions.).

https://github.com/KhronosGroup/Vulkan-Samples/blob/f7e97a19378255e01b51acc211bf6b31c849a34c/samples/performance/async_compute/async_compute.cpp#L409-L410

So I fixed the `old_layout` setting on the `compute_post` barrier, and the validation errors disappeared. Also, because this sample is complex and hard to debug, I'm leaving `set_debug_name()` for future.

- Tested on Windows
- No related issues

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

