### PR TITLE
Fix addition of -fno-strict-aliasing compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,8 @@ endif()
 add_compile_definitions($<$<CONFIG:DEBUG>:VKB_DEBUG>)
 
 # globally set -fno-strict-aliasing, needed due to using reinterpret_cast
-if (!MSVC)
-  add_compile_options(-fno_strict_aliasing)
+if (NOT MSVC)
+  add_compile_options(-fno-strict-aliasing)
 endif()
 
 if(MSVC AND (DEFINED CMAKE_C_COMPILER_LAUNCHER))


### PR DESCRIPTION
## Description

Fixes the addition of -fno-strict-aliasing compiler option which was added in https://github.com/KhronosGroup/Vulkan-Samples/commit/8e87ebc069835e10271abf990e0ee8d6c5d226e8.

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly