### PR TITLE
Don't reopen redirected standard handles on Windows

### DIFF
--- a/components/windows/src/context.cpp
+++ b/components/windows/src/context.cpp
@@ -1,4 +1,5 @@
-/* Copyright (c) 2023, Thomas Atkinson
+/* Copyright (c) 2023-2025, Thomas Atkinson
+ * Copyright (c) 2025, Chris Djali
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -87,13 +88,12 @@ WindowsPlatformContext::WindowsPlatformContext(HINSTANCE hInstance, HINSTANCE hP
 	_temp_directory             = get_temp_path_from_environment();
 	_arguments                  = get_args();
 
-	auto isRedirected = [](DWORD stdHandle)
-	{
+	auto isRedirected = [](DWORD stdHandle) {
 		DWORD fileType = GetFileType(GetStdHandle(stdHandle));
 		return fileType == FILE_TYPE_DISK || fileType == FILE_TYPE_PIPE;
 	};
 
-	bool inRedirected = isRedirected(STD_INPUT_HANDLE);
+	bool inRedirected  = isRedirected(STD_INPUT_HANDLE);
 	bool outRedirected = isRedirected(STD_OUTPUT_HANDLE);
 	bool errRedirected = isRedirected(STD_ERROR_HANDLE);
 


### PR DESCRIPTION
## Description

If the calling process has redirected a standard handle (e.g. `vulkan_samples.exe sample msaa > out.log`), then reopening it will detach it from the file/pipe and connect it to the console instead. We don't want to do that.

Instead, the type of the file should be tested before attaching the parent console. If it's already a disk file or a pipe, then we want to leave it alone.

Note that for PowerShell, this doesn't make `> file` work, but `| Out-File file` does, and `>` works in other shells like Command Prompt and MSYS2 Bash. IIRC from past investigation when I've made similar changes to other projects, it's because PowerShell closes the file handle for `/SUBSYSTEM:WINDOWS` applications immediately.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template) *Note: the script wanted to extend the year range of the first line, which I'm not sure is right, as the person it specifies didn't make any changes to this file in 2025.*
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly *I didn't bother with this as it should have the same effect on all samples and doesn't affect Vulkan itself*
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements) *It builds on Windows and is a Windows-specific file, so wouldn't be expected to build elsewhere*

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

N/A

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
