### PR TITLE
Fix for dynamic rendering local read

### DIFF
--- a/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
+++ b/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
@@ -678,6 +678,16 @@ void DynamicRenderingLocalRead::prepare_pipelines()
 	{
 		pipeline_rendering_create_info.stencilAttachmentFormat = depth_format;
 	}
+
+	VkRenderingInputAttachmentIndexInfo rendering_attachment_index_info{VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO};
+	pipeline_rendering_create_info.pNext = &rendering_attachment_index_info;
+
+	std::array<uint32_t, 4> colorAttachments                     = {VK_ATTACHMENT_UNUSED, 0, 1, 2};
+	rendering_attachment_index_info.pNext                        = nullptr;
+	rendering_attachment_index_info.colorAttachmentCount         = colorAttachments.size();
+	rendering_attachment_index_info.pColorAttachmentInputIndices = colorAttachments.data();
+	rendering_attachment_index_info.pDepthInputAttachmentIndex   = nullptr;
+	rendering_attachment_index_info.pStencilInputAttachmentIndex = nullptr;
 #else
 	pipeline_create_info.subpass = 0;
 #endif


### PR DESCRIPTION
## Description

The input attachments aren't in identity order so have to be remapped appropriately.
This should fix DRLR on mobile devices. Desktop likely doesn't need this to function correctly.

It can be quite hard to see that it was obviously wrong since the lighting is randomly generated every time the sample starts.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Linux

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly
