### PR TITLE
Update and fix proposal links

### DIFF
--- a/samples/extensions/dynamic_rendering_local_read/README.adoc
+++ b/samples/extensions/dynamic_rendering_local_read/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2024, Sascha Willems
+- Copyright (c) 2024-2025, Sascha Willems
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -117,5 +117,5 @@ With the addition of `VK_KHR_dynamic_rendering_local_read` it's now finally poss
 
 == Additional information
 
-* https://docs.vulkan.org/spec/latest/proposals/proposals/VK_KHR_dynamic_rendering_local_read.html[Extension proposal]
+* https://docs.vulkan.org/features/latest/features/proposals/VK_KHR_dynamic_rendering_local_read.html[Extension proposal]
 * https://www.khronos.org/blog/streamlining-subpasses[Extension blog post]

--- a/samples/extensions/graphics_pipeline_library/README.adoc
+++ b/samples/extensions/graphics_pipeline_library/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2022-2023, Sascha Willems
+- Copyright (c) 2022-2025, Sascha Willems
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -147,7 +147,7 @@ Pipelines are created in a background thread and once they're created, command b
 == Additional resources
 
 * https://www.khronos.org/blog/reducing-draw-time-hitching-with-vk-ext-graphics-pipeline-library[Reducing Draw Time Hitching with VK_EXT_graphics_pipeline_library]
-* https://github.com/KhronosGroup/Vulkan-Docs/blob/main/proposals/VK_EXT_graphics_pipeline_library.adoc[Extension proposal]
+* https://docs.vulkan.org/features/latest/features/proposals/VK_EXT_graphics_pipeline_library.html[Extension proposal]
 
 == Conclusion
 

--- a/samples/extensions/host_image_copy/README.adoc
+++ b/samples/extensions/host_image_copy/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2024, Sascha Willems
+- Copyright (c) 2024-2025, Sascha Willems
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/extensions/host_image_copy/README.adoc
+++ b/samples/extensions/host_image_copy/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2024-2025, Sascha Willems
+- Copyright (c) 2024, Sascha Willems
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/samples/extensions/shader_object/README.adoc
+++ b/samples/extensions/shader_object/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright 2023 Nintendo
+- Copyright 2023-2025 Nintendo
  -
  - Licensed under the Apache License, Version 2.0 (the "License");
  - you may not use this file except in compliance with the License.
@@ -458,7 +458,7 @@ Because of this the layer's files will always need to be somewhere accessible to
 == Additional Resources
 
 * https://www.khronos.org/blog/you-can-use-vulkan-without-pipelines-today[You Can Use Vulkan Without Pipelines Today]
-* https://github.com/KhronosGroup/Vulkan-Docs/blob/main/proposals/VK_EXT_shader_object.adoc[Extension Proposal]
+* https://docs.vulkan.org/features/latest/features/proposals/VK_EXT_shader_object.html[Extension Proposal]
 * https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#shaders-objects[Specification]
 * https://github.com/KhronosGroup/Vulkan-ExtensionLayer/blob/main/docs/shader_object_layer.md[Emulation Layer]
 


### PR DESCRIPTION
## Description

A (not so) recent change to the docs site structure moved the proposals into a separate module. That caused some of the links to those proposals to no longer work. This PR updates said links, and also replaces links to proposals on github to the docs site.

**Note**: Pure documentation fix

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly