### PR TITLE
fix the surface resize logic when use wayland wsi

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -976,8 +976,10 @@ void ApiVulkanSample::handle_surface_changes()
 	                                                   get_render_context().get_swapchain().get_surface(),
 	                                                   &surface_properties));
 
-	if (surface_properties.currentExtent.width != get_render_context().get_surface_extent().width ||
-	    surface_properties.currentExtent.height != get_render_context().get_surface_extent().height)
+	if ((surface_properties.currentExtent.width != get_render_context().get_surface_extent().width ||
+	     surface_properties.currentExtent.height != get_render_context().get_surface_extent().height) &&
+	    (surface_properties.currentExtent.width != 0xFFFFFFFF &&
+	     surface_properties.currentExtent.height != 0xFFFFFFFF))
 	{
 		resize(surface_properties.currentExtent.width, surface_properties.currentExtent.height);
 	}

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -848,7 +848,8 @@ void HPPApiVulkanSample::handle_surface_changes()
 	vk::SurfaceCapabilitiesKHR surface_properties =
 	    get_device().get_gpu().get_handle().getSurfaceCapabilitiesKHR(get_render_context().get_swapchain().get_surface());
 
-	if (surface_properties.currentExtent != get_render_context().get_surface_extent())
+	if (surface_properties.currentExtent != get_render_context().get_surface_extent() &&
+	    surface_properties.currentExtent != vk::Extent2D{0xFFFFFFFF, 0xFFFFFFFF})
 	{
 		resize(surface_properties.currentExtent.width, surface_properties.currentExtent.height);
 	}


### PR DESCRIPTION
According to the Vulkan Spec:https://registry.khronos.org/vulkan/ specs/latest/man/html/VkSurfaceCapabilitiesKHR.html

VkSurfaceCapabilitiesKHR->currentExtent can be set to 0xFFFFFFFF which indicating that surface size will be determined by the extent of swapchain targeting the surface rather than driver.

In mali umd, currentExtent are always set to 0xFFFFFFFF which is comply with spec. Since the surface extent size of wayland depends on the dynamic negotiation between the client and compositor, the Vulkan driver cannot determine the valid value of current Extent before vkQueuePresentKHR submission, so the driver alwayas return 0xFFFFFFFF when use wayland wsi.

Affected cases:
    oit_depth_peeling
    oit_linked_lists
    hpp_oit_depth_peeling
    hpp_oit_linked_lists

Signed-off-by: Ryan Zhang ryan.zhang@nxp.com

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc)

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly