### PR TITLE
Fix pMaxDeviation parameter type in calibrated_timestamps sample

### DIFF
--- a/samples/extensions/calibrated_timestamps/calibrated_timestamps.cpp
+++ b/samples/extensions/calibrated_timestamps/calibrated_timestamps.cpp
@@ -802,8 +802,6 @@ void CalibratedTimestamps::get_time_domains()
 
 		// Resize time stamps vector
 		timestamps.resize(time_domain_count);
-		// Resize max deviations vector
-		max_deviations.resize(time_domain_count);
 	}
 
 	is_time_domain_init = ((result == VK_SUCCESS) && (time_domain_count > 0));
@@ -815,7 +813,7 @@ VkResult CalibratedTimestamps::get_timestamps()
 	if (is_time_domain_init)
 	{
 		// Get calibrated timestamps:
-		return vkGetCalibratedTimestampsEXT(get_device().get_handle(), static_cast<uint32_t>(time_domains.size()), timestamps_info.data(), timestamps.data(), max_deviations.data());
+		return vkGetCalibratedTimestampsEXT(get_device().get_handle(), static_cast<uint32_t>(time_domains.size()), timestamps_info.data(), timestamps.data(), &max_deviation);
 	}
 	return VK_ERROR_UNKNOWN;
 }

--- a/samples/extensions/calibrated_timestamps/calibrated_timestamps.h
+++ b/samples/extensions/calibrated_timestamps/calibrated_timestamps.h
@@ -31,7 +31,7 @@ class CalibratedTimestamps : public ApiVulkanSample
 	bool                         is_time_domain_init = false;        // this is just to tell if time domain update has a VK_SUCCESS in the end
 	std::vector<VkTimeDomainEXT> time_domains{};                     // this holds all time domains extracted from the current Instance
 	std::vector<uint64_t>        timestamps{};                       // timestamps vector
-	std::vector<uint64_t>        max_deviations{};                   // max deviations vector
+	uint64_t max_deviation = 0;                   // max deviations vector
 
 	struct
 	{

--- a/samples/extensions/calibrated_timestamps/calibrated_timestamps.h
+++ b/samples/extensions/calibrated_timestamps/calibrated_timestamps.h
@@ -31,7 +31,7 @@ class CalibratedTimestamps : public ApiVulkanSample
 	bool                         is_time_domain_init = false;        // this is just to tell if time domain update has a VK_SUCCESS in the end
 	std::vector<VkTimeDomainEXT> time_domains{};                     // this holds all time domains extracted from the current Instance
 	std::vector<uint64_t>        timestamps{};                       // timestamps vector
-	uint64_t max_deviation = 0;                   // max deviations vector
+	uint64_t                     max_deviation = 0;                  // max deviations vector
 
 	struct
 	{

--- a/samples/extensions/calibrated_timestamps/calibrated_timestamps.h
+++ b/samples/extensions/calibrated_timestamps/calibrated_timestamps.h
@@ -31,7 +31,7 @@ class CalibratedTimestamps : public ApiVulkanSample
 	bool                         is_time_domain_init = false;        // this is just to tell if time domain update has a VK_SUCCESS in the end
 	std::vector<VkTimeDomainEXT> time_domains{};                     // this holds all time domains extracted from the current Instance
 	std::vector<uint64_t>        timestamps{};                       // timestamps vector
-	uint64_t                     max_deviation = 0;                  // max deviations vector
+	uint64_t                     max_deviation = 0;                  // max deviation
 
 	struct
 	{


### PR DESCRIPTION
## Description

Fixes #874

The `vkGetCalibratedTimestampsEXT` function in the calibrated_timestamps sample was using incorrect parameter type for `pMaxDeviation`.
[Vulkan spec](https://docs.vulkan.org/refpages/latest/refpages/source/vkGetCalibratedTimestampsKHR.html)

### Changes
- Changed `std::vector<uint64_t> max_deviations` → `uint64_t max_deviation`
- Updated `vkGetCalibratedTimestampsEXT` call to pass `&max_deviation`
- Removed `max_deviations.resize()` 
## Tested on
- [RTX4080m] / [Windows 11]

## General Checklist:

Please ensure the following points are checked:

- [ x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [x ] I have commented any code that could be hard to understand
- [x ] My changes do not add any new compiler warnings
- [x ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x ] I have updated the header Copyright to reflect the current year
 - [ ] My changes build on Windows, Linux, macOS and Android. 

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
