### PR TITLE
Update NDK version to r28c for Android

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, Arm Limited and Contributors
+# Copyright (c) 2022-2025, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -80,7 +80,7 @@ ENV PATH="$PATH:$ANDROID_HOME/platform-tools:${ANDROID_SDK_TOOLS}/tools/bin:$AND
 RUN mkdir -p $ANDROID_HOME
 
 # Configure Android NDK
-ENV NDK_VERSION=r25b
+ENV NDK_VERSION=r28c
 
 RUN set -x && wget -q https://dl.google.com/android/repository/android-ndk-$NDK_VERSION-linux.zip -O /tmp/android-ndk.zip \
     && unzip -qq /tmp/android-ndk.zip -d /usr/local \

--- a/bldsys/cmake/template/gradle/app.build.gradle.in
+++ b/bldsys/cmake/template/gradle/app.build.gradle.in
@@ -6,7 +6,7 @@ ext.vvl_version='1.3.296.0'
 apply from: "./download_vvl.gradle"
 
 android {
-	ndkVersion '27.2.12479018'
+	ndkVersion '28.2.13676358'
 	compileSdk 35
 
 	defaultConfig {


### PR DESCRIPTION
## Description

Use latest stable NDK version to enable support for 16KB page sizes.

https://developer.android.com/ndk/downloads#stable-downloads

Fixes issue #1399

Also updated the link used for the docker file, but there was already a mismatch between the ndkVersion used and didn't test creating an image and running tests with that.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly