### PR TITLE
Point CI to use official docs site instead of fork

### DIFF
--- a/.github/workflows/build-Antora-doc.yml
+++ b/.github/workflows/build-Antora-doc.yml
@@ -27,11 +27,9 @@ jobs:
       - name: "Checkout Vulkan-Site"
         uses: actions/checkout@v3
         with:
-          # repository: KhronosGroup/Vulkan-Site
-          repository: gpx1000/Vulkan-Site
+          repository: KhronosGroup/Vulkan-Site
           path: ./Vulkan-Site
-          #          ref: main
-          ref: parent-ci
+          ref: main
           submodules: recursive
 
       - name: "Checkout antora ui"


### PR DESCRIPTION
## Description

The CI Antora build step was still pointing at a fork of the docs site instead of the official Khronos repo. Sinc we did some changes to the official repos (e.g. Antora UI) this seems like the cause for the recent Antora UI CI step failures.

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly