### PR TITLE
Apple compatibility fixes for driver optionality (MoltenVK & KosmicKrisp)

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, Arm Limited and Contributors
+# Copyright (c) 2019-2025, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -135,7 +135,7 @@ if(IOS)
                 XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY		"YES"
         )
     endif ()
-    # No need to search for Vulkan package or MoltenVK library, Vulkan cache variables already defined on Apple platforms by global_options.cmake
+    # Vulkan cache variables already defined by main project CMakeLists and updated on Apple platforms by global_options.cmake
     if(Vulkan_LIBRARY AND ${Vulkan_VERSION} VERSION_GREATER_EQUAL 1.3.278)
         target_sources(${PROJECT_NAME} PRIVATE
                 ${Vulkan_Target_SDK}/iOS/share/vulkan
@@ -163,17 +163,24 @@ if(IOS)
     set(FRAMEWORKS_TO_EMBED)
 	if(Vulkan_MoltenVK_LIBRARY)
 		list(APPEND FRAMEWORKS_TO_EMBED "${Vulkan_MoltenVK_LIBRARY};")
+		message(STATUS "Embedding Vulkan driver: ${Vulkan_MoltenVK_LIBRARY}")
+	# add support for potentially other iOS Vulkan drivers here...
+	#elseif(OTHER_IOS_VULKAN_DRIVER)
+		#list(APPEND FRAMEWORKS_TO_EMBED "${OTHER_IOS_VULKAN_DRIVER};")
+		#message(STATUS "Embedding Vulkan driver: ${OTHER_IOS_VULKAN_DRIVER}")
 	else()
-		message(FATAL_ERROR "Can't find MoltenVK library. Please install the Vulkan SDK or MoltenVK project and set VULKAN_SDK.")
+		message(FATAL_ERROR "Can't find Vulkan driver for iOS. Please install the Vulkan SDK and run: 'source <MY_SDK_PATH>/iOS/setup-env.sh'")
 	endif()
 	if(Vulkan_LIBRARY)
 		list(APPEND FRAMEWORKS_TO_EMBED "${Vulkan_LIBRARY};")
+		message(STATUS "Embedding Vulkan loader: ${Vulkan_LIBRARY}")
 	endif()
 	if(Vulkan_Layer_VALIDATION)
 		# trouble is can't turn this on/off if XCode decides to build debug and we're configured for release.  Need to revist
 		# note the Vulkan validation layer must be present and enabled even in release mode for the shader_debugprintf sample
 		#if(("${VKB_DEBUG}" STREQUAL "ON") OR ("${VKB_VALIDATION_LAYERS}" STREQUAL "ON"))
 			list(APPEND FRAMEWORKS_TO_EMBED "${Vulkan_Layer_VALIDATION}")
+			message(STATUS "Embedding Vulkan Validation Layer: ${Vulkan_Layer_VALIDATION}")
 		#endif()
     endif()
     set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -105,6 +105,8 @@ if(APPLE)
 			set(CMAKE_SUPPRESS_REGENERATION ON)
 		endif()
 	endif()
+else()
+    option(VKB_ENABLE_PORTABILITY "Enable portability enumeration and subset features in the framework.  This is default off on non-Apple platforms." OFF)
 endif()
 
 set(VKB_WARNINGS_AS_ERRORS ON CACHE BOOL "Enable Warnings as Errors")

--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -38,7 +38,7 @@ if(APPLE)
 	if(VKB_ENABLE_PORTABILITY)
 		find_package(Vulkan QUIET OPTIONAL_COMPONENTS MoltenVK)
 		if(USE_MoltenVK OR (IOS AND (NOT Vulkan_MoltenVK_FOUND OR ${CMAKE_OSX_SYSROOT} STREQUAL "iphonesimulator")))
-			# if using MoltenVK, or MoltenVK for iOS was not found, or using iOS Simulator, look for MoltenVK in the Vulkan SDK and MoltenVK project locations
+			# if using MoltenVK standalone, or MoltenVK for iOS not found or using iOS Simulator, look for MoltenVK in Vulkan SDK and MoltenVK project paths
 			if(NOT Vulkan_MoltenVK_LIBRARY)
 				# since both are available in the Vulkan SDK and MoltenVK github project, make sure we look for MoltenVK framework on iOS and dylib on macOS
 				set(_saved_cmake_find_framework ${CMAKE_FIND_FRAMEWORK})
@@ -72,13 +72,13 @@ if(APPLE)
 				else()
 					message(FATAL_ERROR "Vulkan library found in MoltenVK search path. Please set VULKAN_SDK to the MoltenVK project install location.")
 				endif()
-				message(STATUS "Using MoltenVK: ${Vulkan_MoltenVK_LIBRARY}")
+				message(STATUS "Using MoltenVK standalone: ${Vulkan_MoltenVK_LIBRARY}")
 			else()
 				message(FATAL_ERROR "Can't find MoltenVK library. Please install the Vulkan SDK or MoltenVK project and set VULKAN_SDK.")
 			endif()
-		elseif(IOS)
-			# if not using MoltenVK standalone on iOS, set up global Vulkan Library define for iOS Vulkan loader
-			add_compile_definitions(_HPP_VULKAN_LIBRARY="vulkan.framework/vulkan")
+		#else()
+			# if not using MoltenVK standalone, retain find_package() results for MoltenVK, Vulkan loader, and Validation Layer library defines
+			# no need to override with _HPP_VULKAN_LIBRARY in this case since Vulkan DynamicLoader will find/load Vulkan library on macOS & iOS
 		endif()
 	endif()
 

--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -33,51 +33,53 @@ endif()
 
 if(APPLE)
     cmake_minimum_required(VERSION 3.24)
-    set(VKB_ENABLE_PORTABILITY ON CACHE BOOL "Enable portability enumeration and subset features in the framework.  This is required to be set when running on Apple platforms." FORCE)
+    option(VKB_ENABLE_PORTABILITY "Enable portability enumeration and subset features in the framework.  This is required for MoltenVK on Apple platforms." ON)
 
-	find_package(Vulkan QUIET OPTIONAL_COMPONENTS MoltenVK)
-	if(USE_MoltenVK OR (IOS AND (NOT Vulkan_MoltenVK_FOUND OR ${CMAKE_OSX_SYSROOT} STREQUAL "iphonesimulator")))
-		# if using MoltenVK, or MoltenVK for iOS was not found, or using iOS Simulator, look for MoltenVK in the Vulkan SDK and MoltenVK project locations
-		if(NOT Vulkan_MoltenVK_LIBRARY)
-			# since both are available in the Vulkan SDK and MoltenVK github project, make sure we look for MoltenVK framework on iOS and dylib on macOS
-			set(_saved_cmake_find_framework ${CMAKE_FIND_FRAMEWORK})
-			if(IOS)
-				set(CMAKE_FIND_FRAMEWORK ALWAYS)
-			else()
-				set(CMAKE_FIND_FRAMEWORK NEVER)
+	if(VKB_ENABLE_PORTABILITY)
+		find_package(Vulkan QUIET OPTIONAL_COMPONENTS MoltenVK)
+		if(USE_MoltenVK OR (IOS AND (NOT Vulkan_MoltenVK_FOUND OR ${CMAKE_OSX_SYSROOT} STREQUAL "iphonesimulator")))
+			# if using MoltenVK, or MoltenVK for iOS was not found, or using iOS Simulator, look for MoltenVK in the Vulkan SDK and MoltenVK project locations
+			if(NOT Vulkan_MoltenVK_LIBRARY)
+				# since both are available in the Vulkan SDK and MoltenVK github project, make sure we look for MoltenVK framework on iOS and dylib on macOS
+				set(_saved_cmake_find_framework ${CMAKE_FIND_FRAMEWORK})
+				if(IOS)
+					set(CMAKE_FIND_FRAMEWORK ALWAYS)
+				else()
+					set(CMAKE_FIND_FRAMEWORK NEVER)
+				endif()
+				find_library(Vulkan_MoltenVK_LIBRARY NAMES MoltenVK HINTS "$ENV{VULKAN_SDK}/lib" "$ENV{VULKAN_SDK}/dynamic" "$ENV{VULKAN_SDK}/dylib/macOS")
+				set(CMAKE_FIND_FRAMEWORK ${_saved_cmake_find_framework})
+				unset(_saved_cmake_find_framework)
 			endif()
-			find_library(Vulkan_MoltenVK_LIBRARY NAMES MoltenVK HINTS "$ENV{VULKAN_SDK}/lib" "$ENV{VULKAN_SDK}/dynamic" "$ENV{VULKAN_SDK}/dylib/macOS")
-			set(CMAKE_FIND_FRAMEWORK ${_saved_cmake_find_framework})
-			unset(_saved_cmake_find_framework)
-		endif()
 
-		if(Vulkan_MoltenVK_LIBRARY)
-			get_filename_component(MoltenVK_LIBRARY_PATH ${Vulkan_MoltenVK_LIBRARY} DIRECTORY)
+			if(Vulkan_MoltenVK_LIBRARY)
+				get_filename_component(MoltenVK_LIBRARY_PATH ${Vulkan_MoltenVK_LIBRARY} DIRECTORY)
 
-			# For both iOS and macOS: set up global Vulkan Library defines so that MoltenVK is dynamically loaded versus the Vulkan loader
-			# on iOS we can control Vulkan library loading priority by selecting which libraries are embedded in the iOS application bundle
-			if(IOS)
-				add_compile_definitions(_HPP_VULKAN_LIBRARY="MoltenVK.framework/MoltenVK")
-				# unset FindVulkan.cmake cache variables so Vulkan loader, Validation Layer, and icd/layer json files are not embedded on iOS
-				unset(Vulkan_LIBRARY CACHE)
-				unset(Vulkan_Layer_VALIDATION CACHE)
+				# For both iOS and macOS: set up global Vulkan Library defines so that MoltenVK is dynamically loaded versus the Vulkan loader
+				# on iOS we can control Vulkan library loading priority by selecting which libraries are embedded in the iOS application bundle
+				if(IOS)
+					add_compile_definitions(_HPP_VULKAN_LIBRARY="MoltenVK.framework/MoltenVK")
+					# unset FindVulkan.cmake cache variables so Vulkan loader, Validation Layer, and icd/layer json files are not embedded on iOS
+					unset(Vulkan_LIBRARY CACHE)
+					unset(Vulkan_Layer_VALIDATION CACHE)
 
-			# on macOS make sure that MoltenVK_LIBRARY_PATH points to the MoltenVK project installation and not to the Vulkan_LIBRARY location
-			# otherwise if DYLD_LIBRARY_PATH points to a common search path, Volk may dynamically load libvulkan.dylib versus libMoltenVK.dylib
-			elseif(NOT Vulkan_LIBRARY MATCHES "${MoltenVK_LIBRARY_PATH}")
-				add_compile_definitions(_HPP_VULKAN_LIBRARY="libMoltenVK.dylib")
-				add_compile_definitions(_GLFW_VULKAN_LIBRARY="libMoltenVK.dylib")
-				set(ENV{DYLD_LIBRARY_PATH} "${MoltenVK_LIBRARY_PATH}:$ENV{DYLD_LIBRARY_PATH}")
+				# on macOS make sure that MoltenVK_LIBRARY_PATH points to the MoltenVK project installation and not to the Vulkan_LIBRARY location
+				# otherwise if DYLD_LIBRARY_PATH points to a common search path, Volk may dynamically load libvulkan.dylib versus libMoltenVK.dylib
+				elseif(NOT Vulkan_LIBRARY MATCHES "${MoltenVK_LIBRARY_PATH}")
+					add_compile_definitions(_HPP_VULKAN_LIBRARY="libMoltenVK.dylib")
+					add_compile_definitions(_GLFW_VULKAN_LIBRARY="libMoltenVK.dylib")
+					set(ENV{DYLD_LIBRARY_PATH} "${MoltenVK_LIBRARY_PATH}:$ENV{DYLD_LIBRARY_PATH}")
+				else()
+					message(FATAL_ERROR "Vulkan library found in MoltenVK search path. Please set VULKAN_SDK to the MoltenVK project install location.")
+				endif()
+				message(STATUS "Using MoltenVK: ${Vulkan_MoltenVK_LIBRARY}")
 			else()
-				message(FATAL_ERROR "Vulkan library found in MoltenVK search path. Please set VULKAN_SDK to the MoltenVK project install location.")
+				message(FATAL_ERROR "Can't find MoltenVK library. Please install the Vulkan SDK or MoltenVK project and set VULKAN_SDK.")
 			endif()
-			message(STATUS "Using MoltenVK: ${Vulkan_MoltenVK_LIBRARY}")
-		else()
-			message(FATAL_ERROR "Can't find MoltenVK library. Please install the Vulkan SDK or MoltenVK project and set VULKAN_SDK.")
+		elseif(IOS)
+			# if not using MoltenVK standalone on iOS, set up global Vulkan Library define for iOS Vulkan loader
+			add_compile_definitions(_HPP_VULKAN_LIBRARY="vulkan.framework/vulkan")
 		endif()
-	elseif(IOS)
-		# if not using MoltenVK on iOS, set up global Vulkan Library define for iOS Vulkan loader
-		add_compile_definitions(_HPP_VULKAN_LIBRARY="vulkan.framework/vulkan")
 	endif()
 
 	if(CMAKE_GENERATOR MATCHES "Xcode")

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -251,7 +251,7 @@ inline bool enable_layer_setting(vk::LayerSettingEXT const        &requested_lay
 	// Vulkan does not provide a reflection API for layer settings. Layer settings are described in each layer JSON manifest.
 	bool is_available = std::ranges::any_of(
 	    enabled_layers, [&requested_layer_setting](auto const &available_layer) { return strcmp(available_layer, requested_layer_setting.pLayerName) == 0; });
-#if defined(PLATFORM__MACOS)
+#if defined(PLATFORM__MACOS) && defined(VKB_ENABLE_PORTABILITY)
 	// On Apple platforms the MoltenVK layer is implicitly enabled and available, and cannot be explicitly added or checked via enabled_layers.
 	is_available = is_available || strcmp(requested_layer_setting.pLayerName, "MoltenVK") == 0;
 #endif

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -1115,7 +1115,7 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 	}
 
 #ifdef VKB_ENABLE_PORTABILITY
-	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
+	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS using MoltenVK with beta extensions enabled)
 	add_device_extension(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, /*optional=*/true);
 #endif
 

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -293,7 +293,7 @@ void HelloTriangle::init_device()
 	}
 
 #if (defined(VKB_ENABLE_PORTABILITY))
