### PR TITLE
MacOS Missing Vulkan Library Fix

### DIFF
--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -36,6 +36,10 @@ if(APPLE)
     set(VKB_ENABLE_PORTABILITY ON CACHE BOOL "Enable portability enumeration and subset features in the framework.  This is required to be set when running on Apple platforms." FORCE)
 
 	find_package(Vulkan QUIET OPTIONAL_COMPONENTS MoltenVK)
+
+	message(STATUS "Vulkan library: ${Vulkan_LIBRARY}")
+	message(STATUS "Vulkan headers: ${Vulkan_INCLUDE_DIR}")
+
 	if(USE_MoltenVK OR (IOS AND (NOT Vulkan_MoltenVK_FOUND OR (${CMAKE_OSX_SYSROOT} STREQUAL "iphonesimulator" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64"))))
 		# if using MoltenVK, or MoltenVK for iOS was not found, or using iOS Simulator on x86_64, look for MoltenVK in the Vulkan SDK and MoltenVK project locations
 		if(NOT Vulkan_MoltenVK_LIBRARY)
@@ -50,6 +54,8 @@ if(APPLE)
 			set(CMAKE_FIND_FRAMEWORK ${_saved_cmake_find_framework})
 			unset(_saved_cmake_find_framework)
 		endif()
+
+		message(STATUS "MoltenVK library: ${Vulkan_MoltenVK_LIBRARY}")
 
 		if(Vulkan_MoltenVK_LIBRARY)
 			get_filename_component(MoltenVK_LIBRARY_PATH ${Vulkan_MoltenVK_LIBRARY} DIRECTORY)
@@ -77,7 +83,7 @@ if(APPLE)
 		endif()
 	elseif(IOS)
 		# if not using MoltenVK on iOS, set up global Vulkan Library define for iOS Vulkan loader
-		add_compile_definitions(_HPP_VULKAN_LIBRARY="vulkan.framework/vulkan")
+		add_compile_definitions(_HPP_VULKAN_LIBRARY=${Vulkan_LIBRARY})
 	endif()
 
 	if(CMAKE_GENERATOR MATCHES "Xcode")

--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -83,7 +83,18 @@ if(APPLE)
 		endif()
 	elseif(IOS)
 		# if not using MoltenVK on iOS, set up global Vulkan Library define for iOS Vulkan loader
-		add_compile_definitions(_HPP_VULKAN_LIBRARY=${Vulkan_LIBRARY})
+		message(STATUS "Using iOS Vulkan loader")
+		add_compile_definitions(_HPP_VULKAN_LIBRARY="vulkan.framework/vulkan")
+	elseif(Vulkan_LIBRARY)
+		# This is a patch for newer macOS versions where the Vulkan Loader is not found in the default search paths
+		# In the future this can be removed when the Vulkan SDK is updated to install the loader in the default search paths or when the
+		# VulkanHPP DynamicLoader is updated to search for the loader in the Vulkan SDK install location
+		string(FIND "${Vulkan_LIBRARY}" "/usr/local/lib" VULKAN_LIBRARY_PREFIX)
+		if(VULKAN_LIBRARY_PREFIX EQUAL 0)
+			message(STATUS "Vulkan found in /usr/local/lib. Patching RPATH.")
+			set(CMAKE_INSTALL_RPATH "/usr/local/lib;${CMAKE_INSTALL_RPATH}")
+			set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+		endif()
 	endif()
 
 	if(CMAKE_GENERATOR MATCHES "Xcode")


### PR DESCRIPTION
## Description

On newer MacOS versions the VulkanHPP loader can no longer find Vulkan due to this issue https://github.com/KhronosGroup/Vulkan-Hpp/issues/1975

This PR is a temporary patch until this is officially fixed in VulkanHPP. This PR proposes adjusting the RPATH of Vulkan Samples on MacOS if vulkan is found in `/usr/local/lib`

I have set this to Urgent as without this fix every sample will load with the following logs as `VulkanSample` will always use the VulkanHPP DynamicLoader

```
[info] Logger initialized
[info] Initializing Vulkan sample
[error] Error Message: Failed to load vulkan library!
[error] Failed when running application AFBC
```

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
