### PR TITLE
Fix regression on iOS Simulator by including TargetConditionals.h in gui.h

### DIFF
--- a/framework/gui.h
+++ b/framework/gui.h
@@ -552,7 +552,9 @@ inline void
 	push_transform       = glm::scale(push_transform, glm::vec3(2.0f / io.DisplaySize.x, 2.0f / io.DisplaySize.y, 0.0f));
 	command_buffer.pushConstants(pipeline_layout, vk::ShaderStageFlagBits::eVertex, 0, sizeof(glm::mat4), &push_transform);
 
-	command_buffer.bindVertexBuffers(0, vertex_buffer->get_handle(), {0});
+	vk::DeviceSize vertex_offsets[1]    = {0};
+	vk::Buffer     vertex_buffer_handle = vertex_buffer->get_handle();
+	command_buffer.bindVertexBuffers(0, vertex_buffer_handle, vertex_offsets);
 
 	command_buffer.bindIndexBuffer(index_buffer->get_handle(), 0, vk::IndexType::eUint16);
 

--- a/framework/gui.h
+++ b/framework/gui.h
@@ -36,6 +36,10 @@
 #include <imgui_internal.h>
 #include <numeric>
 
+#if defined(PLATFORM__MACOS)
+#	include <TargetConditionals.h>
+#endif
+
 namespace vkb
 {
 


### PR DESCRIPTION
## Description

This PR includes **TargetConditionals.h** on Apple platforms, so that `TARGET_OS_IOS` and `TARGET_OS_SIMULATOR` are properly defined for conditional code in the now-unified **gui.h**.  Also restores declarations (used by conditional code) lost during `vkb::Gui` unification.  This corrects a regression caused by #1376.

Fixes #1388.

Tested on macOS Ventura 13.7.6 using Vulkan SDK 1.4.313.1

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
