### PR TITLE
Fix: Swapchain recreation - validation errors

### DIFF
--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -900,6 +900,7 @@ SwapchainRecreation::SwapchainRecreation()
 		add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, true);
 		add_instance_extension(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME, true);
 		add_device_extension(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME, true);
+		has_maintenance1 = true;
 	}
 	else
 	{
@@ -970,6 +971,17 @@ SwapchainRecreation::~SwapchainRecreation()
 	if (render_pass != VK_NULL_HANDLE)
 	{
 		vkDestroyRenderPass(get_device_handle(), render_pass, nullptr);
+	}
+}
+
+void SwapchainRecreation::request_gpu_features(vkb::PhysicalDevice &gpu)
+{
+	if (has_maintenance1)
+	{
+		REQUEST_REQUIRED_FEATURE(gpu,
+		                         VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT,
+		                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT,
+		                         swapchainMaintenance1);
 	}
 }
 

--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -900,11 +900,11 @@ SwapchainRecreation::SwapchainRecreation()
 		add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, true);
 		add_instance_extension(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME, true);
 		add_device_extension(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME, true);
-		has_maintenance1 = true;
 	}
 	else
 	{
 		LOGI("Disabling usage of VK_EXT_surface_maintenance1 due to USE_MAINTENANCE1=no");
+		allow_maintenance1 = false;
 	}
 }
 
@@ -976,9 +976,9 @@ SwapchainRecreation::~SwapchainRecreation()
 
 void SwapchainRecreation::request_gpu_features(vkb::PhysicalDevice &gpu)
 {
-	if (has_maintenance1)
+	if (allow_maintenance1)
 	{
-		REQUEST_REQUIRED_FEATURE(gpu,
+		REQUEST_OPTIONAL_FEATURE(gpu,
 		                         VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT,
 		                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT,
 		                         swapchainMaintenance1);

--- a/samples/api/swapchain_recreation/swapchain_recreation.h
+++ b/samples/api/swapchain_recreation/swapchain_recreation.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2024, Google
+/* Copyright (c) 2023-2025, Google
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/api/swapchain_recreation/swapchain_recreation.h
+++ b/samples/api/swapchain_recreation/swapchain_recreation.h
@@ -168,6 +168,8 @@ class SwapchainRecreation : public vkb::VulkanSampleC
 	// User toggles.
 	bool recreate_swapchain_on_present_mode_change = false;
 
+	// from vkb::VulkanSample
+	void                         request_gpu_features(vkb::PhysicalDevice &gpu) override;
 	std::unique_ptr<vkb::Device> create_device(vkb::PhysicalDevice &gpu) override;
 
 	void get_queue();

--- a/samples/api/swapchain_recreation/swapchain_recreation.h
+++ b/samples/api/swapchain_recreation/swapchain_recreation.h
@@ -114,7 +114,7 @@ class SwapchainRecreation : public vkb::VulkanSampleC
 
 	/// Allow enabling VK_EXT_surface_maintenance1 and VK_EXT_swapchain_maintenance1.
 	///
-	/// Can be set to false by `USE_MAINTENANCE1=no`
+	/// Can be set to false by setting environment variable `USE_MAINTENANCE1=no`
 	bool allow_maintenance1 = true;
 	/// Whether the VK_EXT_surface_maintenance1 and VK_EXT_swapchain_maintenance1 extensions are
 	/// enabled.

--- a/samples/api/swapchain_recreation/swapchain_recreation.h
+++ b/samples/api/swapchain_recreation/swapchain_recreation.h
@@ -112,8 +112,12 @@ class SwapchainRecreation : public vkb::VulkanSampleC
 	/// Submission and present queue.
 	const vkb::Queue *queue = nullptr;
 
+	/// Allow enabling VK_EXT_surface_maintenance1 and VK_EXT_swapchain_maintenance1.
+	///
+	/// Can be set to false by `USE_MAINTENANCE1=no`
+	bool allow_maintenance1 = true;
 	/// Whether the VK_EXT_surface_maintenance1 and VK_EXT_swapchain_maintenance1 extensions are
-	/// to be used.
+	/// enabled.
 	bool has_maintenance1 = false;
 
 	/// Surface data.


### PR DESCRIPTION
## Description

Swapchain recreation sample uses VK_EXT_swapchain_maintenance1, but doesn't activate its features causing several validation errors. This PR doesn't fix all validation errors, only the default ones. The other will be solved separately as
they are unrelated to enabling feature.

Tested on
```
Operating system: macOS-15.3.2-x86_64-i386-64bit 64 Bits
Graphics card: Apple M2 1.2
VulkanSDK: 1.4.309.0
```

Fixes: #1287

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
