### PR TITLE
Fix shader timestamp churn on checked-in shaders

### DIFF
--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -197,6 +197,7 @@ endif()
     endif()
 
     # HLSL compilation via DXC
+    # Only build HLSL shaders when their sources change. Avoid touching source tree unnecessarily.
     if(Vulkan_dxc_EXECUTABLE AND DEFINED SHADERS_HLSL)
         set(OUTPUT_FILES "")
         set(HLSL_TARGET_NAME ${PROJECT_NAME}-HLSL)
@@ -241,9 +242,11 @@ endif()
             add_custom_command(
                 OUTPUT ${OUTPUT_FILE}
                 COMMAND ${Vulkan_dxc_EXECUTABLE} -spirv -T ${DXC_PROFILE} -E main ${TARGET_DXC_ADDITIONAL_ARGUMENTS} ${SHADER_FILE_HLSL} -Fo ${OUTPUT_FILE}
-                COMMAND ${CMAKE_COMMAND} -E copy ${OUTPUT_FILE} ${directory}
-                MAIN_DEPENDENCY ${SHADER_FILE_HLSL}
+                # Only update checked-in shader binaries if contents differ to prevent needless timestamp churn
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${OUTPUT_FILE} ${directory}
+                DEPENDS ${SHADER_FILE_HLSL}
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                VERBATIM
             )
             list(APPEND OUTPUT_FILES ${OUTPUT_FILE})
             set_source_files_properties(${OUTPUT_FILE} PROPERTIES
@@ -282,9 +285,10 @@ endif()
             add_custom_command(
                 OUTPUT ${OUTPUT_FILE}
                 COMMAND ${Vulkan_slang_EXECUTABLE} ${SHADER_FILE_SLANG} -profile ${SLANG_PROFILE} -matrix-layout-column-major -target spirv -o ${OUTPUT_FILE} -entry ${SLANG_ENTRY_POINT}
-                COMMAND ${CMAKE_COMMAND} -E copy ${OUTPUT_FILE} ${directory}
-                MAIN_DEPENDENCY ${SHADER_FILE_SLANG}
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${OUTPUT_FILE} ${directory}
+                DEPENDS ${SHADER_FILE_SLANG}
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                VERBATIM
             )
             list(APPEND OUTPUT_FILES ${OUTPUT_FILE})
             set_source_files_properties(${OUTPUT_FILE} PROPERTIES
@@ -328,9 +332,10 @@ endif()
             add_custom_command(
                 OUTPUT ${OUTPUT_FILE}
                 COMMAND ${COMPILE_COMMAND}
-                COMMAND ${CMAKE_COMMAND} -E copy ${OUTPUT_FILE} ${directory}
-                MAIN_DEPENDENCY ${SHADER_FILE_GLSL}
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${OUTPUT_FILE} ${directory}
+                DEPENDS ${SHADER_FILE_GLSL}
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                VERBATIM
             )
             list(APPEND OUTPUT_FILES ${OUTPUT_FILE})
             set_source_files_properties(${OUTPUT_FILE} PROPERTIES
@@ -357,9 +362,10 @@ endif()
             add_custom_command(
                 OUTPUT ${OUTPUT_FILE}
                 COMMAND ${Vulkan_spirvas_EXECUTABLE} ${SHADER_FILE_SPVASM} -o ${OUTPUT_FILE} ${TARGET_SPVASM_ADDITIONAL_ARGUMENTS}
-                COMMAND ${CMAKE_COMMAND} -E copy ${OUTPUT_FILE} ${directory}
-                MAIN_DEPENDENCY ${SHADER_FILE_SPVASM}
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${OUTPUT_FILE} ${directory}
+                DEPENDS ${SHADER_FILE_SPVASM}
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                VERBATIM
             )
             list(APPEND OUTPUT_FILES ${OUTPUT_FILE})
             set_source_files_properties(${OUTPUT_FILE} PROPERTIES

--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -1,7 +1,7 @@
 #[[
- Copyright (c) 2019-2025, Arm Limited and Contributors
- Copyright (c) 2024-2025, Mobica Limited
- Copyright (c) 2024-2025, Sascha Willems
+ Copyright (c) 2019-2026, Arm Limited and Contributors
+ Copyright (c) 2024-2026, Mobica Limited
+ Copyright (c) 2024-2026, Sascha Willems
 
  SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Optimize shader build system to avoid unnecessary rebuilds and source  tree modifications

Use `copy_if_different` instead of `copy` to prevent timestamp churn on checked-in shader binaries. Change `MAIN_DEPENDENCY` to `DEPENDS` and add `VERBATIM` to custom commands for HLSL, Slang, GLSL, and SPIR-V assembly shader compilation.

This is part of my make the build system better work.  This fixes the issue we have called out for it so I'm breaking this change out of the overall change that I'm working on for cmake to improve our build speed on all platforms.


Fixes #1248

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
