### PR TITLE
Wrap vkb::core::CommandBuffers stored in vkb::core::CommandPool by std::shared_ptr

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -1354,11 +1354,11 @@ void ApiVulkanSample::with_command_buffer(const std::function<void(VkCommandBuff
 
 void ApiVulkanSample::with_vkb_command_buffer(const std::function<void(vkb::core::CommandBufferC &command_buffer)> &f)
 {
-	auto &cmd = get_device().request_command_buffer();
-	cmd.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_NULL_HANDLE);
-	f(cmd);
-	cmd.end();
+	auto cmd = get_device().request_command_buffer();
+	cmd->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_NULL_HANDLE);
+	f(*cmd);
+	cmd->end();
 	auto &queue = get_device().get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0);
-	queue.submit(cmd, get_device().request_fence());
+	queue.submit(*cmd, get_device().request_fence());
 	get_device().get_fence_pool().wait();
 }

--- a/framework/common/utils.cpp
+++ b/framework/common/utils.cpp
@@ -64,9 +64,9 @@ void screenshot(RenderContext &render_context, const std::string &filename)
 
 	const auto &queue = render_context.get_device().get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0);
 
-	auto &cmd_buf = render_context.get_device().request_command_buffer();
+	auto cmd_buf = render_context.get_device().request_command_buffer();
 
-	cmd_buf.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+	cmd_buf->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
 	// Enable destination buffer to be written to
 	{
@@ -76,7 +76,7 @@ void screenshot(RenderContext &render_context, const std::string &filename)
 		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
 		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
 
-		cmd_buf.buffer_memory_barrier(dst_buffer, 0, dst_size, memory_barrier);
+		cmd_buf->buffer_memory_barrier(dst_buffer, 0, dst_size, memory_barrier);
 	}
 
 	// Enable framebuffer image view to be read from
@@ -87,7 +87,7 @@ void screenshot(RenderContext &render_context, const std::string &filename)
 		memory_barrier.src_stage_mask = VK_PIPELINE_STAGE_TRANSFER_BIT;
 		memory_barrier.dst_stage_mask = VK_PIPELINE_STAGE_TRANSFER_BIT;
 
-		cmd_buf.image_memory_barrier(src_image_view, memory_barrier);
+		cmd_buf->image_memory_barrier(src_image_view, memory_barrier);
 	}
 
 	// Check if framebuffer images are in a BGR format
@@ -104,7 +104,7 @@ void screenshot(RenderContext &render_context, const std::string &filename)
 	image_copy_region.imageExtent.height          = height;
 	image_copy_region.imageExtent.depth           = 1;
 
-	cmd_buf.copy_image_to_buffer(src_image_view.get_image(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst_buffer, {image_copy_region});
+	cmd_buf->copy_image_to_buffer(src_image_view.get_image(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst_buffer, {image_copy_region});
 
 	// Enable destination buffer to map memory
 	{
@@ -114,7 +114,7 @@ void screenshot(RenderContext &render_context, const std::string &filename)
 		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
 		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_HOST_BIT;
 
-		cmd_buf.buffer_memory_barrier(dst_buffer, 0, dst_size, memory_barrier);
+		cmd_buf->buffer_memory_barrier(dst_buffer, 0, dst_size, memory_barrier);
 	}
 
 	// Revert back the framebuffer image view from transfer to present
@@ -125,12 +125,12 @@ void screenshot(RenderContext &render_context, const std::string &filename)
 		memory_barrier.src_stage_mask = VK_PIPELINE_STAGE_TRANSFER_BIT;
 		memory_barrier.dst_stage_mask = VK_PIPELINE_STAGE_TRANSFER_BIT;
 
-		cmd_buf.image_memory_barrier(src_image_view, memory_barrier);
+		cmd_buf->image_memory_barrier(src_image_view, memory_barrier);
 	}
 
-	cmd_buf.end();
+	cmd_buf->end();
 
-	queue.submit(cmd_buf, frame.request_fence());
+	queue.submit(*cmd_buf, frame.request_fence());
 
 	queue.wait_idle();
 

--- a/framework/core/device.cpp
+++ b/framework/core/device.cpp
@@ -540,7 +540,7 @@ void Device::prepare_memory_allocator()
 	vkb::allocated::init(*this);
 }
 
-vkb::core::CommandBufferC &Device::request_command_buffer() const
+std::shared_ptr<vkb::core::CommandBufferC> Device::request_command_buffer() const
 {
 	return command_pool->request_command_buffer();
 }

--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -183,7 +183,7 @@ class Device : public vkb::core::VulkanResourceC<VkDevice>
 	 * @brief Requests a command buffer from the general command_pool
 	 * @return A new command buffer
 	 */
-	vkb::core::CommandBufferC &request_command_buffer() const;
+	std::shared_ptr<vkb::core::CommandBufferC> request_command_buffer() const;
 
 	FencePool &get_fence_pool() const;
 

--- a/framework/gui.cpp
+++ b/framework/gui.cpp
@@ -176,12 +176,12 @@ Gui::Gui(VulkanSampleC &sample_, const Window &window, const Stats *stats, const
 	{
 		vkb::core::BufferC stage_buffer = vkb::core::BufferC::create_staging_buffer(device, upload_size, font_data);
 
-		auto &command_buffer = device.request_command_buffer();
+		auto command_buffer = device.request_command_buffer();
 
 		FencePool fence_pool{device};
 
 		// Begin recording
-		command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, 0);
+		command_buffer->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, 0);
 
 		{
 			// Prepare for transfer
@@ -193,7 +193,7 @@ Gui::Gui(VulkanSampleC &sample_, const Window &window, const Stats *stats, const
 			memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_HOST_BIT;
 			memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
 
-			command_buffer.image_memory_barrier(*font_image_view, memory_barrier);
+			command_buffer->image_memory_barrier(*font_image_view, memory_barrier);
 		}
 
 		// Copy
@@ -202,7 +202,7 @@ Gui::Gui(VulkanSampleC &sample_, const Window &window, const Stats *stats, const
 		buffer_copy_region.imageSubresource.aspectMask = font_image_view->get_subresource_range().aspectMask;
 		buffer_copy_region.imageExtent                 = font_image->get_extent();
 
-		command_buffer.copy_buffer_to_image(stage_buffer, *font_image, {buffer_copy_region});
+		command_buffer->copy_buffer_to_image(stage_buffer, *font_image, {buffer_copy_region});
 
 		{
 			// Prepare for fragmen shader
@@ -214,15 +214,15 @@ Gui::Gui(VulkanSampleC &sample_, const Window &window, const Stats *stats, const
 			memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
 			memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 
-			command_buffer.image_memory_barrier(*font_image_view, memory_barrier);
+			command_buffer->image_memory_barrier(*font_image_view, memory_barrier);
 		}
 
 		// End recording
-		command_buffer.end();
+		command_buffer->end();
 
 		auto &queue = device.get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0);
 
-		queue.submit(command_buffer, device.request_fence());
+		queue.submit(*command_buffer, device.request_fence());
 
 		// Wait for the command buffer to finish its work before destroying the staging buffer
 		device.get_fence_pool().wait();

--- a/framework/hpp_gui.cpp
+++ b/framework/hpp_gui.cpp
@@ -144,12 +144,12 @@ HPPGui::HPPGui(VulkanSampleCpp &sample_, const vkb::Window &window, const vkb::s
 	{
 		vkb::core::BufferCpp stage_buffer = vkb::core::BufferCpp::create_staging_buffer(device, upload_size, font_data);
 
-		auto &command_buffer = device.get_command_pool().request_command_buffer();
+		auto command_buffer = device.get_command_pool().request_command_buffer();
 
 		vkb::HPPFencePool fence_pool(device);
 
 		// Begin recording
-		command_buffer.begin(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
+		command_buffer->begin(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
 
 		{
 			// Prepare for transfer
@@ -161,7 +161,7 @@ HPPGui::HPPGui(VulkanSampleCpp &sample_, const vkb::Window &window, const vkb::s
 			memory_barrier.src_stage_mask  = vk::PipelineStageFlagBits::eHost;
 			memory_barrier.dst_stage_mask  = vk::PipelineStageFlagBits::eTransfer;
 
-			command_buffer.image_memory_barrier(*font_image_view, memory_barrier);
+			command_buffer->image_memory_barrier(*font_image_view, memory_barrier);
 		}
 
 		// Copy
@@ -170,7 +170,7 @@ HPPGui::HPPGui(VulkanSampleCpp &sample_, const vkb::Window &window, const vkb::s
 		buffer_copy_region.imageSubresource.aspectMask = font_image_view->get_subresource_range().aspectMask;
 		buffer_copy_region.imageExtent                 = font_image->get_extent();
 
-		command_buffer.copy_buffer_to_image(stage_buffer, *font_image, {buffer_copy_region});
+		command_buffer->copy_buffer_to_image(stage_buffer, *font_image, {buffer_copy_region});
 
 		{
 			// Prepare for fragmen shader
@@ -182,15 +182,15 @@ HPPGui::HPPGui(VulkanSampleCpp &sample_, const vkb::Window &window, const vkb::s
 			memory_barrier.src_stage_mask  = vk::PipelineStageFlagBits::eTransfer;
 			memory_barrier.dst_stage_mask  = vk::PipelineStageFlagBits::eFragmentShader;
 
-			command_buffer.image_memory_barrier(*font_image_view, memory_barrier);
+			command_buffer->image_memory_barrier(*font_image_view, memory_barrier);
 		}
 
 		// End recording
-		command_buffer.end();
+		command_buffer->end();
 
 		auto &queue = device.get_queue_by_flags(vk::QueueFlagBits::eGraphics, 0);
 
-		queue.submit(command_buffer, device.get_fence_pool().request_fence());
+		queue.submit(*command_buffer, device.get_fence_pool().request_fence());
 
 		// Wait for the command buffer to finish its work before destroying the staging buffer
 		device.get_fence_pool().wait();

--- a/framework/rendering/hpp_render_context.cpp
+++ b/framework/rendering/hpp_render_context.cpp
@@ -234,7 +234,7 @@ bool HPPRenderContext::handle_surface_changes(bool force_update)
 	return false;
 }
 
-vkb::core::CommandBufferCpp &HPPRenderContext::begin(vkb::CommandBufferResetMode reset_mode)
+std::shared_ptr<vkb::core::CommandBufferCpp> HPPRenderContext::begin(vkb::CommandBufferResetMode reset_mode)
 {
 	assert(prepared && "HPPRenderContext not prepared for rendering, call prepare()");
 

--- a/framework/rendering/hpp_render_context.h
+++ b/framework/rendering/hpp_render_context.h
@@ -130,7 +130,7 @@ class HPPRenderContext
 	 * @returns A valid command buffer to record commands to be submitted
 	 * Also ensures that there is an active frame if there is no existing active frame already
 	 */
-	vkb::core::CommandBufferCpp &begin(vkb::CommandBufferResetMode reset_mode = vkb::CommandBufferResetMode::ResetPool);
+	std::shared_ptr<vkb::core::CommandBufferCpp> begin(vkb::CommandBufferResetMode reset_mode = vkb::CommandBufferResetMode::ResetPool);
 
 	/**
 	 * @brief Submits the command buffer to the right queue

--- a/framework/rendering/hpp_render_frame.cpp
+++ b/framework/rendering/hpp_render_frame.cpp
@@ -187,10 +187,10 @@ void HPPRenderFrame::release_owned_semaphore(vk::Semaphore semaphore)
 	semaphore_pool.release_owned_semaphore(semaphore);
 }
 
-vkb::core::CommandBufferCpp &HPPRenderFrame::request_command_buffer(const vkb::core::HPPQueue  &queue,
-                                                                    vkb::CommandBufferResetMode reset_mode,
-                                                                    vk::CommandBufferLevel      level,
-                                                                    size_t                      thread_index)
+std::shared_ptr<vkb::core::CommandBufferCpp> HPPRenderFrame::request_command_buffer(const vkb::core::HPPQueue  &queue,
+                                                                                    vkb::CommandBufferResetMode reset_mode,
+                                                                                    vk::CommandBufferLevel      level,
+                                                                                    size_t                      thread_index)
 {
 	assert(thread_index < thread_count && "Thread index is out of bounds");
 

--- a/framework/rendering/hpp_render_frame.h
+++ b/framework/rendering/hpp_render_frame.h
@@ -101,10 +101,10 @@ class HPPRenderFrame
 	 * @param thread_index Selects the thread's command pool used to manage the buffer
 	 * @return A command buffer related to the current active frame
 	 */
-	vkb::core::CommandBufferCpp &request_command_buffer(const vkb::core::HPPQueue  &queue,
-	                                                    vkb::CommandBufferResetMode reset_mode   = vkb::CommandBufferResetMode::ResetPool,
-	                                                    vk::CommandBufferLevel      level        = vk::CommandBufferLevel::ePrimary,
-	                                                    size_t                      thread_index = 0);
+	std::shared_ptr<vkb::core::CommandBufferCpp> request_command_buffer(const vkb::core::HPPQueue  &queue,
+	                                                                    vkb::CommandBufferResetMode reset_mode   = vkb::CommandBufferResetMode::ResetPool,
+	                                                                    vk::CommandBufferLevel      level        = vk::CommandBufferLevel::ePrimary,
+	                                                                    size_t                      thread_index = 0);
 
 	/**
 	 * @brief Sets a new buffer allocation strategy

--- a/framework/rendering/render_context.h
+++ b/framework/rendering/render_context.h
@@ -148,34 +148,34 @@ class RenderContext
 	 * @returns A valid command buffer to record commands to be submitted
 	 * Also ensures that there is an active frame if there is no existing active frame already
 	 */
-	vkb::core::CommandBufferC &begin(vkb::CommandBufferResetMode reset_mode = vkb::CommandBufferResetMode::ResetPool);
+	std::shared_ptr<vkb::core::CommandBufferC> begin(vkb::CommandBufferResetMode reset_mode = vkb::CommandBufferResetMode::ResetPool);
 
 	/**
 	 * @brief Submits the command buffer to the right queue
 	 * @param command_buffer A command buffer containing recorded commands
 	 */
-	void submit(vkb::core::CommandBufferC &command_buffer);
+	void submit(std::shared_ptr<vkb::core::CommandBufferC> command_buffer);
 
 	/**
 	 * @brief Submits multiple command buffers to the right queue
 	 * @param command_buffers Command buffers containing recorded commands
 	 */
-	void submit(const std::vector<vkb::core::CommandBufferC *> &command_buffers);
+	void submit(const std::vector<std::shared_ptr<vkb::core::CommandBufferC>> &command_buffers);
 
 	/**
 	 * @brief begin_frame
 	 */
 	void begin_frame();
 
-	VkSemaphore submit(const Queue                                    &queue,
-	                   const std::vector<vkb::core::CommandBufferC *> &command_buffers,
-	                   VkSemaphore                                     wait_semaphore,
-	                   VkPipelineStageFlags                            wait_pipeline_stage);
+	VkSemaphore submit(const Queue                                                   &queue,
+	                   const std::vector<std::shared_ptr<vkb::core::CommandBufferC>> &command_buffers,
+	                   VkSemaphore                                                    wait_semaphore,
+	                   VkPipelineStageFlags                                           wait_pipeline_stage);
 
 	/**
 	 * @brief Submits a command buffer related to a frame to a queue
 	 */
-	void submit(const Queue &queue, const std::vector<vkb::core::CommandBufferC *> &command_buffers);
+	void submit(const Queue &queue, const std::vector<std::shared_ptr<vkb::core::CommandBufferC>> &command_buffers);
 
 	/**
 	 * @brief Waits a frame to finish its rendering

--- a/framework/rendering/render_frame.cpp
+++ b/framework/rendering/render_frame.cpp
@@ -194,10 +194,10 @@ const RenderTarget &RenderFrame::get_render_target_const() const
 	return *swapchain_render_target;
 }
 
-vkb::core::CommandBufferC &RenderFrame::request_command_buffer(const Queue                &queue,
-                                                               vkb::CommandBufferResetMode reset_mode,
-                                                               VkCommandBufferLevel        level,
-                                                               size_t                      thread_index)
+std::shared_ptr<vkb::core::CommandBufferC> RenderFrame::request_command_buffer(const Queue                &queue,
+                                                                               vkb::CommandBufferResetMode reset_mode,
+                                                                               VkCommandBufferLevel        level,
+                                                                               size_t                      thread_index)
 {
 	assert(thread_index < thread_count && "Thread index is out of bounds");
 

--- a/framework/rendering/render_frame.h
+++ b/framework/rendering/render_frame.h
@@ -118,10 +118,10 @@ class RenderFrame
 	 * @param thread_index Selects the thread's command pool used to manage the buffer
 	 * @return A command buffer related to the current active frame
 	 */
-	vkb::core::CommandBufferC &request_command_buffer(const Queue                &queue,
-	                                                  vkb::CommandBufferResetMode reset_mode   = vkb::CommandBufferResetMode::ResetPool,
-	                                                  VkCommandBufferLevel        level        = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-	                                                  size_t                      thread_index = 0);
+	std::shared_ptr<vkb::core::CommandBufferC> request_command_buffer(const Queue                &queue,
+	                                                                  vkb::CommandBufferResetMode reset_mode   = vkb::CommandBufferResetMode::ResetPool,
+	                                                                  VkCommandBufferLevel        level        = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+	                                                                  size_t                      thread_index = 0);
 
 	VkDescriptorSet request_descriptor_set(const DescriptorSetLayout                &descriptor_set_layout,
 	                                       const BindingMap<VkDescriptorBufferInfo> &buffer_infos,

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -1319,28 +1319,28 @@ inline void VulkanSample<bindingType>::update(float delta_time)
 
 	update_gui(delta_time);
 
-	auto &command_buffer = render_context->begin();
+	auto command_buffer = render_context->begin();
 
 	// Collect the performance data for the sample graphs
 	update_stats(delta_time);
 
-	command_buffer.begin(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
-	stats->begin_sampling(command_buffer);
+	command_buffer->begin(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
+	stats->begin_sampling(*command_buffer);
 
 	if constexpr (bindingType == BindingType::Cpp)
 	{
-		draw(command_buffer, render_context->get_active_frame().get_render_target());
+		draw(*command_buffer, render_context->get_active_frame().get_render_target());
 	}
 	else
 	{
-		draw(reinterpret_cast<vkb::core::CommandBufferC &>(command_buffer),
+		draw(reinterpret_cast<vkb::core::CommandBufferC &>(*command_buffer),
 		     reinterpret_cast<vkb::RenderTarget &>(render_context->get_active_frame().get_render_target()));
 	}
 
-	stats->end_sampling(command_buffer);
-	command_buffer.end();
+	stats->end_sampling(*command_buffer);
+	command_buffer->end();
 
-	render_context->submit(command_buffer);
+	render_context->submit(*command_buffer);
 }
 
 template <vkb::BindingType bindingType>

--- a/samples/extensions/buffer_device_address/buffer_device_address.cpp
+++ b/samples/extensions/buffer_device_address/buffer_device_address.cpp
@@ -199,20 +199,20 @@ std::unique_ptr<vkb::core::BufferC> BufferDeviceAddress::create_index_buffer()
 	staging_buffer.flush();
 	staging_buffer.unmap();
 
-	auto &cmd = get_device().request_command_buffer();
-	cmd.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
-	cmd.copy_buffer(staging_buffer, *index_buffer, size);
+	auto cmd = get_device().request_command_buffer();
+	cmd->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+	cmd->copy_buffer(staging_buffer, *index_buffer, size);
 
 	vkb::BufferMemoryBarrier memory_barrier;
 	memory_barrier.src_access_mask = VK_ACCESS_TRANSFER_WRITE_BIT;
 	memory_barrier.dst_access_mask = VK_ACCESS_INDEX_READ_BIT;
 	memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
 	memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
-	cmd.buffer_memory_barrier(*index_buffer, 0, VK_WHOLE_SIZE, memory_barrier);
-	cmd.end();
+	cmd->buffer_memory_barrier(*index_buffer, 0, VK_WHOLE_SIZE, memory_barrier);
+	cmd->end();
 
 	// Not very optimal, but it's the simplest solution.
-	get_device().get_suitable_graphics_queue().submit(cmd, VK_NULL_HANDLE);
+	get_device().get_suitable_graphics_queue().submit(*cmd, VK_NULL_HANDLE);
 	get_device().get_suitable_graphics_queue().wait_idle();
 	return index_buffer;
 }

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -471,22 +471,22 @@ DescriptorIndexing::TestImage DescriptorIndexing::create_image(const float rgb[3
 	staging_buffer.flush();
 	staging_buffer.unmap();
 
-	auto &cmd = get_device().request_command_buffer();
-	cmd.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+	auto cmd = get_device().request_command_buffer();
+	cmd->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
-	vkb::image_layout_transition(cmd.get_handle(), test_image.image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+	vkb::image_layout_transition(cmd->get_handle(), test_image.image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
 	VkBufferImageCopy copy_info{};
 	copy_info.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
 	copy_info.imageExtent      = image_info.extent;
-	vkCmdCopyBufferToImage(cmd.get_handle(), staging_buffer.get_handle(), test_image.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_info);
+	vkCmdCopyBufferToImage(cmd->get_handle(), staging_buffer.get_handle(), test_image.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_info);
 
-	vkb::image_layout_transition(cmd.get_handle(), test_image.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+	vkb::image_layout_transition(cmd->get_handle(), test_image.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-	cmd.end();
+	cmd->end();
 
 	// Not very optimal, but it's the simplest solution.
-	get_device().get_suitable_graphics_queue().submit(cmd, VK_NULL_HANDLE);
+	get_device().get_suitable_graphics_queue().submit(*cmd, VK_NULL_HANDLE);
 	get_device().get_suitable_graphics_queue().wait_idle();
 
 	return test_image;

--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -194,20 +194,20 @@ void FragmentShadingRateDynamic::create_shading_rate_attachment()
 		frequency_content_image_view = std::make_unique<vkb::core::ImageView>(*frequency_content_image, VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8G8_UINT);
 
 		{
-			auto &_cmd = get_device().request_command_buffer();
-			_cmd.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+			auto _cmd = get_device().request_command_buffer();
+			_cmd->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 			auto _memory_barrier            = vkb::ImageMemoryBarrier();
 			_memory_barrier.dst_access_mask = 0;
 			_memory_barrier.src_access_mask = 0;
 			_memory_barrier.old_layout      = VK_IMAGE_LAYOUT_UNDEFINED;
 			_memory_barrier.new_layout      = VK_IMAGE_LAYOUT_GENERAL;
-			_cmd.image_memory_barrier(*shading_rate_image_compute_view, _memory_barrier);
-			_cmd.image_memory_barrier(*frequency_content_image_view, _memory_barrier);
-			_cmd.end();
+			_cmd->image_memory_barrier(*shading_rate_image_compute_view, _memory_barrier);
+			_cmd->image_memory_barrier(*frequency_content_image_view, _memory_barrier);
+			_cmd->end();
 
 			auto &queue  = get_device().get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0);
 			auto  _fence = get_device().request_fence();
-			queue.submit(_cmd, _fence);
+			queue.submit(*_cmd, _fence);
 			VK_CHECK(vkWaitForFences(get_device().get_handle(), 1, &_fence, VK_TRUE, UINT64_MAX));
 		}
 	}

--- a/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
+++ b/samples/performance/16bit_arithmetic/16bit_arithmetic.cpp
@@ -106,20 +106,20 @@ bool KHR16BitArithmeticSample::prepare(const vkb::ApplicationOptions &options)
                                                        VMA_MEMORY_USAGE_GPU_ONLY);
 	auto staging_buffer = vkb::core::BufferC::create_staging_buffer(device, initial_data_fp16);
 
-	auto &cmd = device.request_command_buffer();
-	cmd.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_NULL_HANDLE);
-	cmd.copy_buffer(staging_buffer, *blob_buffer, sizeof(initial_data_fp16));
+	auto cmd = device.request_command_buffer();
+	cmd->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_NULL_HANDLE);
+	cmd->copy_buffer(staging_buffer, *blob_buffer, sizeof(initial_data_fp16));
 
 	vkb::BufferMemoryBarrier barrier;
 	barrier.src_stage_mask  = VK_PIPELINE_STAGE_TRANSFER_BIT;
 	barrier.dst_stage_mask  = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 	barrier.src_access_mask = VK_ACCESS_TRANSFER_WRITE_BIT;
 	barrier.dst_access_mask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
-	cmd.buffer_memory_barrier(*blob_buffer, 0, VK_WHOLE_SIZE, barrier);
-	cmd.end();
+	cmd->buffer_memory_barrier(*blob_buffer, 0, VK_WHOLE_SIZE, barrier);
+	cmd->end();
 
 	auto &queue = device.get_queue_by_flags(VK_QUEUE_GRAPHICS_BIT, 0);
-	queue.submit(cmd, device.request_fence());
+	queue.submit(*cmd, device.request_fence());
 	device.get_fence_pool().wait();
 
 	// Create the target image we render into in the main compute shader.

--- a/samples/performance/command_buffer_usage/command_buffer_usage.h
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.h
@@ -106,11 +106,11 @@ class CommandBufferUsage : public vkb::VulkanSampleC
 		 * @param thread_index Identifies the resources allocated for this thread
 		 * @return a pointer to the recorded secondary command buffer
 		 */
-		vkb::core::CommandBufferC *record_draw_secondary(vkb::core::CommandBufferC                                         &primary_command_buffer,
-		                                                 const std::vector<std::pair<vkb::sg::Node *, vkb::sg::SubMesh *>> &nodes,
-		                                                 uint32_t                                                           mesh_start,
-		                                                 uint32_t                                                           mesh_end,
-		                                                 size_t                                                             thread_index = 0);
+		std::shared_ptr<vkb::core::CommandBufferC> record_draw_secondary(vkb::core::CommandBufferC                                         &primary_command_buffer,
+		                                                                 const std::vector<std::pair<vkb::sg::Node *, vkb::sg::SubMesh *>> &nodes,
+		                                                                 uint32_t                                                           mesh_start,
+		                                                                 uint32_t                                                           mesh_end,
+		                                                                 size_t                                                             thread_index = 0);
 
 		VkViewport viewport{};
 

--- a/samples/performance/descriptor_management/descriptor_management.cpp
+++ b/samples/performance/descriptor_management/descriptor_management.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2024, Arm Limited and Contributors
+/* Copyright (c) 2019-2025, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -75,7 +75,7 @@ void DescriptorManagement::update(float delta_time)
 
 	auto &render_context = get_render_context();
 
-	auto &command_buffer = render_context.begin();
+	auto command_buffer = render_context.begin();
 
 	update_stats(delta_time);
 
@@ -92,13 +92,13 @@ void DescriptorManagement::update(float delta_time)
 
 	render_context.get_active_frame().set_descriptor_management_strategy(descriptor_management_strategy);
 
-	command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
-	get_stats().begin_sampling(command_buffer);
+	command_buffer->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+	get_stats().begin_sampling(*command_buffer);
 
-	draw(command_buffer, render_context.get_active_frame().get_render_target());
+	draw(*command_buffer, render_context.get_active_frame().get_render_target());
 
-	get_stats().end_sampling(command_buffer);
-	command_buffer.end();
+	get_stats().end_sampling(*command_buffer);
+	command_buffer->end();
 
 	render_context.submit(command_buffer);
 }

--- a/samples/performance/multithreading_render_passes/multithreading_render_passes.h
+++ b/samples/performance/multithreading_render_passes/multithreading_render_passes.h
@@ -165,13 +165,13 @@ class MultithreadingRenderPasses : public vkb::VulkanSampleC
 	 * @param main_command_buffer Already allocated command buffer for the main pass
 	 * @return Single or multiple recorded command buffers
 	 */
-	std::vector<vkb::core::CommandBufferC *> record_command_buffers(vkb::core::CommandBufferC &main_command_buffer);
+	std::vector<std::shared_ptr<vkb::core::CommandBufferC>> record_command_buffers(std::shared_ptr<vkb::core::CommandBufferC> main_command_buffer);
 
-	void record_separate_primary_command_buffers(std::vector<vkb::core::CommandBufferC *> &command_buffers,
-	                                             vkb::core::CommandBufferC                &main_command_buffer);
+	void record_separate_primary_command_buffers(std::vector<std::shared_ptr<vkb::core::CommandBufferC>> &command_buffers,
+	                                             std::shared_ptr<vkb::core::CommandBufferC>               main_command_buffer);
 
-	void record_separate_secondary_command_buffers(std::vector<vkb::core::CommandBufferC *> &command_buffers,
-	                                               vkb::core::CommandBufferC                &main_command_buffer);
+	void record_separate_secondary_command_buffers(std::vector<std::shared_ptr<vkb::core::CommandBufferC>> &command_buffers,
+	                                               std::shared_ptr<vkb::core::CommandBufferC>               main_command_buffer);
 
 	void record_main_pass_image_memory_barriers(vkb::core::CommandBufferC &command_buffer);
 

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -284,21 +284,21 @@ void Profiles::generate_textures()
 		staging_buffer.unmap();
 		staging_buffer.flush();
 
-		auto &cmd = get_device().request_command_buffer();
-		cmd.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+		auto cmd = get_device().request_command_buffer();
+		cmd->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
-		vkb::image_layout_transition(cmd.get_handle(), textures[i].image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+		vkb::image_layout_transition(cmd->get_handle(), textures[i].image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
 		VkBufferImageCopy copy_info{};
 		copy_info.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
 		copy_info.imageExtent      = image_info.extent;
-		vkCmdCopyBufferToImage(cmd.get_handle(), staging_buffer.get_handle(), textures[i].image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_info);
+		vkCmdCopyBufferToImage(cmd->get_handle(), staging_buffer.get_handle(), textures[i].image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_info);
 
-		vkb::image_layout_transition(cmd.get_handle(), textures[i].image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		vkb::image_layout_transition(cmd->get_handle(), textures[i].image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-		cmd.end();
+		cmd->end();
 
-		get_device().get_suitable_graphics_queue().submit(cmd, VK_NULL_HANDLE);
+		get_device().get_suitable_graphics_queue().submit(*cmd, VK_NULL_HANDLE);
 		get_device().get_suitable_graphics_queue().wait_idle();
 	}
 


### PR DESCRIPTION
## Description

Also modified the configuration in `CommandBufferUsage` so that the batch run would fail without this change.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Fixes #1348

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
