### PR TITLE
Fix crash in dynamic rendering local read sample on android

### DIFF
--- a/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
+++ b/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
@@ -873,11 +873,10 @@ void DynamicRenderingLocalRead::build_command_buffers()
 		depth_attachment_info.clearValue                   = clear_values[1];
 
 		VkRenderingInfoKHR render_info   = vkb::initializers::rendering_info();
-		render_info.renderArea           = {0, 0, width, height};
+		render_info.renderArea           = {0, 0, static_cast<uint32_t>(attachment_width), static_cast<uint32_t>(attachment_height)};
 		render_info.layerCount           = 1;
 		render_info.colorAttachmentCount = 4;
 		render_info.pColorAttachments    = &color_attachment_info[0];
-		render_info.renderArea           = {0, 0, width, height};
 
 		render_info.pDepthAttachment = &depth_attachment_info;
 		if (!vkb::is_depth_only_format(depth_format))


### PR DESCRIPTION
## Description

This fixes a crash in the dynamic rendering local read sample on Android.

Important note: In portrait mode, the sample won't be displayed in full screen. That's because the framework somehow does NOT propagate the correct screen dimensions through to the samples on Android.

Fixing that seems to be difficult, so something that should be done in a separate PR.

Fixes #1277

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making