### PR TITLE
Update astc to 4.8.0, enable SSE41 decode, and fix build issues for physical iOS targets

### DIFF
--- a/samples/extensions/ray_tracing_reflection/README.adoc
+++ b/samples/extensions/ray_tracing_reflection/README.adoc
@@ -1,5 +1,5 @@
 ////
-* Copyright (c) 2014-2023, NVIDIA CORPORATION.  All rights reserved.
+* Copyright (c) 2014-2025, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * SPDX-FileCopyrightText: Copyright (c) 2014-2023 NVIDIA CORPORATION
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2025 NVIDIA CORPORATION
  * SPDX-License-Identifier: Apache-2.0
 ////
 = Ray tracing - reflection
@@ -27,7 +27,7 @@ image::./img1.png[]
 
 == Overview
 
-This sample is a extended version of the link:../raytracing_basic[ray tracing basic] with the addition of multiple geometries, instances and materials.
+This sample is a extended version of the link:../ray_tracing_basic[ray tracing basic] with the addition of multiple geometries, instances and materials.
 
 In addition, this sample is showing how to cast shadow rays and reflections.
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -308,8 +308,13 @@ if (NOT (DEFINED ASTC_ARCH))
     # `ld: object file .../libastcdec-avx2-static.a was built for different x86_64 sub-type (8) than link command line (3)`
     # so we fallback to native. If we're on an ARM based mac, there's no need for any SIMD extension, because they support
     # ASTC_LDR natively, so this library won't even be used.
+    # Always build for ARM when compiling or cross-compiling to iOS physical devices, otherwise fall back to native as above
     if (APPLE)
-        set(ASTC_ARCH NATIVE)
+		if(IOS AND ${CMAKE_OSX_SYSROOT} STREQUAL "iphoneos")
+			set(ASTC_ARCH NEON)
+		else()
+			set(ASTC_ARCH NATIVE)
+		endif()
     else()
         include( FindAVX2 )
         include( FindSSE2 )

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -304,23 +304,33 @@ target_include_directories(stb SYSTEM INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/stb
 # Allow the user to specify the ASTC architecture explicitly if building for a platform
 # other than the host architecture (i.e. x86 on an x64 CPU)
 if (NOT (DEFINED ASTC_ARCH))
-    # On an x86_64 macbook, AVX2 is selected, but linking fails with this message,
-    # `ld: object file .../libastcdec-avx2-static.a was built for different x86_64 sub-type (8) than link command line (3)`
-    # so we fallback to native. If we're on an ARM based mac, there's no need for any SIMD extension, because they support
-    # ASTC_LDR natively, so this library won't even be used.
-    # Always build for ARM when compiling or cross-compiling to iOS physical devices, otherwise fall back to native as above
     if (APPLE)
-		if(IOS AND ${CMAKE_OSX_SYSROOT} STREQUAL "iphoneos")
+		# Always use NEON when host is arm64 or cross-compiling to iOS physical devices,
+		# otherwise look for supported vector instructions based on x86_64 host processor.
+		# Don't use AVX2 since it builds for x86_64h which does not match x86_64 project,
+		# and lastly fall back to NATIVE if no matches found.
+		if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64" OR ${CMAKE_OSX_SYSROOT} STREQUAL "iphoneos")
 			set(ASTC_ARCH NEON)
 		else()
-			set(ASTC_ARCH NATIVE)
+			include( FindSSE41 )
+			include( FindSSE2 )
+			if (${SSE41_FOUND})
+				set(ASTC_ARCH SSE41)
+			elseif(${SSE2_FOUND})
+				set(ASTC_ARCH SSE2)
+			else()
+				set(ASTC_ARCH NATIVE)
+			endif()
 		endif()
     else()
         include( FindAVX2 )
+		include( FindSSE41 )
         include( FindSSE2 )
         include( FindNEON )
         if (${AVX2_FOUND})
             set(ASTC_ARCH AVX2)
+		elseif(${SSE41_FOUND})
+			set(ASTC_ARCH SSE41)
         elseif(${SSE2_FOUND})
             set(ASTC_ARCH SSE2)
         elseif(${NEON_FOUND})
@@ -333,6 +343,10 @@ endif()
 
 string(TOUPPER ${ASTC_ARCH} ASTC_ARCH)
 string(TOLOWER ${ASTC_ARCH} ASTC_ARCH_LOWER)
+# This is seemingly inconsistent, but the target library for SSE41 has a "." in its name
+if(${ASTC_ARCH_LOWER} STREQUAL "sse41")
+	set(ASTC_ARCH_LOWER "sse4.1")
+endif()
 
 set(ASTCENC_ISA_${ASTC_ARCH} ON)
 set(ASTCENC_CLI OFF)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -345,21 +345,6 @@ set(ASTC_TARGET ${ASTC_RAW_TARGET} PARENT_SCOPE)
 # astc
 add_subdirectory(astc)
 
-# ASTC apparently tries to build for x86_64 even on Mac arm64 architectures,
-# but we can force it to build for the correct arch
-# Upstream bug: https://github.com/ARM-software/astc-encoder/issues/458
-if(IOS)
-	if(${CMAKE_OSX_SYSROOT} STREQUAL "iphonesimulator")
-		# handle iOS Simulator case, which should always match CMAKE_HOST_SYSTEM_PROCESSOR
-		set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
-	else()
-		set(CMAKE_SYSTEM_PROCESSOR arm64)
-	endif()
-endif ()
-if (APPLE AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64"))
-    set_target_properties(${ASTC_RAW_TARGET} PROPERTIES OSX_ARCHITECTURES "arm64")
-endif()
-
 # astc doesn't have separate directories for it's source code and public interface.  Additionally, it includes it's
 # own copy of STB. In order to avoid conflicts, we copy the only header we need to the build directory and alter the
 # INTERFACE_INCLUDE_DIRECTORIES of the target


### PR DESCRIPTION
## Description

The new astc library from commit https://github.com/KhronosGroup/Vulkan-Samples/commit/7017dc07869aa0fd0eba1fd440010f10d56407b2 does not generate a static (.a) library when cross-compiling from x86_64 hosts to arm64 targets. This PR fixes this build problem by making sure "neon" is set for all iOS physical (not simulator) targets, and "native" otherwise.

This PR also removes a previous workaround for macOS/iOS arm64 targets since the original defect is now fixed.  See fixed issue https://github.com/ARM-software/astc-encoder/issues/458.

Fixes #1294.

Tested on macOS x86_64 (Intel iMac) and arm64 (M1 MacBook Air) hosts building for native macOS execution.  Also tested on macOS x86_64 hosts (Intel iMac) building for iOS physical (arm64 iPhone 15) and simulator (x86_64 host) targets.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
