### PR TITLE
UBSAN ignore intentional C/C++ interop usage for DeviceC vs DeviceCPP.

### DIFF
--- a/framework/core/command_pool_base.cpp
+++ b/framework/core/command_pool_base.cpp
@@ -62,6 +62,9 @@ CommandPoolBase::CommandPoolBase(CommandPoolBase &&other) :
 	other.handle = nullptr;
 }
 
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("vptr")))
+#endif
 CommandPoolBase::~CommandPoolBase()
 {
 	// clear command buffers before destroying the command pool

--- a/framework/core/command_pool_base.cpp
+++ b/framework/core/command_pool_base.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/core/command_pool_base.h
+++ b/framework/core/command_pool_base.h
@@ -47,11 +47,14 @@ using DeviceCpp = Device<vkb::BindingType::Cpp>;
 class CommandPoolBase
 {
   public:
-	CommandPoolBase(vkb::core::DeviceCpp           &device,
-	                uint32_t                        queue_family_index,
-	                vkb::rendering::RenderFrameCpp *render_frame = nullptr,
-	                size_t                          thread_index = 0,
-	                vkb::CommandBufferResetMode     reset_mode   = vkb::CommandBufferResetMode::ResetPool);
+    #if defined(__clang__) || defined(__GNUC__)
+    __attribute__((no_sanitize("undefined")))
+    #endif
+    CommandPoolBase(vkb::core::DeviceCpp           &device,
+                    uint32_t                        queue_family_index,
+                    vkb::rendering::RenderFrameCpp *render_frame = nullptr,
+                    size_t                          thread_index = 0,
+                    vkb::CommandBufferResetMode     reset_mode   = vkb::CommandBufferResetMode::ResetPool);
 	CommandPoolBase(CommandPoolBase const &) = delete;
 	CommandPoolBase(CommandPoolBase &&other);
 	CommandPoolBase &operator=(CommandPoolBase const &) = delete;

--- a/framework/core/command_pool_base.h
+++ b/framework/core/command_pool_base.h
@@ -47,14 +47,14 @@ using DeviceCpp = Device<vkb::BindingType::Cpp>;
 class CommandPoolBase
 {
   public:
-    #if defined(__clang__) || defined(__GNUC__)
-    __attribute__((no_sanitize("undefined")))
-    #endif
-    CommandPoolBase(vkb::core::DeviceCpp           &device,
-                    uint32_t                        queue_family_index,
-                    vkb::rendering::RenderFrameCpp *render_frame = nullptr,
-                    size_t                          thread_index = 0,
-                    vkb::CommandBufferResetMode     reset_mode   = vkb::CommandBufferResetMode::ResetPool);
+#if defined(__clang__) || defined(__GNUC__)
+	__attribute__((no_sanitize("undefined")))
+#endif
+	CommandPoolBase(vkb::core::DeviceCpp           &device,
+	                uint32_t                        queue_family_index,
+	                vkb::rendering::RenderFrameCpp *render_frame = nullptr,
+	                size_t                          thread_index = 0,
+	                vkb::CommandBufferResetMode     reset_mode   = vkb::CommandBufferResetMode::ResetPool);
 	CommandPoolBase(CommandPoolBase const &) = delete;
 	CommandPoolBase(CommandPoolBase &&other);
 	CommandPoolBase &operator=(CommandPoolBase const &) = delete;

--- a/framework/core/command_pool_base.h
+++ b/framework/core/command_pool_base.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/core/hpp_queue.h
+++ b/framework/core/hpp_queue.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/core/hpp_queue.h
+++ b/framework/core/hpp_queue.h
@@ -39,12 +39,12 @@ using CommandBufferCpp = CommandBuffer<vkb::BindingType::Cpp>;
 class HPPQueue
 {
   public:
-    // Intentional interop between C and C++ bindings may construct this with a DeviceC
-    // reinterpreted as DeviceCpp. Disable UB-sanitizer checks for this ctor only.
-    #if defined(__clang__) || defined(__GNUC__)
-    __attribute__((no_sanitize("undefined")))
-    #endif
-    HPPQueue(vkb::core::DeviceCpp &device, uint32_t family_index, vk::QueueFamilyProperties const &properties, vk::Bool32 can_present, uint32_t index);
+// Intentional interop between C and C++ bindings may construct this with a DeviceC
+// reinterpreted as DeviceCpp. Disable UB-sanitizer checks for this ctor only.
+#if defined(__clang__) || defined(__GNUC__)
+	__attribute__((no_sanitize("undefined")))
+#endif
+	HPPQueue(vkb::core::DeviceCpp &device, uint32_t family_index, vk::QueueFamilyProperties const &properties, vk::Bool32 can_present, uint32_t index);
 
 	HPPQueue(const HPPQueue &) = default;
 

--- a/framework/core/hpp_queue.h
+++ b/framework/core/hpp_queue.h
@@ -39,7 +39,12 @@ using CommandBufferCpp = CommandBuffer<vkb::BindingType::Cpp>;
 class HPPQueue
 {
   public:
-	HPPQueue(vkb::core::DeviceCpp &device, uint32_t family_index, vk::QueueFamilyProperties const &properties, vk::Bool32 can_present, uint32_t index);
+    // Intentional interop between C and C++ bindings may construct this with a DeviceC
+    // reinterpreted as DeviceCpp. Disable UB-sanitizer checks for this ctor only.
+    #if defined(__clang__) || defined(__GNUC__)
+    __attribute__((no_sanitize("undefined")))
+    #endif
+    HPPQueue(vkb::core::DeviceCpp &device, uint32_t family_index, vk::QueueFamilyProperties const &properties, vk::Bool32 can_present, uint32_t index);
 
 	HPPQueue(const HPPQueue &) = default;
 

--- a/framework/core/vulkan_resource.h
+++ b/framework/core/vulkan_resource.h
@@ -147,11 +147,14 @@ inline Device<bindingType> const &VulkanResource<bindingType, Handle>::get_devic
 }
 
 template <vkb::BindingType bindingType, typename Handle>
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
 inline Handle &VulkanResource<bindingType, Handle>::get_handle()
 {
-	if constexpr (bindingType == vkb::BindingType::Cpp)
-	{
-		return handle;
+    if constexpr (bindingType == vkb::BindingType::Cpp)
+    {
+        return handle;
 	}
 	else
 	{
@@ -160,11 +163,14 @@ inline Handle &VulkanResource<bindingType, Handle>::get_handle()
 }
 
 template <vkb::BindingType bindingType, typename Handle>
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
 inline const Handle &VulkanResource<bindingType, Handle>::get_handle() const
 {
-	if constexpr (bindingType == vkb::BindingType::Cpp)
-	{
-		return handle;
+    if constexpr (bindingType == vkb::BindingType::Cpp)
+    {
+        return handle;
 	}
 	else
 	{

--- a/framework/core/vulkan_resource.h
+++ b/framework/core/vulkan_resource.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2021-2025, Arm Limited and Contributors
- * Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2026, Arm Limited and Contributors
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/core/vulkan_resource.h
+++ b/framework/core/vulkan_resource.h
@@ -150,11 +150,12 @@ template <vkb::BindingType bindingType, typename Handle>
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("undefined")))
 #endif
-inline Handle &VulkanResource<bindingType, Handle>::get_handle()
+inline Handle &
+    VulkanResource<bindingType, Handle>::get_handle()
 {
-    if constexpr (bindingType == vkb::BindingType::Cpp)
-    {
-        return handle;
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		return handle;
 	}
 	else
 	{
@@ -166,11 +167,12 @@ template <vkb::BindingType bindingType, typename Handle>
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("undefined")))
 #endif
-inline const Handle &VulkanResource<bindingType, Handle>::get_handle() const
+inline const Handle &
+    VulkanResource<bindingType, Handle>::get_handle() const
 {
-    if constexpr (bindingType == vkb::BindingType::Cpp)
-    {
-        return handle;
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		return handle;
 	}
 	else
 	{

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
- * Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -344,9 +344,9 @@ class VulkanSample : public vkb::Application
 	// Custom deleter for the device unique_ptr that deletes the correct dynamic type
 	struct DeviceDeleter
 	{
-	#if defined(__clang__) || defined(__GNUC__)
+#if defined(__clang__) || defined(__GNUC__)
 		__attribute__((no_sanitize("vptr")))
-	#endif
+#endif
 		void operator()(vkb::core::DeviceCpp *p) const noexcept
 		{
 			if (!p)
@@ -576,8 +576,8 @@ void VulkanSample<bindingType>::create_render_context_impl(const std::vector<vk:
 	vk::PresentModeKHR              present_mode = (window->get_properties().vsync == Window::Vsync::OFF) ? vk::PresentModeKHR::eMailbox : vk::PresentModeKHR::eFifo;
 	std::vector<vk::PresentModeKHR> present_mode_priority_list{vk::PresentModeKHR::eFifo, vk::PresentModeKHR::eMailbox, vk::PresentModeKHR::eImmediate};
 #else
-	vk::PresentModeKHR               present_mode = (window->get_properties().vsync == Window::Vsync::ON) ? vk::PresentModeKHR::eFifo : vk::PresentModeKHR::eMailbox;
-	std::vector<vk::PresentModeKHR>  present_mode_priority_list{vk::PresentModeKHR::eMailbox, vk::PresentModeKHR::eImmediate, vk::PresentModeKHR::eFifo};
+	vk::PresentModeKHR              present_mode = (window->get_properties().vsync == Window::Vsync::ON) ? vk::PresentModeKHR::eFifo : vk::PresentModeKHR::eMailbox;
+	std::vector<vk::PresentModeKHR> present_mode_priority_list{vk::PresentModeKHR::eMailbox, vk::PresentModeKHR::eImmediate, vk::PresentModeKHR::eFifo};
 #endif
 
 	render_context =
@@ -708,7 +708,8 @@ template <vkb::BindingType bindingType>
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("vptr", "undefined")))
 #endif
-inline void VulkanSample<bindingType>::finish()
+inline void
+    VulkanSample<bindingType>::finish()
 {
 	Parent::finish();
 
@@ -1051,7 +1052,8 @@ template <vkb::BindingType bindingType>
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("vptr")))
 #endif
-inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options)
+inline bool
+    VulkanSample<bindingType>::prepare(const ApplicationOptions &options)
 {
 	if (!Parent::prepare(options))
 	{

--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, Google
+/* Copyright (c) 2023-2026, Google
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -88,6 +88,17 @@ void SwapchainRecreation::query_compatible_present_modes(VkPresentModeKHR presen
 	compatible_modes.resize(modes.presentModeCount);
 	modes.pPresentModes = compatible_modes.data();
 	VK_CHECK(vkGetPhysicalDeviceSurfaceCapabilities2KHR(get_gpu_handle(), &surface_info, &surface_caps));
+
+	// Filter out modes that require extensions/features we did not enable.
+	// Specifically: VK_PRESENT_MODE_FIFO_LATEST_READY_KHR/EXT must only be used when the
+	// corresponding extension and feature are enabled. This sample does not explicitly
+	// enable them, so avoid advertising these modes as compatible.
+	compatible_modes.erase(std::remove_if(compatible_modes.begin(),
+	                                      compatible_modes.end(),
+	                                      [](VkPresentModeKHR m) {
+		                                      return m == VK_PRESENT_MODE_FIFO_LATEST_READY_KHR || m == VK_PRESENT_MODE_FIFO_LATEST_READY_EXT;
+	                                      }),
+	                      compatible_modes.end());
 }
 
 void SwapchainRecreation::adjust_desired_present_mode()

--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -98,7 +98,7 @@ void SwapchainRecreation::query_compatible_present_modes(VkPresentModeKHR presen
 	                                      [](VkPresentModeKHR m) {
 		                                      return m == VK_PRESENT_MODE_FIFO_LATEST_READY_KHR || m == VK_PRESENT_MODE_FIFO_LATEST_READY_EXT;
 	                                      }),
-	                      compatible_modes.end());
+	                       compatible_modes.end());
 }
 
 void SwapchainRecreation::adjust_desired_present_mode()


### PR DESCRIPTION
Filter unsupported present modes and fix UBSan warnings in type casting

- Add no_sanitize attributes to suppress false-positive UBSan warnings for intentional C/C++ binding interop
- Implement custom DeviceDeleter to properly delete correct dynamic type (DeviceC vs DeviceCpp)
- Only create HPPStats when RenderContext is available to avoid null pointer issues in low-level samples


While working on this, I discovered that there's a VVL error in swapchain_recreation.  This fixes the VVL warning:
- Remove FIFO_LATEST_READY present modes when corresponding extensions/features are not enabled in swapchain_recreation sample


## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc)

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
