### PR TITLE
Remove deprecated VK_IMG_format_pvrtc extension

### DIFF
--- a/samples/performance/hpp_texture_compression_comparison/hpp_texture_compression_comparison.cpp
+++ b/samples/performance/hpp_texture_compression_comparison/hpp_texture_compression_comparison.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024, Holochip
+/* Copyright (c) 2021-2025, Holochip
  * Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -84,10 +84,7 @@ HPPTextureCompressionComparison::HPPTextureCompressionComparison()
 	    {&vk::PhysicalDeviceFeatures::textureCompressionBC, "", vk::Format::eBc7SrgbBlock, KTX_TTF_BC7_RGBA, "KTX_TTF_BC7_RGBA", "BC7"},
 	    {&vk::PhysicalDeviceFeatures::textureCompressionBC, "", vk::Format::eBc3SrgbBlock, KTX_TTF_BC3_RGBA, "KTX_TTF_BC3_RGBA", "BC3"},
 	    {&vk::PhysicalDeviceFeatures::textureCompressionASTC_LDR, "", vk::Format::eAstc4x4SrgbBlock, KTX_TTF_ASTC_4x4_RGBA, "KTX_TTF_ASTC_4x4_RGBA", "ASTC 4x4"},
-	    {&vk::PhysicalDeviceFeatures::textureCompressionETC2, "", vk::Format::eEtc2R8G8B8A8SrgbBlock, KTX_TTF_ETC2_RGBA, "KTX_TTF_ETC2_RGBA", "ETC2"},
-	    {nullptr, VK_IMG_FORMAT_PVRTC_EXTENSION_NAME, vk::Format::ePvrtc14BppSrgbBlockIMG, KTX_TTF_PVRTC1_4_RGBA, "KTX_TTF_PVRTC1_4_RGBA", "PVRTC1 4"}};
-
-	add_device_extension(VK_IMG_FORMAT_PVRTC_EXTENSION_NAME, true);
+	    {&vk::PhysicalDeviceFeatures::textureCompressionETC2, "", vk::Format::eEtc2R8G8B8A8SrgbBlock, KTX_TTF_ETC2_RGBA, "KTX_TTF_ETC2_RGBA", "ETC2"}};
 }
 
 void HPPTextureCompressionComparison::draw_gui()

--- a/samples/performance/texture_compression_basisu/README.adoc
+++ b/samples/performance/texture_compression_basisu/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2021-2024, Sascha Willems
+- Copyright (c) 2021-2025, Sascha Willems
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -35,7 +35,7 @@ Version 2.0 added support for Basis Universal supercompressed textures.
 == Basis Universal
 
 https://github.com/BinomialLLC/basis_universal[Basis Universal] is a supercompressed GPU texture data interchange system that implements the UASTC and ETC1S compressed formats that serve as *transmission formats*.
-Both can be quickly transcoded to a wide variety of GPU native compressed and uncompressed formats like RGB/RGBA, PVRTC1, BCn, ETC1, ETC2, etc.
+Both can be quickly transcoded to a wide variety of GPU native compressed and uncompressed formats like RGB/RGBA, BCn, ETC1, ETC2, etc.
 This means that unlike a KTX 2.0 file storing a BC3 textures, the data needs to be transcoded at runtime.
 
 image::./images/2021-ktx-universal-gpu-compressed-textures.png[KTX and BasisU]
@@ -115,12 +115,6 @@ void TextureCompressionBasisu::get_available_target_formats()
 
 	// Ericsson texture compression
 	if (device_features.textureCompressionETC2)
-	{
-        ...
-    }
-
-	// PowerVR texture compression support needs to be checked via an extension
-	if (get_device().is_extension_supported(VK_IMG_FORMAT_PVRTC_EXTENSION_NAME))
 	{
         ...
     }

--- a/samples/performance/texture_compression_basisu/texture_compression_basisu.cpp
+++ b/samples/performance/texture_compression_basisu/texture_compression_basisu.cpp
@@ -26,8 +26,6 @@ TextureCompressionBasisu::TextureCompressionBasisu()
 	zoom     = -1.75f;
 	rotation = {0.0f, 0.0f, 0.0f};
 	title    = "Basis Universal texture loading";
-
-	add_device_extension(VK_IMG_FORMAT_PVRTC_EXTENSION_NAME, true /* optional */);
 }
 
 TextureCompressionBasisu::~TextureCompressionBasisu()
@@ -103,16 +101,6 @@ void TextureCompressionBasisu::get_available_target_formats()
 		{
 			available_target_formats.push_back(KTX_TTF_ETC2_RGBA);
 			available_target_formats_names.push_back("KTX_TTF_ETC2_RGBA");
-		}
-	}
-
-	// PowerVR texture compression support needs to be checked via an extension
-	if (get_device().is_extension_supported(VK_IMG_FORMAT_PVRTC_EXTENSION_NAME))
-	{
-		if (format_supported(VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG))
-		{
-			available_target_formats.push_back(KTX_TTF_PVRTC1_4_RGBA);
-			available_target_formats_names.push_back("KTX_TTF_PVRTC1_4_RGBA");
 		}
 	}
 

--- a/samples/performance/texture_compression_comparison/texture_compression_comparison.cpp
+++ b/samples/performance/texture_compression_comparison/texture_compression_comparison.cpp
@@ -169,13 +169,7 @@ const std::vector<TextureCompressionComparison::CompressedTexture_t> &TextureCom
 	                        VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK,
 	                        KTX_TTF_ETC2_RGBA,
 	                        "KTX_TTF_ETC2_RGBA",
-	                        "ETC2"},
-	    CompressedTexture_t{nullptr,
-	                        VK_IMG_FORMAT_PVRTC_EXTENSION_NAME,
-	                        VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG,
-	                        KTX_TTF_PVRTC1_4_RGBA,
-	                        "KTX_TTF_PVRTC1_4_RGBA",
-	                        "PVRTC1 4"}};
+	                        "ETC2"}};
 	return formats;
 }
 

--- a/samples/performance/texture_compression_comparison/texture_compression_comparison.cpp
+++ b/samples/performance/texture_compression_comparison/texture_compression_comparison.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024, Holochip
+/* Copyright (c) 2021-2025, Holochip
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
## Description

Related to #1264

VK_IMG_format_pvrtc extension is deprecated (https://registry.khronos.org/vulkan/specs/latest/man/html/VK_IMG_format_pvrtc.html#_deprecation_state)
This PR removes the extension from:
- texture_compression_basisu
- texture_compression_comparison

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
