### PR TITLE
Add explanation of using ssh to clone submodules.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -98,10 +98,31 @@ the tens of kB/s, or fatal timeout errors occurring, these may be due to
 network routing issues to github within your ISP's internal network, rather
 than anything wrong in your own networking setup.
 
-It can be very difficult to get ISPs to acknowledge such problems exist much
-less to fix them. In this case, consider trying the clone while running a
-VPN service.
+It can be very difficult to get ISPs to acknowledge such problems exist, much
+less to fix them.
+
+One workaround is to switch the repository to use ssh protocol prior to the
+submodule download, which can be done via e.g.
+
+[source,sh]
+----
+git clone git@github.com:KhronosGroup/Vulkan-Samples.git
+cd Vulkan-Samples
+perl -i -p -e 's|https://(.*?)/|git@\1:|g' .gitmodules
+git submodule sync
+git submodule update
+----
+
+While this can be a good alternative if you are running into this connection
+issue, you must have GitHub ssh key authentication setup to use ssh
+protocol - see
+link:https://docs.github.com/en/authentication/connecting-to-github-with-ssh[Connecting
+to GitHub with SSH] for details.
+So it is a not a solution we can implement as the repository default.
+
+Another option which may help is to run github through a VPN service.
 ====
+
 
 == Build
 


### PR DESCRIPTION
As another workaround for connection problems. This just modifies the recently added NOTE in the repository README with additional details.