### PR TITLE
Refactor PhysicalDevice selection

### DIFF
--- a/app/plugins/gpu_selection/gpu_selection.cpp
+++ b/app/plugins/gpu_selection/gpu_selection.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2025, Sascha Willems
- * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023-2026, Sascha Willems
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -18,6 +18,7 @@
 
 #include "gpu_selection.h"
 #include "core/instance.h"
+#include "vulkan_sample.h"
 
 #include <algorithm>
 
@@ -45,8 +46,8 @@ bool GpuSelection::handle_option(std::deque<std::string> &arguments)
 		}
 		uint32_t gpu_index = static_cast<uint32_t>(std::stoul(arguments[1]));
 
-		vkb::core::InstanceC::selected_gpu_index   = gpu_index;
-		vkb::core::InstanceCpp::selected_gpu_index = gpu_index;
+		vkb::VulkanSampleC::selected_gpu_index   = gpu_index;
+		vkb::VulkanSampleCpp::selected_gpu_index = gpu_index;
 
 		arguments.pop_front();
 		arguments.pop_front();

--- a/framework/platform/unix/direct_window.cpp
+++ b/framework/platform/unix/direct_window.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -242,22 +242,6 @@ DirectWindow::~DirectWindow()
 	}
 }
 
-VkSurfaceKHR DirectWindow::create_surface(vkb::core::InstanceC &instance)
-{
-	return create_surface(instance.get_handle(), instance.get_first_gpu().get_handle());
-}
-
-// Local structure for holding display candidate information
-struct Candidate
-{
-	VkDisplayKHR                  display;
-	VkDisplayPropertiesKHR        display_props;
-	VkDisplayModePropertiesKHR    mode;
-	VkDisplayPlaneCapabilitiesKHR caps;
-	uint32_t                      plane_index;
-	uint32_t                      stack_index;
-};
-
 // Helper template to get a vector of properties using the Vulkan idiom of
 // querying size, then querying data
 template <typename T, typename F, typename... Targs>
@@ -274,6 +258,22 @@ static std::vector<T> get_props(F func, Targs... args)
 	}
 	return result;
 }
+
+VkSurfaceKHR DirectWindow::create_surface(vkb::core::InstanceC &instance)
+{
+	return create_surface(instance.get_handle(), get_props<VkPhysicalDevice>(vkEnumeratePhysicalDevices, instance.get_handle()).front());
+}
+
+// Local structure for holding display candidate information
+struct Candidate
+{
+	VkDisplayKHR                  display;
+	VkDisplayPropertiesKHR        display_props;
+	VkDisplayModePropertiesKHR    mode;
+	VkDisplayPlaneCapabilitiesKHR caps;
+	uint32_t                      plane_index;
+	uint32_t                      stack_index;
+};
 
 // Find all valid display candidates in the system
 static std::vector<Candidate> find_display_candidates(VkPhysicalDevice phys_dev, Window::Mode window_mode)


### PR DESCRIPTION
## Description

Replaces the vector of PhysicalDevices in Instance by just the one selected PhysicalDevice in VulkanSample.
A virtual function `VulkanSample::determine_physical_device_score()` is introduced to determine the PhysicalDevice that fits best.

The samples `dynamic_multisample_rasterization` and `dynamic_rendering_local_read` where not tested, as they are currently failing (-> #1479, #1462)

Build tested on Win11 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
