### PR TITLE
fix: Initialize all handle which will free in destructor

### DIFF
--- a/samples/api/timestamp_queries/timestamp_queries.h
+++ b/samples/api/timestamp_queries/timestamp_queries.h
@@ -64,17 +64,17 @@ class TimestampQueries : public ApiVulkanSample
 
 	struct
 	{
-		VkPipeline skybox;
-		VkPipeline reflect;
-		VkPipeline composition;
-		VkPipeline bloom[2];
+		VkPipeline skybox      = VK_NULL_HANDLE;
+		VkPipeline reflect     = VK_NULL_HANDLE;
+		VkPipeline composition = VK_NULL_HANDLE;
+		VkPipeline bloom[2]    = {VK_NULL_HANDLE};
 	} pipelines;
 
 	struct
 	{
-		VkPipelineLayout models;
-		VkPipelineLayout composition;
-		VkPipelineLayout bloom_filter;
+		VkPipelineLayout models       = VK_NULL_HANDLE;
+		VkPipelineLayout composition  = VK_NULL_HANDLE;
+		VkPipelineLayout bloom_filter = VK_NULL_HANDLE;
 	} pipeline_layouts;
 
 	struct
@@ -87,17 +87,17 @@ class TimestampQueries : public ApiVulkanSample
 
 	struct
 	{
-		VkDescriptorSetLayout models;
-		VkDescriptorSetLayout composition;
-		VkDescriptorSetLayout bloom_filter;
+		VkDescriptorSetLayout models       = VK_NULL_HANDLE;
+		VkDescriptorSetLayout composition  = VK_NULL_HANDLE;
+		VkDescriptorSetLayout bloom_filter = VK_NULL_HANDLE;
 	} descriptor_set_layouts;
 
 	// Framebuffer for offscreen rendering
 	struct FrameBufferAttachment
 	{
-		VkImage        image;
-		VkDeviceMemory mem;
-		VkImageView    view;
+		VkImage        image = VK_NULL_HANDLE;
+		VkDeviceMemory mem   = VK_NULL_HANDLE;
+		VkImageView    view  = VK_NULL_HANDLE;
 		VkFormat       format;
 		void           destroy(VkDevice device)
 		{
@@ -109,20 +109,20 @@ class TimestampQueries : public ApiVulkanSample
 	struct FrameBuffer
 	{
 		int32_t               width, height;
-		VkFramebuffer         framebuffer;
+		VkFramebuffer         framebuffer = VK_NULL_HANDLE;
 		FrameBufferAttachment color[2];
 		FrameBufferAttachment depth;
-		VkRenderPass          render_pass;
-		VkSampler             sampler;
+		VkRenderPass          render_pass = VK_NULL_HANDLE;
+		VkSampler             sampler     = VK_NULL_HANDLE;
 	} offscreen;
 
 	struct
 	{
 		int32_t               width, height;
-		VkFramebuffer         framebuffer;
+		VkFramebuffer         framebuffer = VK_NULL_HANDLE;
 		FrameBufferAttachment color[1];
-		VkRenderPass          render_pass;
-		VkSampler             sampler;
+		VkRenderPass          render_pass = VK_NULL_HANDLE;
+		VkSampler             sampler     = VK_NULL_HANDLE;
 	} filter_pass;
 
 	std::vector<std::string> object_names;


### PR DESCRIPTION
Fix the random crash caused by free a non‑null garbage value. This patch is the improvement of PR:#1453

## Description
After (https://github.com/KhronosGroup/Vulkan-Samples/pull/1453), still meet random crash. So we need to initialize all the handles that will be free in the destructor.

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc)

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
