### PR TITLE
Fix variable descriptor count info not used in descriptor set creation

### DIFF
--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -470,8 +470,10 @@ void Profiles::setup_descriptor_pool()
 void Profiles::setup_descriptor_set_layout()
 {
 	// We separate the descriptor sets for the uniform buffer + image and samplers, so we don't need to duplicate the descriptors for the former
-	VkDescriptorSetLayoutCreateInfo           descriptor_layout_create_info{};
 	std::vector<VkDescriptorSetLayoutBinding> set_layout_bindings{};
+
+	VkDescriptorSetLayoutCreateInfo descriptor_layout_create_info{};
+	descriptor_layout_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
 
 	// Mark second slot as variable for descriptor indexing
 	VkDescriptorSetLayoutBindingFlagsCreateInfoEXT descriptor_set_layout_binding_flags{};
@@ -497,10 +499,8 @@ void Profiles::setup_descriptor_set_layout()
 	        VK_SHADER_STAGE_FRAGMENT_BIT,
 	        1,
 	        static_cast<uint32_t>(textures.size()))};
-	descriptor_layout_create_info =
-	    vkb::initializers::descriptor_set_layout_create_info(
-	        set_layout_bindings.data(),
-	        static_cast<uint32_t>(set_layout_bindings.size()));
+	descriptor_layout_create_info.bindingCount = static_cast<uint32_t>(set_layout_bindings.size());
+	descriptor_layout_create_info.pBindings    = set_layout_bindings.data();
 	VK_CHECK(vkCreateDescriptorSetLayout(get_device().get_handle(), &descriptor_layout_create_info, nullptr, &base_descriptor_set_layout));
 
 	// Set layout for the samplers
@@ -511,10 +511,8 @@ void Profiles::setup_descriptor_set_layout()
 	        VK_SHADER_STAGE_FRAGMENT_BIT,
 	        0,
 	        static_cast<uint32_t>(textures.size()))};
-	descriptor_layout_create_info =
-	    vkb::initializers::descriptor_set_layout_create_info(
-	        set_layout_bindings.data(),
-	        static_cast<uint32_t>(set_layout_bindings.size()));
+	descriptor_layout_create_info.bindingCount = static_cast<uint32_t>(set_layout_bindings.size());
+	descriptor_layout_create_info.pBindings    = set_layout_bindings.data();
 	VK_CHECK(vkCreateDescriptorSetLayout(get_device().get_handle(), &descriptor_layout_create_info, nullptr, &sampler_descriptor_set_layout));
 
 	// Pipeline layout


### PR DESCRIPTION
## Description

Fixes the pNext containing variable descriptor flags getting reset to null before actually creating descriptor set layouts.

Fixes #1386

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly