### PR TITLE
Use algorithms from the std::ranges namespace instead of std namespace

### DIFF
--- a/app/plugins/batch_mode/batch_mode.cpp
+++ b/app/plugins/batch_mode/batch_mode.cpp
@@ -60,7 +60,7 @@ bool BatchMode::handle_option(std::deque<std::string> &arguments)
 			return false;
 		}
 		std::string category = arguments[1];
-		if (std::any_of(categories.begin(), categories.end(), [&category](auto const &c) { return c == category; }))
+		if (std::ranges::any_of(categories, [&category](auto const &c) { return c == category; }))
 		{
 			LOGW("Option \"category\" lists category \"{}\" multiple times!", category)
 		}
@@ -111,7 +111,7 @@ bool BatchMode::handle_option(std::deque<std::string> &arguments)
 			return false;
 		}
 		std::string tag = arguments[1];
-		if (std::any_of(tags.begin(), tags.end(), [&tag](auto const &t) { return t == tag; }))
+		if (std::ranges::any_of(tags, [&tag](auto const &t) { return t == tag; }))
 		{
 			LOGW("Option \"tag\" lists tag \"{}\" multiple times!", tag)
 		}

--- a/framework/buffer_pool.h
+++ b/framework/buffer_pool.h
@@ -337,12 +337,10 @@ template <vkb::BindingType bindingType>
 BufferBlock<bindingType> &BufferPool<bindingType>::request_buffer_block(DeviceSizeType minimum_size, bool minimal)
 {
 	// Find a block in the range of the blocks which can fit the minimum size
-	auto it = minimal ? std::find_if(buffer_blocks.begin(),
-	                                 buffer_blocks.end(),
-	                                 [&minimum_size](auto const &buffer_block) { return (buffer_block->get_size() == minimum_size) && buffer_block->can_allocate(minimum_size); }) :
-	                    std::find_if(buffer_blocks.begin(),
-	                                 buffer_blocks.end(),
-	                                 [&minimum_size](auto const &buffer_block) { return buffer_block->can_allocate(minimum_size); });
+	auto it = minimal ? std::ranges::find_if(buffer_blocks,
+	                                         [&minimum_size](auto const &buffer_block) { return (buffer_block->get_size() == minimum_size) && buffer_block->can_allocate(minimum_size); }) :
+	                    std::ranges::find_if(buffer_blocks,
+	                                         [&minimum_size](auto const &buffer_block) { return buffer_block->can_allocate(minimum_size); });
 
 	if (it == buffer_blocks.end())
 	{

--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -160,13 +160,11 @@ inline vk::SurfaceFormatKHR select_surface_format(vk::PhysicalDevice            
 	std::vector<vk::SurfaceFormatKHR> supported_surface_formats = gpu.getSurfaceFormatsKHR(surface);
 	assert(!supported_surface_formats.empty());
 
-	auto it = std::find_if(supported_surface_formats.begin(),
-	                       supported_surface_formats.end(),
-	                       [&preferred_formats](vk::SurfaceFormatKHR surface_format) {
-		                       return std::any_of(preferred_formats.begin(),
-		                                          preferred_formats.end(),
-		                                          [&surface_format](vk::Format format) { return format == surface_format.format; });
-	                       });
+	auto it = std::ranges::find_if(supported_surface_formats,
+	                               [&preferred_formats](vk::SurfaceFormatKHR surface_format) {
+		                               return std::ranges::any_of(preferred_formats,
+		                                                          [&surface_format](vk::Format format) { return format == surface_format.format; });
+	                               });
 
 	// We use the first supported format as a fallback in case none of the preferred formats is available
 	return it != supported_surface_formats.end() ? *it : supported_surface_formats[0];

--- a/framework/common/tags.h
+++ b/framework/common/tags.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Arm Limited and Contributors
+/* Copyright (c) 2020-2025, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -52,7 +52,7 @@ class Tag
 
 	static bool has_tag(TagID id)
 	{
-		return std::find(tags.begin(), tags.end(), id) != tags.end();
+		return std::ranges::find(tags, id) != tags.end();
 	}
 
 	template <typename C>

--- a/framework/common/utils.cpp
+++ b/framework/common/utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2024, Arm Limited and Contributors
+/* Copyright (c) 2018-2025, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -92,7 +92,7 @@ void screenshot(RenderContext &render_context, const std::string &filename)
 
 	// Check if framebuffer images are in a BGR format
 	auto bgr_formats = {VK_FORMAT_B8G8R8A8_SRGB, VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_B8G8R8A8_SNORM};
-	bool swizzle     = std::find(bgr_formats.begin(), bgr_formats.end(), src_image_view.get_format()) != bgr_formats.end();
+	bool swizzle     = std::ranges::find(bgr_formats, src_image_view.get_format()) != bgr_formats.end();
 
 	// Copy framebuffer image memory
 	VkBufferImageCopy image_copy_region{};

--- a/framework/common/vk_common.cpp
+++ b/framework/common/vk_common.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2024, Arm Limited and Contributors
- * Copyright (c) 2019-2024, Sascha Willems
+/* Copyright (c) 2018-2025, Arm Limited and Contributors
+ * Copyright (c) 2019-2025, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -675,13 +675,11 @@ VkSurfaceFormatKHR select_surface_format(VkPhysicalDevice gpu, VkSurfaceKHR surf
 	std::vector<VkSurfaceFormatKHR> supported_surface_formats(surface_format_count);
 	vkGetPhysicalDeviceSurfaceFormatsKHR(gpu, surface, &surface_format_count, supported_surface_formats.data());
 
-	auto it = std::find_if(supported_surface_formats.begin(),
-	                       supported_surface_formats.end(),
-	                       [&preferred_formats](VkSurfaceFormatKHR surface_format) {
-		                       return std::any_of(preferred_formats.begin(),
-		                                          preferred_formats.end(),
-		                                          [&surface_format](VkFormat format) { return format == surface_format.format; });
-	                       });
+	auto it = std::ranges::find_if(supported_surface_formats,
+	                               [&preferred_formats](VkSurfaceFormatKHR surface_format) {
+		                               return std::ranges::any_of(preferred_formats,
+		                                                          [&surface_format](VkFormat format) { return format == surface_format.format; });
+	                               });
 
 	// We use the first supported format as a fallback in case none of the preferred formats is available
 	return it != supported_surface_formats.end() ? *it : supported_surface_formats[0];

--- a/framework/core/descriptor_set.cpp
+++ b/framework/core/descriptor_set.cpp
@@ -178,7 +178,7 @@ void DescriptorSet::update(const std::vector<uint32_t> &bindings_to_update)
 		{
 			const auto &write_operation = write_descriptor_sets[i];
 
-			if (std::find(bindings_to_update.begin(), bindings_to_update.end(), write_operation.dstBinding) != bindings_to_update.end())
+			if (std::ranges::find(bindings_to_update, write_operation.dstBinding) != bindings_to_update.end())
 			{
 				size_t write_operation_hash = 0;
 				hash_param(write_operation_hash, write_operation);

--- a/framework/core/device.cpp
+++ b/framework/core/device.cpp
@@ -224,7 +224,7 @@ bool Device::is_extension_supported(const std::string &requested_extension) cons
 
 bool Device::is_enabled(const char *extension) const
 {
-	return std::find_if(enabled_extensions.begin(), enabled_extensions.end(), [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) != enabled_extensions.end();
+	return std::ranges::find_if(enabled_extensions, [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) != enabled_extensions.end();
 }
 
 const PhysicalDevice &Device::get_gpu() const

--- a/framework/core/hpp_device.cpp
+++ b/framework/core/hpp_device.cpp
@@ -199,9 +199,8 @@ bool HPPDevice::is_extension_supported(std::string const &requested_extension) c
 
 bool HPPDevice::is_enabled(std::string const &extension) const
 {
-	return std::find_if(enabled_extensions.begin(),
-	                    enabled_extensions.end(),
-	                    [extension](const char *enabled_extension) { return extension == enabled_extension; }) != enabled_extensions.end();
+	return std::ranges::find_if(enabled_extensions,
+	                            [extension](const char *enabled_extension) { return extension == enabled_extension; }) != enabled_extensions.end();
 }
 
 vkb::core::HPPPhysicalDevice const &HPPDevice::get_gpu() const

--- a/framework/core/hpp_instance.cpp
+++ b/framework/core/hpp_instance.cpp
@@ -118,15 +118,13 @@ bool enable_extension(const char                                 *requested_exte
                       std::vector<const char *>                  &enabled_extensions)
 {
 	bool is_available =
-	    std::any_of(available_extensions.begin(),
-	                available_extensions.end(),
-	                [&requested_extension](auto const &available_extension) { return strcmp(requested_extension, available_extension.extensionName) == 0; });
+	    std::ranges::any_of(available_extensions,
+	                        [&requested_extension](auto const &available_extension) { return strcmp(requested_extension, available_extension.extensionName) == 0; });
 	if (is_available)
 	{
 		bool is_already_enabled =
-		    std::any_of(enabled_extensions.begin(),
-		                enabled_extensions.end(),
-		                [&requested_extension](auto const &enabled_extension) { return strcmp(requested_extension, enabled_extension) == 0; });
+		    std::ranges::any_of(enabled_extensions,
+		                        [&requested_extension](auto const &enabled_extension) { return strcmp(requested_extension, enabled_extension) == 0; });
 		if (!is_already_enabled)
 		{
 			LOGI("Extension {} available, enabling it", requested_extension);
@@ -146,15 +144,13 @@ bool enable_layer(const char                             *requested_layer,
                   std::vector<const char *>              &enabled_layers)
 {
 	bool is_available =
-	    std::any_of(available_layers.begin(),
-	                available_layers.end(),
-	                [&requested_layer](auto const &available_layer) { return strcmp(requested_layer, available_layer.layerName) == 0; });
+	    std::ranges::any_of(available_layers,
+	                        [&requested_layer](auto const &available_layer) { return strcmp(requested_layer, available_layer.layerName) == 0; });
 	if (is_available)
 	{
 		bool is_already_enabled =
-		    std::any_of(enabled_layers.begin(),
-		                enabled_layers.end(),
-		                [&requested_layer](auto const &enabled_layer) { return strcmp(requested_layer, enabled_layer) == 0; });
+		    std::ranges::any_of(enabled_layers,
+		                        [&requested_layer](auto const &enabled_layer) { return strcmp(requested_layer, enabled_layer) == 0; });
 		if (!is_already_enabled)
 		{
 			LOGI("Layer {} available, enabling it", requested_layer);
@@ -452,9 +448,8 @@ vkb::core::HPPPhysicalDevice &HPPInstance::get_suitable_gpu(vk::SurfaceKHR surfa
 
 bool HPPInstance::is_enabled(const char *extension) const
 {
-	return std::find_if(enabled_extensions.begin(),
-	                    enabled_extensions.end(),
-	                    [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) != enabled_extensions.end();
+	return std::ranges::find_if(enabled_extensions,
+	                            [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) != enabled_extensions.end();
 }
 
 void HPPInstance::query_gpus()

--- a/framework/core/hpp_physical_device.cpp
+++ b/framework/core/hpp_physical_device.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -83,9 +83,8 @@ void *HPPPhysicalDevice::get_extension_feature_chain() const
 
 bool HPPPhysicalDevice::is_extension_supported(const std::string &requested_extension) const
 {
-	return std::find_if(device_extensions.begin(),
-	                    device_extensions.end(),
-	                    [requested_extension](auto &device_extension) { return std::strcmp(device_extension.extensionName, requested_extension.c_str()) == 0; }) != device_extensions.end();
+	return std::ranges::find_if(device_extensions,
+	                            [requested_extension](auto &device_extension) { return std::strcmp(device_extension.extensionName, requested_extension.c_str()) == 0; }) != device_extensions.end();
 }
 
 const vk::PhysicalDeviceFeatures &HPPPhysicalDevice::get_features() const

--- a/framework/core/hpp_pipeline_layout.cpp
+++ b/framework/core/hpp_pipeline_layout.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -127,9 +127,8 @@ HPPPipelineLayout::~HPPPipelineLayout()
 
 vkb::core::HPPDescriptorSetLayout const &HPPPipelineLayout::get_descriptor_set_layout(const uint32_t set_index) const
 {
-	auto it = std::find_if(descriptor_set_layouts.begin(),
-	                       descriptor_set_layouts.end(),
-	                       [&set_index](auto const *descriptor_set_layout) { return descriptor_set_layout->get_index() == set_index; });
+	auto it = std::ranges::find_if(descriptor_set_layouts,
+	                               [&set_index](auto const *descriptor_set_layout) { return descriptor_set_layout->get_index() == set_index; });
 	if (it == descriptor_set_layouts.end())
 	{
 		throw std::runtime_error("Couldn't find descriptor set layout at set index " + to_string(set_index));

--- a/framework/core/hpp_swapchain.cpp
+++ b/framework/core/hpp_swapchain.cpp
@@ -60,14 +60,13 @@ vk::PresentModeKHR choose_present_mode(vk::PresentModeKHR                     re
                                        const std::vector<vk::PresentModeKHR> &present_mode_priority_list)
 {
 	// Try to find the requested present mode in the available present modes
-	auto const present_mode_it = std::find(available_present_modes.begin(), available_present_modes.end(), request_present_mode);
+	auto const present_mode_it = std::ranges::find(available_present_modes, request_present_mode);
 	if (present_mode_it == available_present_modes.end())
 	{
 		// If the requested present mode isn't found, then try to find a mode from the priority list
 		auto const chosen_present_mode_it =
-		    std::find_if(present_mode_priority_list.begin(),
-		                 present_mode_priority_list.end(),
-		                 [&available_present_modes](vk::PresentModeKHR present_mode) { return std::find(available_present_modes.begin(), available_present_modes.end(), present_mode) != available_present_modes.end(); });
+		    std::ranges::find_if(present_mode_priority_list,
+		                         [&available_present_modes](vk::PresentModeKHR present_mode) { return std::ranges::find(available_present_modes, present_mode) != available_present_modes.end(); });
 
 		// If nothing found, always default to FIFO
 		vk::PresentModeKHR const chosen_present_mode = (chosen_present_mode_it != present_mode_priority_list.end()) ? *chosen_present_mode_it : vk::PresentModeKHR::eFifo;
@@ -87,15 +86,14 @@ vk::SurfaceFormatKHR choose_surface_format(const vk::SurfaceFormatKHR           
                                            const std::vector<vk::SurfaceFormatKHR> &surface_format_priority_list)
 {
 	// Try to find the requested surface format in the available surface formats
-	auto const surface_format_it = std::find(available_surface_formats.begin(), available_surface_formats.end(), requested_surface_format);
+	auto const surface_format_it = std::ranges::find(available_surface_formats, requested_surface_format);
 
 	// If the requested surface format isn't found, then try to request a format from the priority list
 	if (surface_format_it == available_surface_formats.end())
 	{
 		auto const chosen_surface_format_it =
-		    std::find_if(surface_format_priority_list.begin(),
-		                 surface_format_priority_list.end(),
-		                 [&available_surface_formats](vk::SurfaceFormatKHR surface_format) { return std::find(available_surface_formats.begin(), available_surface_formats.end(), surface_format) != available_surface_formats.end(); });
+		    std::ranges::find_if(surface_format_priority_list,
+		                         [&available_surface_formats](vk::SurfaceFormatKHR surface_format) { return std::ranges::find(available_surface_formats, surface_format) != available_surface_formats.end(); });
 
 		// If nothing found, default to the first available format
 		vk::SurfaceFormatKHR const &chosen_surface_format = (chosen_surface_format_it != surface_format_priority_list.end()) ? *chosen_surface_format_it : available_surface_formats[0];
@@ -183,9 +181,8 @@ std::set<vk::ImageUsageFlagBits> choose_image_usage(const std::set<vk::ImageUsag
 		    vk::ImageUsageFlagBits::eColorAttachment, vk::ImageUsageFlagBits::eStorage, vk::ImageUsageFlagBits::eSampled, vk::ImageUsageFlagBits::eTransferDst};
 
 		auto const priority_list_it =
-		    std::find_if(image_usage_priority_list.begin(),
-		                 image_usage_priority_list.end(),
-		                 [&supported_image_usage, &supported_features](auto const image_usage) { return ((image_usage & supported_image_usage) && validate_format_feature(image_usage, supported_features)); });
+		    std::ranges::find_if(image_usage_priority_list,
+		                         [&supported_image_usage, &supported_features](auto const image_usage) { return ((image_usage & supported_image_usage) && validate_format_feature(image_usage, supported_features)); });
 		if (priority_list_it != image_usage_priority_list.end())
 		{
 			validated_image_usage_flags.insert(*priority_list_it);

--- a/framework/core/instance.cpp
+++ b/framework/core/instance.cpp
@@ -111,15 +111,13 @@ bool enable_extension(const char                               *requested_extens
                       std::vector<const char *>                &enabled_extensions)
 {
 	bool is_available =
-	    std::any_of(available_extensions.begin(),
-	                available_extensions.end(),
-	                [&requested_extension](auto const &available_extension) { return strcmp(requested_extension, available_extension.extensionName) == 0; });
+	    std::ranges::any_of(available_extensions,
+	                        [&requested_extension](auto const &available_extension) { return strcmp(requested_extension, available_extension.extensionName) == 0; });
 	if (is_available)
 	{
 		bool is_already_enabled =
-		    std::any_of(enabled_extensions.begin(),
-		                enabled_extensions.end(),
-		                [&requested_extension](auto const &enabled_extension) { return strcmp(requested_extension, enabled_extension) == 0; });
+		    std::ranges::any_of(enabled_extensions,
+		                        [&requested_extension](auto const &enabled_extension) { return strcmp(requested_extension, enabled_extension) == 0; });
 		if (!is_already_enabled)
 		{
 			LOGI("Extension {} available, enabling it", requested_extension);
@@ -139,15 +137,13 @@ bool enable_layer(const char                           *requested_layer,
                   std::vector<const char *>            &enabled_layers)
 {
 	bool is_available =
-	    std::any_of(available_layers.begin(),
-	                available_layers.end(),
-	                [&requested_layer](auto const &available_layer) { return strcmp(requested_layer, available_layer.layerName) == 0; });
+	    std::ranges::any_of(available_layers,
+	                        [&requested_layer](auto const &available_layer) { return strcmp(requested_layer, available_layer.layerName) == 0; });
 	if (is_available)
 	{
 		bool is_already_enabled =
-		    std::any_of(enabled_layers.begin(),
-		                enabled_layers.end(),
-		                [&requested_layer](auto const &enabled_layer) { return strcmp(requested_layer, enabled_layer) == 0; });
+		    std::ranges::any_of(enabled_layers,
+		                        [&requested_layer](auto const &enabled_layer) { return strcmp(requested_layer, enabled_layer) == 0; });
 		if (!is_already_enabled)
 		{
 			LOGI("Layer {} available, enabling it", requested_layer);
@@ -504,7 +500,7 @@ PhysicalDevice &Instance::get_suitable_gpu(VkSurfaceKHR surface, bool headless_s
 
 bool Instance::is_enabled(const char *extension) const
 {
-	return std::find_if(enabled_extensions.begin(), enabled_extensions.end(), [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) != enabled_extensions.end();
+	return std::ranges::find_if(enabled_extensions, [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) != enabled_extensions.end();
 }
 
 VkInstance Instance::get_handle() const

--- a/framework/core/physical_device.cpp
+++ b/framework/core/physical_device.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2024, Arm Limited and Contributors
+/* Copyright (c) 2020-2025, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -69,10 +69,10 @@ VkBool32 PhysicalDevice::is_present_supported(VkSurfaceKHR surface, uint32_t que
 
 bool PhysicalDevice::is_extension_supported(const std::string &requested_extension) const
 {
-	return std::find_if(device_extensions.begin(), device_extensions.end(),
-	                    [requested_extension](auto &device_extension) {
-		                    return std::strcmp(device_extension.extensionName, requested_extension.c_str()) == 0;
-	                    }) != device_extensions.end();
+	return std::ranges::find_if(device_extensions,
+	                            [requested_extension](auto &device_extension) {
+		                            return std::strcmp(device_extension.extensionName, requested_extension.c_str()) == 0;
+	                            }) != device_extensions.end();
 }
 
 const VkFormatProperties PhysicalDevice::get_format_properties(VkFormat format) const
@@ -120,8 +120,8 @@ uint32_t PhysicalDevice::get_queue_family_performance_query_passes(
 
 void PhysicalDevice::enumerate_queue_family_performance_query_counters(
     uint32_t                            queue_family_index,
-    uint32_t *                          count,
-    VkPerformanceCounterKHR *           counters,
+    uint32_t                           *count,
+    VkPerformanceCounterKHR            *counters,
     VkPerformanceCounterDescriptionKHR *descriptions) const
 {
 	VK_CHECK(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(

--- a/framework/core/shader_module.cpp
+++ b/framework/core/shader_module.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2024, Arm Limited and Contributors
+/* Copyright (c) 2019-2025, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -171,7 +171,7 @@ const std::vector<uint32_t> &ShaderModule::get_binary() const
 
 void ShaderModule::set_resource_mode(const std::string &resource_name, const ShaderResourceMode &resource_mode)
 {
-	auto it = std::find_if(resources.begin(), resources.end(), [&resource_name](const ShaderResource &resource) { return resource.name == resource_name; });
+	auto it = std::ranges::find_if(resources, [&resource_name](const ShaderResource &resource) { return resource.name == resource_name; });
 
 	if (it != resources.end())
 	{

--- a/framework/core/swapchain.cpp
+++ b/framework/core/swapchain.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2024, Arm Limited and Contributors
+/* Copyright (c) 2019-2025, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -81,7 +81,7 @@ inline VkPresentModeKHR choose_present_mode(
     const std::vector<VkPresentModeKHR> &available_present_modes,
     const std::vector<VkPresentModeKHR> &present_mode_priority_list)
 {
-	auto present_mode_it = std::find(available_present_modes.begin(), available_present_modes.end(), request_present_mode);
+	auto present_mode_it = std::ranges::find(available_present_modes, request_present_mode);
 
 	if (present_mode_it == available_present_modes.end())
 	{
@@ -90,7 +90,7 @@ inline VkPresentModeKHR choose_present_mode(
 
 		for (auto &present_mode : present_mode_priority_list)
 		{
-			if (std::find(available_present_modes.begin(), available_present_modes.end(), present_mode) != available_present_modes.end())
+			if (std::ranges::find(available_present_modes, present_mode) != available_present_modes.end())
 			{
 				chosen_present_mode = present_mode;
 				break;
@@ -113,9 +113,8 @@ inline VkSurfaceFormatKHR choose_surface_format(
     const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list)
 {
 	// Try to find the requested surface format in the supported surface formats
-	auto surface_format_it = std::find_if(
-	    available_surface_formats.begin(),
-	    available_surface_formats.end(),
+	auto surface_format_it = std::ranges::find_if(
+	    available_surface_formats,
 	    [&requested_surface_format](const VkSurfaceFormatKHR &surface) {
 		    if (surface.format == requested_surface_format.format &&
 		        surface.colorSpace == requested_surface_format.colorSpace)
@@ -131,9 +130,8 @@ inline VkSurfaceFormatKHR choose_surface_format(
 	{
 		for (auto &surface_format : surface_format_priority_list)
 		{
-			surface_format_it = std::find_if(
-			    available_surface_formats.begin(),
-			    available_surface_formats.end(),
+			surface_format_it = std::ranges::find_if(
+			    available_surface_formats,
 			    [&surface_format](const VkSurfaceFormatKHR &surface) {
 				    if (surface.format == surface_format.format &&
 				        surface.colorSpace == surface_format.colorSpace)

--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -512,7 +512,7 @@ sg::Scene GLTFLoader::load_scene(int scene_index, VkBufferUsageFlags additional_
 		if (it == supported_extensions.end())
 		{
 			// If extension is required then we shouldn't allow the scene to be loaded
-			if (std::find(model.extensionsRequired.begin(), model.extensionsRequired.end(), used_extension) != model.extensionsRequired.end())
+			if (std::ranges::find(model.extensionsRequired, used_extension) != model.extensionsRequired.end())
 			{
 				throw std::runtime_error("Cannot load glTF file. Contains a required unsupported extension: " + used_extension);
 			}

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -773,7 +773,7 @@ Font &Gui::get_font(const std::string &font_name)
 {
 	assert(!fonts.empty() && "No fonts exist");
 
-	auto it = std::find_if(fonts.begin(), fonts.end(), [&font_name](Font &font) { return font.name == font_name; });
+	auto it = std::ranges::find_if(fonts, [&font_name](Font &font) { return font.name == font_name; });
 
 	if (it != fonts.end())
 	{

--- a/framework/hpp_gui.cpp
+++ b/framework/hpp_gui.cpp
@@ -712,7 +712,7 @@ HPPFont const &HPPGui::get_font(const std::string &font_name) const
 {
 	assert(!fonts.empty() && "No fonts exist");
 
-	auto it = std::find_if(fonts.begin(), fonts.end(), [&font_name](HPPFont const &font) { return font.name == font_name; });
+	auto it = std::ranges::find_if(fonts, [&font_name](HPPFont const &font) { return font.name == font_name; });
 
 	if (it != fonts.end())
 	{

--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -70,7 +70,7 @@ ExitCode Platform::initialize(const std::vector<Plugin *> &plugins_)
 	{
 		return ExitCode::NoSample;
 	}
-	else if (std::any_of(arguments.begin(), arguments.end(), [](auto const &arg) { return arg == "-h" || arg == "--help"; }))
+	else if (std::ranges::any_of(arguments, [](auto const &arg) { return arg == "-h" || arg == "--help"; }))
 	{
 		return ExitCode::Help;
 	}
@@ -177,13 +177,13 @@ void Platform::register_hooks(Plugin *plugin)
 			it = r.first;
 		}
 
-		if (std::none_of(it->second.begin(), it->second.end(), [plugin](auto p) { return p == plugin; }))
+		if (std::ranges::none_of(it->second, [plugin](auto p) { return p == plugin; }))
 		{
 			it->second.emplace_back(plugin);
 		}
 	}
 
-	if (std::none_of(active_plugins.begin(), active_plugins.end(), [plugin](auto p) { return p == plugin; }))
+	if (std::ranges::none_of(active_plugins, [plugin](auto p) { return p == plugin; }))
 	{
 		active_plugins.emplace_back(plugin);
 	}

--- a/framework/rendering/hpp_render_frame.cpp
+++ b/framework/rendering/hpp_render_frame.cpp
@@ -197,9 +197,8 @@ vkb::core::CommandBufferCpp &HPPRenderFrame::request_command_buffer(const vkb::c
 	auto &command_pools = get_command_pools(queue, reset_mode);
 
 	auto command_pool_it =
-	    std::find_if(command_pools.begin(),
-	                 command_pools.end(),
-	                 [&thread_index](std::unique_ptr<vkb::core::CommandPoolCpp> &cmd_pool) { return cmd_pool->get_thread_index() == thread_index; });
+	    std::ranges::find_if(command_pools,
+	                         [&thread_index](std::unique_ptr<vkb::core::CommandPoolCpp> &cmd_pool) { return cmd_pool->get_thread_index() == thread_index; });
 	assert(command_pool_it != command_pools.end());
 
 	return (*command_pool_it)->request_command_buffer(level);

--- a/framework/rendering/hpp_render_target.cpp
+++ b/framework/rendering/hpp_render_target.cpp
@@ -47,7 +47,7 @@ HPPRenderTarget::HPPRenderTarget(std::vector<core::HPPImage> &&images_) :
 	assert(!images.empty() && "Should specify at least 1 image");
 
 	// check that every image is 2D
-	auto it = std::find_if(images.begin(), images.end(), [](core::HPPImage const &image) { return image.get_type() != vk::ImageType::e2D; });
+	auto it = std::ranges::find_if(images, [](core::HPPImage const &image) { return image.get_type() != vk::ImageType::e2D; });
 	if (it != images.end())
 	{
 		throw VulkanException{VK_ERROR_INITIALIZATION_FAILED, "Image type is not 2D"};

--- a/framework/rendering/postprocessing_renderpass.cpp
+++ b/framework/rendering/postprocessing_renderpass.cpp
@@ -250,14 +250,14 @@ void PostProcessingRenderPass::update_load_stores(
 	for (uint32_t j = 0; j < static_cast<uint32_t>(render_target.get_attachments().size()); j++)
 	{
 		const bool is_input   = input_attachments.find(j) != input_attachments.end();
-		const bool is_sampled = std::find_if(sampled_attachments.begin(), sampled_attachments.end(),
-		                                     [&render_target, j](auto &pair) {
-			                                     // NOTE: if RT not set, default is the currently-active one
-			                                     auto *sampled_rt = pair.first ? pair.first : &render_target;
-			                                     // unpack attachment
-			                                     uint32_t attachment = pair.second & ATTACHMENT_BITMASK;
-			                                     return attachment == j && sampled_rt == &render_target;
-		                                     }) != sampled_attachments.end();
+		const bool is_sampled = std::ranges::find_if(sampled_attachments,
+		                                             [&render_target, j](auto &pair) {
+			                                             // NOTE: if RT not set, default is the currently-active one
+			                                             auto *sampled_rt = pair.first ? pair.first : &render_target;
+			                                             // unpack attachment
+			                                             uint32_t attachment = pair.second & ATTACHMENT_BITMASK;
+			                                             return attachment == j && sampled_rt == &render_target;
+		                                             }) != sampled_attachments.end();
 		const bool is_output  = output_attachments.find(j) != output_attachments.end();
 
 		VkAttachmentLoadOp load;

--- a/framework/rendering/render_frame.cpp
+++ b/framework/rendering/render_frame.cpp
@@ -142,7 +142,7 @@ std::vector<uint32_t> RenderFrame::collect_bindings_to_update(const DescriptorSe
 		{
 			uint32_t binding_index = pair.first;
 			if (!(descriptor_set_layout.get_layout_binding_flag(binding_index) & VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT) &&
-			    std::find(bindings_to_update.begin(), bindings_to_update.end(), binding_index) == bindings_to_update.end())
+			    std::ranges::find(bindings_to_update, binding_index) == bindings_to_update.end())
 			{
 				bindings_to_update.push_back(binding_index);
 			}
@@ -203,10 +203,7 @@ vkb::core::CommandBufferC &RenderFrame::request_command_buffer(const Queue      
 
 	auto &command_pools = get_command_pools(queue, reset_mode);
 
-	auto command_pool_it =
-	    std::find_if(command_pools.begin(),
-	                 command_pools.end(),
-	                 [&thread_index](std::unique_ptr<vkb::core::CommandPoolC> &cmd_pool) { return cmd_pool->get_thread_index() == thread_index; });
+	auto command_pool_it = std::ranges::find_if(command_pools, [&thread_index](std::unique_ptr<vkb::core::CommandPoolC> &cmd_pool) { return cmd_pool->get_thread_index() == thread_index; });
 
 	return (*command_pool_it)->request_command_buffer(level);
 }

--- a/framework/scene_graph/components/image/astc.cpp
+++ b/framework/scene_graph/components/image/astc.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2024, Arm Limited and Contributors
+/* Copyright (c) 2019-2025, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -165,8 +165,8 @@ Astc::Astc(const Image &image) :
 	init();
 
 	// Locate mip #0 in the KTX. This is the first one in the data array for KTX1s, but the last one in KTX2s!
-	auto mip_it = std::find_if(image.get_mipmaps().begin(), image.get_mipmaps().end(),
-	                           [](auto &mip) { return mip.level == 0; });
+	auto mip_it = std::ranges::find_if(image.get_mipmaps(),
+	                                   [](auto &mip) { return mip.level == 0; });
 	assert(mip_it != image.get_mipmaps().end() && "Mip #0 not found");
 
 	// When decoding ASTC on CPU (as it is the case in here), we don't decode all mips in the mip chain.

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -1051,9 +1051,8 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 	{
 		std::vector<vk::ExtensionProperties> available_instance_extensions = vk::enumerateInstanceExtensionProperties();
 		auto                                 debugExtensionIt =
-		    std::find_if(available_instance_extensions.begin(),
-		                 available_instance_extensions.end(),
-		                 [](vk::ExtensionProperties const &ep) { return strcmp(ep.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0; });
+		    std::ranges::find_if(available_instance_extensions,
+		                         [](vk::ExtensionProperties const &ep) { return strcmp(ep.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0; });
 		if (debugExtensionIt != available_instance_extensions.end())
 		{
 			LOGI("Vulkan debug utils enabled ({})", VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
@@ -1123,9 +1122,8 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 	{
 		std::vector<vk::ExtensionProperties> available_device_extensions = gpu.get_handle().enumerateDeviceExtensionProperties();
 		auto                                 debugExtensionIt =
-		    std::find_if(available_device_extensions.begin(),
-		                 available_device_extensions.end(),
-		                 [](vk::ExtensionProperties const &ep) { return strcmp(ep.extensionName, VK_EXT_DEBUG_MARKER_EXTENSION_NAME) == 0; });
+		    std::ranges::find_if(available_device_extensions,
+		                         [](vk::ExtensionProperties const &ep) { return strcmp(ep.extensionName, VK_EXT_DEBUG_MARKER_EXTENSION_NAME) == 0; });
 		if (debugExtensionIt != available_device_extensions.end())
 		{
 			LOGI("Vulkan debug utils enabled ({})", VK_EXT_DEBUG_MARKER_EXTENSION_NAME);

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -162,9 +162,8 @@ void HelloTriangle::init_instance()
 #if (defined(VKB_ENABLE_PORTABILITY))
 	required_instance_extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	bool portability_enumeration_available = false;
-	if (std::any_of(available_instance_extensions.begin(),
-	                available_instance_extensions.end(),
-	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
+	if (std::ranges::any_of(available_instance_extensions,
+	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
 	{
 		required_instance_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 		portability_enumeration_available = true;
@@ -205,7 +204,7 @@ void HelloTriangle::init_instance()
 	std::vector<VkLayerProperties> supported_instance_layers(instance_layer_count);
 	VK_CHECK(vkEnumerateInstanceLayerProperties(&instance_layer_count, supported_instance_layers.data()));
 
-	if (std::any_of(supported_instance_layers.begin(), supported_instance_layers.end(), [&validationLayer](auto const &lp) { return strcmp(lp.layerName, validationLayer) == 0; }))
+	if (std::ranges::any_of(supported_instance_layers, [&validationLayer](auto const &lp) { return strcmp(lp.layerName, validationLayer) == 0; }))
 	{
 		requested_instance_layers.push_back(validationLayer);
 		LOGI("Enabled Validation Layer {}", validationLayer);
@@ -329,9 +328,8 @@ void HelloTriangle::init_device()
 
 #if (defined(VKB_ENABLE_PORTABILITY))
 	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
-	if (std::any_of(device_extensions.begin(),
-	                device_extensions.end(),
-	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
+	if (std::ranges::any_of(device_extensions,
+	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
 	{
 		required_device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 	}

--- a/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
+++ b/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
@@ -133,9 +133,8 @@ void HelloTriangleV13::init_instance()
 #if (defined(VKB_ENABLE_PORTABILITY))
 	required_instance_extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	bool portability_enumeration_available = false;
-	if (std::any_of(available_instance_extensions.begin(),
-	                available_instance_extensions.end(),
-	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
+	if (std::ranges::any_of(available_instance_extensions,
+	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
 	{
 		required_instance_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 		portability_enumeration_available = true;
@@ -176,7 +175,7 @@ void HelloTriangleV13::init_instance()
 	std::vector<VkLayerProperties> supported_instance_layers(instance_layer_count);
 	VK_CHECK(vkEnumerateInstanceLayerProperties(&instance_layer_count, supported_instance_layers.data()));
 
-	if (std::any_of(supported_instance_layers.begin(), supported_instance_layers.end(), [&validationLayer](auto const &lp) { return strcmp(lp.layerName, validationLayer) == 0; }))
+	if (std::ranges::any_of(supported_instance_layers, [&validationLayer](auto const &lp) { return strcmp(lp.layerName, validationLayer) == 0; }))
 	{
 		requested_instance_layers.push_back(validationLayer);
 		LOGI("Enabled Validation Layer {}", validationLayer);
@@ -312,9 +311,8 @@ void HelloTriangleV13::init_device()
 
 #if (defined(VKB_ENABLE_PORTABILITY))
 	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
-	if (std::any_of(device_extensions.begin(),
-	                device_extensions.end(),
-	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
+	if (std::ranges::any_of(device_extensions,
+	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
 	{
 		required_device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 	}

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -61,15 +61,13 @@ bool validate_extensions(const std::vector<const char *>            &required,
 {
 	// inner find_if gives true if the extension was not found
 	// outer find_if gives true if none of the extensions were not found, that is if all extensions were found
-	return std::find_if(required.begin(),
-	                    required.end(),
-	                    [&available](auto extension) {
-		                    return std::find_if(available.begin(),
-		                                        available.end(),
-		                                        [&extension](auto const &ep) {
-			                                        return strcmp(ep.extensionName, extension) == 0;
-		                                        }) == available.end();
-	                    }) == required.end();
+	return std::ranges::find_if(required,
+	                            [&available](auto extension) {
+		                            return std::ranges::find_if(available,
+		                                                        [&extension](auto const &ep) {
+			                                                        return strcmp(ep.extensionName, extension) == 0;
+		                                                        }) == available.end();
+	                            }) == required.end();
 }
 
 HPPHelloTriangle::HPPHelloTriangle()
@@ -312,9 +310,8 @@ vk::Device HPPHelloTriangle::create_device(const std::vector<const char *> &requ
 
 #if (defined(VKB_ENABLE_PORTABILITY))
 	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
-	if (std::any_of(device_extensions.begin(),
-	                device_extensions.end(),
-	                [](vk::ExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
+	if (std::ranges::any_of(device_extensions,
+	                        [](vk::ExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
 	{
 		active_device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 	}
@@ -401,9 +398,8 @@ vk::Instance HPPHelloTriangle::create_instance(std::vector<const char *> const &
 #if (defined(VKB_ENABLE_PORTABILITY))
 	active_instance_extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	bool portability_enumeration_available = false;
-	if (std::any_of(available_instance_extensions.begin(),
-	                available_instance_extensions.end(),
-	                [](vk::ExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
+	if (std::ranges::any_of(available_instance_extensions,
+	                        [](vk::ExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
 	{
 		active_instance_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 		portability_enumeration_available = true;
@@ -440,7 +436,7 @@ vk::Instance HPPHelloTriangle::create_instance(std::vector<const char *> const &
 
 	std::vector<vk::LayerProperties> supported_instance_layers = vk::enumerateInstanceLayerProperties();
 
-	if (std::any_of(supported_instance_layers.begin(), supported_instance_layers.end(), [&validationLayer](auto const &lp) { return strcmp(lp.layerName, validationLayer) == 0; }))
+	if (std::ranges::any_of(supported_instance_layers, [&validationLayer](auto const &lp) { return strcmp(lp.layerName, validationLayer) == 0; }))
 	{
 		requested_instance_layers.push_back(validationLayer);
 		LOGI("Enabled Validation Layer {}", validationLayer);

--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2024, Google
+/* Copyright (c) 2023-2025, Google
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -101,13 +101,13 @@ void SwapchainRecreation::adjust_desired_present_mode()
 
 	// When switching to MAILBOX, fallback to IMMEDIATE if not available and back to FIFO if
 	// neither are available.
-	if (desired_present_mode == VK_PRESENT_MODE_MAILBOX_KHR && std::find(present_modes.begin(), present_modes.end(), desired_present_mode) != present_modes.end())
+	if (desired_present_mode == VK_PRESENT_MODE_MAILBOX_KHR && std::ranges::find(present_modes, desired_present_mode) != present_modes.end())
 	{
 		return;
 	}
 
 	desired_present_mode = VK_PRESENT_MODE_IMMEDIATE_KHR;
-	if (std::find(present_modes.begin(), present_modes.end(), desired_present_mode) == present_modes.end())
+	if (std::ranges::find(present_modes, desired_present_mode) == present_modes.end())
 	{
 		LOGW("Neither MAILBOX nor IMMEDIATE are supported, falling back to FIFO");
 		desired_present_mode = VK_PRESENT_MODE_FIFO_KHR;
@@ -164,7 +164,7 @@ bool SwapchainRecreation::are_present_modes_compatible()
 	// While this functionality was introduced by VK_EXT_surface_maintenance1, compatible_modes
 	// is always set up such that every present mode is assumed to be compatible only with
 	// itself; there is no need for an extension check here.
-	return std::find(compatible_modes.begin(), compatible_modes.end(), desired_present_mode) != compatible_modes.end();
+	return std::ranges::find(compatible_modes, desired_present_mode) != compatible_modes.end();
 }
 
 /**
@@ -684,7 +684,7 @@ void SwapchainRecreation::cleanup_present_history()
 		// Move clean up data to the next (now first) present operation, if any.  Note that
 		// there cannot be any clean up data on the rest of the present operations, because
 		// the first present already gathers every old swapchain to clean up.
-		assert(std::all_of(present_history.begin(), present_history.end(), [](const PresentOperationInfo &op) {
+		assert(std::ranges::all_of(present_history, [](const PresentOperationInfo &op) {
 			return op.old_swapchains.empty();
 		}));
 		present_history.front().old_swapchains = std::move(present_info.old_swapchains);

--- a/samples/extensions/calibrated_timestamps/calibrated_timestamps.cpp
+++ b/samples/extensions/calibrated_timestamps/calibrated_timestamps.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2024, Holochip Corporation
+/* Copyright (c) 2023-2025, Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -826,7 +826,7 @@ void CalibratedTimestamps::get_device_time_domain()
 
 	if (is_time_domain_init && (time_domains.size() > 1))
 	{
-		auto iterator_device = std::find(time_domains.begin(), time_domains.end(), VK_TIME_DOMAIN_DEVICE_EXT);
+		auto iterator_device = std::ranges::find(time_domains, VK_TIME_DOMAIN_DEVICE_EXT);
 
 		int device_index = static_cast<int>(iterator_device - time_domains.begin());
 

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2024, Mobica Limited
+/* Copyright (c) 2023-2025, Mobica Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -170,18 +170,12 @@ void ExtendedDynamicState2::render(float delta_time)
  */
 void ExtendedDynamicState2::prepare_uniform_buffers()
 {
-	uniform_buffers.common      = std::make_unique<vkb::core::BufferC>(get_device(),
-                                                                  sizeof(ubo_common),
-                                                                  VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                                                                  VMA_MEMORY_USAGE_CPU_TO_GPU);
-	uniform_buffers.baseline    = std::make_unique<vkb::core::BufferC>(get_device(),
-                                                                    sizeof(ubo_baseline),
-                                                                    VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                                                                    VMA_MEMORY_USAGE_CPU_TO_GPU);
-	uniform_buffers.tesselation = std::make_unique<vkb::core::BufferC>(get_device(),
-	                                                                   sizeof(ubo_tess),
-	                                                                   VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-	                                                                   VMA_MEMORY_USAGE_CPU_TO_GPU);
+	uniform_buffers.common =
+	    std::make_unique<vkb::core::BufferC>(get_device(), sizeof(ubo_common), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	uniform_buffers.baseline =
+	    std::make_unique<vkb::core::BufferC>(get_device(), sizeof(ubo_baseline), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+	uniform_buffers.tesselation =
+	    std::make_unique<vkb::core::BufferC>(get_device(), sizeof(ubo_tess), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
 	update_uniform_buffers();
 }
 
@@ -1079,12 +1073,9 @@ void ExtendedDynamicState2::cube_animation(float delta_time)
 	constexpr float move_step  = 0.0005f;
 	static float    time_pass  = 0.0f;
 	time_pass += delta_time;
-	static auto &transform = std::find_if(scene_elements_baseline.begin(),
-	                                      scene_elements_baseline.end(),
-	                                      [](SceneNode const &scene_node) {
-		                                      return scene_node.node->get_name() == "Cube_1";
-	                                      })
-	                             ->node->get_transform();
+	static auto &transform =
+	    std::ranges::find_if(scene_elements_baseline, [](SceneNode const &scene_node) { return scene_node.node->get_name() == "Cube_1"; })
+	        ->node->get_transform();
 	static auto  translation = transform.get_translation();
 	static float difference  = 0.0f;
 	static bool  rising      = true;

--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024, Holochip
+/* Copyright (c) 2021-2025, Holochip
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -177,27 +177,21 @@ void FragmentShadingRateDynamic::create_shading_rate_attachment()
 		VK_CHECK(vkQueueSubmit(queue, 1, &submit, fence));
 		VK_CHECK(vkWaitForFences(get_device().get_handle(), 1, &fence, VK_TRUE, UINT64_MAX));
 
-		shading_rate_image_view         = std::make_unique<vkb::core::ImageView>(*shading_rate_image, VK_IMAGE_VIEW_TYPE_2D,
-                                                                         VK_FORMAT_R8_UINT);
-		shading_rate_image_compute_view = std::make_unique<vkb::core::ImageView>(*shading_rate_image_compute,
-		                                                                         VK_IMAGE_VIEW_TYPE_2D,
-		                                                                         VK_FORMAT_R8_UINT);
+		shading_rate_image_view         = std::make_unique<vkb::core::ImageView>(*shading_rate_image, VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8_UINT);
+		shading_rate_image_compute_view = std::make_unique<vkb::core::ImageView>(*shading_rate_image_compute, VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8_UINT);
 
 		// Create an attachment to store the frequency content of the rendered image during the render pass
 		VkExtent3D frequency_image_extent{};
 		frequency_image_extent.width  = this->width;
 		frequency_image_extent.height = this->height;
 		frequency_image_extent.depth  = 1;
-		frequency_content_image       = std::make_unique<vkb::core::Image>(get_device(),
-                                                                     frequency_image_extent,
-                                                                     VK_FORMAT_R8G8_UINT,
-                                                                     VK_IMAGE_USAGE_STORAGE_BIT |
-                                                                         VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-                                                                         VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT,
-                                                                     VMA_MEMORY_USAGE_GPU_ONLY);
-		frequency_content_image_view  = std::make_unique<vkb::core::ImageView>(*frequency_content_image,
-                                                                              VK_IMAGE_VIEW_TYPE_2D,
-                                                                              VK_FORMAT_R8G8_UINT);
+		frequency_content_image =
+		    std::make_unique<vkb::core::Image>(get_device(),
+		                                       frequency_image_extent,
+		                                       VK_FORMAT_R8G8_UINT,
+		                                       VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT,
+		                                       VMA_MEMORY_USAGE_GPU_ONLY);
+		frequency_content_image_view = std::make_unique<vkb::core::ImageView>(*frequency_content_image, VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8G8_UINT);
 
 		{
 			auto &_cmd = get_device().request_command_buffer();
@@ -1120,9 +1114,8 @@ bool FragmentShadingRateDynamic::prepare(const vkb::ApplicationOptions &options)
 
 	const auto enabled_instance_extensions = get_instance().get_extensions();
 	debug_utils_supported =
-	    std::find_if(enabled_instance_extensions.cbegin(), enabled_instance_extensions.cend(), [](const char *ext) {
-		    return strcmp(ext, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0;
-	    }) != enabled_instance_extensions.cend();
+	    std::ranges::find_if(enabled_instance_extensions, [](const char *ext) { return strcmp(ext, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0; }) !=
+	    enabled_instance_extensions.cend();
 
 	camera.type = vkb::CameraType::FirstPerson;
 	camera.set_position(glm::vec3(0.0f, 0.0f, -4.0f));

--- a/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
+++ b/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
@@ -149,7 +149,7 @@ void FullScreenExclusive::init_instance(const std::vector<const char *> &require
 	std::vector<VkLayerProperties> supported_instance_layers(instance_layer_count);
 	VK_CHECK(vkEnumerateInstanceLayerProperties(&instance_layer_count, supported_instance_layers.data()));
 
-	if (std::any_of(supported_instance_layers.begin(), supported_instance_layers.end(), [&validationLayer](auto const &lp) { return strcmp(lp.layerName, validationLayer) == 0; }))
+	if (std::ranges::any_of(supported_instance_layers, [&validationLayer](auto const &lp) { return strcmp(lp.layerName, validationLayer) == 0; }))
 	{
 		requested_instance_layers.push_back(validationLayer);
 		LOGI("Enabled Validation Layer {}", validationLayer);

--- a/samples/extensions/open_cl_interop/open_cl_interop.cpp
+++ b/samples/extensions/open_cl_interop/open_cl_interop.cpp
@@ -799,7 +799,7 @@ void OpenCLInterop::prepare_opencl_resources()
 		while (std::getline(extension_stream, extension, ' '))
 		{
 			// Remove trailing zeroes from all extensions (which otherwise may make support checks fail)
-			extension.erase(std::find(extension.begin(), extension.end(), '\0'), extension.end());
+			extension.erase(std::ranges::find(extension, '\0'), extension.end());
 			available_extensions.push_back(extension);
 		}
 
@@ -807,7 +807,7 @@ void OpenCLInterop::prepare_opencl_resources()
 
 		for (auto &extension : required_extensions)
 		{
-			if (std::find(available_extensions.begin(), available_extensions.end(), extension) == available_extensions.end())
+			if (std::ranges::find(available_extensions, extension) == available_extensions.end())
 			{
 				extensions_present = false;
 				break;

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024 Holochip Corporation
+/* Copyright (c) 2021-2025 Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -632,7 +632,7 @@ void RaytracingExtended::create_top_level_acceleration_structure(bool print_time
 	{
 		// find the flame particle object, then add the particles as instances
 		auto &model_buffers = raytracing_scene->model_buffers;
-		auto  iter          = std::find_if(model_buffers.begin(), model_buffers.end(), [](const ModelBuffer &model_buffer) {
+		auto  iter          = std::ranges::find_if(model_buffers, [](const ModelBuffer &model_buffer) {
             return model_buffer.object_type == ObjectType::OBJECT_FLAME;
         });
 		ASSERT_LOG(iter != model_buffers.cend(), "Can't find flame object.")

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -432,9 +432,8 @@ std::unique_ptr<vkb::Instance> ShaderDebugPrintf::create_instance()
 	std::vector<VkLayerProperties> layer_properties(layer_property_count);
 	VK_CHECK(vkEnumerateInstanceLayerProperties(&layer_property_count, layer_properties.data()));
 
-	const auto vvl_properties = std::find_if(layer_properties.begin(),
-	                                         layer_properties.end(),
-	                                         [](VkLayerProperties const &properties) { return strcmp(properties.layerName, validation_layer_name) == 0; });
+	const auto vvl_properties = std::ranges::find_if(layer_properties,
+	                                                 [](VkLayerProperties const &properties) { return strcmp(properties.layerName, validation_layer_name) == 0; });
 
 	// Make sure we have found the validation layer before checking the VVL version and enumerating VVL instance extensions for VK_EXT_layer_settings
 	if (vvl_properties != layer_properties.end())
@@ -456,9 +455,8 @@ std::unique_ptr<vkb::Instance> ShaderDebugPrintf::create_instance()
 
 		// When VK_EXT_layer_settings is available at runtime, the debugPrintfEXT layer feature is enabled using the standard framework
 		// For this case set Vulkan API version and return via base class, otherwise the remainder of this custom override is required
-		if (std::any_of(vvl_instance_extensions.begin(),
-		                vvl_instance_extensions.end(),
-		                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0; }))
+		if (std::ranges::any_of(vvl_instance_extensions,
+		                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0; }))
 		{
 			set_api_version(debugprintf_api_version);
 
@@ -501,9 +499,8 @@ std::unique_ptr<vkb::Instance> ShaderDebugPrintf::create_instance()
 
 	// If VK_KHR_portability_enumeration is available in the portability implementation, then we must enable the extension
 	bool portability_enumeration_available = false;
-	if (std::any_of(available_instance_extensions.begin(),
-	                available_instance_extensions.end(),
-	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
+	if (std::ranges::any_of(available_instance_extensions,
+	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
 	{
 		enabled_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 		portability_enumeration_available = true;

--- a/samples/performance/image_compression_control/image_compression_control.cpp
+++ b/samples/performance/image_compression_control/image_compression_control.cpp
@@ -157,9 +157,9 @@ void ImageCompressionControlSample::create_render_context()
 		std::vector<VkSurfaceFormatKHR> new_surface_priority_list;
 		for (auto const &surface_priority : get_surface_priority_list())
 		{
-			auto it = std::find_if(surface_formats_that_support_compression.begin(), surface_formats_that_support_compression.end(),
-			                       [&](VkSurfaceFormatKHR &sf) { return surface_priority.format == sf.format &&
-				                                                        surface_priority.colorSpace == sf.colorSpace; });
+			auto it = std::ranges::find_if(surface_formats_that_support_compression,
+			                               [&](VkSurfaceFormatKHR &sf) { return surface_priority.format == sf.format &&
+				                                                                surface_priority.colorSpace == sf.colorSpace; });
 			if (it != surface_formats_that_support_compression.end())
 			{
 				new_surface_priority_list.push_back(*it);
@@ -484,7 +484,7 @@ inline T generate_combo(T current_value, const char *combo_label, const std::uno
 	{
 		for (const auto &it : enum_to_string)
 		{
-			if (skip_values && std::find(skip_values->begin(), skip_values->end(), it.first) != skip_values->end())
+			if (skip_values && std::ranges::find(*skip_values, it.first) != skip_values->end())
 			{
 				continue;
 			}

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024, Holochip Corporation
+/* Copyright (c) 2021-2025, Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -886,7 +886,7 @@ struct VisibilityTester
 	{
 		using namespace glm;
 		std::array<int, 4> V{0, 1, 4, 5};
-		return std::all_of(V.begin(), V.end(), [this, origin, radius](size_t i) {
+		return std::ranges::all_of(V, [this, origin, radius](size_t i) {
 			const auto &plane = planes[i];
 			return dot(origin, vec3(plane.xyz)) + plane.w + radius >= 0;
 		});

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -159,9 +159,8 @@ std::unique_ptr<vkb::Instance> Profiles::create_instance()
 	VK_CHECK(vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, available_instance_extensions.data()));
 
 	// If VK_KHR_portability_enumeration is available at runtime, enable the extension and flag for instance creation
-	if (std::any_of(available_instance_extensions.begin(),
-	                available_instance_extensions.end(),
-	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
+	if (std::ranges::any_of(available_instance_extensions,
+	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))
 	{
 		enabled_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 		create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
@@ -173,9 +172,8 @@ std::unique_ptr<vkb::Instance> Profiles::create_instance()
 	const int32_t                useMetalArgumentBuffers = 1;
 	VkLayerSettingsCreateInfoEXT layerSettingsCreateInfo{};
 
-	if (std::any_of(available_instance_extensions.begin(),
-	                available_instance_extensions.end(),
-	                [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0; }))
+	if (std::ranges::any_of(available_instance_extensions,
+	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0; }))
 	{
 		enabled_extensions.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
 


### PR DESCRIPTION
## Description

With our change to use Cpp20, we can replace most of the std::find, std::find_if, std::all_of, std::any_of, and std::none_of by their equivalent but more concise algorigthms from the std::ranges namespace.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