-	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
+	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS using MoltenVK with beta extensions enabled)
 	if (std::ranges::any_of(device_extensions,
 	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
 	{

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -997,7 +997,10 @@ HelloTriangle::~HelloTriangle()
 {
 	// When destroying the application, we need to make sure the GPU is no longer accessing any resources
 	// This is done by doing a device wait idle, which blocks until the GPU signals
-	vkDeviceWaitIdle(context.device);
+	if (context.device != VK_NULL_HANDLE)
+	{
+		vkDeviceWaitIdle(context.device);
+	}
 
 	for (auto &framebuffer : context.swapchain_framebuffers)
 	{

--- a/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
+++ b/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
@@ -309,7 +309,7 @@ void HelloTriangleV13::init_device()
 	}
 
 #if (defined(VKB_ENABLE_PORTABILITY))
-	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
+	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS using MoltenVK with beta extensions enabled)
 	if (std::ranges::any_of(device_extensions,
 	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
 	{

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -76,7 +76,10 @@ HPPHelloTriangle::HPPHelloTriangle()
 HPPHelloTriangle::~HPPHelloTriangle()
 {
 	// Don't release anything until the GPU is completely idle.
-	device.waitIdle();
+	if (device)
+	{
+		device.waitIdle();
+	}
 
 	teardown_framebuffers();
 
@@ -142,7 +145,10 @@ HPPHelloTriangle::~HPPHelloTriangle()
 		instance.destroyDebugUtilsMessengerEXT(debug_utils_messenger);
 	}
 
-	instance.destroy();
+	if (instance)
+	{
+		instance.destroy();
+	}
 }
 
 bool HPPHelloTriangle::prepare(const vkb::ApplicationOptions &options)
@@ -915,7 +921,10 @@ void HPPHelloTriangle::select_physical_device_and_surface()
 void HPPHelloTriangle::teardown_framebuffers()
 {
 	// Wait until device is idle before teardown.
-	queue.waitIdle();
+	if (queue)
+	{
+		queue.waitIdle();
+	}
 
 	for (auto &framebuffer : swapchain_data.framebuffers)
 	{

--- a/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
+++ b/samples/api/hpp_hello_triangle/hpp_hello_triangle.cpp
@@ -331,7 +331,7 @@ vk::Device HPPHelloTriangle::create_device(const std::vector<const char *> &requ
 	std::vector<const char *> active_device_extensions(required_device_extensions);
 
 #if (defined(VKB_ENABLE_PORTABILITY))
-	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
+	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS using MoltenVK with beta extensions enabled)
 	if (std::ranges::any_of(device_extensions,
 	                        [](vk::ExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
 	{

--- a/samples/api/hpp_hello_triangle_1_3/hpp_hello_triangle_1_3.cpp
+++ b/samples/api/hpp_hello_triangle_1_3/hpp_hello_triangle_1_3.cpp
@@ -386,7 +386,7 @@ void HPPHelloTriangleV13::init_device()
 	}
 
 #if (defined(VKB_ENABLE_PORTABILITY))
-	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS with beta extensions enabled)
+	// VK_KHR_portability_subset must be enabled if present in the implementation (e.g on macOS/iOS using MoltenVK with beta extensions enabled)
 	if (std::ranges::any_of(device_extensions,
 	                        [](vk::ExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0; }))
 	{

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -31,23 +31,6 @@ DescriptorIndexing::DescriptorIndexing()
 	// Works around a validation layer bug with descriptor pool allocation with VARIABLE_COUNT.
 	// See: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2350.
 	add_device_extension(VK_KHR_MAINTENANCE1_EXTENSION_NAME);
-
-#if defined(PLATFORM__MACOS)
-	// On Apple use layer setting to enable MoltenVK's Metal argument buffers - needed for descriptor indexing/scaling
-	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional*/ true);
-
-	VkLayerSettingEXT layerSetting;
-	layerSetting.pLayerName   = "MoltenVK";
-	layerSetting.pSettingName = "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS";
-	layerSetting.type         = VK_LAYER_SETTING_TYPE_INT32_EXT;
-	layerSetting.valueCount   = 1;
-
-	// Make this static so layer setting reference remains valid after leaving constructor scope
-	static const int32_t useMetalArgumentBuffers = 1;
-	layerSetting.pValues                         = &useMetalArgumentBuffers;
-
-	add_layer_setting(layerSetting);
-#endif
 }
 
 DescriptorIndexing::~DescriptorIndexing()
@@ -212,14 +195,6 @@ void DescriptorIndexing::create_bindless_descriptors()
 {
 	uint32_t descriptorCount = descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindSampledImages;
 
-#if defined(PLATFORM__MACOS)
-	// On Apple Vulkan API <= 1.2.283 variable descriptor counts don't work, use max expected count instead. Fixed in later versions.
-	if (get_device().get_gpu().get_properties().apiVersion <= VK_MAKE_API_VERSION(0, 1, 2, 283))
-	{
-		descriptorCount = std::max(NumDescriptorsStreaming, NumDescriptorsNonUniform);
-	}
-#endif
-
 	VkDescriptorSetLayoutBinding    binding                = vkb::initializers::descriptor_set_layout_binding(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_SHADER_STAGE_FRAGMENT_BIT, 0, descriptorCount);
 	VkDescriptorSetLayoutCreateInfo set_layout_create_info = vkb::initializers::descriptor_set_layout_create_info(&binding, 1);
 
@@ -261,14 +236,6 @@ void DescriptorIndexing::create_bindless_descriptors()
 	// We're going to allocate two separate descriptor sets from the same pool, and here VARIABLE_DESCRIPTOR_COUNT comes in handy!
 	// For the non-uniform indexing part, we allocate few descriptors, and for the streaming case, we allocate a fairly large ring buffer of descriptors we can play around with.
 	uint32_t poolCount = NumDescriptorsStreaming + NumDescriptorsNonUniform;
-
-#if defined(PLATFORM__MACOS)
-	// On Apple Vulkan API <= 1.2.283 variable descriptor counts don't work, use pool size of max expected count x 2 (for 2 allocations). Fixed in later versions.
-	if (get_device().get_gpu().get_properties().apiVersion <= VK_MAKE_API_VERSION(0, 1, 2, 283))
-	{
-		poolCount = std::max(NumDescriptorsStreaming, NumDescriptorsNonUniform) * 2;
-	}
-#endif
 
 	VkDescriptorPoolSize       pool_size = vkb::initializers::descriptor_pool_size(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, poolCount);
 	VkDescriptorPoolCreateInfo pool      = vkb::initializers::descriptor_pool_create_info(1, &pool_size, 2);

--- a/samples/extensions/portability/portability.cpp
+++ b/samples/extensions/portability/portability.cpp
@@ -33,10 +33,12 @@ Portability::Portability() :
     filter_pass()
 {
 	title = "Portability";
-	// Portability is a Vulkan 1.3 extension
-	set_api_version(VK_API_VERSION_1_3);
-	add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-	add_instance_extension(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, /*optional*/ true);
+	// These instance extensions are conditionally added by the sample framework when VKB_ENABLE_PORTABILITY is enabled
+	// add_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+	// add_instance_extension(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, /*optional=*/true);
+
+	// VK_KHR_portability_subset depends on VK_KHR_get_physical_device_properties2 or Vulkan 1.1 (default for project)
+	// This device extension is conditionally added by the sample framework when VKB_ENABLE_PORTABILITY is enabled
 }
 
 Portability::~Portability()
@@ -868,41 +870,48 @@ void Portability::render(float delta_time)
 void Portability::on_update_ui_overlay(vkb::Drawer &drawer)
 {
 #ifdef VKB_ENABLE_PORTABILITY
-	std::string portability_support_list;
-	if (portability_features.constantAlphaColorBlendFactors)
-		portability_support_list += "constantAlphaColorBlendFactors\n";
-	if (portability_features.events)
-		portability_support_list += "events\n";
-	if (portability_features.imageView2DOn3DImage)
-		portability_support_list += "imageView2DOn3dImage\n";
-	if (portability_features.imageViewFormatReinterpretation)
-		portability_support_list += "imageViewFormatReinterpretation\n";
-	if (portability_features.imageViewFormatSwizzle)
-		portability_support_list += "imageViewFormatSwizzle\n";
-	if (portability_features.multisampleArrayImage)
-		portability_support_list += "multisampleArrayImage\n";
-	if (portability_features.mutableComparisonSamplers)
-		portability_support_list += "mutableComparisonSamplers\n";
-	if (portability_features.pointPolygons)
-		portability_support_list += "pointPolygons\n";
-	if (portability_features.samplerMipLodBias)
-		portability_support_list += "samplerMipLodBias\n";
-	if (portability_features.separateStencilMaskRef)
-		portability_support_list += "separateStencilMaskRef\n";
-	if (portability_features.shaderSampleRateInterpolationFunctions)
-		portability_support_list += "shaderSampleRateInterpolationFunctions\n";
-	if (portability_features.tessellationIsolines)
-		portability_support_list += "tessellationIsolines\n";
-	if (portability_features.tessellationPointMode)
-		portability_support_list += "tessellationPointMode\n";
-	if (portability_features.triangleFans)
-		portability_support_list += "triangleFans\n";
-	if (portability_features.vertexAttributeAccessBeyondStride)
-		portability_support_list += "vertexAttributeAccessBeyondStride\n";
-	drawer.text("Device Portability feature support list:\n%s", portability_support_list.c_str());
-#else
-	drawer.text("VKB_ENABLE_PORTABILITY not enabled can't list portability feature set");
+	// VK_KHR_portability_subset extension must be available in the implementation to list device portability feature set
+	if (get_device().get_gpu().is_extension_supported(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+	{
+		std::string portability_support_list;
+		if (portability_features.constantAlphaColorBlendFactors)
+			portability_support_list += "constantAlphaColorBlendFactors\n";
+		if (portability_features.events)
+			portability_support_list += "events\n";
+		if (portability_features.imageView2DOn3DImage)
+			portability_support_list += "imageView2DOn3dImage\n";
+		if (portability_features.imageViewFormatReinterpretation)
+			portability_support_list += "imageViewFormatReinterpretation\n";
+		if (portability_features.imageViewFormatSwizzle)
+			portability_support_list += "imageViewFormatSwizzle\n";
+		if (portability_features.multisampleArrayImage)
+			portability_support_list += "multisampleArrayImage\n";
+		if (portability_features.mutableComparisonSamplers)
+			portability_support_list += "mutableComparisonSamplers\n";
+		if (portability_features.pointPolygons)
+			portability_support_list += "pointPolygons\n";
+		if (portability_features.samplerMipLodBias)
+			portability_support_list += "samplerMipLodBias\n";
+		if (portability_features.separateStencilMaskRef)
+			portability_support_list += "separateStencilMaskRef\n";
+		if (portability_features.shaderSampleRateInterpolationFunctions)
+			portability_support_list += "shaderSampleRateInterpolationFunctions\n";
+		if (portability_features.tessellationIsolines)
+			portability_support_list += "tessellationIsolines\n";
+		if (portability_features.tessellationPointMode)
+			portability_support_list += "tessellationPointMode\n";
+		if (portability_features.triangleFans)
+			portability_support_list += "triangleFans\n";
+		if (portability_features.vertexAttributeAccessBeyondStride)
+			portability_support_list += "vertexAttributeAccessBeyondStride\n";
+		drawer.text("Device Portability feature support list:\n%s", portability_support_list.c_str());
+	}
+	else
 #endif
+	{
+		drawer.text("VK_KHR_portability_subset not available can't list portability feature set");
+	}
+
 	if (drawer.header("Settings"))
 	{
 		if (drawer.checkbox("Bloom", &bloom))

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -497,7 +497,7 @@ std::unique_ptr<vkb::core::InstanceC> ShaderDebugPrintf::create_instance()
 	std::vector<VkExtensionProperties> available_instance_extensions(available_extension_count);
 	VK_CHECK(vkEnumerateInstanceExtensionProperties(nullptr, &available_extension_count, available_instance_extensions.data()));
 
-	// If VK_KHR_portability_enumeration is available in the portability implementation, then we must enable the extension
+	// If VK_KHR_portability_enumeration is available in the implementation, then we must enable the extension
 	bool portability_enumeration_available = false;
 	if (std::ranges::any_of(available_instance_extensions,
 	                        [](VkExtensionProperties const &extension) { return strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0; }))

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -42,7 +42,7 @@ void AsyncComputeSample::request_gpu_features(vkb::core::PhysicalDeviceC &gpu)
 {
 #ifdef VKB_ENABLE_PORTABILITY
 	// Since sampler_info.compareEnable = VK_TRUE, must enable the mutableComparisonSamplers feature of VK_KHR_portability_subset
-	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDevicePortabilitySubsetFeaturesKHR, mutableComparisonSamplers);
+	REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDevicePortabilitySubsetFeaturesKHR, mutableComparisonSamplers);
 #endif
 }
 

--- a/samples/performance/layout_transitions/layout_transitions.cpp
+++ b/samples/performance/layout_transitions/layout_transitions.cpp
@@ -37,7 +37,7 @@ LayoutTransitions::LayoutTransitions()
 	config.insert<vkb::IntSetting>(0, reinterpret_cast<int &>(layout_transition_type), LayoutTransitionType::UNDEFINED);
 	config.insert<vkb::IntSetting>(1, reinterpret_cast<int &>(layout_transition_type), LayoutTransitionType::LAST_LAYOUT);
 
-#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
+#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR && defined(VKB_ENABLE_PORTABILITY)
 	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
 	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional*/ true);
 
@@ -48,8 +48,8 @@ LayoutTransitions::LayoutTransitions()
 	layerSetting.valueCount   = 1;
 
 	// Make this static so layer setting reference remains valid after leaving constructor scope
-	static const int32_t useMetalArgumentBuffers = 0;
-	layerSetting.pValues                         = &useMetalArgumentBuffers;
+	static const int32_t disableMetalArgumentBuffers = 0;
+	layerSetting.pValues                             = &disableMetalArgumentBuffers;
 
 	add_layer_setting(layerSetting);
 #endif

--- a/samples/performance/layout_transitions/layout_transitions.cpp
+++ b/samples/performance/layout_transitions/layout_transitions.cpp
@@ -37,9 +37,9 @@ LayoutTransitions::LayoutTransitions()
 	config.insert<vkb::IntSetting>(0, reinterpret_cast<int &>(layout_transition_type), LayoutTransitionType::UNDEFINED);
 	config.insert<vkb::IntSetting>(1, reinterpret_cast<int &>(layout_transition_type), LayoutTransitionType::LAST_LAYOUT);
 
-#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR && defined(VKB_ENABLE_PORTABILITY)
+#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
 	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
-	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional*/ true);
+	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional=*/true);
 
 	VkLayerSettingEXT layerSetting;
 	layerSetting.pLayerName   = "MoltenVK";

--- a/samples/performance/multithreading_render_passes/multithreading_render_passes.cpp
+++ b/samples/performance/multithreading_render_passes/multithreading_render_passes.cpp
@@ -43,7 +43,7 @@ void MultithreadingRenderPasses::request_gpu_features(vkb::core::PhysicalDeviceC
 {
 #ifdef VKB_ENABLE_PORTABILITY
 	// Since shadowmap_sampler_create_info.compareEnable = VK_TRUE, must enable the mutableComparisonSamplers feature of VK_KHR_portability_subset
-	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDevicePortabilitySubsetFeaturesKHR, mutableComparisonSamplers);
+	REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDevicePortabilitySubsetFeaturesKHR, mutableComparisonSamplers);
 #endif
 }
 

--- a/samples/performance/pipeline_barriers/pipeline_barriers.cpp
+++ b/samples/performance/pipeline_barriers/pipeline_barriers.cpp
@@ -39,7 +39,7 @@ PipelineBarriers::PipelineBarriers()
 	config.insert<vkb::IntSetting>(1, reinterpret_cast<int &>(dependency_type), DependencyType::FRAG_TO_VERT);
 	config.insert<vkb::IntSetting>(2, reinterpret_cast<int &>(dependency_type), DependencyType::FRAG_TO_FRAG);
 
-#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
+#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR && defined(VKB_ENABLE_PORTABILITY)
 	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
 	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional*/ true);
 
@@ -50,8 +50,8 @@ PipelineBarriers::PipelineBarriers()
 	layerSetting.valueCount   = 1;
 
 	// Make this static so layer setting reference remains valid after leaving constructor scope
-	static const int32_t useMetalArgumentBuffers = 0;
-	layerSetting.pValues                         = &useMetalArgumentBuffers;
+	static const int32_t disableMetalArgumentBuffers = 0;
+	layerSetting.pValues                             = &disableMetalArgumentBuffers;
 
 	add_layer_setting(layerSetting);
 #endif

--- a/samples/performance/pipeline_barriers/pipeline_barriers.cpp
+++ b/samples/performance/pipeline_barriers/pipeline_barriers.cpp
@@ -39,9 +39,9 @@ PipelineBarriers::PipelineBarriers()
 	config.insert<vkb::IntSetting>(1, reinterpret_cast<int &>(dependency_type), DependencyType::FRAG_TO_VERT);
 	config.insert<vkb::IntSetting>(2, reinterpret_cast<int &>(dependency_type), DependencyType::FRAG_TO_FRAG);
 
-#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR && defined(VKB_ENABLE_PORTABILITY)
+#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
 	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
-	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional*/ true);
+	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional=*/true);
 
 	VkLayerSettingEXT layerSetting;
 	layerSetting.pLayerName   = "MoltenVK";

--- a/samples/performance/subpasses/subpasses.cpp
+++ b/samples/performance/subpasses/subpasses.cpp
@@ -51,9 +51,9 @@ Subpasses::Subpasses()
 	config.insert<vkb::IntSetting>(3, configs[Config::TransientAttachments].value, 0);
 	config.insert<vkb::IntSetting>(3, configs[Config::GBufferSize].value, 1);
 
-#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR && defined(VKB_ENABLE_PORTABILITY)
+#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
 	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
-	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional*/ true);
+	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional=*/true);
 
 	VkLayerSettingEXT layerSetting;
 	layerSetting.pLayerName   = "MoltenVK";

--- a/samples/performance/subpasses/subpasses.cpp
+++ b/samples/performance/subpasses/subpasses.cpp
@@ -51,7 +51,7 @@ Subpasses::Subpasses()
 	config.insert<vkb::IntSetting>(3, configs[Config::TransientAttachments].value, 0);
 	config.insert<vkb::IntSetting>(3, configs[Config::GBufferSize].value, 1);
 
-#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
+#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR && defined(VKB_ENABLE_PORTABILITY)
 	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
 	add_instance_extension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, /*optional*/ true);
 
@@ -62,8 +62,8 @@ Subpasses::Subpasses()
 	layerSetting.valueCount   = 1;
 
 	// Make this static so layer setting reference remains valid after leaving constructor scope
-	static const int32_t useMetalArgumentBuffers = 0;
-	layerSetting.pValues                         = &useMetalArgumentBuffers;
+	static const int32_t disableMetalArgumentBuffers = 0;
+	layerSetting.pValues                             = &disableMetalArgumentBuffers;
 
 	add_layer_setting(layerSetting);
 #endif

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -167,27 +167,6 @@ std::unique_ptr<vkb::core::InstanceC> Profiles::create_instance()
 	}
 #endif
 
-#if defined(PLATFORM__MACOS)
-	// On Apple use layer setting to enable MoltenVK's Metal argument buffers - needed for descriptor indexing/scaling
-	enabled_extensions.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
-
-	VkLayerSettingEXT layerSetting{};
-	layerSetting.pLayerName   = "MoltenVK";
-	layerSetting.pSettingName = "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS";
-	layerSetting.type         = VK_LAYER_SETTING_TYPE_INT32_EXT;
-	layerSetting.valueCount   = 1;
-
-	const int32_t useMetalArgumentBuffers = 1;
-	layerSetting.pValues                  = &useMetalArgumentBuffers;
-
-	VkLayerSettingsCreateInfoEXT layerSettingsCreateInfo{};
-	layerSettingsCreateInfo.sType        = VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT;
-	layerSettingsCreateInfo.settingCount = 1;
-	layerSettingsCreateInfo.pSettings    = &layerSetting;
-
-	create_info.pNext = &layerSettingsCreateInfo;
-#endif
-
 	create_info.sType                   = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
 	create_info.ppEnabledExtensionNames = enabled_extensions.data();
 	create_info.enabledExtensionCount   = static_cast<uint32_t>(enabled_extensions.size());

--- a/samples/tooling/profiles/vulkan_profiles.hpp
+++ b/samples/tooling/profiles/vulkan_profiles.hpp
@@ -33648,25 +33648,6 @@ VPAPI_ATTR VkResult vpCreateInstance(
 		}
 	}
 
