### PR TITLE
Update VVL version to 1.4.321.0 for Android

### DIFF
--- a/bldsys/cmake/template/gradle/app.build.gradle.in
+++ b/bldsys/cmake/template/gradle/app.build.gradle.in
@@ -2,7 +2,7 @@ plugins {
 	id 'com.android.application'
 }
 
-ext.vvl_version='1.3.296.0'
+ext.vvl_version='1.4.321.0'
 apply from: "./download_vvl.gradle"
 
 android {

--- a/bldsys/cmake/template/gradle/download_vvl.gradle
+++ b/bldsys/cmake/template/gradle/download_vvl.gradle
@@ -36,7 +36,7 @@ apply plugin: 'com.android.application'
  */
 
 // get the validation layer version.
-def VVL_VER = "1.3.296.0"
+def VVL_VER = "1.4.321.0"
 if (ext.has("vvl_version")) {
     VVL_VER = ext.vvl_version
 }


### PR DESCRIPTION
Required for supporting 16KB page sizes. Issue #1399 

## Description

Simply updates VVL version used on Android download scripts from 1.3.296.0 to 1.4.321.0, as newer version is compiled with new NDK libraries and compatible with 16KB page sizes.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly
