### PR TITLE
Make more samples deterministic in benchmark mode

### DIFF
--- a/samples/api/compute_nbody/compute_nbody.cpp
+++ b/samples/api/compute_nbody/compute_nbody.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Sascha Willems
+/* Copyright (c) 2019-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -53,6 +53,7 @@ ComputeNBody::~ComputeNBody()
 		vkDestroyDescriptorSetLayout(get_device().get_handle(), compute.descriptor_set_layout, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), compute.pipeline_calculate, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), compute.pipeline_integrate, nullptr);
+		vkDestroyFence(get_device().get_handle(), compute.fence, nullptr);
 		vkDestroySemaphore(get_device().get_handle(), compute.semaphore, nullptr);
 		vkDestroyCommandPool(get_device().get_handle(), compute.command_pool, nullptr);
 
@@ -664,6 +665,11 @@ void ComputeNBody::prepare_compute()
 	VkSemaphoreCreateInfo semaphore_create_info = vkb::initializers::semaphore_create_info();
 	VK_CHECK(vkCreateSemaphore(get_device().get_handle(), &semaphore_create_info, nullptr, &compute.semaphore));
 
+	// Fence to ensure compute dispatch has finished reading the UBO before we update it.
+	// Created signaled so the first frame's wait doesn't block forever.
+	VkFenceCreateInfo fence_create_info = vkb::initializers::fence_create_info(VK_FENCE_CREATE_SIGNALED_BIT);
+	VK_CHECK(vkCreateFence(get_device().get_handle(), &fence_create_info, nullptr, &compute.fence));
+
 	// Signal the semaphore
 	VkSubmitInfo submit_info         = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
 	submit_info.signalSemaphoreCount = 1;
@@ -825,7 +831,7 @@ void ComputeNBody::draw()
 	compute_submit_info.pWaitDstStageMask    = &wait_stage_mask;
 	compute_submit_info.signalSemaphoreCount = 1;
 	compute_submit_info.pSignalSemaphores    = &compute.semaphore;
-	VK_CHECK(vkQueueSubmit(compute.queue, 1, &compute_submit_info, VK_NULL_HANDLE));
+	VK_CHECK(vkQueueSubmit(compute.queue, 1, &compute_submit_info, compute.fence));
 }
 
 bool ComputeNBody::prepare(const vkb::ApplicationOptions &options)
@@ -859,12 +865,17 @@ void ComputeNBody::render(float delta_time)
 	{
 		return;
 	}
-	draw();
+
+	// Wait for the previous compute dispatch to finish before updating the UBO
+	VK_CHECK(vkWaitForFences(get_device().get_handle(), 1, &compute.fence, VK_TRUE, UINT64_MAX));
+	VK_CHECK(vkResetFences(get_device().get_handle(), 1, &compute.fence));
+
 	update_compute_uniform_buffers(delta_time);
 	if (camera.updated)
 	{
 		update_graphics_uniform_buffers();
 	}
+	draw();
 }
 
 bool ComputeNBody::resize(const uint32_t width, const uint32_t height)

--- a/samples/api/compute_nbody/compute_nbody.h
+++ b/samples/api/compute_nbody/compute_nbody.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Sascha Willems
+/* Copyright (c) 2019-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -69,6 +69,7 @@ class ComputeNBody : public ApiVulkanSample
 		VkQueue                             queue;                        // Separate queue for compute commands (queue family may differ from the one used for graphics)
 		VkCommandPool                       command_pool;                 // Use a separate command pool (queue family may differ from the one used for graphics)
 		VkCommandBuffer                     command_buffer;               // Command buffer storing the dispatch commands and barriers
+		VkFence                             fence;                        // Fence to wait for compute dispatch completion before UBO update
 		VkSemaphore                         semaphore;                    // Execution dependency between compute & graphic submission
 		VkDescriptorSetLayout               descriptor_set_layout;        // Compute shader binding layout
 		VkDescriptorSet                     descriptor_set;               // Compute shader bindings

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -139,12 +139,19 @@ void HPPComputeNBody::render(float delta_time)
 {
 	if (prepared)
 	{
-		draw();
+		vk::Device device = get_device().get_handle();
+
+		// Wait for the previous compute dispatch to finish before updating the UBO
+		auto result = device.waitForFences(compute.fence, VK_TRUE, UINT64_MAX);
+		assert(result == vk::Result::eSuccess);
+		device.resetFences(compute.fence);
+
 		update_compute_uniform_buffers(delta_time);
 		if (camera.updated)
 		{
 			update_graphics_uniform_buffers();
 		}
+		draw();
 	}
 }
 
@@ -360,7 +367,7 @@ void HPPComputeNBody::draw()
 	                                           .pCommandBuffers      = &compute.command_buffer,
 	                                           .signalSemaphoreCount = 1,
 	                                           .pSignalSemaphores    = &compute.semaphore};
-	compute.queue.submit(compute_submit_info);
+	compute.queue.submit(compute_submit_info, compute.fence);
 }
 
 void HPPComputeNBody::initializeCamera()
@@ -462,6 +469,10 @@ void HPPComputeNBody::prepare_compute()
 
 	// Semaphore for compute & graphics sync
 	compute.semaphore = device.createSemaphore({});
+
+	// Fence to ensure compute dispatch has finished reading the UBO before we update it.
+	// Created signaled so the first frame's wait doesn't block forever.
+	compute.fence = device.createFence({.flags = vk::FenceCreateFlagBits::eSignaled});
 
 	// Signal the semaphore
 	vkb::common::submit_and_wait(device, queue, {}, {compute.semaphore});

--- a/samples/api/hpp_compute_nbody/hpp_compute_nbody.h
+++ b/samples/api/hpp_compute_nbody/hpp_compute_nbody.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -55,6 +55,7 @@ class HPPComputeNBody : public HPPApiVulkanSample
 		vk::PipelineLayout                    pipeline_layout;              // Layout of the compute pipeline
 		vk::Queue                             queue;                        // Separate queue for compute commands (queue family may differ from the one used for graphics)
 		uint32_t                              queue_family_index = ~0;
+		vk::Fence                             fence;            // Fence to wait for compute dispatch completion before UBO update
 		vk::Semaphore                         semaphore;        // Execution dependency between compute & graphic submission
 		uint32_t                              shared_data_size = 1024;
 		std::unique_ptr<vkb::core::BufferCpp> storage_buffer;        // (Shader) storage buffer object containing the particles
@@ -71,6 +72,7 @@ class HPPComputeNBody : public HPPApiVulkanSample
 			device.destroyPipelineLayout(pipeline_layout);
 			// no need to free the descriptor_set, as it's implicitly free'd with the descriptor_pool
 			device.destroyDescriptorSetLayout(descriptor_set_layout);
+			device.destroyFence(fence);
 			device.destroySemaphore(semaphore);
 			device.freeCommandBuffers(command_pool, command_buffer);
 			device.destroyCommandPool(command_pool);

--- a/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
+++ b/samples/extensions/dynamic_rendering_local_read/dynamic_rendering_local_read.cpp
@@ -443,8 +443,7 @@ void DynamicRenderingLocalRead::prepare_buffers()
 
 void DynamicRenderingLocalRead::update_lights_buffer()
 {
-	std::random_device                    rnd_device;
-	std::default_random_engine            rnd_gen(rnd_device());
+	std::default_random_engine            rnd_gen(lock_simulation_speed ? 0 : std::random_device{}());
 	std::uniform_real_distribution<float> rnd_dist(-1.0f, 1.0f);
 	std::uniform_real_distribution<float> rnd_col(0.0f, 0.5f);
 

--- a/samples/extensions/synchronization_2/synchronization_2.cpp
+++ b/samples/extensions/synchronization_2/synchronization_2.cpp
@@ -55,6 +55,7 @@ Synchronization2::~Synchronization2()
 		vkDestroyDescriptorSetLayout(get_device().get_handle(), compute.descriptor_set_layout, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), compute.pipeline_calculate, nullptr);
 		vkDestroyPipeline(get_device().get_handle(), compute.pipeline_integrate, nullptr);
+		vkDestroyFence(get_device().get_handle(), compute.fence, nullptr);
 		vkDestroySemaphore(get_device().get_handle(), compute.semaphore, nullptr);
 		vkDestroyCommandPool(get_device().get_handle(), compute.command_pool, nullptr);
 
@@ -644,6 +645,11 @@ void Synchronization2::prepare_compute()
 	VkSemaphoreCreateInfo semaphore_create_info = vkb::initializers::semaphore_create_info();
 	VK_CHECK(vkCreateSemaphore(get_device().get_handle(), &semaphore_create_info, nullptr, &compute.semaphore));
 
+	// Fence to ensure compute dispatch has finished reading the UBO before we update it.
+	// Created signaled so the first frame's wait doesn't block forever.
+	VkFenceCreateInfo fence_create_info = vkb::initializers::fence_create_info(VK_FENCE_CREATE_SIGNALED_BIT);
+	VK_CHECK(vkCreateFence(get_device().get_handle(), &fence_create_info, nullptr, &compute.fence));
+
 	// Signal the semaphore
 	VkSubmitInfo submit_info         = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
 	submit_info.signalSemaphoreCount = 1;
@@ -813,7 +819,7 @@ void Synchronization2::draw()
 	compute_submit_info.pWaitSemaphoreInfos      = &computeWaitSemaphore;
 	compute_submit_info.signalSemaphoreInfoCount = 1;
 	compute_submit_info.pSignalSemaphoreInfos    = &computeSignalSemaphore;
-	VK_CHECK(vkQueueSubmit2KHR(compute.queue, 1, &compute_submit_info, VK_NULL_HANDLE));
+	VK_CHECK(vkQueueSubmit2KHR(compute.queue, 1, &compute_submit_info, compute.fence));
 }
 
 bool Synchronization2::prepare(const vkb::ApplicationOptions &options)
@@ -847,12 +853,17 @@ void Synchronization2::render(float delta_time)
 	{
 		return;
 	}
-	draw();
+
+	// Wait for the previous compute dispatch to finish before updating the UBO
+	VK_CHECK(vkWaitForFences(get_device().get_handle(), 1, &compute.fence, VK_TRUE, UINT64_MAX));
+	VK_CHECK(vkResetFences(get_device().get_handle(), 1, &compute.fence));
+
 	update_compute_uniform_buffers(delta_time);
 	if (camera.updated)
 	{
 		update_graphics_uniform_buffers();
 	}
+	draw();
 }
 
 bool Synchronization2::resize(const uint32_t width, const uint32_t height)

--- a/samples/extensions/synchronization_2/synchronization_2.h
+++ b/samples/extensions/synchronization_2/synchronization_2.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, Sascha Willems
+/* Copyright (c) 2021-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -70,6 +70,7 @@ class Synchronization2 : public ApiVulkanSample
 		VkQueue                             queue;                        // Separate queue for compute commands (queue family may differ from the one used for graphics)
 		VkCommandPool                       command_pool;                 // Use a separate command pool (queue family may differ from the one used for graphics)
 		VkCommandBuffer                     command_buffer;               // Command buffer storing the dispatch commands and barriers
+		VkFence                             fence;                        // Fence to wait for compute dispatch completion before UBO update
 		VkSemaphore                         semaphore;                    // Execution dependency between compute & graphic submission
 		VkDescriptorSetLayout               descriptor_set_layout;        // Compute shader binding layout
 		VkDescriptorSet                     descriptor_set;               // Compute shader bindings


### PR DESCRIPTION
## Description

Includes a simple change to dynamic_rendering_local_read that seeds the random generator in benchmark mode.

This also addresses race conditions in compute_nbody and its variants (hpp_compute_nbody & synchronization_2) which can cause the compute UBO to be updated by the CPU whilst its being read by the GPU. This often causes no issue, but can cause the frame ordering to be non-deterministic. Worst case could see the GPU read a partially written UBO entry I guess.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Linux

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly
