### PR TITLE
Adding GUI Support for Dynamic Rendering

### DIFF
--- a/framework/api_vulkan_sample.h
+++ b/framework/api_vulkan_sample.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019-2025, Sascha Willems
- * Copyright (c) 2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Sascha Willems
+ * Copyright (c) 2025-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -149,6 +149,12 @@ class ApiVulkanSample : public vkb::VulkanSampleC
 
 	// Global render pass for frame buffer writes
 	VkRenderPass render_pass = VK_NULL_HANDLE;
+
+	// Returns true if using dynamic rendering
+	bool uses_dynamic_rendering() const
+	{
+		return render_pass == VK_NULL_HANDLE;
+	}
 
 	// List of available frame buffers (same as number of swap chain images)
 	std::vector<VkFramebuffer> framebuffers;
@@ -372,6 +378,16 @@ class ApiVulkanSample : public vkb::VulkanSampleC
 	void draw_ui(const VkCommandBuffer command_buffer);
 
 	/**
+	 * @brief Draw UI for dynamic rendering mode
+	 * @param command_buffer A valid command buffer (after ending your main rendering pass)
+	 * @param swapchain_image_index The swapchain image index to render onto
+	 *
+	 * This method starts its own rendering pass, draws the UI, and ends the pass.
+	 * Call this after ending your main rendering pass (vkCmdEndRenderingKHR).
+	 */
+	void draw_ui(const VkCommandBuffer command_buffer, uint32_t swapchain_image_index);
+
+	/**
 	 * @brief Prepare the frame for workload submission, acquires the next image from the swap chain and
 	 *        sets the default wait and signal semaphores
 	 */
@@ -392,6 +408,15 @@ class ApiVulkanSample : public vkb::VulkanSampleC
 	 * @brief Initializes the UI. Can be overridden to customize the way it is displayed.
 	 */
 	virtual void prepare_gui();
+
+	/**
+	 * @brief Returns the subpass index used for GUI rendering (render pass path only).
+	 *        Override in samples that use a multi-subpass render pass with the GUI in a later subpass.
+	 */
+	virtual uint32_t get_gui_subpass() const
+	{
+		return 0;
+	}
 
   private:
 	/** brief Indicates that the view (position, rotation) has changed and buffers containing camera matrices need to be updated */

--- a/framework/hpp_api_vulkan_sample.h
+++ b/framework/hpp_api_vulkan_sample.h
@@ -1,4 +1,5 @@
-/* Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -109,6 +110,12 @@ class HPPApiVulkanSample : public vkb::VulkanSampleCpp
 
 	// Global render pass for frame buffer writes
 	vk::RenderPass render_pass;
+
+	// Returns true if using dynamic rendering
+	bool uses_dynamic_rendering() const
+	{
+		return render_pass == VK_NULL_HANDLE;
+	}
 
 	// List of available frame buffers (same as number of swap chain images)
 	std::vector<vk::Framebuffer> framebuffers;
@@ -328,6 +335,16 @@ class HPPApiVulkanSample : public vkb::VulkanSampleCpp
 	void draw_ui(const vk::CommandBuffer command_buffer);
 
 	/**
+	 * @brief Draw UI for dynamic rendering mode
+	 * @param command_buffer A valid command buffer (after ending your main rendering pass)
+	 * @param swapchain_image_index The swapchain image index to render onto
+	 *
+	 * This method starts its own rendering pass, draws the UI, and ends the pass.
+	 * Call this after ending your main rendering pass (vkCmdEndRenderingKHR).
+	 */
+	void draw_ui(const vk::CommandBuffer command_buffer, uint32_t swapchain_image_index);
+
+	/**
 	 * @brief Prepare the frame for workload submission, acquires the next image from the swap chain and
 	 *        sets the default wait and signal semaphores
 	 */
@@ -348,6 +365,15 @@ class HPPApiVulkanSample : public vkb::VulkanSampleCpp
 	 * @brief Initializes the UI. Can be overridden to customize the way it is displayed.
 	 */
 	virtual void prepare_gui();
+
+	/**
+	 * @brief Returns the subpass index used for GUI rendering (render pass path only).
+	 *        Override in samples that use a multi-subpass render pass with the GUI in a later subpass.
+	 */
+	virtual uint32_t get_gui_subpass() const
+	{
+		return 0;
+	}
 
   private:
 	/** brief Indicates that the view (position, rotation) has changed and buffers containing camera matrices need to be updated */

--- a/samples/extensions/color_write_enable/color_write_enable.cpp
+++ b/samples/extensions/color_write_enable/color_write_enable.cpp
@@ -1,4 +1,5 @@
 /* Copyright (c) 2023-2026, Mobica Limited
+ * Copyright (c) 2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -62,13 +63,9 @@ bool ColorWriteEnable::prepare(const vkb::ApplicationOptions &options)
 	return true;
 }
 
-void ColorWriteEnable::prepare_gui()
+uint32_t ColorWriteEnable::get_gui_subpass() const
 {
-	create_gui(*window, nullptr, 15.0f, true);
-	get_gui().set_subpass(1);
-	get_gui().prepare(pipeline_cache, render_pass,
-	                  {load_shader("uioverlay/uioverlay.vert.spv", VK_SHADER_STAGE_VERTEX_BIT),
-	                   load_shader("uioverlay/uioverlay.frag.spv", VK_SHADER_STAGE_FRAGMENT_BIT)});
+	return 1;
 }
 
 void ColorWriteEnable::prepare_pipelines()

--- a/samples/extensions/color_write_enable/color_write_enable.h
+++ b/samples/extensions/color_write_enable/color_write_enable.h
@@ -1,4 +1,5 @@
-/* Copyright (c) 2023-2025, Mobica Limited
+/* Copyright (c) 2023-2026, Mobica Limited
+ * Copyright (c) 2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -40,7 +41,10 @@ class ColorWriteEnable : public ApiVulkanSample
 	void request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
 	void setup_render_pass() override;
 	void setup_framebuffer() override;
-	void prepare_gui() override;
+
+  private:
+	// from ApiVulkanSample
+	uint32_t get_gui_subpass() const override;
 
   private:
 	struct FrameBufferAttachment

--- a/samples/extensions/dynamic_rendering/dynamic_rendering.h
+++ b/samples/extensions/dynamic_rendering/dynamic_rendering.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021-2026, Holochip Corporation
+ * Copyright (c) 2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -33,6 +34,8 @@ class DynamicRendering : public ApiVulkanSample
 	void view_changed() override;
 	void on_update_ui_overlay(vkb::Drawer &drawer) override;
 	void request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
+	void setup_render_pass() override;
+	void setup_framebuffer() override;
 
   private:
 	// from vkb::VulkanSample
@@ -46,7 +49,6 @@ class DynamicRendering : public ApiVulkanSample
 	void create_descriptor_sets();
 	void create_descriptor_pool();
 	void create_pipeline();
-	void create_render_pass_non_dynamic();
 	void draw();
 
 	struct

--- a/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.h
+++ b/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2024-2026, Sascha Willems
+ * Copyright (c) 2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -38,6 +39,9 @@ class DynamicRenderingLocalRead : public ApiVulkanSample
   private:
 	// from vkb::VulkanSample
 	uint32_t get_api_version() const override;
+
+	// from ApiVulkanSample
+	uint32_t get_gui_subpass() const override;
 
   private:
 	struct Scenes
@@ -110,7 +114,6 @@ class DynamicRenderingLocalRead : public ApiVulkanSample
 
 	void setup_framebuffer() override;
 	void setup_render_pass() override;
-	void prepare_gui() override;
 
 	void load_assets();
 	void create_attachment(VkFormat format, VkImageUsageFlags usage, FrameBufferAttachment &attachment);


### PR DESCRIPTION
## Description

Adds framework support for rendering the GUI overlay when samples use dynamic rendering instead of render passes, and introduces a cleaner `get_gui_subpass()` pattern for samples that render the GUI in a non-zero subpass.

### Changes
**Gui class (gui.h):**
- Added `prepare()` overload that accepts color/depth formats instead of a render pass, creating the GUI pipeline with `VkPipelineRenderingCreateInfoKHR`
- Added `draw()` overload that manages its own rendering pass internally for dynamic rendering
- Added `subpass` parameter to the render pass `prepare()` overload (default 0), replacing the old `set_subpass()` method
- Removed `set_subpass()` method and `subpass` member variable — subpass is now passed directly at prepare time

**ApiVulkanSample / HppApiVulkanSample (api_vulkan_sample.h/cpp, hpp_api_vulkan_sample.h):**
- Added `uses_dynamic_rendering()` helper that checks if `render_pass == VK_NULL_HANDLE`
- Updated `prepare_gui()` to automatically detect dynamic rendering and call the appropriate `Gui::prepare()` overload
- `prepare_gui()` now passes `get_gui_subpass()` to `Gui::prepare()` for the render pass path
- Added `virtual uint32_t get_gui_subpass() const` (returns 0) — samples override this to render the GUI in a later subpass
- Added `draw_ui(cmd, swapchain_index)` overload for dynamic rendering
- Updated destructor to use the `uses_dynamic_rendering()` check

**dynamic_rendering sample:**
- Removed `prepare_gui()` override — the base class now handles both dynamic rendering and render pass GUI paths
- Added `setup_render_pass()` and `setup_framebuffer()` overrides that skip creation when using dynamic rendering, ensuring `uses_dynamic_rendering()` returns the correct value
- Added `draw_ui(cmd)` call in the render pass command buffer path (was previously missing)
- Fixed `clearValueCount` to use `clear_values.size()` instead of a hardcoded 3

**dynamic_rendering_local_read sample:**
- Replaced `prepare_gui()` override with `get_gui_subpass()` override returning 2
- Uses the new `draw_ui(cmd, swapchain_index)` overload for the dynamic rendering path

**color_write_enable sample:**
- Replaced `prepare_gui()` override with `get_gui_subpass()` override returning 1

### Usage
For samples using dynamic rendering, call `draw_ui()` after ending your main rendering pass:

```cpp
vkCmdEndRenderingKHR(cmd);
draw_ui(cmd, swapchain_image_index);
```

Unlike render passes which support subpasses with different attachment configurations, dynamic rendering has a fixed attachment configuration per vkCmdBeginRenderingKHR block. Since the GUI renders to a single color attachment but samples may use multiple attachments (e.g., G-buffer), the GUI must render in its own separate rendering pass - requiring the main pass to be ended first. Otherwise you'll get validation errors, like in the dynamic_rendering_local_read sample.

For samples using render passes, the existing `draw_ui(cmd)` call remains unchanged. If the GUI needs to render in a non-zero subpass, override `get_gui_subpass()` instead of `prepare_gui()`.

### Screenshots
Below is a screenshot from the dynamic_rendering sample.
<img width="2800" height="1260" alt="dynamic_rendering" src="https://github.com/user-attachments/assets/aa27834c-84d3-4948-be92-da994645b784" />

Below are two screenshots, from the dynamic_rendering_local_read sample, first one using renderpasses and the other dynamic rendering.

<img width="2800" height="1260" alt="image" src="https://github.com/user-attachments/assets/25569b19-32eb-4208-b29f-e4a94437dba1" />

<img width="2800" height="1260" alt="image" src="https://github.com/user-attachments/assets/23e5a46c-3a3c-40b4-9726-709edf86319c" />

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site

## Jira Task
https://jira.arm.com/browse/STEGFX-369