### PR TITLE
Resolve macro conflicts in Windows

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -409,7 +409,7 @@ else()
 endif()
 
 # mask out the min/max macros from minwindef.h
-if(MSVC)
+if(WIN32)
     add_definitions(-DNOMINMAX)
 endif()
 

--- a/samples/extensions/open_gl_interop/open_gl_interop.cpp
+++ b/samples/extensions/open_gl_interop/open_gl_interop.cpp
@@ -172,7 +172,7 @@ void OpenGLInterop::prepare_shared_resources()
 		VK_CHECK(vkCreateSemaphore(deviceHandle, &semaphoreCreateInfo, nullptr,
 		                           &sharedSemaphores.gl_ready));
 
-#if WIN32
+#ifdef WIN32
 		VkSemaphoreGetWin32HandleInfoKHR semaphoreGetHandleInfo{
 		    VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR, nullptr,
 		    VK_NULL_HANDLE, compatable_semaphore_type};
@@ -193,7 +193,7 @@ void OpenGLInterop::prepare_shared_resources()
 
 	{
 		VkExternalMemoryImageCreateInfo external_memory_image_create_info{VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO};
-#if WIN32
+#ifdef WIN32
 		external_memory_image_create_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR;
 #else
 		external_memory_image_create_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
@@ -224,7 +224,7 @@ void OpenGLInterop::prepare_shared_resources()
 		VkExportMemoryAllocateInfo export_memory_allocate_Info;
 		export_memory_allocate_Info.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
 		export_memory_allocate_Info.pNext = &dedicated_allocate_info;
-#if WIN32
+#ifdef WIN32
 		export_memory_allocate_Info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR;
 #else
 		export_memory_allocate_Info.handleTypes       = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
@@ -237,7 +237,7 @@ void OpenGLInterop::prepare_shared_resources()
 		VK_CHECK(vkAllocateMemory(deviceHandle, &memAllocInfo, nullptr, &sharedTexture.memory));
 		VK_CHECK(vkBindImageMemory(deviceHandle, sharedTexture.image, sharedTexture.memory, 0));
 
-#if WIN32
+#ifdef WIN32
 		VkMemoryGetWin32HandleInfoKHR memoryFdInfo{VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, nullptr,
 		                                           sharedTexture.memory,
 		                                           VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT};


### PR DESCRIPTION
## Description

This PR addresses two problems related to Windows macro conflicts:

-  **max/min definition**
Changed the check from `if(MSVC)` to `if(WIN32)` when defining NOMINMAX. This ensures that the min/max macros from <windows.h> are masked on all Windows compilers (MSVC, clang-cl, MinGW).

- **#ifdef checks in source**
Replaced `#if WIN32` with `#ifdef WIN32` to ensure correct macro detection. This avoids potential compilation errors when building with Clang + MSVC, where undefined macros could cause preprocessing issues.

## General Checklist:
Please ensure the following points are checked:
- [√] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [√] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- ~~[ ] I have commented any added functions (in line with Doxygen)~~
- ~~[ ] I have commented any code that could be hard to understand~~
- [√] My changes do not add any new compiler warnings
- [√] My changes do not add any new validation layer errors or warnings
- [√] I have used existing framework/helper functions where possible
- [√] My changes do not add any regressions
- [√] I have tested every sample to ensure everything runs correctly
- [√] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - ~~[ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)~~
 - [√] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

