### PR TITLE
Specialization constants: Cleanup compilation warning

### DIFF
--- a/samples/performance/specialization_constants/specialization_constants.h
+++ b/samples/performance/specialization_constants/specialization_constants.h
@@ -93,7 +93,7 @@ class SpecializationConstants : public vkb::VulkanSampleC
 				}
 			}
 
-			std::copy(lights.begin(), lights.end(), light_info.lights);
+			std::copy_n(lights.begin(), light_count, light_info.lights);
 
 			auto                  &render_frame = get_render_context().get_active_frame();
 			vkb::BufferAllocationC light_buffer = render_frame.allocate_buffer(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, sizeof(T));


### PR DESCRIPTION
## Description

On linux/gcc specialization constants sample has a compilation warning.

```
n static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = vkb::rendering::Light; _Up = vkb::rendering::Light; bool _IsMove = false]’,
    inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = vkb::rendering::Light*; _OI = vkb::rendering::Light*]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
    inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = vkb::rendering::Light*; _OI = vkb::rendering::Light*]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
    inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<vkb::rendering::Light*, vector<vkb::rendering::Light> >; _OI = vkb::rendering::Light*]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
    inlined from ‘_OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<vkb::rendering::Light*, vector<vkb::rendering::Light> >; _OI = vkb::rendering::Light*]’ at /usr/include/c++/13/bits/stl_algobase.h:633:7,
    inlined from ‘vkb::BufferAllocationC SpecializationConstants::ForwardSubpassCustomLights::allocate_custom_lights(vkb::CommandBuffer&, const std::vector<vkb::sg::Light*>&, size_t) [with T = CustomForwardLights]’ at /home/jeroen/vulkan-git/vulkan-samples/samples/performance/specialization_constants/specialization_constants.h:96:13,
    inlined from ‘virtual void SpecializationConstants::ForwardSubpassCustomLights::draw(vkb::CommandBuffer&)’ at /home/jeroen/vulkan-git/vulkan-samples/samples/performance/specialization_constants/specialization_constants.cpp:142:66:
/usr/include/c++/13/bits/stl_algobase.h:437:30: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ writing between 65 and 9223372036854775807 bytes into a region of size 64 overflows the destination [-Wstringop-overflow=]
  437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jeroen/vulkan-git/vulkan-samples/samples/performance/specialization_constants/specialization_constants.h: In member function ‘virtual void SpecializationConstants::ForwardSubpassCustomLights::draw(vkb::CommandBuffer&)’:
/home/jeroen/vulkan-git/vulkan-samples/samples/performance/specialization_constants/specialization_constants.h:76:27: note: at offset 16 into destination object ‘light_info’ of size 80
   76 |                         T light_info;
      |                           ^~~~~~~~~~
```

This PR replaces the `std::copy` with `std::copy_n`.
Sample has been retested on Linux/AMD 6000 and Apple/M2

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
