### PR TITLE
No point rounding or casting something that's already an int in a shader

### DIFF
--- a/shaders/multi_draw_indirect/multi_draw_indirect.frag
+++ b/shaders/multi_draw_indirect/multi_draw_indirect.frag
@@ -1,6 +1,6 @@
 #version 460
 
-/* Copyright (c) 2021 Holochip Corporation
+/* Copyright (c) 2021-2025 Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,6 +26,6 @@ layout(binding = 1, set = 0) uniform sampler2D textures[225];
 
 void main(void)
 {
-	o_color = vec4(texture(textures[uint(round(in_texture_index))], in_uv));
+	o_color = vec4(texture(textures[in_texture_index], in_uv));
 	o_color.rgb *= 1.5;
 }


### PR DESCRIPTION
## Description

This shader was casting and rounding something that is already an integer.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements) - tested on Linux
