### PR TITLE
Fix use of --width and --height by setting extent earlier

### DIFF
--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -35,6 +35,10 @@ bool ApiVulkanSample::prepare(const vkb::ApplicationOptions &options)
 
 	depth_format = vkb::get_suitable_depth_format(get_device().get_gpu().get_handle());
 
+	// Update width and height from surface extent to reflect command line arguments
+	width  = get_render_context().get_surface_extent().width;
+	height = get_render_context().get_surface_extent().height;
+
 	// Create synchronization objects
 	VkSemaphoreCreateInfo semaphore_create_info = vkb::initializers::semaphore_create_info();
 	// Create a semaphore used to synchronize image presentation
@@ -62,11 +66,6 @@ bool ApiVulkanSample::prepare(const vkb::ApplicationOptions &options)
 	create_command_buffers();
 	create_synchronization_primitives();
 	setup_depth_stencil();
-
-	// Update width and height before setup methods so samples can use correct dimensions
-	width  = get_render_context().get_surface_extent().width;
-	height = get_render_context().get_surface_extent().height;
-
 	setup_render_pass();
 	create_pipeline_cache();
 	setup_framebuffer();

--- a/framework/api_vulkan_sample.cpp
+++ b/framework/api_vulkan_sample.cpp
@@ -62,12 +62,14 @@ bool ApiVulkanSample::prepare(const vkb::ApplicationOptions &options)
 	create_command_buffers();
 	create_synchronization_primitives();
 	setup_depth_stencil();
+
+	// Update width and height before setup methods so samples can use correct dimensions
+	width  = get_render_context().get_surface_extent().width;
+	height = get_render_context().get_surface_extent().height;
+
 	setup_render_pass();
 	create_pipeline_cache();
 	setup_framebuffer();
-
-	width  = get_render_context().get_surface_extent().width;
-	height = get_render_context().get_surface_extent().height;
 
 	prepare_gui();
 

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -56,11 +56,13 @@ bool HPPApiVulkanSample::prepare(const vkb::ApplicationOptions &options)
 	create_command_buffers();
 	create_synchronization_primitives();
 	setup_depth_stencil();
+
+	// Update extent before setup methods so samples can use correct dimensions
+	extent = get_render_context().get_surface_extent();
+
 	setup_render_pass();
 	create_pipeline_cache();
 	setup_framebuffer();
-
-	extent = get_render_context().get_surface_extent();
 
 	prepare_gui();
 

--- a/framework/hpp_api_vulkan_sample.cpp
+++ b/framework/hpp_api_vulkan_sample.cpp
@@ -32,6 +32,9 @@ bool HPPApiVulkanSample::prepare(const vkb::ApplicationOptions &options)
 
 	depth_format = vkb::common::get_suitable_depth_format(get_device().get_gpu().get_handle());
 
+	// Update extent from surface extent to reflect command line arguments
+	extent = get_render_context().get_surface_extent();
+
 	// Create synchronization objects
 	// Create a semaphore used to synchronize image presentation
 	// Ensures that the current swapchain render target has completed presentation and has been released by the presentation engine, ready for rendering
@@ -56,10 +59,6 @@ bool HPPApiVulkanSample::prepare(const vkb::ApplicationOptions &options)
 	create_command_buffers();
 	create_synchronization_primitives();
 	setup_depth_stencil();
-
-	// Update extent before setup methods so samples can use correct dimensions
-	extent = get_render_context().get_surface_extent();
-
 	setup_render_pass();
 	create_pipeline_cache();
 	setup_framebuffer();


### PR DESCRIPTION
## Description

dynamic_rendering_local_read (at least) would go horribly wrong if --width and --height were given on the command line.

This change ensures the framework extent is set before it's used by the samples (in setup_render_pass() for DRLR).

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Linux. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly
