### PR TITLE
Fix usage of debug utils labels with secondary command buffers.

### DIFF
--- a/framework/rendering/render_pipeline.cpp
+++ b/framework/rendering/render_pipeline.cpp
@@ -113,11 +113,14 @@ void RenderPipeline::draw(vkb::core::CommandBufferC &command_buffer, RenderTarge
 			command_buffer.next_subpass();
 		}
 
-		if (subpass->get_debug_name().empty())
+		if (contents != VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS)
 		{
-			subpass->set_debug_name(fmt::format("RP subpass #{}", i));
+			if (subpass->get_debug_name().empty())
+			{
+				subpass->set_debug_name(fmt::format("RP subpass #{}", i));
+			}
+			ScopedDebugLabel subpass_debug_label{command_buffer, subpass->get_debug_name().c_str()};
 		}
-		ScopedDebugLabel subpass_debug_label{command_buffer, subpass->get_debug_name().c_str()};
 
 		subpass->draw(command_buffer);
 	}

--- a/samples/performance/command_buffer_usage/command_buffer_usage.h
+++ b/samples/performance/command_buffer_usage/command_buffer_usage.h
@@ -183,6 +183,7 @@ class CommandBufferUsage : public vkb::VulkanSampleC
 		 * @param nodes The meshes to draw
 		 * @param mesh_start Index to the first mesh to draw
 		 * @param mesh_end Index to the mesh where recording will stop (not included)
+		 * @param subpass_index Index of the subpass being recorded
 		 * @param thread_index Identifies the resources allocated for this thread
 		 * @return a pointer to the recorded secondary command buffer
 		 */
@@ -190,6 +191,7 @@ class CommandBufferUsage : public vkb::VulkanSampleC
 		                                                                 const std::vector<std::pair<vkb::scene_graph::NodeC *, vkb::sg::SubMesh *>> &nodes,
 		                                                                 uint32_t                                                                     mesh_start,
 		                                                                 uint32_t                                                                     mesh_end,
+		                                                                 uint32_t                                                                     subpass_index,
 		                                                                 size_t                                                                       thread_index = 0);
 
 		VkViewport viewport{};


### PR DESCRIPTION
## Description

For secondary command buffers, any debug labels need to be issued at record time of the secondary command buffers, not at record time of the primary command buffer. This PR fixes this in the framework and the sample commands_buffer_usage.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Fixes #1430

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
