### PR TITLE
Use correct device feature in multi draw indirect sample documentation

### DIFF
--- a/samples/performance/multi_draw_indirect/README.adoc
+++ b/samples/performance/multi_draw_indirect/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2021-2023, Holochip Corporation
+- Copyright (c) 2021-2025, Holochip Corporation
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -49,7 +49,7 @@ Each command contains the vertex offset, index offset, and index count.
 To control whether a sub-mesh is drawn, the instance count is set to either 0 or 1.
 Alternatively, the draw command could be completely removed from the array.
 
-If = device supports multi-draw indirect (`VkPhysicalDeviceFeatures2::bufferDeviceAddress`), then the entire array of draw commands can be executed through a single call to `VkDrawIndexedIndirectCommand`.
+If the device supports multi-draw indirect (`VkPhysicalDeviceFeatures2::multiDrawIndirect`), then the entire array of draw commands can be executed through a single call to `VkDrawIndexedIndirectCommand`.
 Otherwise, each draw call must be executed through a separate call to `VkDrawIndexIndirectCommand`:
 
 [,cpp]


### PR DESCRIPTION
## Description

This PR fixes the documentation for the multi draw indirect sample to check for the correct device feature (multiDrawIndirect instead of bufferDeviceAddress).

Note: Documentation only PR, no code changes.

Fixes #1266

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly