### PR TITLE
Remove shader variants from msaa sample

### DIFF
--- a/samples/performance/msaa/msaa.h
+++ b/samples/performance/msaa/msaa.h
@@ -96,6 +96,13 @@ class MSAASample : public vkb::VulkanSample<vkb::BindingType::C>
 	std::unique_ptr<vkb::PostProcessingPipeline> postprocessing_pipeline{};
 
 	/**
+	 * @brief Postprocessing pipeline using multi-sampled depth
+	 *        Read in the output color and depth attachments from the
+	 *        scene subpass and use them to apply a screen-based effect
+	 */
+	std::unique_ptr<vkb::PostProcessingPipeline> ms_depth_postprocessing_pipeline{};
+
+	/**
 	 * @brief Update MSAA options and accordingly set the load/store
 	 *        attachment operations for the renderpasses
 	 *        This will trigger a swapchain recreation

--- a/shaders/postprocessing/outline_ms_depth.frag
+++ b/shaders/postprocessing/outline_ms_depth.frag
@@ -18,7 +18,7 @@
 
 precision highp float;
 
-layout(set = 0, binding = 1) uniform sampler2D depth_sampler;
+layout(set = 0, binding = 1) uniform sampler2DMS ms_depth_sampler;
 layout(set = 0, binding = 2) uniform sampler2D color_sampler;
 
 layout(location = 0) in vec2 in_uv;
@@ -38,7 +38,7 @@ float linearizeDepth(float depth, float near, float far)
 float getDepth(ivec2 offset)
 {
 	float depth;
-	depth = texelFetch(depth_sampler, ivec2(gl_FragCoord.xy) + offset, 0).r;
+	depth = texelFetch(ms_depth_sampler, ivec2(gl_FragCoord.xy) + offset, 0).r;
 	return linearizeDepth(depth, postprocessing_uniform.near_far.x, postprocessing_uniform.near_far.y);
 }
 


### PR DESCRIPTION
## Description

Contribution towards #1107 

Removes shader variant usage from MSAA (other than base shaders)

Keeps existing behavior by creating two pipelines. One with MS Depth enabled and one without

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
