### PR TITLE
Remove framework goal from Readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2019-2024, Arm Limited and Contributors
+- Copyright (c) 2019-2025, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/README.adoc
+++ b/README.adoc
@@ -56,7 +56,6 @@ They are more advanced but also contain a detailed tutorial with more in-detail 
 
 * Create a collection of resources that demonstrate best-practice recommendations in Vulkan
 * Create tutorials that explain the implementation of best-practices and include performance analysis guides
-* Create a xref:framework/README.adoc[framework] that can be used as reference material and also as a sandbox for advanced experimentation with Vulkan
 
 == Samples
 


### PR DESCRIPTION
## Description

As discussed on the docs call on 2025-05-05, this removes the following framework goal from the readme to avoid further confusion:

"Create a framework that can be used as reference material and also as a sandbox for advanced experimentation with Vulkan"

**Note:** Pure documentation fix