### PR TITLE
Resolve VVL warning on incompatible OpTypeImage vs. image view format

### DIFF
--- a/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
+++ b/samples/extensions/ray_tracing_basic/ray_tracing_basic.cpp
@@ -62,6 +62,12 @@ RaytracingBasic::~RaytracingBasic()
 	}
 }
 
+void RaytracingBasic::create_render_context()
+{
+	// select an RGB8A8_SRGB surface format, skipping the ApiVulkanSample::create_render_context implementation
+	VulkanSample::create_render_context({{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}});
+}
+
 void RaytracingBasic::request_gpu_features(vkb::core::PhysicalDeviceC &gpu)
 {
 	// Enable extension features required by this sample
@@ -83,7 +89,7 @@ void RaytracingBasic::create_storage_image()
 
 	VkImageCreateInfo image = vkb::initializers::image_create_info();
 	image.imageType         = VK_IMAGE_TYPE_2D;
-	image.format            = VK_FORMAT_B8G8R8A8_UNORM;
+	image.format            = VK_FORMAT_R8G8B8A8_UNORM;
 	image.extent.width      = storage_image.width;
 	image.extent.height     = storage_image.height;
 	image.extent.depth      = 1;
@@ -105,7 +111,7 @@ void RaytracingBasic::create_storage_image()
 
 	VkImageViewCreateInfo color_image_view           = vkb::initializers::image_view_create_info();
 	color_image_view.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-	color_image_view.format                          = VK_FORMAT_B8G8R8A8_UNORM;
+	color_image_view.format                          = image.format;
 	color_image_view.subresourceRange                = {};
 	color_image_view.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
 	color_image_view.subresourceRange.baseMipLevel   = 0;

--- a/samples/extensions/ray_tracing_basic/ray_tracing_basic.h
+++ b/samples/extensions/ray_tracing_basic/ray_tracing_basic.h
@@ -59,12 +59,11 @@ class RaytracingBasic : public ApiVulkanSample
 
 	struct StorageImage
 	{
-		VkDeviceMemory memory;
-		VkImage        image = VK_NULL_HANDLE;
-		VkImageView    view;
-		VkFormat       format;
-		uint32_t       width;
-		uint32_t       height;
+		VkDeviceMemory memory = VK_NULL_HANDLE;
+		VkImage        image  = VK_NULL_HANDLE;
+		VkImageView    view   = VK_NULL_HANDLE;
+		uint32_t       width  = 0;
+		uint32_t       height = 0;
 	} storage_image;
 
 	struct UniformData
@@ -82,6 +81,7 @@ class RaytracingBasic : public ApiVulkanSample
 	RaytracingBasic();
 	~RaytracingBasic();
 
+	void          create_render_context() override;
 	void          request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
 	uint64_t      get_buffer_device_address(VkBuffer buffer);
 	ScratchBuffer create_scratch_buffer(VkDeviceSize size);

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.cpp
@@ -133,6 +133,12 @@ RaytracingExtended::~RaytracingExtended()
 	}
 }
 
+void RaytracingExtended::create_render_context()
+{
+	// select an RGB8A8_SRGB surface format, skipping the ApiVulkanSample::create_render_context implementation
+	VulkanSample::create_render_context({{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}});
+}
+
 void RaytracingExtended::request_gpu_features(vkb::core::PhysicalDeviceC &gpu)
 {
 	// Enable extension features required by this sample
@@ -161,7 +167,7 @@ void RaytracingExtended::create_storage_image()
 
 	VkImageCreateInfo image = vkb::initializers::image_create_info();
 	image.imageType         = VK_IMAGE_TYPE_2D;
-	image.format            = VK_FORMAT_B8G8R8A8_UNORM;
+	image.format            = VK_FORMAT_R8G8B8A8_UNORM;
 	image.extent.width      = storage_image.width;
 	image.extent.height     = storage_image.height;
 	image.extent.depth      = 1;
@@ -183,7 +189,7 @@ void RaytracingExtended::create_storage_image()
 
 	VkImageViewCreateInfo color_image_view           = vkb::initializers::image_view_create_info();
 	color_image_view.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-	color_image_view.format                          = VK_FORMAT_B8G8R8A8_UNORM;
+	color_image_view.format                          = image.format;
 	color_image_view.subresourceRange                = {};
 	color_image_view.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
 	color_image_view.subresourceRange.baseMipLevel   = 0;

--- a/samples/extensions/ray_tracing_extended/ray_tracing_extended.h
+++ b/samples/extensions/ray_tracing_extended/ray_tracing_extended.h
@@ -260,6 +260,7 @@ class RaytracingExtended : public ApiVulkanSample
 	RaytracingExtended();
 	~RaytracingExtended() override;
 
+	void                 create_render_context() override;
 	void                 request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
 	uint64_t             get_buffer_device_address(VkBuffer buffer);
 	void                 create_storage_image();

--- a/samples/extensions/ray_tracing_position_fetch/ray_tracing_position_fetch.cpp
+++ b/samples/extensions/ray_tracing_position_fetch/ray_tracing_position_fetch.cpp
@@ -60,6 +60,12 @@ RayTracingPositionFetch::~RayTracingPositionFetch()
 	}
 }
 
+void RayTracingPositionFetch::create_render_context()
+{
+	// select an RGB8A8_SRGB surface format, skipping the ApiVulkanSample::create_render_context implementation
+	VulkanSample::create_render_context({{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}});
+}
+
 void RayTracingPositionFetch::request_gpu_features(vkb::core::PhysicalDeviceC &gpu)
 {
 	// Features required for ray tracing
@@ -81,7 +87,7 @@ void RayTracingPositionFetch::create_storage_image()
 
 	VkImageCreateInfo image = vkb::initializers::image_create_info();
 	image.imageType         = VK_IMAGE_TYPE_2D;
-	image.format            = VK_FORMAT_B8G8R8A8_UNORM;
+	image.format            = VK_FORMAT_R8G8B8A8_UNORM;
 	image.extent.width      = storage_image.width;
 	image.extent.height     = storage_image.height;
 	image.extent.depth      = 1;
@@ -103,7 +109,7 @@ void RayTracingPositionFetch::create_storage_image()
 
 	VkImageViewCreateInfo color_image_view           = vkb::initializers::image_view_create_info();
 	color_image_view.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-	color_image_view.format                          = VK_FORMAT_B8G8R8A8_UNORM;
+	color_image_view.format                          = image.format;
 	color_image_view.subresourceRange                = {};
 	color_image_view.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
 	color_image_view.subresourceRange.baseMipLevel   = 0;

--- a/samples/extensions/ray_tracing_position_fetch/ray_tracing_position_fetch.h
+++ b/samples/extensions/ray_tracing_position_fetch/ray_tracing_position_fetch.h
@@ -63,6 +63,7 @@ class RayTracingPositionFetch : public ApiVulkanSample
 	RayTracingPositionFetch();
 	virtual ~RayTracingPositionFetch();
 
+	void         create_render_context() override;
 	void         request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
 	void         create_storage_image();
 	void         create_bottom_level_acceleration_structure();

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.cpp
@@ -124,6 +124,12 @@ RaytracingReflection::~RaytracingReflection()
 	}
 }
 
+void RaytracingReflection::create_render_context()
+{
+	// select an RGB8A8_SRGB surface format, skipping the ApiVulkanSample::create_render_context implementation
+	VulkanSample::create_render_context({{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}});
+}
+
 /*
     Enable extension features required by this sample
     These are passed to device creation via a pNext structure chain
@@ -155,7 +161,7 @@ void RaytracingReflection::create_storage_image()
 
 	VkImageCreateInfo image{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
 	image.imageType     = VK_IMAGE_TYPE_2D;
-	image.format        = VK_FORMAT_B8G8R8A8_UNORM;
+	image.format        = VK_FORMAT_R8G8B8A8_UNORM;
 	image.extent.width  = storage_image.width;
 	image.extent.height = storage_image.height;
 	image.extent.depth  = 1;
@@ -177,7 +183,7 @@ void RaytracingReflection::create_storage_image()
 
 	VkImageViewCreateInfo color_image_view{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
 	color_image_view.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-	color_image_view.format                          = VK_FORMAT_B8G8R8A8_UNORM;
+	color_image_view.format                          = image.format;
 	color_image_view.subresourceRange                = {};
 	color_image_view.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
 	color_image_view.subresourceRange.baseMipLevel   = 0;

--- a/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.h
+++ b/samples/extensions/ray_tracing_reflection/ray_tracing_reflection.h
@@ -127,6 +127,7 @@ class RaytracingReflection : public ApiVulkanSample
 	void draw();
 
 	void build_command_buffers() override;
+	void create_render_context() override;
 	void request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
 	bool prepare(const vkb::ApplicationOptions &options) override;
 	void render(float delta_time) override;


### PR DESCRIPTION
## Description

One possible way to resolve the VVL warnings on incompatible `OpTypeImage`, without the need of additional extensions.
Just needs to switch the generated image from BGRA8 to RGBA8, and overwrites the function `create_render_context` to enforce selection of an RGBA surface format.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Fixes #1423

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
