### PR TITLE
Filesystem create directories

### DIFF
--- a/components/filesystem/src/legacy.cpp
+++ b/components/filesystem/src/legacy.cpp
@@ -96,10 +96,11 @@ void create_directory(const std::string &path)
 
 void create_path(const std::string &root, const std::string &path)
 {
-	for (auto it = path.begin(); it != path.end(); ++it)
+	std::filesystem::path full_path = std::filesystem::path(root) / path;
+
+	if (!vkb::filesystem::get()->create_directory(full_path))
 	{
-		it = std::find(it, path.end(), '/');
-		create_directory(root + '/' + std::string(path.begin(), it));
+		ERRORF("Failed to create directory: {}", full_path.string());
 	}
 }
 

--- a/components/filesystem/src/std_filesystem.cpp
+++ b/components/filesystem/src/std_filesystem.cpp
@@ -75,7 +75,7 @@ bool StdFileSystem::create_directory(const Path &path)
 {
 	std::error_code ec;
 
-	std::filesystem::create_directory(path, ec);
+	std::filesystem::create_directories(path, ec);
 
 	if (ec)
 	{
@@ -132,7 +132,7 @@ void StdFileSystem::remove(const Path &path)
 {
 	std::error_code ec;
 
-	std::filesystem::remove(path, ec);
+	std::filesystem::remove_all(path, ec);
 
 	if (ec)
 	{

--- a/components/filesystem/tests/filesystem.test.cpp
+++ b/components/filesystem/tests/filesystem.test.cpp
@@ -124,3 +124,38 @@ TEST_CASE("Read binary file", "[filesystem]")
 
 	delete_test_file(fs, test_file);
 }
+
+TEST_CASE("Create Directory", "[filesystem]")
+{
+	vkb::filesystem::init();
+
+	auto fs = vkb::filesystem::get();
+
+	const auto test_dir = fs->temp_directory() / "vulkan_samples_directory_test" / "test_dir";
+
+	REQUIRE(fs->create_directory(test_dir));
+	REQUIRE(fs->exists(test_dir));
+	REQUIRE(fs->is_directory(test_dir));
+
+	std::vector<uint8_t> data = {0, 1, 2, 3, 4, 5};
+	for (uint8_t i : data)
+	{
+		// Create sub directories
+		const auto sub_dir = test_dir / fmt::format("sub_dir_{}", i);
+		REQUIRE(fs->create_directory(sub_dir));
+	}
+
+	// Check in a separate pass to ensure create_directory called multiple times doesn't fail
+	for (uint8_t i : data)
+	{
+		// Check sub directories
+		const auto sub_dir = test_dir / fmt::format("sub_dir_{}", i);
+		REQUIRE(fs->exists(sub_dir));
+		REQUIRE(fs->is_directory(sub_dir));
+	}
+
+	// Remove both the directory and its parent
+	fs->remove(fs->temp_directory() / "vulkan_samples_directory_test");
+
+	REQUIRE_FALSE(fs->exists(test_dir));
+}

--- a/components/filesystem/tests/filesystem.test.cpp
+++ b/components/filesystem/tests/filesystem.test.cpp
@@ -159,3 +159,25 @@ TEST_CASE("Create Directory", "[filesystem]")
 
 	REQUIRE_FALSE(fs->exists(test_dir));
 }
+
+TEST_CASE("Remove File Test", "[filesystem]")
+{
+	vkb::filesystem::init();
+
+	auto fs = vkb::filesystem::get();
+
+	const auto test_file = fs->temp_directory() / "vulkan_samples_remove_file_test" / "remove_test.txt";
+
+	REQUIRE(fs->create_directory(test_file.parent_path()));
+
+	fs->write_file(test_file, "Hello, World!");
+
+	REQUIRE(fs->exists(test_file));
+	REQUIRE(fs->is_file(test_file));
+
+	REQUIRE_NOTHROW(fs->remove(test_file));
+
+	REQUIRE_FALSE(fs->exists(test_file));
+
+	fs->remove(test_file.parent_path());
+}

--- a/components/filesystem/tests/filesystem.test.cpp
+++ b/components/filesystem/tests/filesystem.test.cpp
@@ -21,6 +21,24 @@
 
 using namespace vkb::filesystem;
 
+Path create_test_directory(FileSystemPtr fs, const std::string &test_name)
+{
+	const auto test_dir = fs->temp_directory() / "vulkan_samples_tests" / test_name;
+
+	REQUIRE(fs->create_directory(test_dir));
+	REQUIRE(fs->exists(test_dir));
+	REQUIRE(fs->is_directory(test_dir));
+
+	return test_dir;
+}
+
+void delete_test_directory(FileSystemPtr fs, const Path &test_dir)
+{
+	REQUIRE(fs->exists(test_dir));
+	fs->remove(test_dir);
+	REQUIRE_FALSE(fs->exists(test_dir));
+}
+
 void create_test_file(FileSystemPtr fs, const Path &path, const std::string &data)
 {
 	REQUIRE(fs);
@@ -47,11 +65,13 @@ TEST_CASE("File read and write", "[filesystem]")
 
 	auto fs = vkb::filesystem::get();
 
-	const auto        test_file = fs->temp_directory() / "vulkan_samples" / "test.txt";
+	const auto        test_dir  = create_test_directory(fs, "file_test");
+	const auto        test_file = test_dir / "test.txt";
 	const std::string test_data = "Hello, World!";
 
 	create_test_file(fs, test_file, test_data);
 	delete_test_file(fs, test_file);
+	delete_test_directory(fs, test_dir);
 }
 
 TEST_CASE("Read file chunk", "[filesystem]")
@@ -60,7 +80,8 @@ TEST_CASE("Read file chunk", "[filesystem]")
 
 	auto fs = vkb::filesystem::get();
 
-	const auto        test_file = fs->temp_directory() / "vulkan_samples" / "chunk_test.txt";
+	const auto        test_dir  = create_test_directory(fs, "chunk_test");
+	const auto        test_file = test_dir / "chunk_test.txt";
 	const std::string test_data = "Hello, World!";
 
 	create_test_file(fs, test_file, test_data);
@@ -70,6 +91,7 @@ TEST_CASE("Read file chunk", "[filesystem]")
 	REQUIRE(chunk_str == "Hello");
 
 	delete_test_file(fs, test_file);
+	delete_test_directory(fs, test_dir);
 }
 
 TEST_CASE("Read file chunk out of bounds", "[filesystem]")
@@ -78,7 +100,8 @@ TEST_CASE("Read file chunk out of bounds", "[filesystem]")
 
 	auto fs = vkb::filesystem::get();
 
-	const auto        test_file = fs->temp_directory() / "vulkan_samples" / "chunk_oob_test.txt";
+	const auto        test_dir  = create_test_directory(fs, "chunk_oob");
+	const auto        test_file = test_dir / "chunk_oob_test.txt";
 	const std::string test_data = "Hello, World!";
 
 	create_test_file(fs, test_file, test_data);
@@ -87,6 +110,7 @@ TEST_CASE("Read file chunk out of bounds", "[filesystem]")
 	REQUIRE(chunk.empty());
 
 	delete_test_file(fs, test_file);
+	delete_test_directory(fs, test_dir);
 }
 
 TEST_CASE("Read file chunk with offset", "[filesystem]")
