### PR TITLE
Add missing VK_KHR_portability_subset extension to [hpp_]hello_triangle[*] samples

### DIFF
--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -327,6 +327,16 @@ void HelloTriangle::init_device()
 		throw std::runtime_error("Required device extensions are missing.");
 	}
 
+#if (defined(VKB_ENABLE_PORTABILITY))
+	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
+	if (std::any_of(device_extensions.begin(),
+	                device_extensions.end(),
+	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
+	{
+		required_device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+	}
+#endif
+
 	// The sample uses a single graphics queue
 	const float queue_priority = 1.0f;
 

--- a/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
+++ b/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
@@ -310,6 +310,16 @@ void HelloTriangleV13::init_device()
 		throw std::runtime_error("Required device extensions are missing");
 	}
 
+#if (defined(VKB_ENABLE_PORTABILITY))
+	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
+	if (std::any_of(device_extensions.begin(),
+	                device_extensions.end(),
+	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
+	{
+		required_device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+	}
+#endif
+
 	// Query for Vulkan 1.3 features
 	VkPhysicalDeviceFeatures2                       query_device_features2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
 	VkPhysicalDeviceVulkan13Features                query_vulkan13_features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -307,10 +307,22 @@ vk::Device HPPHelloTriangle::create_device(const std::vector<const char *> &requ
 		throw std::runtime_error("Required device extensions are missing, will try without.");
 	}
 
+	std::vector<const char *> active_device_extensions(required_device_extensions);
+
+#if (defined(VKB_ENABLE_PORTABILITY))
+	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
+	if (std::any_of(device_extensions.begin(),
+	                device_extensions.end(),
+	                [](vk::ExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
+	{
+		active_device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+	}
+#endif
+
 	// Create a device with one queue
 	float                     queue_priority = 1.0f;
 	vk::DeviceQueueCreateInfo queue_info({}, graphics_queue_index, 1, &queue_priority);
-	vk::DeviceCreateInfo      device_info({}, queue_info, {}, required_device_extensions);
+	vk::DeviceCreateInfo      device_info({}, queue_info, {}, active_device_extensions);
 	vk::Device                device = gpu.createDevice(device_info);
 
 	// initialize function pointers for device


### PR DESCRIPTION
## Description

If portability is enabled (i.e. `VKB_ENABLE_PORTABILITY`) and the device supports the extension at runtime, this PR adds the `VK_KHR_portability_subset` device extension in the standalone samples: `hello_triangle`, `hpp_hello_triangle`, and `hello_triangle_1_3`.  This is required by the spec and prevents validation errors when the validation layer is enabled.

There is no change to the general framework where `VK_KHR_portability_subset` is already enabled as required for other non-standalone samples.

Fixes #1283

Tested on macOS Ventura and iOS (iPhone 15 physical device and simulator).

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
