### PR TITLE
Fix layer settings for shader_debugPrintf and reenable iOS Simulator execution

### DIFF
--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -1343,7 +1343,8 @@ inline void VulkanSample<bindingType>::request_instance_extensions(std::unordere
 #endif
 
 #if defined(VKB_ENABLE_PORTABILITY)
-	requested_extensions[VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME] = vkb::RequestMode::Required;
+	// VK_KHR_portability_enumeration must be optional to support MoltenVK standalone on macOS and iOS Simulator
+	requested_extensions[VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME] = vkb::RequestMode::Optional;
 #endif
 
 	// VK_KHR_get_physical_device_properties2 is a prerequisite of VK_KHR_performance_query

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -799,6 +799,7 @@ inline void *VulkanSample<bindingType>::get_instance_create_info_extensions(std:
 		request_layer_settings(requested_layer_settings);
 
 		static std::vector<vk::LayerSettingEXT> enabled_layer_settings;
+		enabled_layer_settings.clear();
 		for (auto const &layer_setting : requested_layer_settings)
 		{
 			enable_layer_setting(layer_setting, enabled_layers, enabled_layer_settings);

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -799,6 +799,7 @@ inline void *VulkanSample<bindingType>::get_instance_create_info_extensions(std:
 		request_layer_settings(requested_layer_settings);
 
 		static std::vector<vk::LayerSettingEXT> enabled_layer_settings;
+		// since enabled_layer_settings is static, clear on every get_instance_create_info_extensions() call to support batch mode
 		enabled_layer_settings.clear();
 		for (auto const &layer_setting : requested_layer_settings)
 		{

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -781,15 +781,15 @@ inline void *VulkanSample<bindingType>::get_instance_create_info_extensions(std:
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
 	if (contains(enabled_extensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
 	{
-		static vk::DebugReportCallbackCreateInfoEXT debug_report_create_info = vkb::core::getDefaultDebugReportCallbackCreateInfoEXT();
-		debug_report_create_info.pNext                                       = pNext;
-		pNext                                                                = &debug_report_create_info;
-	}
-	else if (contains(enabled_extensions, VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
-	{
 		static vk::DebugUtilsMessengerCreateInfoEXT debug_utils_create_info = vkb::core::getDefaultDebugUtilsMessengerCreateInfoEXT();
 		debug_utils_create_info.pNext                                       = pNext;
 		pNext                                                               = &debug_utils_create_info;
+	}
+	else if (contains(enabled_extensions, VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
+	{
+		static vk::DebugReportCallbackCreateInfoEXT debug_report_create_info = vkb::core::getDefaultDebugReportCallbackCreateInfoEXT();
+		debug_report_create_info.pNext                                       = pNext;
+		pNext                                                                = &debug_report_create_info;
 	}
 #endif
 

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -121,7 +121,7 @@ void ShaderDebugPrintf::request_gpu_features(vkb::core::PhysicalDeviceC &gpu)
 void ShaderDebugPrintf::request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const
 {
 	ApiVulkanSample::request_instance_extensions(requested_extensions);
-	// MoltenVK requires VK_EXT_layer_settings enabled to use layer settings, but set as optional to support other platforms/drivers
+	// Vulkan Samples framework requires VK_EXT_layer_settings extension to use layer settings for configuring the Validation Layer
 	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
 }
 

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -118,6 +118,13 @@ void ShaderDebugPrintf::request_gpu_features(vkb::core::PhysicalDeviceC &gpu)
 	}
 }
 
+void ShaderDebugPrintf::request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const
+{
+	ApiVulkanSample::request_instance_extensions(requested_extensions);
+	// MoltenVK requires VK_EXT_layer_settings enabled to use layer settings, but set as optional to support other platforms/drivers
+	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
+}
+
 void ShaderDebugPrintf::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const
 {
 	// Make this static so layer setting reference remains valid after leaving the current scope

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.h
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.h
@@ -83,6 +83,7 @@ class ShaderDebugPrintf : public ApiVulkanSample
 	ShaderDebugPrintf();
 	~ShaderDebugPrintf();
 	void         request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
+	void         request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
 	void         request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
 	void         request_validation_feature_enables(std::vector<ValidationFeatureEnableType> &requested_layer_settings) const override;
 	void         build_command_buffers() override;

--- a/samples/performance/layout_transitions/layout_transitions.cpp
+++ b/samples/performance/layout_transitions/layout_transitions.cpp
@@ -36,21 +36,6 @@ LayoutTransitions::LayoutTransitions()
 
 	config.insert<vkb::IntSetting>(0, reinterpret_cast<int &>(layout_transition_type), LayoutTransitionType::UNDEFINED);
 	config.insert<vkb::IntSetting>(1, reinterpret_cast<int &>(layout_transition_type), LayoutTransitionType::LAST_LAYOUT);
-
-#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
-	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
-	VkLayerSettingEXT layerSetting;
-	layerSetting.pLayerName   = "MoltenVK";
-	layerSetting.pSettingName = "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS";
-	layerSetting.type         = VK_LAYER_SETTING_TYPE_INT32_EXT;
-	layerSetting.valueCount   = 1;
-
-	// Make this static so layer setting reference remains valid after leaving constructor scope
-	static const int32_t disableMetalArgumentBuffers = 0;
-	layerSetting.pValues                             = &disableMetalArgumentBuffers;
-
-	add_layer_setting(layerSetting);
-#endif
 }
 
 bool LayoutTransitions::prepare(const vkb::ApplicationOptions &options)
@@ -97,6 +82,15 @@ void LayoutTransitions::request_instance_extensions(std::unordered_map<std::stri
 	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
 	vkb::VulkanSampleC::request_instance_extensions(requested_extensions);
 	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
+}
+
+void LayoutTransitions::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const
+{
+	// Make this static so layer setting reference remains valid after leaving the current scope
+	static const int32_t disableMetalArgumentBuffers = 0;
+
+	vkb::VulkanSampleC::request_layer_settings(requested_layer_settings);
+	requested_layer_settings.push_back({"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &disableMetalArgumentBuffers});
 }
 #endif
 

--- a/samples/performance/layout_transitions/layout_transitions.h
+++ b/samples/performance/layout_transitions/layout_transitions.h
@@ -35,6 +35,7 @@ class LayoutTransitions : public vkb::VulkanSampleC
 	bool prepare(const vkb::ApplicationOptions &options) override;
 #if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
 	void request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
+	void request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
 #endif
 
   private:

--- a/samples/performance/pipeline_barriers/pipeline_barriers.cpp
+++ b/samples/performance/pipeline_barriers/pipeline_barriers.cpp
@@ -38,21 +38,6 @@ PipelineBarriers::PipelineBarriers()
 	config.insert<vkb::IntSetting>(0, reinterpret_cast<int &>(dependency_type), DependencyType::BOTTOM_TO_TOP);
 	config.insert<vkb::IntSetting>(1, reinterpret_cast<int &>(dependency_type), DependencyType::FRAG_TO_VERT);
 	config.insert<vkb::IntSetting>(2, reinterpret_cast<int &>(dependency_type), DependencyType::FRAG_TO_FRAG);
-
-#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
-	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
-	VkLayerSettingEXT layerSetting;
-	layerSetting.pLayerName   = "MoltenVK";
-	layerSetting.pSettingName = "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS";
-	layerSetting.type         = VK_LAYER_SETTING_TYPE_INT32_EXT;
-	layerSetting.valueCount   = 1;
-
-	// Make this static so layer setting reference remains valid after leaving constructor scope
-	static const int32_t disableMetalArgumentBuffers = 0;
-	layerSetting.pValues                             = &disableMetalArgumentBuffers;
-
-	add_layer_setting(layerSetting);
-#endif
 }
 
 bool PipelineBarriers::prepare(const vkb::ApplicationOptions &options)
@@ -132,6 +117,15 @@ void PipelineBarriers::request_instance_extensions(std::unordered_map<std::strin
 	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
 	vkb::VulkanSampleC::request_instance_extensions(requested_extensions);
 	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
+}
+
+void PipelineBarriers::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const
+{
+	// Make this static so layer setting reference remains valid after leaving the current scope
+	static const int32_t disableMetalArgumentBuffers = 0;
+
+	vkb::VulkanSampleC::request_layer_settings(requested_layer_settings);
+	requested_layer_settings.push_back({"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &disableMetalArgumentBuffers});
 }
 #endif
 

--- a/samples/performance/pipeline_barriers/pipeline_barriers.h
+++ b/samples/performance/pipeline_barriers/pipeline_barriers.h
@@ -35,6 +35,7 @@ class PipelineBarriers : public vkb::VulkanSampleC
 	bool prepare(const vkb::ApplicationOptions &options) override;
 #if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
 	void request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
+	void request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
 #endif
 
   private:

--- a/samples/performance/subpasses/subpasses.cpp
+++ b/samples/performance/subpasses/subpasses.cpp
@@ -50,21 +50,6 @@ Subpasses::Subpasses()
 	config.insert<vkb::IntSetting>(3, configs[Config::RenderTechnique].value, 0);
 	config.insert<vkb::IntSetting>(3, configs[Config::TransientAttachments].value, 0);
 	config.insert<vkb::IntSetting>(3, configs[Config::GBufferSize].value, 1);
-
-#if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
-	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
-	VkLayerSettingEXT layerSetting;
-	layerSetting.pLayerName   = "MoltenVK";
-	layerSetting.pSettingName = "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS";
-	layerSetting.type         = VK_LAYER_SETTING_TYPE_INT32_EXT;
-	layerSetting.valueCount   = 1;
-
-	// Make this static so layer setting reference remains valid after leaving constructor scope
-	static const int32_t disableMetalArgumentBuffers = 0;
-	layerSetting.pValues                             = &disableMetalArgumentBuffers;
-
-	add_layer_setting(layerSetting);
-#endif
 }
 
 std::unique_ptr<vkb::RenderTarget> Subpasses::create_render_target(vkb::core::Image &&swapchain_image)
@@ -189,6 +174,15 @@ void Subpasses::request_instance_extensions(std::unordered_map<std::string, vkb:
 	// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
 	vkb::VulkanSampleC::request_instance_extensions(requested_extensions);
 	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
+}
+
+void Subpasses::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const
+{
+	// Make this static so layer setting reference remains valid after leaving the current scope
+	static const int32_t disableMetalArgumentBuffers = 0;
+
+	vkb::VulkanSampleC::request_layer_settings(requested_layer_settings);
+	requested_layer_settings.push_back({"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &disableMetalArgumentBuffers});
 }
 #endif
 

--- a/samples/performance/subpasses/subpasses.h
+++ b/samples/performance/subpasses/subpasses.h
@@ -36,6 +36,7 @@ class Subpasses : public vkb::VulkanSampleC
 	bool prepare(const vkb::ApplicationOptions &options) override;
 #if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
 	void request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
+	void request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
 #endif
 
 	void update(float delta_time) override;


### PR DESCRIPTION
## Description

This PR contains the following:

1. Fixes a layer settings regression in the _shader_debugPrintf_ sample for Release builds - all platforms.
2. Addresses a layer settings holdover problem in the Vulkan Samples framework when running in batch mode - all platforms.
3. Corrects a reversed DebugUtils and DebugReport callback setup in `get_instance_create_info_extensions()` - all platforms.
4. Re-enables samples to run on the iOS Simulator target by fixing a regression in the framework that incorrectly made `VK_KHR_portability_enumeration` mandatory - should be optional.
5. Completes the new layer settings framework transition work to allow _layout_transitions_, _pipeline_barriers_, and _subpasses_ to compile and run for the iOS Simulator target.

Fixes #1496 and #1497.

Tested with Vulkan SDK 1.4.341 on: a) Windows 11, b) macOS Sequoia 15.7.4 (MoltenVK and KosmicKrisp), and c) iOS 26.2 on iOS Simulator.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
