### PR TITLE
Fix buffer copy size check

### DIFF
--- a/framework/core/device.cpp
+++ b/framework/core/device.cpp
@@ -420,7 +420,7 @@ const Queue &Device::get_suitable_graphics_queue() const
 
 void Device::copy_buffer(vkb::core::BufferC &src, vkb::core::BufferC &dst, VkQueue queue, VkBufferCopy *copy_region)
 {
-	assert(dst.get_size() <= src.get_size());
+	assert(dst.get_size() >= src.get_size());
 	assert(src.get_handle());
 
 	VkCommandBuffer command_buffer = create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);

--- a/framework/core/hpp_device.cpp
+++ b/framework/core/hpp_device.cpp
@@ -347,7 +347,7 @@ std::pair<vk::Image, vk::DeviceMemory> HPPDevice::create_image(vk::Format format
 
 void HPPDevice::copy_buffer(vkb::core::BufferCpp &src, vkb::core::BufferCpp &dst, vk::Queue queue, vk::BufferCopy *copy_region) const
 {
-	assert(dst.get_size() <= src.get_size());
+	assert(dst.get_size() >= src.get_size());
 	assert(src.get_handle());
 
 	vk::CommandBuffer command_buffer = create_command_buffer(vk::CommandBufferLevel::ePrimary, true);


### PR DESCRIPTION
## Description

Fixes a wrong size assertion for buffer copy functions. Instead of checking if the destination buffer is greater then the source, it checked if it was smaller. This never caused any issues, as there are no samples where destination is smaller than source, but fixing this avoids possible future issues.

Fixes #1346

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly