### PR TITLE
dynamic_blending: fix uninitialized eds_feature_support

### DIFF
--- a/samples/extensions/dynamic_blending/dynamic_blending.cpp
+++ b/samples/extensions/dynamic_blending/dynamic_blending.cpp
@@ -153,11 +153,15 @@ void DynamicBlending::request_gpu_features(vkb::core::PhysicalDeviceC &gpu)
 	                         VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
 	                         extendedDynamicState3ColorBlendEnable);
 
-	// Only request the features that we support
-	REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, extendedDynamicState3ColorWriteMask);
-	REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, extendedDynamicState3ColorBlendEnable);
-	REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, extendedDynamicState3ColorBlendAdvanced);
-	REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, extendedDynamicState3ColorBlendEquation);
+	// Only request the features that we support, and record which ones are available
+	eds_feature_support.extendedDynamicState3ColorWriteMask =
+	    REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, extendedDynamicState3ColorWriteMask);
+	eds_feature_support.extendedDynamicState3ColorBlendEnable =
+	    REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, extendedDynamicState3ColorBlendEnable);
+	eds_feature_support.extendedDynamicState3ColorBlendAdvanced =
+	    REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, extendedDynamicState3ColorBlendAdvanced);
+	eds_feature_support.extendedDynamicState3ColorBlendEquation =
+	    REQUEST_OPTIONAL_FEATURE(gpu, VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, extendedDynamicState3ColorBlendEquation);
 
 	REQUEST_REQUIRED_FEATURE(gpu, VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT, advancedBlendCoherentOperations);
 }

--- a/samples/extensions/dynamic_blending/dynamic_blending.h
+++ b/samples/extensions/dynamic_blending/dynamic_blending.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, Mobica
+/* Copyright (c) 2023-2026, Mobica
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -118,7 +118,7 @@ class DynamicBlending : public ApiVulkanSample
 	VkDescriptorSet       descriptor_set;
 	VkPipeline            pipeline;
 
-	VkPhysicalDeviceExtendedDynamicState3FeaturesEXT eds_feature_support;
+	VkPhysicalDeviceExtendedDynamicState3FeaturesEXT eds_feature_support{};
 
 	std::array<float, 4> clear_color = {0.5f, 0.5f, 0.5f, 1.0f};
 	int32_t              current_blend_color_operator_index;


### PR DESCRIPTION
## Description

Capture REQUEST_OPTIONAL_FEATURE return values into eds_feature_support so the sample correctly knows which dynamic state features are available.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - x ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Linux. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

