### PR TITLE
Simplify CMake generation step for Windows and refer to CMake docs

### DIFF
--- a/docs/build.adoc
+++ b/docs/build.adoc
@@ -182,33 +182,14 @@ Please make sure, when running any sample, that you either:
 * Run Command Prompt or Visual Studio as administrator
 ____
 
-`Step 1.` The following command will generate the VS project
+`Step 1.` Generate the VS solution from the root of the repository
 
-----
-cmake -G "Visual Studio 15 2017 Win64" -S . -Bbuild/windows
-----
-
-(Prior to CMake v3.13)
-
-----
-cmake -G "Visual Studio 15 2017 Win64" . -Bbuild/windows
-----
-
-(New in CMake v3.14.
-Visual Studio 2019 must be installed)
-
-----
- cmake -G "Visual Studio 16 2019" -A x64 -S . -Bbuild/windows
-----
-
-(New in CMake v3.21.
-Visual Studio 2022 must be installed)
-
+(For other VS versions please refer to https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#id15[CMake Generators])
 ----
  cmake -G "Visual Studio 17 2022" -A x64 -S . -Bbuild/windows
 ----
 
-Open the *vulkan_samples.sln* VS project inside build/windows and build with Ctrl-Shift-B. To run Vulkan Samples, use Visual Studio's Debug Properties selection and set the Debugging Command Arguments to --help. Click the "Local Windows Debugger" button and you should see the help output in the terminal. For convenience, the default setting is to run the hello_triangle sample; just edit that to your desired sample to run.
+Open the *vulkan_samples.sln* or *vulkan_samples.slnx* VS solution inside *build/windows* and build with Ctrl-Shift-B. To run Vulkan Samples, use Visual Studio's Debug Properties selection and set the Debugging Command Arguments to --help. Click the "Local Windows Debugger" button and you should see the help output in the terminal. For convenience, the default setting is to run the hello_triangle sample; just edit that to your desired sample to run.
 
 Alternatively, for command line builds use the steps below:
 


### PR DESCRIPTION
## Description

This pull request contains changes to simplify the example used in the CMake generation step for Windows. 
As the minimum CMake version is set to 3.12, the -S and -A platform and folder arguments are available, so the only variable left is the generator itself. Ommiting the other text removes the noise between CMake versions and makes the example easier to read.

I tested up to VS 2026 and the Vulkan Samples solution is created as expected, although with VS 2026 the solution file has the .slnx extension.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
