### PR TITLE
Add possible Linux WSI options to build documentation

### DIFF
--- a/docs/build.adoc
+++ b/docs/build.adoc
@@ -229,6 +229,26 @@ build\windows\app\bin\Release\AMD64\vulkan_samples.exe
 sudo apt-get install cmake g++ xorg-dev libglu1-mesa-dev libwayland-dev libxkbcommon-dev
 ----
 
+=== Selecting the window system
+
+On Linux, the samples support different window systems. If not explicitly set, default is X11 Xcb. If you want to build with another window system, use the `VKB_WSI_SELECTION` CMake option like this:
+
+----
+cmake -G "Unix Makefiles" -Bbuild/linux -DCMAKE_BUILD_TYPE=Release -DVKB_WSI_SELECTION=WAYLAND
+----
+
+Available Linux window systems:
+
+[cols="1,1"]
+|===
+| VKB_WSI_SELECTION | Window system
+
+| XCB | X11 Xcb (Default)
+| XLIB | X11 Xlib
+| WAYLAND | Wayland
+| D2D | Direct to Display (`VK_KHR_DISPLAY`)
+|===
+
 === Build with CMake
 
 `Step 1.` The following command will generate the project


### PR DESCRIPTION
## Description

Linux has multiple window systems like X11 and Wayland. You can select the one you want to use at CMake level, but we never documented that option. This PR adds documentation for the supported window systems to the build documentation.

Note: Pure documentation fix;

Fixes #1361

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly