### PR TITLE
Fix 1251: Texture Compression BasisU: Missing device extension

### DIFF
--- a/samples/performance/texture_compression_basisu/texture_compression_basisu.cpp
+++ b/samples/performance/texture_compression_basisu/texture_compression_basisu.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024, Sascha Willems
+/* Copyright (c) 2021-2025, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,6 +26,8 @@ TextureCompressionBasisu::TextureCompressionBasisu()
 	zoom     = -1.75f;
 	rotation = {0.0f, 0.0f, 0.0f};
 	title    = "Basis Universal texture loading";
+
+	add_device_extension(VK_IMG_FORMAT_PVRTC_EXTENSION_NAME, /* optional */);
 }
 
 TextureCompressionBasisu::~TextureCompressionBasisu()

--- a/samples/performance/texture_compression_basisu/texture_compression_basisu.cpp
+++ b/samples/performance/texture_compression_basisu/texture_compression_basisu.cpp
@@ -27,7 +27,7 @@ TextureCompressionBasisu::TextureCompressionBasisu()
 	rotation = {0.0f, 0.0f, 0.0f};
 	title    = "Basis Universal texture loading";
 
-	add_device_extension(VK_IMG_FORMAT_PVRTC_EXTENSION_NAME, /* optional */);
+	add_device_extension(VK_IMG_FORMAT_PVRTC_EXTENSION_NAME, true /* optional */);
 }
 
 TextureCompressionBasisu::~TextureCompressionBasisu()


### PR DESCRIPTION
## Description

Sample checks if device contains an extension, but never enabled them.
This PR marks the `VK_IMG_format_pvrct` extension optional. 

Fixes #1251
> [!NOTE]
> Requires assets from https://github.com/KhronosGroup/Vulkan-Samples-Assets/pull/27 for testing. The updated images will not be merged due to the deprecation of the extension. A new PR will be created to remove the texture format from the sample.

> [!NOTE]
> Currently still under investigation if this works. On MacM2 (1.3.296.0 or 1.4.304.0) the decoding is incorrect See screenshot below, but no validation warnings. Other formats do give correct results.
> Could also be related to the new assets. As it wasn't clear how there were originally created. 
> On Linux (Pro + Mesa AMD PRO W6800) this extension is not supported.

![image](https://github.com/user-attachments/assets/eaef1d57-275a-4de4-a7bc-a04a67c98ce5)



## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
