### PR TITLE
Make VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT optional so that Image Compression Control sample runs without error on Pixel 9 Pro.

### DIFF
--- a/samples/performance/image_compression_control/image_compression_control.cpp
+++ b/samples/performance/image_compression_control/image_compression_control.cpp
@@ -54,7 +54,7 @@ void ImageCompressionControlSample::request_gpu_features(vkb::PhysicalDevice &gp
 
 	if (gpu.is_extension_supported(VK_EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_EXTENSION_NAME))
 	{
-		REQUEST_REQUIRED_FEATURE(gpu,
+		REQUEST_OPTIONAL_FEATURE(gpu,
 		                         VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT,
 		                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT,
 		                         imageCompressionControlSwapchain);


### PR DESCRIPTION
## Description

This change fixes #1317 
The change only impacts the `image_compression_control` sample. In my testing, I saw that the error was cleared and the sample could run on a Pixel 9 Pro with this change implemented.

## General Checklist:

Please ensure the following points are checked:

- [X] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [X] I have commented any added functions (in line with Doxygen)
- [X] I have commented any code that could be hard to understand
- [X] My changes do not add any new compiler warnings
- [X] My changes do not add any new validation layer errors or warnings
- [X] I have used existing framework/helper functions where possible
- [X] My changes do not add any regressions
- [X] I have tested every sample to ensure everything runs correctly
- [X] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [X] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [X] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:

**N/A: No framework changes.**

 - [X] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

**N/A: No new samples.**

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [X] I have tested the sample on at least one compliant Vulkan implementation
- [X] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [X] Any dependent assets have been merged and published in downstream modules
- [X] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [X] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [X] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