-#ifdef __APPLE__
-	bool has_portability_ext = false;
-	for (std::size_t ext_index = 0, ext_count = extensions.size(); ext_index < ext_count; ++ext_index)
-	{
-		if (strcmp(extensions[ext_index], VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0)
-		{
-			has_portability_ext = true;
-			break;
-		}
-	}
-
-	if (!has_portability_ext)
-	{
-		extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-	}
-
-	createInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-#endif
-
 	if (!extensions.empty())
 	{
 		createInfo.enabledExtensionCount   = static_cast<uint32_t>(extensions.size());


### PR DESCRIPTION
## Description

This WIP PR removes the Apple = MoltenVK driver assumption and provides compatibility for the coming KosmicKrisp driver on supported platforms (macOS, arm64). In addition, it provides a simple mechanism to allow the user to build for either situation. The already-existant CMake variable `VKB_ENABLE_PORTABILITY` is now externalized as a CMake command line option ~~for users to select building for MoltenVK vs. KosmicKrisp~~.  The option is set in this PR to default = ON for backwards compatibility.  To build for KosmicKrisp the user will likely have to execute a specific **setup-env.sh** from the SDK (or set the `VK_DRIVER_FILES` environment variable) and then run CMake using the macOS instructions ~~adding the option `-DVKB_ENABLE_PORTABILITY=OFF`~~.

Specifics are:

1. Change `VKB_ENABLE_PORTABILITY` from being an internally set CMake variable to a cmdline option (default ON).
2. Guard a small number of Apple-specific layer settings-related code blocks used for configuring MoltenVK.
3. Remove unneeded Apple-specific #ifdef legacy code blocks from the _descriptor_indexing_ sample.
4. Update the _profiles_ sample to run with VKB_ENABLE_PORTABILITY set to ON or OFF on Apple platforms.  The only issue here is that I had to remove a hard-coded `#ifdef __APPLE__` code block from **vulkan_profiles.hpp** to provide this flexibility.  I realize this is a generated file, but the .hpp file makes a bad assumption that Apple = PORTABILITY and turns on the portability extensions by itself.  This is not correct going forward and the sample itself should control that, not the hpp file.  This really should be changed in the generator script, but I do not have access to that within this project.
5. Add a few missing null object checks in the _[hpp\_]hello_triangle_ samples so they do not crash on exit if no valid driver is found.  I discovered this during regression testing.
6. [_new_] Update comments and messages for iOS config and build framework.  These changes retain the assumption that MoltenVK is used for iOS, but the framework now exists for adding alternative iOS drivers.  Comments welcome.
7. [_new_] Update _profiles_ sample to include previously missing items: a) enable `VK_KHR_portability_subset` device extension when `VKB_ENABLE_PORTABILITY=ON`, b) allocate descriptors from update-after-bind pool for descriptor indexing scalability, and c) destroy images and sampler on exit - all to eliminate validation errors.

Fixes #1434

Regression tested for MoltenVK on macOS Ventura on x86_64 + AMD 6600 and on macOS Sequoia on M1 Air using SDK 1.4.328.1 as well as the latest development build of MoltenVK.

@aitor-lunarg if you could review and/or test this functionality with KosmicKrisp that would be great.  See macOS [build instructions](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/docs/build.adoc#macos). ~~Simply add `-DVKB_ENABLE_PORTABILITY=OFF` to the command line.~~  There are some unknowns regarding project dependencies on components like the Vulkan **DynamicLoader** and **volk**, but I am hoping those work as-is for KosmicKrisp.

Once this PR has been verified as working by others, I will add an additional commit for macOS build instructions.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
