### PR TITLE
Set default queue priorities to 0.5f

### DIFF
--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -634,7 +634,7 @@ inline void Device<bindingType>::init(std::unordered_map<const char *, bool> con
 		if (gpu.has_high_priority_graphics_queue() &&
 		    (vkb::common::get_queue_family_index(queue_family_properties, vk::QueueFlagBits::eGraphics) == queue_family_index))
 		{
-			queue_priorities.back()[0] = 0.0f;
+			queue_priorities.back()[0] = 0.5f;
 		}
 
 		queue_create_infos.push_back({.queueFamilyIndex = queue_family_index,

--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -634,7 +634,7 @@ inline void Device<bindingType>::init(std::unordered_map<const char *, bool> con
 		if (gpu.has_high_priority_graphics_queue() &&
 		    (vkb::common::get_queue_family_index(queue_family_properties, vk::QueueFlagBits::eGraphics) == queue_family_index))
 		{
-			queue_priorities.back()[0] = 1.0f;
+			queue_priorities.back()[0] = 0.0f;
 		}
 
 		queue_create_infos.push_back({.queueFamilyIndex = queue_family_index,

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -302,7 +302,7 @@ void HelloTriangle::init_device()
 #endif
 
 	// The sample uses a single graphics queue
-	const float queue_priority = 1.0f;
+	const float queue_priority = 0.0f;
 
 	VkDeviceQueueCreateInfo queue_info{
 	    .sType            = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -302,7 +302,7 @@ void HelloTriangle::init_device()
 #endif
 
 	// The sample uses a single graphics queue
-	const float queue_priority = 0.0f;
+	const float queue_priority = 0.5f;
 
 	VkDeviceQueueCreateInfo queue_info{
 	    .sType            = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,

--- a/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
+++ b/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
@@ -360,7 +360,7 @@ void HelloTriangleV13::init_device()
 	    .pNext = &enable_vulkan13_features};
 	// Create the logical device
 
-	float queue_priority = 1.0f;
+	float queue_priority = 0.0f;
 
 	// Create one queue
 	VkDeviceQueueCreateInfo queue_info{

--- a/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
+++ b/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
@@ -360,7 +360,7 @@ void HelloTriangleV13::init_device()
 	    .pNext = &enable_vulkan13_features};
 	// Create the logical device
 
-	float queue_priority = 0.0f;
+	float queue_priority = 0.5f;
 
 	// Create one queue
 	VkDeviceQueueCreateInfo queue_info{

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -334,7 +334,7 @@ vk::Device HPPHelloTriangle::create_device(const std::vector<const char *> &requ
 #endif
 
 	// Create a device with one queue
-	float                     queue_priority = 0.0f;
+	float                     queue_priority = 0.5f;
 	vk::DeviceQueueCreateInfo queue_info{.queueFamilyIndex = graphics_queue_index, .queueCount = 1, .pQueuePriorities = &queue_priority};
 	vk::DeviceCreateInfo      device_info{.queueCreateInfoCount    = 1,
 	                                      .pQueueCreateInfos       = &queue_info,

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -334,7 +334,7 @@ vk::Device HPPHelloTriangle::create_device(const std::vector<const char *> &requ
 #endif
 
 	// Create a device with one queue
-	float                     queue_priority = 1.0f;
+	float                     queue_priority = 0.0f;
 	vk::DeviceQueueCreateInfo queue_info{.queueFamilyIndex = graphics_queue_index, .queueCount = 1, .pQueuePriorities = &queue_priority};
 	vk::DeviceCreateInfo      device_info{.queueCreateInfoCount    = 1,
 	                                      .pQueueCreateInfos       = &queue_info,

--- a/samples/api/hpp_hello_triangle_1_3/hpp_hello_triangle_1_3.cpp
+++ b/samples/api/hpp_hello_triangle_1_3/hpp_hello_triangle_1_3.cpp
@@ -419,7 +419,7 @@ void HPPHelloTriangleV13::init_device()
 	    enabled_features_chain = {{}, {.synchronization2 = true, .dynamicRendering = true}, {.extendedDynamicState = true}};
 
 	// Create the logical device
-	float queue_priority = 0.0f;
+	float queue_priority = 0.5f;
 
 	// Create one queue
 	vk::DeviceQueueCreateInfo queue_info{.queueFamilyIndex = static_cast<uint32_t>(context.graphics_queue_index),

--- a/samples/api/hpp_hello_triangle_1_3/hpp_hello_triangle_1_3.cpp
+++ b/samples/api/hpp_hello_triangle_1_3/hpp_hello_triangle_1_3.cpp
@@ -419,7 +419,7 @@ void HPPHelloTriangleV13::init_device()
 	    enabled_features_chain = {{}, {.synchronization2 = true, .dynamicRendering = true}, {.extendedDynamicState = true}};
 
 	// Create the logical device
-	float queue_priority = 1.0f;
+	float queue_priority = 0.0f;
 
 	// Create one queue
 	vk::DeviceQueueCreateInfo queue_info{.queueFamilyIndex = static_cast<uint32_t>(context.graphics_queue_index),

--- a/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
+++ b/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
@@ -220,7 +220,7 @@ void FullScreenExclusive::init_device(const std::vector<const char *> &required_
 		throw std::runtime_error("Required device extensions are missing, will try without.");
 	}
 
-	float queue_priority = 1.0f;
+	float queue_priority = 0.0f;
 
 	VkDeviceQueueCreateInfo queue_info{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
 	queue_info.queueFamilyIndex = context.graphics_queue_index;

--- a/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
+++ b/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
@@ -220,7 +220,7 @@ void FullScreenExclusive::init_device(const std::vector<const char *> &required_
 		throw std::runtime_error("Required device extensions are missing, will try without.");
 	}
 
-	float queue_priority = 0.0f;
+	float queue_priority = 0.5f;
 
 	VkDeviceQueueCreateInfo queue_info{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
 	queue_info.queueFamilyIndex = context.graphics_queue_index;

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<vkb::core::DeviceC> Profiles::create_device(vkb::core::PhysicalD
 	// Simplified queue setup (only graphics)
 	uint32_t                selected_queue_family   = 0;
 	const auto             &queue_family_properties = gpu.get_queue_family_properties();
-	const float             default_queue_priority{0.0f};
+	const float             default_queue_priority{0.5f};
 	VkDeviceQueueCreateInfo queue_create_info{};
 	queue_create_info.sType            = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
 	queue_create_info.queueCount       = 1;


### PR DESCRIPTION
## Description

As discussed on the last sample call, always setting queue priorities to 1.0f (max.) is not a good practice. This PR adjusts all places where queue priorities are set to use 0.5f instead. Won't make a difference anyway, as we rarely (if at all) use multiple queues from the same family.

Refs https://github.com/KhronosGroup/Vulkan-Tutorial/pull/166

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly