### PR TITLE
Fix image link in surface rotation sample readme

### DIFF
--- a/samples/performance/surface_rotation/README.adoc
+++ b/samples/performance/surface_rotation/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2019-2023, Arm Limited and Contributors
+- Copyright (c) 2019-2024, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/performance/surface_rotation/README.adoc
+++ b/samples/performance/surface_rotation/README.adoc
@@ -36,7 +36,7 @@ Therefore in Vulkan the application is responsible for supporting rotation.
 
 In this sample we focus on the rotation step, and analyse the performance implications of implementing it correctly with Vulkan.
 
-./rotation_cases.jpg[Pre-rotation]
+image::./images/rotation_cases.jpg[Pre-rotation]
 
 == Pre-rotation
 


### PR DESCRIPTION
## Description

This PR fixes a broken image link in the readme for the surface rotation sample, which resulted in a missing image:

![image](https://github.com/user-attachments/assets/7c1e964b-5df0-4e54-811f-4c1969ceea7e)

**Note:** Documentation only change.

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly