### PR TITLE
Add missing call to vkCmdSetRenderingInputAttachmentIndicesKHR in sample dynamic_rendering_local_read

### DIFF
--- a/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
+++ b/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
@@ -686,15 +686,7 @@ void DynamicRenderingLocalRead::prepare_pipelines()
 		pipeline_rendering_create_info.stencilAttachmentFormat = depth_format;
 	}
 
-	VkRenderingInputAttachmentIndexInfo rendering_attachment_index_info{VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO};
 	pipeline_rendering_create_info.pNext = &rendering_attachment_index_info;
-
-	std::array<uint32_t, 4> colorAttachments                     = {VK_ATTACHMENT_UNUSED, 0, 1, 2};
-	rendering_attachment_index_info.pNext                        = nullptr;
-	rendering_attachment_index_info.colorAttachmentCount         = colorAttachments.size();
-	rendering_attachment_index_info.pColorAttachmentInputIndices = colorAttachments.data();
-	rendering_attachment_index_info.pDepthInputAttachmentIndex   = nullptr;
-	rendering_attachment_index_info.pStencilInputAttachmentIndex = nullptr;
 #else
 	pipeline_create_info.subpass = 0;
 #endif
@@ -901,6 +893,9 @@ void DynamicRenderingLocalRead::build_command_buffers()
 
 		VkRect2D scissor = vkb::initializers::rect2D(width, height, 0, 0);
 		vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+		// Set input attachment indices for the composition and transparent passes
+		vkCmdSetRenderingInputAttachmentIndicesKHR(cmd, &rendering_attachment_index_info);
 
 		/*
 		    First draw

--- a/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.h
+++ b/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.h
@@ -98,6 +98,12 @@ class DynamicRenderingLocalRead : public ApiVulkanSample
 	int32_t attachment_width{0};
 	int32_t attachment_height{0};
 
+	std::array<uint32_t, 4>             color_attachment_input_indices{VK_ATTACHMENT_UNUSED, 0, 1, 2};
+	VkRenderingInputAttachmentIndexInfo rendering_attachment_index_info{VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR,
+	                                                                    nullptr,
+	                                                                    static_cast<uint32_t>(color_attachment_input_indices.size()),
+	                                                                    color_attachment_input_indices.data()};
+
 	void setup_framebuffer() override;
 	void setup_render_pass() override;
 	void prepare_gui() override;


### PR DESCRIPTION
## Description

When input attachment index mappings is used during dynamic rendering, this mapping not only has to be provided on pipeline creation, but also on rendering.
See [vkCmdSetRenderingInputAttachmentIndices description](https://registry.khronos.org/vulkan/specs/latest/man/html/vkCmdSetRenderingInputAttachmentIndices.html#_description)

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Resolves #1429.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
