### PR TITLE
Remove unnecessary access to the old swapchain in hello triangle sample

### DIFF
--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -539,12 +539,9 @@ void HelloTriangle::init_swapchain()
 			vkDestroyImageView(context.device, image_view, nullptr);
 		}
 
-		uint32_t image_count;
-		VK_CHECK(vkGetSwapchainImagesKHR(context.device, old_swapchain, &image_count, nullptr));
-
-		for (size_t i = 0; i < image_count; i++)
+		for (auto &per_frame : context.per_frame)
 		{
-			teardown_per_frame(context.per_frame[i]);
+			teardown_per_frame(per_frame);
 		}
 
 		context.swapchain_image_views.clear();


### PR DESCRIPTION
## Description

This PR removes an unnecessary access to the retired swapchain just get a number to iterate over a vector. Instead of doing that, the code now simply iterates over that vector.

Replaces #1019

Fixes #1015

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)