### PR TITLE
Improve and fix async compute sample

### DIFF
--- a/framework/common/hpp_vk_common.h
+++ b/framework/common/hpp_vk_common.h
@@ -47,8 +47,8 @@ struct HPPImageMemoryBarrier
 	vk::AccessFlags        dst_access_mask;
 	vk::ImageLayout        old_layout       = vk::ImageLayout::eUndefined;
 	vk::ImageLayout        new_layout       = vk::ImageLayout::eUndefined;
-	uint32_t               old_queue_family = VK_QUEUE_FAMILY_IGNORED;
-	uint32_t               new_queue_family = VK_QUEUE_FAMILY_IGNORED;
+	uint32_t               src_queue_family = VK_QUEUE_FAMILY_IGNORED;
+	uint32_t               dst_queue_family = VK_QUEUE_FAMILY_IGNORED;
 };
 
 struct HPPLoadStoreInfo

--- a/framework/common/vk_common.h
+++ b/framework/common/vk_common.h
@@ -182,9 +182,9 @@ struct ImageMemoryBarrier
 
 	VkImageLayout new_layout{VK_IMAGE_LAYOUT_UNDEFINED};
 
-	uint32_t old_queue_family{VK_QUEUE_FAMILY_IGNORED};
+	uint32_t src_queue_family{VK_QUEUE_FAMILY_IGNORED};
 
-	uint32_t new_queue_family{VK_QUEUE_FAMILY_IGNORED};
+	uint32_t dst_queue_family{VK_QUEUE_FAMILY_IGNORED};
 };
 
 /**

--- a/framework/core/command_buffer.h
+++ b/framework/core/command_buffer.h
@@ -979,13 +979,13 @@ inline void CommandBuffer<bindingType>::image_memory_barrier_impl(vkb::core::HPP
 		subresource_range.aspectMask = vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
 	}
 
-	// actively ignore queue family indices provided by memory_barrier !!
+	// This can cause a queue family ownership transfer. Check the async_compute sample.
 	vk::ImageMemoryBarrier image_memory_barrier{.srcAccessMask       = memory_barrier.src_access_mask,
 	                                            .dstAccessMask       = memory_barrier.dst_access_mask,
 	                                            .oldLayout           = memory_barrier.old_layout,
 	                                            .newLayout           = memory_barrier.new_layout,
-	                                            .srcQueueFamilyIndex = vk::QueueFamilyIgnored,
-	                                            .dstQueueFamilyIndex = vk::QueueFamilyIgnored,
+	                                            .srcQueueFamilyIndex = memory_barrier.src_queue_family,
+	                                            .dstQueueFamilyIndex = memory_barrier.dst_queue_family,
 	                                            .image               = image_view.get_image().get_handle(),
 	                                            .subresourceRange    = subresource_range};
 

--- a/framework/core/hpp_instance.h
+++ b/framework/core/hpp_instance.h
@@ -48,15 +48,15 @@ class HPPInstance
 	 * @param application_name The name of the application
 	 * @param requested_extensions The extensions requested to be enabled
 	 * @param requested_layers The validation layers to be enabled
-	 * @param required_layer_settings The layer settings to be enabled
+	 * @param requested_layer_settings The layer settings to be enabled
 	 * @param api_version The Vulkan API version that the instance will be using
 	 * @throws runtime_error if the required extensions and validation layers are not found
 	 */
 	HPPInstance(const std::string                            &application_name,
-	            const std::unordered_map<const char *, bool> &requested_extensions    = {},
-	            const std::unordered_map<const char *, bool> &requested_layers        = {},
-	            const std::vector<vk::LayerSettingEXT>       &required_layer_settings = {},
-	            uint32_t                                      api_version             = VK_API_VERSION_1_1);
+	            const std::unordered_map<const char *, bool> &requested_extensions     = {},
+	            const std::unordered_map<const char *, bool> &requested_layers         = {},
+	            const std::vector<vk::LayerSettingEXT>       &requested_layer_settings = {},
+	            uint32_t                                      api_version              = VK_API_VERSION_1_1);
 
 	/**
 	 * @brief Queries the GPUs of a vk::Instance that is already created

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -44,15 +44,15 @@ class Instance
 	 * @param application_name The name of the application
 	 * @param requested_extensions The extensions requested to be enabled
 	 * @param requested_layers The validation layers to be enabled
-	 * @param required_layer_settings The layer settings to be enabled
+	 * @param requested_layer_settings The layer settings to be enabled
 	 * @param api_version The Vulkan API version that the instance will be using
 	 * @throws runtime_error if the required extensions and validation layers are not found
 	 */
 	Instance(const std::string                            &application_name,
-	         const std::unordered_map<const char *, bool> &requested_extensions    = {},
-	         const std::unordered_map<const char *, bool> &requested_layers        = {},
-	         const std::vector<VkLayerSettingEXT>         &required_layer_settings = {},
-	         uint32_t                                      api_version             = VK_API_VERSION_1_1);
+	         const std::unordered_map<const char *, bool> &requested_extensions     = {},
+	         const std::unordered_map<const char *, bool> &requested_layers         = {},
+	         const std::vector<VkLayerSettingEXT>         &requested_layer_settings = {},
+	         uint32_t                                      api_version              = VK_API_VERSION_1_1);
 
 	/**
 	 * @brief Queries the GPUs of a VkInstance that is already created

--- a/framework/gltf_loader.cpp
+++ b/framework/gltf_loader.cpp
@@ -1462,6 +1462,11 @@ std::unique_ptr<sg::Image> GLTFLoader::parse_image(tinygltf::Image &gltf_image) 
 {
 	std::unique_ptr<sg::Image> image{nullptr};
 
+	if (gltf_image.name.empty())
+	{
+		gltf_image.name = gltf_image.uri;
+	}
+
 	if (!gltf_image.image.empty())
 	{
 		// Image embedded in gltf file

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -438,8 +438,12 @@ VkSemaphore AsyncComputeSample::render_forward_offscreen_pass(VkSemaphore hdr_wa
 
 	// Conditionally waits on hdr_wait_semaphore.
 	// This resolves the write-after-read hazard where previous frame tonemap read from HDR buffer.
-	auto signal_semaphore = get_render_context().submit(queue, {command_buffer},
-	                                                    hdr_wait_semaphore, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+
+	// We are not using VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR
+	// so VK_PIPELINE_STAGE_ALL_COMMANDS_BIT is the only valid stage to wait for queue transfer operations.
+	const VkPipelineStageFlags wait_stage = queue_family_transfer ? VK_PIPELINE_STAGE_ALL_COMMANDS_BIT : VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+
+	auto signal_semaphore = get_render_context().submit(queue, {command_buffer}, hdr_wait_semaphore, wait_stage);
 
 	if (hdr_wait_semaphore)
 	{

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -409,26 +409,27 @@ VkSemaphore AsyncComputeSample::render_forward_offscreen_pass(VkSemaphore hdr_wa
 	forward_render_pipeline.draw(*command_buffer, get_current_forward_render_target(), VK_SUBPASS_CONTENTS_INLINE);
 	command_buffer->end_render_pass();
 
+	const bool queue_family_transfer = early_graphics_queue->get_family_index() != post_compute_queue->get_family_index();
 	{
-		vkb::ImageMemoryBarrier memory_barrier{};
-		memory_barrier.old_layout      = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-		memory_barrier.new_layout      = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		memory_barrier.src_access_mask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-		memory_barrier.dst_access_mask = 0;
-		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		// When doing async compute this barrier is used to do a queue family ownership transfer
 
-		// In a release barrier, dst_stage_mask/access_mask should be BOTTOM_OF_PIPE/0.
-		// We cannot access the resource anymore after all. Semaphore takes care of things from here.
-
-		// Release barrier if we're going to read HDR texture in compute queue
-		// of a different queue family index. We'll have to duplicate this barrier
-		// on compute queue's end.
-		if (early_graphics_queue->get_family_index() != post_compute_queue->get_family_index())
-		{
-			memory_barrier.src_queue_family = early_graphics_queue->get_family_index();
-			memory_barrier.dst_queue_family = post_compute_queue->get_family_index();
-		}
+		// release_barrier_0: Releasing color_target[0] from early_graphics to post_compute
+		//     This release barrier is replicated by the corresponding acquire_barrier_0 in the post_compute queue
+		//     The application must ensure the release operation happens before the acquire operation. This sample uses semaphores for that.
+		//     The transfer ownership barriers are submitted twice (release and acquire) but they are only executed once.
+		vkb::ImageMemoryBarrier memory_barrier{
+		    .src_stage_mask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+		    .dst_stage_mask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,        // Ignored for the release barrier.
+		                                                                   // Release barriers ignore dst_access_mask unless using VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR
+		    .src_access_mask  = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+		    .dst_access_mask  = 0,                                               // dst_access_mask is ignored for release barriers, without affecting its validity
+		    .old_layout       = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,        // We want a layout transition, so the old_layout and new_layout values need to be replicated in the acquire barrier
+		    .new_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		    .src_queue_family = queue_family_transfer ?
+		                            early_graphics_queue->get_family_index() :
+		                            VK_QUEUE_FAMILY_IGNORED,        // Release barriers are executed from a queue of the source queue family
+		    .dst_queue_family = queue_family_transfer ? post_compute_queue->get_family_index() : VK_QUEUE_FAMILY_IGNORED,
+		};
 
 		command_buffer->image_memory_barrier(views[0], memory_barrier);
 	}
@@ -458,16 +459,21 @@ VkSemaphore AsyncComputeSample::render_swapchain(VkSemaphore post_semaphore)
 
 	if (post_compute_queue->get_family_index() != present_graphics_queue->get_family_index())
 	{
-		// Purely ownership transfer here. No layout change required.
-		vkb::ImageMemoryBarrier memory_barrier{};
-		memory_barrier.old_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		memory_barrier.new_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		memory_barrier.src_access_mask  = 0;
-		memory_barrier.dst_access_mask  = 0;
-		memory_barrier.src_stage_mask   = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-		memory_barrier.dst_stage_mask   = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-		memory_barrier.src_queue_family = post_compute_queue->get_family_index();
-		memory_barrier.dst_queue_family = present_graphics_queue->get_family_index();
+		// acquire_barrier_1: Acquiring color_target[0] from  post_compute to present_graphics
+		//     This acquire barrier is replicated by the corresponding release_barrier_1 in the post_compute queue
+		//     The application must ensure the acquire operation happens after the release operation. This sample uses semaphores for that.
+		//     The transfer ownership barriers are submitted twice (release and acquire) but they are only executed once.
+		vkb::ImageMemoryBarrier memory_barrier{
+		    .src_stage_mask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,        // Ignored for the acquire barrier.
+		                                                                    // Acquire barriers ignore src_access_mask unless using VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR
+		    .dst_stage_mask   = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+		    .src_access_mask  = 0,        // src_access_mask is ignored for acquire barriers, without affecting its validity
+		    .dst_access_mask  = VK_ACCESS_SHADER_READ_BIT,
+		    .old_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,        // Purely ownership transfer. We do not need a layout transition.
+		    .new_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		    .src_queue_family = post_compute_queue->get_family_index(),
+		    .dst_queue_family = present_graphics_queue->get_family_index(),        // Acquire barriers are executed from a queue of the destination queue family
+		};
 
 		command_buffer->image_memory_barrier(get_current_forward_render_target().get_views()[0], memory_barrier);
 	}
@@ -524,22 +530,23 @@ VkSemaphore AsyncComputeSample::render_compute_post(VkSemaphore wait_graphics_se
 
 	command_buffer->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
-	// Acquire barrier if we're going to read HDR texture in compute queue
-	// of a different queue family index. We'll have to duplicate this barrier
-	// on compute queue's end.
 	if (early_graphics_queue->get_family_index() != post_compute_queue->get_family_index())
 	{
-		vkb::ImageMemoryBarrier memory_barrier{};
-		memory_barrier.old_layout      = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		memory_barrier.new_layout      = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		memory_barrier.src_access_mask = 0;
-		memory_barrier.dst_access_mask = VK_ACCESS_SHADER_READ_BIT;
-		// Match pWaitDstStages for src stage here.
-		memory_barrier.src_stage_mask   = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
-		memory_barrier.dst_stage_mask   = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
-		memory_barrier.src_queue_family = early_graphics_queue->get_family_index();
-		memory_barrier.dst_queue_family = post_compute_queue->get_family_index();
-
+		// acquire_barrier_0: Acquiring color_target[0] from early_graphics to post_compute
+		//     This acquire barrier is replicated by the corresponding release_barrier_0 in the early_graphics queue
+		//     The application must ensure the acquire operation happens after the release operation. This sample uses semaphores for that.
+		//     The transfer ownership barriers are submitted twice (release and acquire) but they are only executed once.
+		vkb::ImageMemoryBarrier memory_barrier{
+		    .src_stage_mask = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,        // Ignored for the acquire barrier.
+		                                                                   // Acquire barriers ignore src_access_mask unless using VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR
+		    .dst_stage_mask   = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+		    .src_access_mask  = 0,        // src_access_mask is ignored for acquire barriers, without affecting its validity
+		    .dst_access_mask  = VK_ACCESS_SHADER_READ_BIT,
+		    .old_layout       = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,        // We want a layout transition, so the old_layout and new_layout values need to be replicated in the release barrier
+		    .new_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		    .src_queue_family = early_graphics_queue->get_family_index(),
+		    .dst_queue_family = post_compute_queue->get_family_index(),        // Acquire barriers are executed from a queue of the destination queue family
+		};
 		command_buffer->image_memory_barrier(get_current_forward_render_target().get_views()[0], memory_barrier);
 	}
 
@@ -618,19 +625,23 @@ VkSemaphore AsyncComputeSample::render_compute_post(VkSemaphore wait_graphics_se
 		dispatch_pass(*blur_chain_views[index], *blur_chain_views[index + 1], index == 1);
 	}
 
-	// We're going to read the HDR texture again in the present queue.
-	// Need to release ownership back to that queue.
 	if (post_compute_queue->get_family_index() != present_graphics_queue->get_family_index())
 	{
-		vkb::ImageMemoryBarrier memory_barrier{};
-		memory_barrier.old_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		memory_barrier.new_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		memory_barrier.src_access_mask  = 0;
-		memory_barrier.dst_access_mask  = 0;
-		memory_barrier.src_stage_mask   = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
-		memory_barrier.dst_stage_mask   = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		memory_barrier.src_queue_family = post_compute_queue->get_family_index();
-		memory_barrier.dst_queue_family = present_graphics_queue->get_family_index();
+		// release_barrier_1: Releasing color_target[0] from post_compute to present_graphics
+		//     This release barrier is replicated by the corresponding acquire_barrier_1 in the present_graphics queue
+		//     The application must ensure the release operation happens before the acquire operation. This sample uses semaphores for that.
+		//     The transfer ownership barriers are submitted twice (release and acquire) but they are only executed once.
+		vkb::ImageMemoryBarrier memory_barrier{
+		    .src_stage_mask = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+		    .dst_stage_mask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,        // Ignored for the release barrier.
+		                                                                   // Release barriers ignore dst_access_mask unless using VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR
+		    .src_access_mask  = VK_ACCESS_SHADER_READ_BIT,
+		    .dst_access_mask  = 0,                                               // dst_access_mask is ignored for release barriers, without affecting its validity
+		    .old_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,        // Purely ownership transfer. We do not need a layout transition.
+		    .new_layout       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		    .src_queue_family = post_compute_queue->get_family_index(),        // Release barriers are executed from a queue of the source queue family
+		    .dst_queue_family = present_graphics_queue->get_family_index(),
+		};
 
 		command_buffer->image_memory_barrier(get_current_forward_render_target().get_views()[0], memory_barrier);
 	}

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -588,7 +588,6 @@ VkSemaphore AsyncComputeSample::render_compute_post(VkSemaphore wait_graphics_se
 	}
 
 	const auto discard_blur_view = [&](const vkb::core::ImageView &view) {
-
 		// If maintenance9 is not enabled, resources with VK_SHARING_MODE_EXCLUSIVE must only be accessed by queues in the queue family that has ownership of the resource.
 		// Upon creation resources with VK_SHARING_MODE_EXCLUSIVE are not owned by any queue, ownership is implicitly acquired upon first use.
 		// The application must perform a queue family ownership transfer if it wishes to make the memory contents of the resource accessible to a different queue family.

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -353,6 +353,7 @@ void AsyncComputeSample::render_shadow_pass()
 		memory_barrier.old_layout      = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 		memory_barrier.new_layout      = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		memory_barrier.src_access_mask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+		memory_barrier.dst_access_mask = VK_ACCESS_SHADER_READ_BIT;
 		memory_barrier.src_stage_mask  = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
 		memory_barrier.dst_stage_mask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -252,9 +252,9 @@ bool AsyncComputeSample::prepare(const vkb::ApplicationOptions &options)
 
 			// Hardcoded to fit to the scene.
 			auto ortho_camera = std::make_unique<vkb::sg::OrthographicCamera>("shadow_camera",
-			                                                                  -2000, 3000,
-			                                                                  -2500, 1500,
-			                                                                  -2000, 2000);
+			                                                                  -2000.0f, 3000.0f,
+			                                                                  -2500.0f, 1500.0f,
+			                                                                  -2000.0f, 2000.0f);
 
 			ortho_camera->set_node(*node);
 			get_scene().add_component(std::move(ortho_camera), *node);

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -275,6 +275,7 @@ bool AsyncComputeSample::prepare(const vkb::ApplicationOptions &options)
 	auto              shadow_scene_subpass =
 	    std::make_unique<DepthMapSubpass>(get_render_context(), std::move(shadow_vert_shader), std::move(shadow_frag_shader), get_scene(), *shadow_camera);
 	shadow_render_pipeline.add_subpass(std::move(shadow_scene_subpass));
+	shadow_render_pipeline.set_load_store({{VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE}});
 
 	vkb::ShaderSource composite_vert_shader("async_compute/composite.vert");
 	vkb::ShaderSource composite_frag_shader("async_compute/composite.frag");

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -425,8 +425,8 @@ VkSemaphore AsyncComputeSample::render_forward_offscreen_pass(VkSemaphore hdr_wa
 		// on compute queue's end.
 		if (early_graphics_queue->get_family_index() != post_compute_queue->get_family_index())
 		{
-			memory_barrier.old_queue_family = early_graphics_queue->get_family_index();
-			memory_barrier.new_queue_family = post_compute_queue->get_family_index();
+			memory_barrier.src_queue_family = early_graphics_queue->get_family_index();
+			memory_barrier.dst_queue_family = post_compute_queue->get_family_index();
 		}
 
 		command_buffer->image_memory_barrier(views[0], memory_barrier);
@@ -465,8 +465,8 @@ VkSemaphore AsyncComputeSample::render_swapchain(VkSemaphore post_semaphore)
 		memory_barrier.dst_access_mask  = 0;
 		memory_barrier.src_stage_mask   = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 		memory_barrier.dst_stage_mask   = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-		memory_barrier.old_queue_family = post_compute_queue->get_family_index();
-		memory_barrier.new_queue_family = present_graphics_queue->get_family_index();
+		memory_barrier.src_queue_family = post_compute_queue->get_family_index();
+		memory_barrier.dst_queue_family = present_graphics_queue->get_family_index();
 
 		command_buffer->image_memory_barrier(get_current_forward_render_target().get_views()[0], memory_barrier);
 	}
@@ -536,8 +536,8 @@ VkSemaphore AsyncComputeSample::render_compute_post(VkSemaphore wait_graphics_se
 		// Match pWaitDstStages for src stage here.
 		memory_barrier.src_stage_mask   = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 		memory_barrier.dst_stage_mask   = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
-		memory_barrier.old_queue_family = early_graphics_queue->get_family_index();
-		memory_barrier.new_queue_family = post_compute_queue->get_family_index();
+		memory_barrier.src_queue_family = early_graphics_queue->get_family_index();
+		memory_barrier.dst_queue_family = post_compute_queue->get_family_index();
 
 		command_buffer->image_memory_barrier(get_current_forward_render_target().get_views()[0], memory_barrier);
 	}
@@ -628,8 +628,8 @@ VkSemaphore AsyncComputeSample::render_compute_post(VkSemaphore wait_graphics_se
 		memory_barrier.dst_access_mask  = 0;
 		memory_barrier.src_stage_mask   = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 		memory_barrier.dst_stage_mask   = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		memory_barrier.old_queue_family = post_compute_queue->get_family_index();
-		memory_barrier.new_queue_family = present_graphics_queue->get_family_index();
+		memory_barrier.src_queue_family = post_compute_queue->get_family_index();
+		memory_barrier.dst_queue_family = present_graphics_queue->get_family_index();
 
 		command_buffer->image_memory_barrier(get_current_forward_render_target().get_views()[0], memory_barrier);
 	}


### PR DESCRIPTION
## Description

This PR adds missing barriers to the async_compute sample as highlighted by #1331. We have also added comments to the code to better explain how the sample works. A few validation synchronization errors have also been fixed.

When looking at this sample I found some problems in the framework that I also fix in this PR:

- Barriers were actively ignoring `old_queue_family ` and `new_queue_family`. The async compute sample is the only place using them so I re-enable them and I stop ignoring them. I also renamed them to `src_queue_family` and `dst_queue_family` to be closer to the vulkan spec.
- `VKB_VALIDATION_LAYERS_GPU_ASSISTED`, `VKB_VALIDATION_LAYERS_BEST_PRACTICES `and `VKB_VALIDATION_LAYERS_SYNCHRONIZATION `were being ignored. I use this chance to update how we control the validation layers, replacing `VK_EXT_validation_features `with `VK_EXT_layer_settings`. This should close #863
- I noticed that some gltfs have images without a name, this makes more difficult to debug the samples using render doc, so images without a name will use the URI instead.

Tested on Android using a Mali G715 and on Windows using a Nvidia RTX 4070 Super

Fixes #1331 #863 

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [NA] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [NA] Any dependent assets have been merged and published in downstream modules
- [NA] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [NA] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [NA] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