@@ -95,7 +119,8 @@ TEST_CASE("Read file chunk with offset", "[filesystem]")
 
 	auto fs = vkb::filesystem::get();
 
-	const auto        test_file = fs->temp_directory() / "vulkan_samples" / "chunk_offset_test.txt";
+	const auto        test_dir  = create_test_directory(fs, "chunk_offset");
+	const auto        test_file = test_dir / "chunk_offset_test.txt";
 	const std::string test_data = "Hello, World!";
 
 	create_test_file(fs, test_file, test_data);
@@ -105,6 +130,7 @@ TEST_CASE("Read file chunk with offset", "[filesystem]")
 	REQUIRE(chunk_str == "World");
 
 	delete_test_file(fs, test_file);
+	delete_test_directory(fs, test_dir);
 }
 
 TEST_CASE("Read binary file", "[filesystem]")
@@ -113,7 +139,8 @@ TEST_CASE("Read binary file", "[filesystem]")
 
 	auto fs = vkb::filesystem::get();
 
-	const auto        test_file = fs->temp_directory() / "vulkan_samples" / "binary_test.txt";
+	const auto        test_dir  = create_test_directory(fs, "binary_test");
+	const auto        test_file = test_dir / "binary_test.txt";
 	const std::string test_data = "Hello, World!";
 
 	create_test_file(fs, test_file, test_data);
@@ -123,6 +150,7 @@ TEST_CASE("Read binary file", "[filesystem]")
 	REQUIRE(binary_str == test_data);
 
 	delete_test_file(fs, test_file);
+	delete_test_directory(fs, test_dir);
 }
 
 TEST_CASE("Create Directory", "[filesystem]")
@@ -131,17 +159,18 @@ TEST_CASE("Create Directory", "[filesystem]")
 
 	auto fs = vkb::filesystem::get();
 
-	const auto test_dir = fs->temp_directory() / "vulkan_samples_directory_test" / "test_dir";
+	const auto test_dir     = create_test_directory(fs, "create_directory_test");
+	const auto test_sub_dir = test_dir / "test_dir";
 
-	REQUIRE(fs->create_directory(test_dir));
-	REQUIRE(fs->exists(test_dir));
-	REQUIRE(fs->is_directory(test_dir));
+	REQUIRE(fs->create_directory(test_sub_dir));
+	REQUIRE(fs->exists(test_sub_dir));
+	REQUIRE(fs->is_directory(test_sub_dir));
 
 	std::vector<uint8_t> data = {0, 1, 2, 3, 4, 5};
 	for (uint8_t i : data)
 	{
 		// Create sub directories
-		const auto sub_dir = test_dir / fmt::format("sub_dir_{}", i);
+		const auto sub_dir = test_sub_dir / fmt::format("sub_dir_{}", i);
 		REQUIRE(fs->create_directory(sub_dir));
 	}
 
@@ -149,35 +178,15 @@ TEST_CASE("Create Directory", "[filesystem]")
 	for (uint8_t i : data)
 	{
 		// Check sub directories
-		const auto sub_dir = test_dir / fmt::format("sub_dir_{}", i);
+		const auto sub_dir = test_sub_dir / fmt::format("sub_dir_{}", i);
 		REQUIRE(fs->exists(sub_dir));
 		REQUIRE(fs->is_directory(sub_dir));
 	}
 
 	// Remove both the directory and its parent
-	fs->remove(fs->temp_directory() / "vulkan_samples_directory_test");
+	fs->remove(test_sub_dir);
 
-	REQUIRE_FALSE(fs->exists(test_dir));
-}
+	REQUIRE_FALSE(fs->exists(test_sub_dir));
 
-TEST_CASE("Remove File Test", "[filesystem]")
-{
-	vkb::filesystem::init();
-
-	auto fs = vkb::filesystem::get();
-
-	const auto test_file = fs->temp_directory() / "vulkan_samples_remove_file_test" / "remove_test.txt";
-
-	REQUIRE(fs->create_directory(test_file.parent_path()));
-
-	fs->write_file(test_file, "Hello, World!");
-
-	REQUIRE(fs->exists(test_file));
-	REQUIRE(fs->is_file(test_file));
-
-	REQUIRE_NOTHROW(fs->remove(test_file));
-
-	REQUIRE_FALSE(fs->exists(test_file));
-
-	fs->remove(test_file.parent_path());
+	delete_test_directory(fs, test_dir);
 }


### PR DESCRIPTION
## Description

An alternate approach to fixing the `create_path` bug in the legacy filesystem

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
