### PR TITLE
Fix documentation links

### DIFF
--- a/samples/api/README.adoc
+++ b/samples/api/README.adoc
@@ -40,55 +40,55 @@ A self-contained (minimal use of framework) sample that illustrates the renderin
 
 === xref:./{api_samplespath}hpp_compute_nbody/README.adoc[HPP Compute shader N-Body simulation]
 
-A transcoded version of the API sample <<compute_nbody,Compute N-Body>> that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}compute_nbody/README.adoc[Compute N-Body] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_dynamic_uniform_buffers/README.adoc[HPP Dynamic Uniform Buffers]
 
-A transcoded version of the API sample <<dynamic_uniform_buffers,Dynamic Uniform buffers>> that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}dynamic_uniform_buffers/README.adoc[Dynamic Uniform buffers] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_hdr/README.adoc[HPP High dynamic range]
 
-A transcoded version of the API sample <<hdr,High dynamic range>>that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}hdr/README.adoc[High dynamic range] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_hello_triangle/README.adoc[HPP Hello Triangle]
 
-A transcoded version of the API sample <<hello_triangle,Hello Triangle>> that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}hello_triangle/README.adoc[Hello Triangle] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_hlsl_shaders/README.adoc[HPP HLSL shaders]
 
-A transcoded version of the API sample <<hlsl_shaders,HLSL Shaders>> that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}hlsl_shaders/README.adoc[HLSL Shaders] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_instancing/README.adoc[HPP Instancing]
 
-A transcoded version of the API sample <<instancing,Instancing>> that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}instancing/README.adoc[Instancing] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_oit_depth_peeling/README.adoc[HPP OIT Depth Peeling]
 
-A transcoded version of the API sample <<oit_depth_peeling,OIT Depth Peeling>> that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}oit_depth_peeling/README.adoc[OIT Depth Peeling] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_oit_linked_lists/README.adoc[HPP OIT Linked Lists]
 
-A transcoded version of the API sample <<oit_linked_lists,OIT Linked Lists>> that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}oit_linked_lists/README.adoc[OIT Linked Lists] that illustrates the usage of the C{pp} bindings of Vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_separate_image_sampler/README.adoc[HPP Separate image sampler]
 
-A transcoded version of the API sample <<separate_image_sampler,Separate image sampler>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}separate_image_sampler/README.adoc[Separate image sampler] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_terrain_tessellation/README.adoc[HPP Terrain Tessellation]
 
-A transcoded version of the API sample <<terrain_tessellation,Terrain Tessellation>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}terrain_tessellation/README.adoc[Terrain Tessellation] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_texture_loading/README.adoc[HPP Texture Loading]
 
-A transcoded version of the API sample <<texture_loading,Texture loading>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}texture_loading/README.adoc[Texture loading] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_texture_mipmap_generation/README.adoc[HPP Texture run-time mip-map generation]
 
-A transcoded version of the API sample <<texture_mipmap_generation,Texture run-time mip-map generation>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+A transcoded version of the API sample xref:./{api_samplespath}texture_mipmap_generation/README.adoc[Texture run-time mip-map generation] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}hpp_timestamp_queries/README.adoc[HPP Timestamp queries]
 
-A transcoded version of the API sample <<timestamp_queries,Timestamp queries>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+A transcoded version of the API samplexref:./{api_samplespath}timestamp_queries/README.adoc[Timestamp queries] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./{api_samplespath}instancing/README.adoc[Instancing]
 

--- a/samples/extensions/README.adoc
+++ b/samples/extensions/README.adoc
@@ -52,7 +52,7 @@ Instead of creating per-object descriptor sets, this example passes descriptors 
 
 === xref:./{extension_samplespath}hpp_push_descriptors/README.adoc[HPP Push Descriptors]
 
-A transcoded version of the Extensions sample <<push_descriptors,Push Descriptors>> that illustrates the usage of the C{pp} bindings of vulkan provided by Vulkan-Hpp.
+A transcoded version of the Extensions sample xref:./{extension_samplespath}push_descriptors/README.adoc[Push Descriptors] that illustrates the usage of the C{pp} bindings of vulkan provided by Vulkan-Hpp.
 
 === xref:./{extension_samplespath}debug_utils/README.adoc[Debug Utilities]
 
@@ -111,7 +111,7 @@ This replaces the vertex /  geometry shader standard pipeline.
 
 === xref:./{extension_samplespath}hpp_mesh_shading/README.adoc[HPP Mesh shading]
 
-A transcoded version of the Extensions sample <<mesh_shading,Mesh shading>> that illustrates the usage of the C{pp} bindings of vulkan provided by Vulkan-Hpp.
+A transcoded version of the Extensions sample xref:./{extension_samplespath}mesh_shading/README.adoc[Mesh shading] that illustrates the usage of the C{pp} bindings of vulkan provided by Vulkan-Hpp.
 
 === xref:./{extension_samplespath}open_gl_interop/README.adoc[OpenGL interoperability]
 

--- a/samples/performance/README.adoc
+++ b/samples/performance/README.adoc
@@ -27,7 +27,7 @@ To visualize this, they also include real-time profiling information.
 
 AFBC (Arm Frame Buffer Compression) is a real-time lossless compression algorithm found in Arm Mali GPUs, designed to tackle the ever-growing demand for higher resolution graphics.
 This format is applied to the framebuffers that are to be written to the GPU.
-This technology can offer bandwidth reductions of https://developer.arm.com/technologies/graphics-technologies/arm-frame-buffer-compression[up to 50%].
+This technology can offer bandwidth reductions of https://developer.arm.com/Architectures/Arm%20Frame%20Buffer%20Compression[up to 50%].
 
 === xref:./{performance_samplespath}command_buffer_usage/README.adoc[Command buffer usage]
 
@@ -51,15 +51,15 @@ This sample will explore a few options to improve both descriptor and buffer man
 
 === xref:./{performance_samplespath}hpp_pipeline_cache/README.adoc[HPP Pipeline cache]
 
-A transcoded version of the Performance sample <<pipeline_cache,Pipeline cache>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+A transcoded version of the Performance sample xref:./{performance_samplespath}pipeline_cache/README.adoc[Pipeline cache] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./{performance_samplespath}hpp_swapchain_images/README.adoc[HPP Swapchain images]
 
-A transcoded version of the Performance sample <<swapchain_images,Swapchain images>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+A transcoded version of the Performance samplexref:./{performance_samplespath}swapchain_images/README.adoc[Swapchain images] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./{performance_samplespath}hpp_texture_compression_comparison/README.adoc[HPP Texture compression comparison]
 
-A transcoded version of the Performance sample <<texture_compression_comparison,Texture compression comparison>> that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
+A transcoded version of the Performance sample xref:./{performance_samplespath}texture_compression_comparison/README.adoc[Texture compression comparison] that illustrates the usage of the C{pp} bindings of vulkan provided by vulkan.hpp.
 
 === xref:./{performance_samplespath}image_compression_control/README.adoc[Image compression control]
 


### PR DESCRIPTION
## Description

This PR fixes a few links in the sample listings that were either outdated (ARM developer resource) or plainly not working due to a wrong internal link format.

**Note**: Documentation change only

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly
