### PR TITLE
Change *Builder::with_implicit_sharing_mode to select concurrent sharing mode when the queueFamilyIndexCount is greater than 1, not different from zero.

### DIFF
--- a/framework/builder_base.h
+++ b/framework/builder_base.h
@@ -123,7 +123,7 @@ inline BuilderType &BuilderBase<bindingType, BuilderType, CreateInfoType>::with_
 template <vkb::BindingType bindingType, typename BuilderType, typename CreateInfoType>
 inline BuilderType &BuilderBase<bindingType, BuilderType, CreateInfoType>::with_implicit_sharing_mode()
 {
-	create_info.sharingMode = (create_info.queueFamilyIndexCount != 0) ? vk::SharingMode::eConcurrent : vk::SharingMode::eExclusive;
+	create_info.sharingMode = (1 < create_info.queueFamilyIndexCount) ? vk::SharingMode::eConcurrent : vk::SharingMode::eExclusive;
 	return *static_cast<BuilderType *>(this);
 }
 
@@ -153,11 +153,11 @@ inline BuilderType &BuilderBase<bindingType, BuilderType, CreateInfoType>::with_
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
-		create_info.sharingMode = static_cast<VkSharingMode>(sharing_mode);
+		create_info.sharingMode = sharing_mode;
 	}
 	else
 	{
-		create_info.sharingMode = sharing_mode;
+		create_info.sharingMode = static_cast<vk::SharingMode>(sharing_mode);
 	}
 	return *static_cast<BuilderType *>(this);
 }

--- a/framework/core/hpp_image.h
+++ b/framework/core/hpp_image.h
@@ -101,15 +101,6 @@ struct HPPImageBuilder : public vkb::BuilderBaseCpp<HPPImageBuilder, vk::ImageCr
 		return *this;
 	}
 
-	HPPImageBuilder &with_implicit_sharing_mode()
-	{
-		if (create_info.queueFamilyIndexCount != 0)
-		{
-			create_info.sharingMode = vk::SharingMode::eConcurrent;
-		}
-		return *this;
-	}
-
 	HPPImage    build(HPPDevice &device) const;
 	HPPImagePtr build_unique(HPPDevice &device) const;
 };

--- a/framework/core/image.h
+++ b/framework/core/image.h
@@ -70,12 +70,6 @@ struct ImageBuilder : public vkb::BuilderBaseC<ImageBuilder, VkImageCreateInfo>
 		return *this;
 	}
 
-	ImageBuilder &with_sharing_mode(VkSharingMode sharing_mode)
-	{
-		get_create_info().sharingMode = sharing_mode;
-		return *this;
-	}
-
 	ImageBuilder &with_flags(VkImageCreateFlags flags)
 	{
 		get_create_info().flags = flags;
@@ -109,16 +103,6 @@ struct ImageBuilder : public vkb::BuilderBaseC<ImageBuilder, VkImageCreateInfo>
 	ImageBuilder &with_tiling(VkImageTiling tiling)
 	{
 		get_create_info().tiling = tiling;
-		return *this;
-	}
-
-	ImageBuilder &with_implicit_sharing_mode()
-	{
-		VkImageCreateInfo &create_info = get_create_info();
-		if (create_info.queueFamilyIndexCount != 0)
-		{
-			create_info.sharingMode = VK_SHARING_MODE_CONCURRENT;
-		}
 		return *this;
 	}
 


### PR DESCRIPTION
## Description

This PR resolves a VVL error with the performance sample multi_draw_indirect:
```
Validation Error: [ VUID-VkBufferCreateInfo-sharingMode-00914 ] | MessageID = 0xa9d5cd94 | vkCreateBuffer(): pCreateInfo->sharingMode VK_SHARING_MODE_CONCURRENT, but queueFamilyIndexCount is 1.
The Vulkan spec states: If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1 (https://vulkan.lunarg.com/doc/view/1.3.296.0/windows/1.3-extensions/vkspec.html#VUID-VkBufferCreateInfo-sharingMode-00914)
```

Includes some cleanup in buffer.h, hpp_image.h, and image.h.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
