### PR TITLE
Remove submodule CTPL, replace its functionality by calls to std::async

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,9 +34,6 @@
 [submodule "third_party/astc"]
 	path = third_party/astc
 	url = https://github.com/ARM-software/astc-encoder
-[submodule "third_party/CTPL"]
-	path = third_party/CTPL
-	url = https://github.com/vit-vit/CTPL
 [submodule "third_party/vulkan"]
 	path = third_party/vulkan
 	url = https://github.com/KhronosGroup/Vulkan-Headers

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -503,7 +503,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
     vma
     spirv-cross-glsl
     spdlog
-    ctpl
     plugins)
 
 if(${NEED_LINK_ATOMIC})

--- a/samples/performance/command_buffer_usage/command_buffer_usage.cpp
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.cpp
@@ -369,10 +369,13 @@ void CommandBufferUsage::ForwardSubpassSecondary::draw(vkb::core::CommandBufferC
 
 			if (state.multi_threading)
 			{
-				auto fut = thread_pool.push(
-				    [this, cb_count, &primary_command_buffer, &sorted_opaque_nodes, mesh_start, mesh_end](size_t thread_id) {
-					    return record_draw_secondary(primary_command_buffer, sorted_opaque_nodes, mesh_start, mesh_end, thread_id);
-				    });
+				auto fut = thread_pool.push(std::bind(&CommandBufferUsage::ForwardSubpassSecondary::record_draw_secondary,
+				                                      this,
+				                                      std::ref(primary_command_buffer),
+				                                      std::cref(sorted_opaque_nodes),
+				                                      mesh_start,
+				                                      mesh_end,
+				                                      std::placeholders::_1));
 
 				secondary_cmd_buf_futures.push_back(std::move(fut));
 			}

--- a/samples/performance/multithreading_render_passes/multithreading_render_passes.h
+++ b/samples/performance/multithreading_render_passes/multithreading_render_passes.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include <ctpl_stl.h>
-
 #include "core/command_buffer.h"
 #include "rendering/render_pipeline.h"
 #include "rendering/subpasses/forward_subpass.h"
@@ -149,8 +147,6 @@ class MultithreadingRenderPasses : public vkb::VulkanSampleC
 	 * @brief Main camera for scene rendering
 	 */
 	vkb::sg::Camera *camera{};
-
-	ctpl::thread_pool thread_pool;
 
 	uint32_t swapchain_attachment_index{0};
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -371,12 +371,6 @@ set(SPDLOG_FMT_EXTERNAL ON)
 add_subdirectory(spdlog)
 set_property(TARGET spdlog PROPERTY FOLDER "ThirdParty")
 
-# ctpl
-add_library(ctpl INTERFACE)
-set(CTPL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/CTPL)
-target_sources(ctpl INTERFACE ${CTPL_DIR}/ctpl_stl.h)
-target_include_directories(ctpl SYSTEM INTERFACE ${CTPL_DIR})
-
 # OpenCL
 add_library(opencl INTERFACE)
 set(OPENCL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/opencl)

--- a/third_party/README.adoc
+++ b/third_party/README.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2019-2024, Arm Limited and Contributors
+- Copyright (c) 2019-2025, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -
@@ -23,9 +23,7 @@
 This project has multiple third-party dependencies, each of which may have independent licensing:
 
 * https://github.com/ARM-software/astc-encoder[astc-encoder]: ASTC Evaluation Codec
-* https://github.com/catchorg/Catch2[Catch2]: Modern C++ test framework
 * https://github.com/CLIUtils/CLI11[CLI11] Command line parser for C++11 and beyond
-* https://github.com/vit-vit/CTPL[CTPL]: Thread Pool Library
 * https://github.com/fmtlib/fmt[fmt]: A modern formating library
 * https://github.com/glfw/glfw[glfw]: A multi-platform library for OpenGL, OpenGL ES, Vulkan, window and input
 * https://github.com/g-truc/glm[glm]: OpenGL Mathematics


### PR DESCRIPTION
## Description

In order to simplify the build environment, the (pretty outdated) submodule `CTPL` can be easily replaced by some calls to `std::async`. The only sample that actually used thread pool functionality is `performance/command_buffer_usage`. Adding some very basic homegrown `ThreadPool` resolves that as well.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
