### PR TITLE
Fix synchronization in Subpasses sample

### DIFF
--- a/framework/core/command_buffer.h
+++ b/framework/core/command_buffer.h
@@ -185,6 +185,7 @@ class CommandBuffer
 	                                       std::vector<LoadStoreInfoType> const                                     &load_store_infos,
 	                                       std::vector<std::unique_ptr<vkb::rendering::Subpass<bindingType>>> const &subpasses);
 	void                   image_memory_barrier(ImageViewType const &image_view, ImageMemoryBarrierType const &memory_barrier) const;
+	void                   image_memory_barrier(RenderTargetType &render_target, uint32_t view_index, ImageMemoryBarrierType const &memory_barrier) const;
 	void                   next_subpass();
 
 	/**
@@ -919,6 +920,24 @@ inline vkb::core::HPPRenderPass &
 	}
 
 	return device.get_resource_cache().request_render_pass(render_target.get_attachments(), load_store_infos, subpass_infos);
+}
+
+template <vkb::BindingType bindingType>
+inline void CommandBuffer<bindingType>::image_memory_barrier(RenderTargetType &render_target, uint32_t view_index, ImageMemoryBarrierType const &memory_barrier) const
+{
+	auto const &image_view = render_target.get_views()[view_index];
+
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		image_memory_barrier_impl(image_view, memory_barrier);
+	}
+	else
+	{
+		image_memory_barrier_impl(reinterpret_cast<vkb::core::HPPImageView const &>(image_view),
+		                          reinterpret_cast<vkb::common::HPPImageMemoryBarrier const &>(memory_barrier));
+	}
+
+	render_target.set_layout(view_index, memory_barrier.new_layout);
 }
 
 template <vkb::BindingType bindingType>

--- a/framework/core/render_pass.cpp
+++ b/framework/core/render_pass.cpp
@@ -256,7 +256,7 @@ bool is_depth_a_dependency(std::vector<T_SubpassDescription> &subpass_descriptio
 		if (subpass.pDepthStencilAttachment)
 		{
 			times_used++;
-			if (times_used > 1) 
+			if (times_used > 1)
 			{
 				return true;
 			}

--- a/framework/core/render_pass.cpp
+++ b/framework/core/render_pass.cpp
@@ -326,12 +326,12 @@ T get_attachment_reference(const uint32_t attachment, const VkImageLayout layout
 template <typename T_SubpassDescription, typename T_AttachmentDescription, typename T_AttachmentReference, typename T_SubpassDependency, typename T_RenderPassCreateInfo>
 void RenderPass::create_renderpass(const std::vector<Attachment> &attachments, const std::vector<LoadStoreInfo> &load_store_infos, const std::vector<SubpassInfo> &subpasses)
 {
-	auto attachment_descriptions = get_attachment_descriptions<T_AttachmentDescription>(attachments, load_store_infos);
-
 	if (attachments.size() != load_store_infos.size())
 	{
 		LOGW("Render Pass creation: size of attachment list and load/store info list does not match: {} vs {}", attachments.size(), load_store_infos.size());
 	}
+
+	auto attachment_descriptions = get_attachment_descriptions<T_AttachmentDescription>(attachments, load_store_infos);
 
 	// Store attachments for every subpass
 	std::vector<std::vector<T_AttachmentReference>> input_attachments{subpass_count};

--- a/samples/performance/subpasses/subpasses.cpp
+++ b/samples/performance/subpasses/subpasses.cpp
@@ -408,7 +408,7 @@ void Subpasses::draw_renderpasses(vkb::core::CommandBufferC &command_buffer, vkb
 			barrier.old_layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 			barrier.new_layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
 
-			barrier.src_stage_mask  = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+			barrier.src_stage_mask  = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
 			barrier.dst_stage_mask  = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
 			barrier.src_access_mask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
 			barrier.dst_access_mask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;

--- a/samples/performance/subpasses/subpasses.cpp
+++ b/samples/performance/subpasses/subpasses.cpp
@@ -403,13 +403,15 @@ void Subpasses::draw_renderpasses(vkb::core::CommandBufferC &command_buffer, vkb
 
 		vkb::ImageMemoryBarrier barrier;
 
-		if (i == 1)
+		if (vkb::is_depth_format(view.get_format()))
 		{
 			barrier.old_layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 			barrier.new_layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
 
-			barrier.src_stage_mask  = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+			barrier.src_stage_mask  = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+			barrier.dst_stage_mask  = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
 			barrier.src_access_mask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+			barrier.dst_access_mask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
 		}
 		else
 		{
@@ -417,13 +419,12 @@ void Subpasses::draw_renderpasses(vkb::core::CommandBufferC &command_buffer, vkb
 			barrier.new_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
 			barrier.src_stage_mask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+			barrier.dst_stage_mask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 			barrier.src_access_mask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+			barrier.dst_access_mask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
 		}
 
-		barrier.dst_stage_mask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-		barrier.dst_access_mask = VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
-
-		command_buffer.image_memory_barrier(view, barrier);
+		command_buffer.image_memory_barrier(render_target, i, barrier);
 	}
 
 	// Second render pass


### PR DESCRIPTION
## Description

Achieve clean synchronization validation (Vulkan SDK 1.4.304.1) for the Subpasses sample

- When issuing a barrier, save the final image layout to be used consistently in other calls.
- Add correct subpass dependencies to avoid READ_AFTER_WRITE and WRITE_AFTER_WRITE hazards.
- Set correct layouts at render pass creation.
- Fix barriers in Subpasses sample.

Fixes #1197
Fixes #455
(maybe #867, #920)

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly