### PR TITLE
Minimal invasive fix for the memory leak in the performance sample multi_draw_indirect.

### DIFF
--- a/framework/core/command_pool.h
+++ b/framework/core/command_pool.h
@@ -68,7 +68,7 @@ class CommandPool : private vkb::core::CommandPoolBase
 	            uint32_t                                  queue_family_index,
 	            vkb::rendering::RenderFrame<bindingType> *render_frame = nullptr,
 	            size_t                                    thread_index = 0,
-	            vkb::CommandBufferResetMode               reset_mode   = vkb::CommandBufferResetMode::ResetPool);
+	            vkb::CommandBufferResetMode               reset_mode   = vkb::CommandBufferResetMode::ResetIndividually);
 	CommandPool(CommandPool<bindingType> const &)            = delete;
 	CommandPool(CommandPool<bindingType> &&other)            = default;
 	CommandPool &operator=(CommandPool<bindingType> const &) = delete;

--- a/samples/performance/multi_draw_indirect/multi_draw_indirect.h
+++ b/samples/performance/multi_draw_indirect/multi_draw_indirect.h
@@ -128,6 +128,8 @@ class MultiDrawIndirect : public ApiVulkanSample
 	const vkb::Queue                      *compute_queue{nullptr};
 	std::vector<uint32_t>                  queue_families;
 
+	std::shared_ptr<vkb::core::CommandBufferC> ui_overlay_command_buffer;
+
 	// CPU Draw Calls
 	void                                      cpu_cull();
 	std::vector<VkDrawIndexedIndirectCommand> cpu_commands;


### PR DESCRIPTION
## Description

Essentially, there's no general approach in the framework to re-use or selectively reset command buffers.
This minimal change in the framework and the sample resolves the memory leak.

Build tested on Win10 with VS2022. Run tested on Win10 with NVidia GPU.

Fixes #1415

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
