### PR TITLE
Fix some non-deterministic samples when in benchmark mode

### DIFF
--- a/framework/platform/platform.cpp
+++ b/framework/platform/platform.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -477,7 +477,7 @@ bool Platform::start_app()
 	auto sample_info = static_cast<const apps::SampleInfo *>(requested_app_info);
 	active_app->set_name(sample_info->name);
 
-	if (!active_app->prepare({false, window.get()}))
+	if (!active_app->prepare({fixed_simulation_fps, window.get()}))
 	{
 		LOGE("Failed to prepare vulkan app.");
 		return false;

--- a/samples/extensions/synchronization_2/synchronization_2.cpp
+++ b/samples/extensions/synchronization_2/synchronization_2.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, Sascha Willems
+/* Copyright (c) 2021-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -264,7 +264,7 @@ void Synchronization2::prepare_storage_buffers()
 	// Initial particle positions
 	std::vector<Particle> particle_buffer(num_particles);
 
-	std::default_random_engine      rnd_engine(window->get_window_mode() == vkb::Window::Mode::Headless ? 0 : static_cast<unsigned>(time(nullptr)));
+	std::default_random_engine      rnd_engine((lock_simulation_speed || window->get_window_mode() == vkb::Window::Mode::Headless) ? 0 : static_cast<unsigned>(time(nullptr)));
 	std::normal_distribution<float> rnd_distribution(0.0f, 1.0f);
 
 	for (uint32_t i = 0; i < static_cast<uint32_t>(attractors.size()); i++)

--- a/samples/performance/afbc/afbc.cpp
+++ b/samples/performance/afbc/afbc.cpp
@@ -73,9 +73,6 @@ bool AFBCSample::prepare(const vkb::ApplicationOptions &options)
 
 	create_gui(*window, &get_stats());
 
-	// Store the start time to calculate rotation
-	start_time = std::chrono::system_clock::now();
-
 	return true;
 }
 
@@ -91,7 +88,8 @@ void AFBCSample::update(float delta_time)
 	/* Pan the camera back and forth. */
 	auto &camera_transform = camera->get_node()->get_component<vkb::sg::Transform>();
 
-	float rotation_factor = std::chrono::duration<float>(std::chrono::system_clock::now() - start_time).count();
+	elapsed_time += delta_time;
+	float rotation_factor = elapsed_time;
 
 	glm::quat qy          = glm::angleAxis(0.003f * sin(rotation_factor * 0.7f), glm::vec3(0.0f, 1.0f, 0.0f));
 	glm::quat orientation = glm::normalize(qy * camera_transform.get_rotation() * glm::angleAxis(0.0f, glm::vec3(1.0f, 0.0f, 0.0f)));

--- a/samples/performance/afbc/afbc.h
+++ b/samples/performance/afbc/afbc.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2024, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -47,7 +47,7 @@ class AFBCSample : public vkb::VulkanSampleC
 
 	bool afbc_enabled{false};
 
-	std::chrono::system_clock::time_point start_time;
+	float elapsed_time{0.0f};
 };
 
 std::unique_ptr<vkb::VulkanSampleC> create_afbc();

--- a/samples/performance/async_compute/async_compute.cpp
+++ b/samples/performance/async_compute/async_compute.cpp
@@ -305,9 +305,6 @@ bool AsyncComputeSample::prepare(const vkb::ApplicationOptions &options)
 
 	create_gui(*window, &get_stats());
 
-	// Store the start time to calculate rotation
-	start_time = std::chrono::system_clock::now();
-
 	auto &threshold_module = get_device().get_resource_cache().request_shader_module(VK_SHADER_STAGE_COMPUTE_BIT,
 	                                                                                 vkb::ShaderSource("async_compute/threshold.comp.spv"));
 	auto &blur_up_module   = get_device().get_resource_cache().request_shader_module(VK_SHADER_STAGE_COMPUTE_BIT,
@@ -752,7 +749,8 @@ void AsyncComputeSample::update(float delta_time)
 
 	composite_subpass->set_texture(&get_current_forward_render_target().get_views()[0], blur_chain_views[1].get(), linear_sampler.get());        // blur_chain[1] and color_targets[0] will be used by the present queue
 
-	float rotation_factor = std::chrono::duration<float>(std::chrono::system_clock::now() - start_time).count();
+	elapsed_time += delta_time;
+	float rotation_factor = elapsed_time;
 
 	glm::quat orientation;
 

--- a/samples/performance/async_compute/async_compute.h
+++ b/samples/performance/async_compute/async_compute.h
@@ -47,7 +47,7 @@ class AsyncComputeSample : public vkb::VulkanSampleC
 
 	virtual void draw_gui() override;
 
-	std::chrono::system_clock::time_point start_time;
+	float elapsed_time{0.0f};
 
 	void        render_shadow_pass();
 	VkSemaphore render_forward_offscreen_pass(VkSemaphore hdr_wait_semaphore);

--- a/samples/tooling/profiles/profiles.cpp
+++ b/samples/tooling/profiles/profiles.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2022-2025, Sascha Willems
- * Copyright (c) 2024-2025, Arm Limited and Contributors
+/* Copyright (c) 2022-2026, Sascha Willems
+ * Copyright (c) 2024-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -253,8 +253,7 @@ void Profiles::generate_textures()
 		VK_CHECK(vkCreateImageView(get_device().get_handle(), &image_view, nullptr, &textures[i].image_view));
 
 		// Generate a random texture
-		std::random_device                   rnd_device;
-		std::default_random_engine           rnd_engine(rnd_device());
+		std::default_random_engine           rnd_engine(lock_simulation_speed ? static_cast<unsigned>(i) : std::random_device{}());
 		std::uniform_int_distribution<short> rnd_dist(0, 255);
 		const size_t                         buffer_size = dim * dim * 4;
 		uint8_t                             *buffer      = staging_buffer.map();
@@ -311,8 +310,7 @@ void Profiles::generate_cubes()
 	std::vector<uint32_t>        indices;
 
 	// Generate random per-face texture indices
-	std::random_device                     rndDevice;
-	std::default_random_engine             rndEngine(rndDevice());
+	std::default_random_engine             rndEngine(lock_simulation_speed ? 0u : std::random_device{}());
 	std::uniform_int_distribution<int32_t> rndDist(0, static_cast<uint32_t>(textures.size()) - 1);
 
 	// Generate cubes with random per-face texture indices


### PR DESCRIPTION
## Description

I'm using --benchmark and --hideui to build some automatic testing capabilities locally using our driver's CRC mechanism.

Most samples behave deterministically when --benchmark is used, as it fixes the frame-rate for example, but some samples weren't quite right.

Note: some still aren't entirely deterministic for other reasons (multiple queues in use, some other random generators being used etc), but this fixes up the main issues at least.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Linux (other platforms not tested)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly
