### PR TITLE
In the Vulkan API, the timeout parameter of vkWaitForFences is of typ…

### DIFF
--- a/framework/fence_pool.cpp
+++ b/framework/fence_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2023, Arm Limited and Contributors
+/* Copyright (c) 2019-2025, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -66,7 +66,7 @@ VkFence FencePool::request_fence()
 	return fences.back();
 }
 
-VkResult FencePool::wait(uint32_t timeout) const
+VkResult FencePool::wait(uint64_t timeout) const
 {
 	if (active_fence_count < 1 || fences.empty())
 	{

--- a/framework/fence_pool.h
+++ b/framework/fence_pool.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2020, Arm Limited and Contributors
+/* Copyright (c) 2019-2025, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -40,7 +40,7 @@ class FencePool
 
 	VkFence request_fence();
 
-	VkResult wait(uint32_t timeout = std::numeric_limits<uint32_t>::max()) const;
+	VkResult wait(uint64_t timeout = std::numeric_limits<uint64_t>::max()) const;
 
 	VkResult reset();
 


### PR DESCRIPTION
Description
In the Vulkan API, the timeout parameter of vkWaitForFences is of type uint64_t. If the API is expected to wait indefinitely (until the GPU signals the fence), the correct value to pass is UINT64_MAX (the maximum 64-bit unsigned integer), not the maximum 32-bit value (UINT32_MAX).

see vulkan spec

> // Provided by VK_VERSION_1_0
> VkResult vkWaitForFences(
> VkDevice device,
> uint32_t fenceCount,
> const VkFence* pFences,
> VkBool32 waitAll,
> uint64_t timeout);