### PR TITLE
ray_tracing_invocation_reorder: set scratch buffer alignment

### DIFF
--- a/samples/extensions/ray_tracing_invocation_reorder/ray_tracing_invocation_reorder.cpp
+++ b/samples/extensions/ray_tracing_invocation_reorder/ray_tracing_invocation_reorder.cpp
@@ -419,6 +419,7 @@ void RaytracingInvocationReorder::create_bottom_level_acceleration_structure(boo
 			    model_buffer.vertex_offset + (model_buffer.is_static ? static_vertex_handle : dynamic_vertex_handle),
 			    model_buffer.index_offset + (model_buffer.is_static ? static_index_handle : dynamic_index_handle));
 		}
+		model_buffer.bottom_level_acceleration_structure->set_scrach_buffer_alignment(acceleration_structure_properties.minAccelerationStructureScratchOffsetAlignment);
 		model_buffer.bottom_level_acceleration_structure->build(queue,
 		                                                        model_buffer.is_static ? VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR : VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_BUILD_BIT_KHR | VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR,
 		                                                        is_update ? VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR : VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
@@ -548,6 +549,7 @@ void RaytracingInvocationReorder::create_top_level_acceleration_structure(bool p
 	{
 		top_level_acceleration_structure->update_instance_geometry(instance_uid, instances_buffer, static_cast<uint32_t>(instances.size()));
 	}
+	top_level_acceleration_structure->set_scrach_buffer_alignment(acceleration_structure_properties.minAccelerationStructureScratchOffsetAlignment);
 	top_level_acceleration_structure->build(queue);
 }
 
@@ -1183,6 +1185,9 @@ bool RaytracingInvocationReorder::prepare(const vkb::ApplicationOptions &options
 	VkPhysicalDeviceProperties2 device_properties{};
 	device_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
 	device_properties.pNext = &ray_tracing_pipeline_properties;
+	ray_tracing_pipeline_properties.pNext = &acceleration_structure_properties;
+	vkGetPhysicalDeviceProperties2(get_device().get_gpu().get_handle(), &device_properties);
+
 	vkGetPhysicalDeviceProperties2(get_device().get_gpu().get_handle(), &device_properties);
 
 	// Get the acceleration structure features, which we'll need later on in the sample

--- a/samples/extensions/ray_tracing_invocation_reorder/ray_tracing_invocation_reorder.cpp
+++ b/samples/extensions/ray_tracing_invocation_reorder/ray_tracing_invocation_reorder.cpp
@@ -1186,7 +1186,6 @@ bool RaytracingInvocationReorder::prepare(const vkb::ApplicationOptions &options
 	device_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
 	device_properties.pNext = &ray_tracing_pipeline_properties;
 	ray_tracing_pipeline_properties.pNext = &acceleration_structure_properties;
-	vkGetPhysicalDeviceProperties2(get_device().get_gpu().get_handle(), &device_properties);
 
 	vkGetPhysicalDeviceProperties2(get_device().get_gpu().get_handle(), &device_properties);
 

--- a/samples/extensions/ray_tracing_invocation_reorder/ray_tracing_invocation_reorder.h
+++ b/samples/extensions/ray_tracing_invocation_reorder/ray_tracing_invocation_reorder.h
@@ -32,6 +32,8 @@ class RaytracingInvocationReorder : public ApiVulkanSample
   public:
 	VkPhysicalDeviceRayTracingPipelinePropertiesKHR  ray_tracing_pipeline_properties{};
 	VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure_features{};
+	// Acceleration structure properties.
+	VkPhysicalDeviceAccelerationStructurePropertiesKHR acceleration_structure_properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR};
 #ifdef VK_EXT_ray_tracing_invocation_reorder
 	VkPhysicalDeviceRayTracingInvocationReorderPropertiesEXT invocation_reorder_properties_ext{};
 #endif


### PR DESCRIPTION
## Description

ray_tracing_invocation_reorder not set scratch buffer alignment.
This PR set it to follow spec.
