### PR TITLE
Move debug messenger/callback from vkb::core::Instance to VulkanSample; cleanup of vkb::core::Instance

### DIFF
--- a/framework/core/hpp_debug.h
+++ b/framework/core/hpp_debug.h
@@ -166,13 +166,6 @@ inline VKAPI_ATTR vk::Bool32 VKAPI_CALL debug_utils_messenger_callback(vk::Debug
 	return false;
 }
 
-inline vk::DebugUtilsMessengerCreateInfoEXT getDefaultDebugUtilsMessengerCreateInfoEXT()
-{
-	return vk::DebugUtilsMessengerCreateInfoEXT{.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning,
-	                                            .messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance,
-	                                            .pfnUserCallback = debug_utils_messenger_callback};
-}
-
 inline VKAPI_ATTR vk::Bool32 VKAPI_CALL debug_callback(vk::DebugReportFlagsEXT flags,
                                                        vk::DebugReportObjectTypeEXT /*type*/,
                                                        uint64_t /*object*/,
@@ -200,13 +193,6 @@ inline VKAPI_ATTR vk::Bool32 VKAPI_CALL debug_callback(vk::DebugReportFlagsEXT f
 	}
 	return false;
 }
-
-inline vk::DebugReportCallbackCreateInfoEXT getDefaultDebugReportCallbackCreateInfoEXT()
-{
-	return vk::DebugReportCallbackCreateInfoEXT{.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
-	                                            .pfnCallback = debug_callback};
-}
-
 #endif
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -25,6 +25,27 @@ namespace vkb
 {
 namespace core
 {
+namespace
+{
+template <vkb::BindingType bindingType>
+typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCreateFlags, VkInstanceCreateFlags>::type get_default_create_flags(std::vector<std::string> const &)
+{
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		return vk::InstanceCreateFlags{};
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+void const *get_default_pNext(std::vector<std::string> const &, std::vector<std::string> const &)
+{
+	return nullptr;
+}
+}        // namespace
+
 /**
  * @brief A wrapper class for InstanceType
  *
@@ -54,19 +75,8 @@ class Instance
 	    uint32_t                                                                                               api_version          = VK_API_VERSION_1_1,
 	    std::unordered_map<std::string, vkb::RequestMode> const                                               &requested_layers     = {},
 	    std::unordered_map<std::string, vkb::RequestMode> const                                               &requested_extensions = {},
-	    std::function<void const *(std::vector<std::string> const &, std::vector<std::string> const &)> const &get_pNext =
-	        [](std::vector<std::string> const &, std::vector<std::string> const &) { return nullptr; },
-	    std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const &get_create_flags =
-	        [](std::vector<std::string> const &) {
-		        if constexpr (bindingType == vkb::BindingType::Cpp)
-		        {
-			        return vk::InstanceCreateFlags{};
-		        }
-		        else
-		        {
-			        return 0;
-		        }
-	        });
+	    std::function<void const *(std::vector<std::string> const &, std::vector<std::string> const &)> const &get_pNext            = get_default_pNext,
+	    std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const                        &get_create_flags     = get_default_create_flags);
 
 	Instance(vk::Instance instance, std::vector<char const *> const &externally_enabled_extensions = {}, bool needsToInitializeDispatcher = false);
 	Instance(VkInstance instance, std::vector<char const *> const &externally_enabled_extensions = {});

--- a/framework/core/physical_device.h
+++ b/framework/core/physical_device.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2020-2025, Arm Limited and Contributors
- * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2020-2026, Arm Limited and Contributors
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -229,7 +229,7 @@ template <typename FeatureType>
 inline FeatureType &PhysicalDevice<bindingType>::add_extension_features_impl()
 {
 	// We cannot request extension features if the physical device properties 2 instance extension isn't enabled
-	if (!instance.is_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
+	if (!instance.is_extension_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
 	{
 		throw std::runtime_error("Couldn't request feature from device as " + std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) +
 		                         " isn't enabled!");
@@ -320,7 +320,7 @@ template <typename FeatureType>
 inline FeatureType PhysicalDevice<bindingType>::get_extension_features_impl()
 {
 	// We cannot request extension features if the physical device properties 2 instance extension isn't enabled
-	if (!instance.is_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
+	if (!instance.is_extension_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
 	{
 		throw std::runtime_error("Couldn't request feature from device as " + std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) +
 		                         " isn't enabled!");

--- a/framework/core/swapchain.cpp
+++ b/framework/core/swapchain.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -602,7 +602,7 @@ std::vector<Swapchain::SurfaceFormatCompression> Swapchain::query_supported_fixe
 
 	if (device.is_extension_enabled(VK_EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_EXTENSION_NAME))
 	{
-		if (device.get_gpu().get_instance().is_enabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME))
+		if (device.get_gpu().get_instance().is_extension_enabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME))
 		{
 			VkPhysicalDeviceSurfaceInfo2KHR surface_info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR};
 			surface_info.surface = surface;

--- a/framework/platform/unix/direct_window.cpp
+++ b/framework/platform/unix/direct_window.cpp
@@ -261,7 +261,7 @@ static std::vector<T> get_props(F func, Targs... args)
 
 VkSurfaceKHR DirectWindow::create_surface(vkb::core::InstanceC &instance)
 {
-	return create_surface(instance.get_handle(), get_props<VkPhysicalDevice>(vkEnumeratePhysicalDevices, instance.get_handle()).front());
+	return create_surface(instance.get_handle(), VK_NULL_HANDLE);
 }
 
 // Local structure for holding display candidate information
@@ -366,9 +366,14 @@ static std::vector<Candidate> find_display_candidates(VkPhysicalDevice phys_dev,
 
 VkSurfaceKHR DirectWindow::create_surface(VkInstance instance, VkPhysicalDevice phys_dev)
 {
-	if (instance == VK_NULL_HANDLE || phys_dev == VK_NULL_HANDLE)
+	if (instance == VK_NULL_HANDLE)
 	{
 		return VK_NULL_HANDLE;
+	}
+
+	if (phys_dev == VK_NULL_HANDLE)
+	{
+		phys_dev = get_props<VkPhysicalDevice>(vkEnumeratePhysicalDevices, instance).front();
 	}
 
 	// Find possible display config candidates

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -20,6 +20,7 @@
 
 #include "common/hpp_utils.h"
 #include "core/debug.h"
+#include "core/hpp_debug.h"
 #include "gui.h"
 #include "hpp_gltf_loader.h"
 #include "platform/application.h"
@@ -139,13 +140,15 @@ class VulkanSample : public vkb::Application
 	using SceneType        = typename std::conditional<bindingType == BindingType::Cpp, vkb::scene_graph::HPPScene, vkb::sg::Scene>::type;
 	using StatsType        = typename std::conditional<bindingType == BindingType::Cpp, vkb::stats::HPPStats, vkb::Stats>::type;
 
-	using Extent2DType                = typename std::conditional<bindingType == BindingType::Cpp, vk::Extent2D, VkExtent2D>::type;
-	using InstanceCreateFlagsType     = typename std::conditional<bindingType == BindingType::Cpp, vk::InstanceCreateFlags, VkInstanceCreateFlags>::type;
-	using LayerSettingType            = typename std::conditional<bindingType == BindingType::Cpp, vk::LayerSettingEXT, VkLayerSettingEXT>::type;
-	using PhysicalDeviceType          = typename std::conditional<bindingType == BindingType::Cpp, vk::PhysicalDevice, VkPhysicalDevice>::type;
-	using SurfaceFormatType           = typename std::conditional<bindingType == BindingType::Cpp, vk::SurfaceFormatKHR, VkSurfaceFormatKHR>::type;
-	using SurfaceType                 = typename std::conditional<bindingType == BindingType::Cpp, vk::SurfaceKHR, VkSurfaceKHR>::type;
-	using ValidationFeatureEnableType = typename std::conditional<bindingType == BindingType::Cpp, vk::ValidationFeatureEnableEXT, VkValidationFeatureEnableEXT>::type;
+	using Extent2DType                      = typename std::conditional<bindingType == BindingType::Cpp, vk::Extent2D, VkExtent2D>::type;
+	using DebugReportCallbackCreateInfoType = typename std::conditional<bindingType == BindingType::Cpp, vk::DebugReportCallbackCreateInfoEXT, VkDebugReportCallbackCreateInfoEXT>::type;
+	using DebugUtilsMessengerCreateInfoType = typename std::conditional<bindingType == BindingType::Cpp, vk::DebugUtilsMessengerCreateInfoEXT, VkDebugUtilsMessengerCreateInfoEXT>::type;
+	using InstanceCreateFlagsType           = typename std::conditional<bindingType == BindingType::Cpp, vk::InstanceCreateFlags, VkInstanceCreateFlags>::type;
+	using LayerSettingType                  = typename std::conditional<bindingType == BindingType::Cpp, vk::LayerSettingEXT, VkLayerSettingEXT>::type;
+	using PhysicalDeviceType                = typename std::conditional<bindingType == BindingType::Cpp, vk::PhysicalDevice, VkPhysicalDevice>::type;
+	using SurfaceFormatType                 = typename std::conditional<bindingType == BindingType::Cpp, vk::SurfaceFormatKHR, VkSurfaceFormatKHR>::type;
+	using SurfaceType                       = typename std::conditional<bindingType == BindingType::Cpp, vk::SurfaceKHR, VkSurfaceKHR>::type;
+	using ValidationFeatureEnableType       = typename std::conditional<bindingType == BindingType::Cpp, vk::ValidationFeatureEnableEXT, VkValidationFeatureEnableEXT>::type;
 
 	Configuration                                    &get_configuration();
 	vkb::rendering::RenderContext<bindingType>       &get_render_context();
@@ -199,9 +202,11 @@ class VulkanSample : public vkb::Application
 	 */
 	virtual void draw_renderpass(vkb::core::CommandBuffer<bindingType> &command_buffer, RenderTargetType &render_target);
 
-	virtual uint32_t                get_api_version() const;
-	virtual InstanceCreateFlagsType get_instance_create_flags(std::vector<std::string> const &enabled_extensions) const;
-	virtual void                   *get_instance_create_info_extensions(std::vector<std::string> const &enabled_layers, std::vector<std::string> const &enabled_extensions) const;
+	virtual uint32_t                                 get_api_version() const;
+	virtual DebugReportCallbackCreateInfoType const *get_debug_report_callback_create_info() const;
+	virtual DebugUtilsMessengerCreateInfoType const *get_debug_utils_messenger_create_info() const;
+	virtual InstanceCreateFlagsType                  get_instance_create_flags(std::vector<std::string> const &enabled_extensions) const;
+	virtual void const                              *get_instance_create_info_extensions(std::vector<std::string> const &enabled_layers, std::vector<std::string> const &enabled_extensions) const;
 
 	/**
 	 * @brief Override this to customise the creation of the swapchain and render_context
@@ -355,6 +360,9 @@ class VulkanSample : public vkb::Application
 	 */
 	std::unique_ptr<vkb::core::InstanceCpp> instance;
 
+	vk::DebugReportCallbackEXT debug_report_callback;
+	vk::DebugUtilsMessengerEXT debug_utils_messenger;
+
 	/**
 	 * @brief The physical device selected for this sample
 	 */
@@ -440,6 +448,14 @@ inline VulkanSample<bindingType>::~VulkanSample()
 	if (surface)
 	{
 		instance->get_handle().destroySurfaceKHR(surface);
+	}
+	if (debug_utils_messenger)
+	{
+		instance->get_handle().destroyDebugUtilsMessengerEXT(debug_utils_messenger);
+	}
+	if (debug_report_callback)
+	{
+		instance->get_handle().destroyDebugReportCallbackEXT(debug_report_callback);
 	}
 
 	instance.reset();
@@ -750,6 +766,45 @@ inline bool enable_layer_setting(VkLayerSettingEXT const          &requested_lay
 }
 
 template <vkb::BindingType bindingType>
+inline typename VulkanSample<bindingType>::DebugReportCallbackCreateInfoType const *VulkanSample<bindingType>::get_debug_report_callback_create_info() const
+{
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	static vk::DebugReportCallbackCreateInfoEXT debug_report_callback_createInfo{.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
+	                                                                             .pfnCallback = vkb::core::debug_callback};
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		return &debug_report_callback_createInfo;
+	}
+	else
+	{
+		return reinterpret_cast<VkDebugReportCallbackCreateInfoEXT *>(&debug_report_callback_createInfo);
+	}
+#else
+	return nullptr;
+#endif
+}
+
+template <vkb::BindingType bindingType>
+inline typename VulkanSample<bindingType>::DebugUtilsMessengerCreateInfoType const *VulkanSample<bindingType>::get_debug_utils_messenger_create_info() const
+{
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	static vk::DebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info{.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning,
+	                                                                              .messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance,
+	                                                                              .pfnUserCallback = vkb::core::debug_utils_messenger_callback};
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		return &debug_utils_messenger_create_info;
+	}
+	else
+	{
+		return reinterpret_cast<VkDebugUtilsMessengerCreateInfoEXT *>(&debug_utils_messenger_create_info);
+	}
+#else
+	return nullptr;
+#endif
+}
+
+template <vkb::BindingType bindingType>
 inline typename VulkanSample<bindingType>::InstanceCreateFlagsType VulkanSample<bindingType>::get_instance_create_flags(std::vector<std::string> const &enabled_extensions) const
 {
 	vk::InstanceCreateFlags flags;
@@ -771,12 +826,11 @@ inline typename VulkanSample<bindingType>::InstanceCreateFlagsType VulkanSample<
 }
 
 template <vkb::BindingType bindingType>
-inline void *VulkanSample<bindingType>::get_instance_create_info_extensions(std::vector<std::string> const &enabled_layers,
-                                                                            std::vector<std::string> const &enabled_extensions) const
+inline void const *VulkanSample<bindingType>::get_instance_create_info_extensions(std::vector<std::string> const &enabled_layers,
+                                                                                  std::vector<std::string> const &enabled_extensions) const
 {
-	void *pNext = nullptr;
+	void const *pNext = nullptr;
 
-#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
 	if (contains(enabled_extensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
 	{
 		static vk::DebugUtilsMessengerCreateInfoEXT debug_utils_create_info = vkb::core::getDefaultDebugUtilsMessengerCreateInfoEXT();
@@ -789,7 +843,6 @@ inline void *VulkanSample<bindingType>::get_instance_create_info_extensions(std:
 		debug_report_create_info.pNext                                       = pNext;
 		pNext                                                                = &debug_report_create_info;
 	}
-#endif
 
 	if (contains(enabled_extensions, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME))
 	{
@@ -1180,6 +1233,38 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 		instance.reset(reinterpret_cast<vkb::core::InstanceCpp *>(create_instance().release()));
 	}
 
+	// initialize debug utils or report callback based on enabled extensions, if any
+	if (instance->is_extension_enabled(VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
+	{
+		auto const *debug_utils_messenger_create_info = get_debug_utils_messenger_create_info();
+		if (debug_utils_messenger_create_info)
+		{
+			if constexpr (bindingType == BindingType::Cpp)
+			{
+				debug_utils_messenger = instance->get_handle().createDebugUtilsMessengerEXT(*debug_utils_messenger_create_info);
+			}
+			else
+			{
+				debug_utils_messenger = instance->get_handle().createDebugUtilsMessengerEXT(*reinterpret_cast<vk::DebugUtilsMessengerCreateInfoEXT const *>(debug_utils_messenger_create_info));
+			}
+		}
+	}
+	else if (instance->is_extension_enabled(VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
+	{
+		auto const *debug_report_callback_create_info = get_debug_report_callback_create_info();
+		if (debug_report_callback_create_info)
+		{
+			if constexpr (bindingType == BindingType::Cpp)
+			{
+				debug_report_callback = instance->get_handle().createDebugReportCallbackEXT(*debug_report_callback_create_info);
+			}
+			else
+			{
+				debug_report_callback = instance->get_handle().createDebugReportCallbackEXT(*reinterpret_cast<vk::DebugReportCallbackCreateInfoEXT const *>(debug_report_callback_create_info));
+			}
+		}
+	}
+
 	// Getting a valid vulkan surface from the platform
 	surface = static_cast<vk::SurfaceKHR>(window->create_surface(reinterpret_cast<vkb::core::InstanceC &>(*instance)));
 	if (!surface)
@@ -1202,7 +1287,7 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 	{
 		add_device_extension(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
-		if (instance->is_enabled(VK_KHR_DISPLAY_EXTENSION_NAME))
+		if (instance->is_extension_enabled(VK_KHR_DISPLAY_EXTENSION_NAME))
 		{
 			add_device_extension(VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME, /*optional=*/true);
 		}

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -833,15 +833,11 @@ inline void const *VulkanSample<bindingType>::get_instance_create_info_extension
 
 	if (contains(enabled_extensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
 	{
-		static vk::DebugUtilsMessengerCreateInfoEXT debug_utils_create_info = vkb::core::getDefaultDebugUtilsMessengerCreateInfoEXT();
-		debug_utils_create_info.pNext                                       = pNext;
-		pNext                                                               = &debug_utils_create_info;
+		pNext = get_debug_utils_messenger_create_info();
 	}
 	else if (contains(enabled_extensions, VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
 	{
-		static vk::DebugReportCallbackCreateInfoEXT debug_report_create_info = vkb::core::getDefaultDebugReportCallbackCreateInfoEXT();
-		debug_report_create_info.pNext                                       = pNext;
-		pNext                                                                = &debug_report_create_info;
+		pNext = get_debug_report_callback_create_info();
 	}
 
 	if (contains(enabled_extensions, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME))

--- a/samples/api/hello_triangle/hello_triangle.cpp
+++ b/samples/api/hello_triangle/hello_triangle.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2025, Arm Limited and Contributors
- * Copyright (c) 2025, Sascha Willems
+/* Copyright (c) 2018-2026, Arm Limited and Contributors
+ * Copyright (c) 2025-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -1076,8 +1076,6 @@ HelloTriangle::~HelloTriangle()
 	{
 		vkDestroyDebugUtilsMessengerEXT(context.instance, context.debug_callback, nullptr);
 	}
-
-	vk_instance.reset();
 }
 
 bool HelloTriangle::prepare(const vkb::ApplicationOptions &options)
@@ -1088,9 +1086,7 @@ bool HelloTriangle::prepare(const vkb::ApplicationOptions &options)
 
 	init_instance();
 
-	vk_instance = std::make_unique<vkb::core::InstanceC>(context.instance);
-
-	context.surface                     = options.window->create_surface(*vk_instance);
+	context.surface                     = options.window->create_surface(context.instance, nullptr);
 	auto &extent                        = options.window->get_extent();
 	context.swapchain_dimensions.width  = extent.width;
 	context.swapchain_dimensions.height = extent.height;

--- a/samples/api/hello_triangle/hello_triangle.h
+++ b/samples/api/hello_triangle/hello_triangle.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2018-2025, Arm Limited and Contributors
- * Copyright (c) 2025, Sascha Willems
+/* Copyright (c) 2018-2026, Arm Limited and Contributors
+ * Copyright (c) 2025-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -172,8 +172,6 @@ class HelloTriangle : public vkb::Application
 
   private:
 	Context context;
-
-	std::unique_ptr<vkb::core::InstanceC> vk_instance;
 };
 
 std::unique_ptr<vkb::Application> create_hello_triangle();

--- a/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
+++ b/samples/api/hello_triangle_1_3/hello_triangle_1_3.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025, Huawei Technologies Co., Ltd.
+/* Copyright (c) 2024-2026, Huawei Technologies Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -1198,8 +1198,6 @@ HelloTriangleV13::~HelloTriangleV13()
 		vkDestroyDebugUtilsMessengerEXT(context.instance, context.debug_callback, nullptr);
 		context.debug_callback = VK_NULL_HANDLE;
 	}
-
-	vk_instance.reset();
 }
 
 bool HelloTriangleV13::prepare(const vkb::ApplicationOptions &options)
@@ -1208,9 +1206,7 @@ bool HelloTriangleV13::prepare(const vkb::ApplicationOptions &options)
 
 	init_instance();
 
-	vk_instance = std::make_unique<vkb::core::InstanceC>(context.instance);
-
-	context.surface                     = options.window->create_surface(*vk_instance);
+	context.surface                     = options.window->create_surface(context.instance, nullptr);
 	auto &extent                        = options.window->get_extent();
 	context.swapchain_dimensions.width  = extent.width;
 	context.swapchain_dimensions.height = extent.height;

--- a/samples/api/hello_triangle_1_3/hello_triangle_1_3.h
+++ b/samples/api/hello_triangle_1_3/hello_triangle_1_3.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025, Huawei Technologies Co., Ltd.
+/* Copyright (c) 2024-2026, Huawei Technologies Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -170,8 +170,6 @@ class HelloTriangleV13 : public vkb::Application
 
   private:
 	Context context;
-
-	std::unique_ptr<vkb::core::InstanceC> vk_instance;
 };
 
 std::unique_ptr<vkb::Application> create_hello_triangle_1_3();

--- a/samples/api/swapchain_recreation/swapchain_recreation.cpp
+++ b/samples/api/swapchain_recreation/swapchain_recreation.cpp
@@ -993,8 +993,8 @@ std::unique_ptr<vkb::core::DeviceC> SwapchainRecreation::create_device(vkb::core
 {
 	std::unique_ptr<vkb::core::DeviceC> device = vkb::VulkanSampleC::create_device(gpu);
 
-	has_maintenance1 = get_instance().is_enabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME) &&
-	                   get_instance().is_enabled(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME) &&
+	has_maintenance1 = get_instance().is_extension_enabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME) &&
+	                   get_instance().is_extension_enabled(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME) &&
 	                   device->is_extension_enabled(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME);
 
 	LOGI("------------------------------------");

--- a/samples/extensions/debug_utils/debug_utils.cpp
+++ b/samples/extensions/debug_utils/debug_utils.cpp
@@ -71,7 +71,7 @@ DebugUtils::~DebugUtils()
  */
 void DebugUtils::debug_check_extension()
 {
-	std::vector<std::string> enabled_instance_extensions = get_instance().get_extensions();
+	std::vector<std::string> enabled_instance_extensions = get_instance().get_enabled_extensions();
 	for (auto &enabled_extension : enabled_instance_extensions)
 	{
 		if (enabled_extension == VK_EXT_DEBUG_UTILS_EXTENSION_NAME)

--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -1105,7 +1105,7 @@ bool FragmentShadingRateDynamic::prepare(const vkb::ApplicationOptions &options)
 		return false;
 	}
 
-	const auto enabled_instance_extensions = get_instance().get_extensions();
+	const auto enabled_instance_extensions = get_instance().get_enabled_extensions();
 	debug_utils_supported =
 	    std::ranges::find_if(enabled_instance_extensions, [](std::string const &ext) { return ext == VK_EXT_DEBUG_UTILS_EXTENSION_NAME; }) !=
 	    enabled_instance_extensions.cend();

--- a/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
+++ b/samples/extensions/full_screen_exclusive/full_screen_exclusive.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, Holochip Corporation
+/* Copyright (c) 2023-2026, Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -790,8 +790,6 @@ void FullScreenExclusive::teardown()
 		vkDestroyDebugUtilsMessengerEXT(context.instance, context.debug_callback, nullptr);
 		context.debug_callback = VK_NULL_HANDLE;
 	}
-
-	vk_instance.reset();
 }
 
 FullScreenExclusive::~FullScreenExclusive()
@@ -824,9 +822,7 @@ bool FullScreenExclusive::prepare(const vkb::ApplicationOptions &options)
 
 	init_instance({VK_KHR_SURFACE_EXTENSION_NAME}, {});
 
-	vk_instance = std::make_unique<vkb::core::InstanceC>(context.instance);
-
-	context.surface = window->create_surface(*vk_instance);
+	context.surface = window->create_surface(context.instance, nullptr);
 	if (!context.surface)
 		throw std::runtime_error("Failed to create window surface.");
 	auto &extent                        = window->get_extent();

--- a/samples/extensions/full_screen_exclusive/full_screen_exclusive.h
+++ b/samples/extensions/full_screen_exclusive/full_screen_exclusive.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, Holochip Corporation
+/* Copyright (c) 2023-2026, Holochip Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -75,8 +75,7 @@ class FullScreenExclusive : public vkb::Application
 	};
 
   private:
-	Context                               context{};
-	std::unique_ptr<vkb::core::InstanceC> vk_instance{};
+	Context context{};
 
 	HWND                                     HWND_application_window{};                       // sync the application HWND handle
 	bool                                     is_windowed = true;                              // this is to tell if the application window is already set in the desired mode

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -62,11 +62,6 @@ ShaderDebugPrintf::~ShaderDebugPrintf()
 
 		vkDestroySampler(get_device().get_handle(), textures.skysphere.sampler, nullptr);
 	}
-
-	if (has_instance())
-	{
-		vkDestroyDebugUtilsMessengerEXT(get_instance().get_handle(), debug_utils_messenger, nullptr);
-	}
 }
 
 uint32_t ShaderDebugPrintf::get_api_version() const
@@ -447,13 +442,6 @@ bool ShaderDebugPrintf::prepare(const vkb::ApplicationOptions &options)
 		return false;
 	}
 
-	// Register debug utils callback here so it works with both override and layer settings
-	VkDebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info{VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT};
-	debug_utils_messenger_create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
-	debug_utils_messenger_create_info.messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-	debug_utils_messenger_create_info.pfnUserCallback = debug_utils_message_callback;
-	VK_CHECK(vkCreateDebugUtilsMessengerEXT(get_instance().get_handle(), &debug_utils_messenger_create_info, nullptr, &debug_utils_messenger));
-
 	camera.type = vkb::CameraType::LookAt;
 	camera.set_position(glm::vec3(0.0f, 0.0f, -6.0f));
 	camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
@@ -470,6 +458,17 @@ bool ShaderDebugPrintf::prepare(const vkb::ApplicationOptions &options)
 	build_command_buffers();
 	prepared = true;
 	return true;
+}
+
+VkDebugUtilsMessengerCreateInfoEXT const *ShaderDebugPrintf::get_debug_utils_messenger_create_info() const
+{
+	// Register a sample specific debug utils callback in addition to the one registered by the base class
+	static VkDebugUtilsMessengerCreateInfoEXT local_debug_utils_messenger_create_info{.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
+	                                                                                  .pNext           = ApiVulkanSample::get_debug_utils_messenger_create_info(),
+	                                                                                  .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
+	                                                                                  .messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+	                                                                                  .pfnUserCallback = debug_utils_message_callback};
+	return &local_debug_utils_messenger_create_info;
 }
 
 void ShaderDebugPrintf::render(float delta_time)

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.h
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.h
@@ -70,8 +70,6 @@ class ShaderDebugPrintf : public ApiVulkanSample
 		uint32_t  object_type{0};
 	} push_const_block;
 
-	VkDebugUtilsMessengerEXT debug_utils_messenger{VK_NULL_HANDLE};
-
 	static std::string debug_output;
 
 	VKAPI_ATTR static VkBool32 VKAPI_CALL debug_utils_message_callback(
@@ -82,23 +80,23 @@ class ShaderDebugPrintf : public ApiVulkanSample
 
 	ShaderDebugPrintf();
 	~ShaderDebugPrintf();
-	void         request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
-	void         request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
-	void         request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
-	void         request_validation_feature_enables(std::vector<ValidationFeatureEnableType> &requested_layer_settings) const override;
-	void         build_command_buffers() override;
-	void         load_assets();
-	void         setup_descriptor_pool();
-	void         setup_descriptor_set_layout();
-	void         setup_descriptor_sets();
-	void         prepare_pipelines();
-	void         prepare_uniform_buffers();
-	void         update_uniform_buffers();
-	void         draw();
-	bool         prepare(const vkb::ApplicationOptions &options) override;
-	virtual void render(float delta_time) override;
-	virtual void on_update_ui_overlay(vkb::Drawer &drawer) override;
-	virtual bool resize(const uint32_t width, const uint32_t height) override;
+	void                                              request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
+	void                                              request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
+	void                                              request_validation_feature_enables(std::vector<ValidationFeatureEnableType> &requested_layer_settings) const override;
+	void                                              build_command_buffers() override;
+	void                                              load_assets();
+	void                                              setup_descriptor_pool();
+	void                                              setup_descriptor_set_layout();
+	void                                              setup_descriptor_sets();
+	void                                              prepare_pipelines();
+	void                                              prepare_uniform_buffers();
+	void                                              update_uniform_buffers();
+	void                                              draw();
+	bool                                              prepare(const vkb::ApplicationOptions &options) override;
+	virtual VkDebugUtilsMessengerCreateInfoEXT const *get_debug_utils_messenger_create_info() const override;
+	virtual void                                      render(float delta_time) override;
+	virtual void                                      on_update_ui_overlay(vkb::Drawer &drawer) override;
+	virtual bool                                      resize(const uint32_t width, const uint32_t height) override;
 
   private:
 	// from vkb::VulkanSample

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.h
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.h
@@ -81,6 +81,7 @@ class ShaderDebugPrintf : public ApiVulkanSample
 	ShaderDebugPrintf();
 	~ShaderDebugPrintf();
 	void                                              request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
+	void                                              request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
 	void                                              request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
 	void                                              request_validation_feature_enables(std::vector<ValidationFeatureEnableType> &requested_layer_settings) const override;
 	void                                              build_command_buffers() override;

--- a/samples/performance/constant_data/constant_data.cpp
+++ b/samples/performance/constant_data/constant_data.cpp
@@ -88,7 +88,7 @@ bool ConstantData::prepare(const vkb::ApplicationOptions &options)
 	}
 
 	// If descriptor indexing and its dependencies were enabled, then we can mark the update after bind method as supported
-	if (get_instance().is_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) &&
+	if (get_instance().is_extension_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) &&
 	    get_device().is_extension_enabled(VK_KHR_MAINTENANCE3_EXTENSION_NAME) &&
 	    get_device().is_extension_enabled(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME))
 	{

--- a/samples/performance/msaa/msaa.cpp
+++ b/samples/performance/msaa/msaa.cpp
@@ -731,7 +731,7 @@ void MSAASample::prepare_supported_sample_count_list()
 
 void MSAASample::prepare_depth_resolve_mode_list()
 {
-	if (get_instance().is_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
+	if (get_instance().is_extension_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
 	{
 		VkPhysicalDeviceProperties2KHR gpu_properties{};
 		gpu_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;


### PR DESCRIPTION
## Description

The debug messenger/callback are not integral parts of vkb::core::Instance, but simple members of a VulkanSample.
After moving them over into the VulkanSample, the vkb::core::Instance could completely be cleaned up.

Note that the exensions sample `shader_debugprintf` showcases how this approach can be used to register multiple debug messengers.

Build tested on Win11 with VS2022. Run tested on Win11 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
