### PR TITLE
Remove unnecessary host query reset feature and flag

### DIFF
--- a/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
+++ b/samples/api/hpp_timestamp_queries/hpp_timestamp_queries.cpp
@@ -24,9 +24,6 @@
 HPPTimestampQueries::HPPTimestampQueries()
 {
 	title = "Timestamp queries";
-	// This sample uses vk::CommandBuffer::resetQueryPool to reset the timestamp query pool on the host, which requires VK_EXT_host_query_reset or Vulkan 1.2
-	add_device_extension(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
-	// This also requires us to enable the feature in the appropriate feature struct, see request_gpu_features()
 }
 
 HPPTimestampQueries::~HPPTimestampQueries()
@@ -94,9 +91,6 @@ bool HPPTimestampQueries::resize(const uint32_t width, const uint32_t height)
 
 void HPPTimestampQueries::request_gpu_features(vkb::core::HPPPhysicalDevice &gpu)
 {
-	// We need to enable the command pool reset feature in the extension struct
-	HPP_REQUEST_REQUIRED_FEATURE(gpu, vk::PhysicalDeviceHostQueryResetFeaturesEXT, hostQueryReset);
-
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)
 	{

--- a/samples/api/timestamp_queries/README.adoc
+++ b/samples/api/timestamp_queries/README.adoc
@@ -104,26 +104,7 @@ For this sample we'll be using 6 time points, one for the start and one for the 
 
 == Resetting the query pool
 
-Before we can start writing data to the query pool, we need to reset it.
-When using Vulkan 1.0 or 1.1, this requires us to enable the `VK_EXT_host_query_reset` extension:
-
-[,cpp]
-----
-add_device_extension(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
-----
-
-With using Vulkan 1.2 this extension has become part of the core and we won't have to manually enable it.
-
-Independent of this, we also need to enable the `hostQueryReset` physical device feature:
-
-[,cpp]
-----
-auto &requested_extension_features= gpu.request_extension_features<VkPhysicalDeviceHostQueryResetFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT);
-requested_extension_features.hostQueryReset = VK_TRUE;
-----
-
-With features and extensions properly enabled, we can now reset the pool at the start of the command buffer, before writing the first timestamp.
-This is done using `vkCmdResetQueryPool`:
+Before we can start writing data to the query pool, we need to reset it. This is done using `vkCmdResetQueryPool` at the start of the command buffer:
 
 [,cpp]
 ----

--- a/samples/api/timestamp_queries/timestamp_queries.cpp
+++ b/samples/api/timestamp_queries/timestamp_queries.cpp
@@ -26,9 +26,6 @@
 TimestampQueries::TimestampQueries()
 {
 	title = "Timestamp queries";
-	// This sample uses vkCmdResetQueryPool to reset the timestamp query pool on the host, which requires VK_EXT_host_query_reset or Vulkan 1.2
-	add_device_extension(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
-	// This also requires us to enable the feature in the appropriate feature struct, see request_gpu_features()
 }
 
 TimestampQueries::~TimestampQueries()
@@ -72,9 +69,6 @@ TimestampQueries::~TimestampQueries()
 
 void TimestampQueries::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	// We need to enable the command pool reset feature in the extension struct
-	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceHostQueryResetFeaturesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT, hostQueryReset);
-
 	// Enable anisotropic filtering if supported
 	if (gpu.get_features().samplerAnisotropy)
 	{


### PR DESCRIPTION
## Description

This PR removes an unnecessary extension and device feature in the timestamp query sample. The sample requested an extension for query pool resets on the host and never used that feature. It only ever resets pools on the device via a command buffer.

Fixes #1141

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
