### PR TITLE
Update iOS build and CI to support standardization of FindVulkan.cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,5 +194,5 @@ jobs:
       - name: build_ios
         run: |
           source ~/VulkanSDK/iOS/setup-env.sh
-          cmake -H"." -B"build/ios" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_DEPLOYMENT_TARGET=16.3 -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
+          cmake -G Xcode -B"build/ios" --toolchain bldsys/toolchain/ios.cmake -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
           cmake --build "build/ios" --target vulkan_samples --config ${{ matrix.build_type }} -- -allowProvisioningUpdates

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,9 +187,9 @@ jobs:
       - name: retrieve VulkanSDK
         if: steps.VulkanSDK.outputs.cache-hit != 'true'
         run: |
-          wget https://sdk.lunarg.com/sdk/download/1.4.304.1/mac/vulkansdk-macos-1.4.304.1.zip
-          unzip vulkansdk-macos-1.4.304.1.zip
-          sudo InstallVulkan-1.4.304.1.app/Contents/MacOS/InstallVulkan-1.4.304.1 --root ~/VulkanSDK --accept-licenses --default-answer --confirm-command install com.lunarg.vulkan.ios
+          wget https://sdk.lunarg.com/sdk/download/1.4.341.1/mac/vulkansdk-macos-1.4.341.1.zip
+          unzip vulkansdk-macos-1.4.341.1.zip
+          sudo vulkansdk-macOS-1.4.341.1.app/Contents/MacOS/vulkansdk-macOS-1.4.341.1 --root ~/VulkanSDK --accept-licenses --default-answer --confirm-command install com.lunarg.vulkan.ios
 
       - name: build_ios
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,9 @@ else ()
 # search for Vulkan SDK
 find_package(Vulkan)
 
-if(Vulkan_FOUND)
+# Apple platforms always define Vulkan_SDK, so don't look for shader compilers otherwise we will build
+# the shaders for every new config - instead use pre-built shaders which improves project build times.
+if(Vulkan_FOUND AND NOT APPLE)
     if(NOT Vulkan_dxc_exe_FOUND)
         find_program(Vulkan_dxc_EXECUTABLE
                     NAMES dxc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright (c) 2020-2025, Arm Limited and Contributors
-# Copyright (c) 2024-2025, Mobica Limited
-# Copyright (c) 2024-2025, Sascha Willems
+# Copyright (c) 2020-2026, Arm Limited and Contributors
+# Copyright (c) 2024-2026, Mobica Limited
+# Copyright (c) 2024-2026, Sascha Willems
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2025, Arm Limited and Contributors
+# Copyright (c) 2019-2026, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -137,12 +137,12 @@ if(IOS)
     endif ()
     # Vulkan cache variables already defined by main project CMakeLists and updated on Apple platforms by global_options.cmake
     if(Vulkan_LIBRARY AND ${Vulkan_VERSION} VERSION_GREATER_EQUAL 1.3.278)
-        get_filename_component(Vulkan_Target_SDK "$ENV{VULKAN_SDK}" REALPATH)
+        get_filename_component(Vulkan_Target_SDK "$ENV{VULKAN_SDK}/.." REALPATH)
         target_sources(${PROJECT_NAME} PRIVATE
-                ${Vulkan_Target_SDK}/share/vulkan
+                ${Vulkan_Target_SDK}/iOS/share/vulkan
         )
         set_source_files_properties(
-                ${Vulkan_Target_SDK}/share/vulkan
+                ${Vulkan_Target_SDK}/iOS/share/vulkan
                 PROPERTIES
                 MACOSX_PACKAGE_LOCATION Resources
         )

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -137,11 +137,12 @@ if(IOS)
     endif ()
     # Vulkan cache variables already defined by main project CMakeLists and updated on Apple platforms by global_options.cmake
     if(Vulkan_LIBRARY AND ${Vulkan_VERSION} VERSION_GREATER_EQUAL 1.3.278)
+        get_filename_component(Vulkan_Target_SDK "$ENV{VULKAN_SDK}" REALPATH)
         target_sources(${PROJECT_NAME} PRIVATE
-                ${Vulkan_Target_SDK}/iOS/share/vulkan
+                ${Vulkan_Target_SDK}/share/vulkan
         )
         set_source_files_properties(
-                ${Vulkan_Target_SDK}/iOS/share/vulkan
+                ${Vulkan_Target_SDK}/share/vulkan
                 PROPERTIES
                 MACOSX_PACKAGE_LOCATION Resources
         )

--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -1,5 +1,5 @@
 #[[
- Copyright (c) 2019-2025, Arm Limited and Contributors
+ Copyright (c) 2019-2026, Arm Limited and Contributors
 
  SPDX-License-Identifier: Apache-2.0
 
@@ -78,10 +78,10 @@ if(APPLE)
 		else()
 			message(FATAL_ERROR "Can't find MoltenVK library. Please install the Vulkan SDK or MoltenVK project and set VULKAN_SDK.")
 		endif()
-	#elseif(OTHER_VULKAN_DRIVER)
-		# handle any special processing here for other Vulkan driver (e.g. KosmicKrisp) for standalone usage on macOS or deployment to iOS
-		# would likely require extensions to CMake find_package() OPTIONAL_COMPONENTS and library variables to identify & use other driver
-	#else()
+	elseif(IOS AND NOT Vulkan_Layer_VALIDATION)
+		# if building for iOS devices (not iOS Simulator as above) and Vulkan_Layer_VALIDATION is not defined or found, search in the Vulkan SDK
+		find_library(Vulkan_Layer_VALIDATION NAMES VkLayer_khronos_validation HINTS "$ENV{VULKAN_SDK}/lib")
+	else()
 		# if not using standalone driver, retain find_package() results for Vulkan driver, Vulkan loader, and Validation Layer library variables
 		# no need to override with _HPP_VULKAN_LIBRARY in this case since Vulkan DynamicLoader will find/load Vulkan library on macOS & iOS
 	endif()

--- a/bldsys/toolchain/ios.cmake
+++ b/bldsys/toolchain/ios.cmake
@@ -1,9 +1,9 @@
 #[[
 
- Copyright (c) 2026, Francesco Giancane
+ Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  Copyright (c) 2026, Stephen Saunders
 
- SPDX-License-Identifier: Apache-2.0
+ SPDX-License-Identifier: BSD-3-Clause-Clear
 
  Licensed under the Apache License, Version 2.0 the "License";
  you may not use this file except in compliance with the License.
@@ -16,6 +16,11 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+ ------------------------------------------------------------------------
+ 
+ Co-Authored-By: (Qualcomm) Giancane, Francesco <fgiancan@qti.qualcomm.com>
+ Co-Authored-By: Stephen Saunders
 
  ]]
 

--- a/bldsys/toolchain/ios.cmake
+++ b/bldsys/toolchain/ios.cmake
@@ -1,0 +1,18 @@
+# As per upstream CMake recommendation in https://gitlab.kitware.com/cmake/cmake/-/issues/27661
+# for iOS we can use a toolchain file to augment search paths and simplify command line
+#
+# iOS/setup-env.sh will first take care of defining the VULKAN_SDK environment variable
+# Toolchain file shall define:
+# - Target system name to iOS
+# - Minimum deployment target to iOS 16.3
+# - Build only the active arch for devices and simulator
+# - Export the $ENV{VULKAN_SDK} variable to `CMAKE_FIND_ROOT_PATH`
+#
+# Note: We augment CMAKE_FIND_ROOT_PATH to find the iOS Vulkan frameworks from the SDK.
+# We don't define CMAKE_OSX_SYSROOT here since we need to build for both physical devices
+# (iphoneos) and simulator (iphonesimulator) - do that instead on the cmake command line.
+
+set(CMAKE_SYSTEM_NAME iOS)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 16.3)
+set(CMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH YES)
+list(APPEND CMAKE_FIND_ROOT_PATH "$ENV{VULKAN_SDK}")

--- a/bldsys/toolchain/ios.cmake
+++ b/bldsys/toolchain/ios.cmake
@@ -3,13 +3,13 @@
  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  Copyright (c) 2026, Stephen Saunders
 
- SPDX-License-Identifier: BSD-3-Clause-Clear
+ SPDX-License-Identifier: Apache-2.0
 
- Licensed under the BSD-3-Clause-Clear License the "License";
+ Licensed under the Apache License, Version 2.0 the "License";
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     https://spdx.org/licenses/BSD-3-Clause-Clear.html
+     http://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@
  ]]
 
 # As per upstream CMake recommendation in https://gitlab.kitware.com/cmake/cmake/-/issues/27661
-# for iOS we can use a toolchain file to augment search paths and simplify command line
+# for iOS we can use a toolchain file to set up search paths and simplify the command line
 #
 # iOS/setup-env.sh will first take care of defining the VULKAN_SDK environment variable
 # Toolchain file shall define:
@@ -34,11 +34,11 @@
 # - Build only the active arch for devices and simulator
 # - Export the $ENV{VULKAN_SDK} variable to `CMAKE_FIND_ROOT_PATH`
 #
-# Note: We augment CMAKE_FIND_ROOT_PATH to find the iOS Vulkan frameworks from the SDK.
+# Note: We define CMAKE_FIND_ROOT_PATH to locate the iOS Vulkan frameworks from the SDK.
 # We don't define CMAKE_OSX_SYSROOT here since we need to build for both physical devices
 # (iphoneos) and simulator (iphonesimulator) - do that instead on the cmake command line.
 
 set(CMAKE_SYSTEM_NAME iOS)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 16.3)
 set(CMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH YES)
-list(APPEND CMAKE_FIND_ROOT_PATH "$ENV{VULKAN_SDK}")
+set(CMAKE_FIND_ROOT_PATH "$ENV{VULKAN_SDK}")

--- a/bldsys/toolchain/ios.cmake
+++ b/bldsys/toolchain/ios.cmake
@@ -1,3 +1,24 @@
+#[[
+
+ Copyright (c) 2026, Francesco Giancane
+ Copyright (c) 2026, Stephen Saunders
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 the "License";
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ ]]
+
 # As per upstream CMake recommendation in https://gitlab.kitware.com/cmake/cmake/-/issues/27661
 # for iOS we can use a toolchain file to augment search paths and simplify command line
 #

--- a/bldsys/toolchain/ios.cmake
+++ b/bldsys/toolchain/ios.cmake
@@ -5,11 +5,11 @@
 
  SPDX-License-Identifier: BSD-3-Clause-Clear
 
- Licensed under the Apache License, Version 2.0 the "License";
+ Licensed under the BSD-3-Clause-Clear License the "License";
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://spdx.org/licenses/BSD-3-Clause-Clear.html
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/docs/build.adoc
+++ b/docs/build.adoc
@@ -327,14 +327,14 @@ source /PATH/TO/VULKAN/SDK/iOS/setup-env.sh
 `Step 1.` The following command will generate the project
 
 ----
-cmake -G Xcode -Bbuild/ios -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_DEPLOYMENT_TARGET=16.3 -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=YES -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_IOS_INSTALL_COMBINED=NO -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM="XXXX" -DMACOSX_BUNDLE_GUI_IDENTIFIER="com.YYYY.vulkansamples"
+cmake -G Xcode -Bbuild/ios --toolchain bldsys/toolchain/ios.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM="XXXX" -DMACOSX_BUNDLE_GUI_IDENTIFIER="com.YYYY.vulkansamples"
 ----
 NB:  You MUST change the XXXX in the above to your TeamID (or Organizational Unit identifier in your Apple Development certificate) for code signing, and YYYY to your bundle identifier. iOS will NOT allow the application to run without code signing and bundle identifier setup.
 
-Alternatively, you can build for the iOS Simulator (requires Vulkan SDK 1.4.321.0 or later) without code signing or specifying a bundle identifier (a default bundle id will be used). However, depending on your host architecture, you MUST select either arm64 (Apple Silicon) or x86_64 in the command below. _Note: On arm64 (Apple Silicon) hosts the Vulkan library may not load on iOS Simulator without specifying your TeamID and bundle identifier as shown above._
+Alternatively, you can build for the iOS Simulator (requires Vulkan SDK 1.4.321.0 or later) without code signing or specifying a bundle identifier (a default bundle id will be used). However, depending on your host architecture, you MUST select either arm64 (Apple Silicon) OR x86_64 in the command below. _Note: On arm64 hosts (Apple Silicon) the Vulkan library may not load on iOS Simulator without specifying your TeamID and bundle identifier as shown above._
 
 ----
-cmake -G Xcode -Bbuild/ios-sim -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_DEPLOYMENT_TARGET=16.3 -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=YES -DCMAKE_OSX_ARCHITECTURES=<arm64|x86_64> -DCMAKE_IOS_INSTALL_COMBINED=NO
+cmake -G Xcode -Bbuild/ios-sim --toolchain bldsys/toolchain/ios.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_ARCHITECTURES=<arm64|x86_64>
 ----
 
 `Step 2.` Build the project

--- a/docs/build.adoc
+++ b/docs/build.adoc
@@ -1,5 +1,5 @@
 ////
-- Copyright (c) 2019-2025, Arm Limited and Contributors
+- Copyright (c) 2019-2026, Arm Limited and Contributors
 -
 - SPDX-License-Identifier: Apache-2.0
 -

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -1362,7 +1362,8 @@ template <vkb::BindingType bindingType>
 inline void VulkanSample<bindingType>::request_layers(std::unordered_map<std::string, vkb::RequestMode> &requested_layers) const
 {
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	requested_layers["VK_LAYER_KHRONOS_validation"] = vkb::RequestMode::Required;
+	// VK_LAYER_KHRONOS_validation must be optional in case layer not available for debug builds (e.g. running on Windows with no SDK installed or on iOS Simulator)
+	requested_layers["VK_LAYER_KHRONOS_validation"] = vkb::RequestMode::Optional;
 #endif
 }
 

--- a/samples/api/texture_loading/texture_loading.cpp
+++ b/samples/api/texture_loading/texture_loading.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Sascha Willems
+/* Copyright (c) 2019-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -408,10 +408,13 @@ void TextureLoading::load_texture()
 // Free all Vulkan resources used by a texture object
 void TextureLoading::destroy_texture(Texture texture)
 {
-	vkDestroyImageView(get_device().get_handle(), texture.view, nullptr);
-	vkDestroyImage(get_device().get_handle(), texture.image, nullptr);
-	vkDestroySampler(get_device().get_handle(), texture.sampler, nullptr);
-	vkFreeMemory(get_device().get_handle(), texture.device_memory, nullptr);
+	if (has_device())
+	{
+		vkDestroyImageView(get_device().get_handle(), texture.view, nullptr);
+		vkDestroyImage(get_device().get_handle(), texture.image, nullptr);
+		vkDestroySampler(get_device().get_handle(), texture.sampler, nullptr);
+		vkFreeMemory(get_device().get_handle(), texture.device_memory, nullptr);
+	}
 }
 
 void TextureLoading::build_command_buffers()

--- a/samples/api/texture_mipmap_generation/texture_mipmap_generation.cpp
+++ b/samples/api/texture_mipmap_generation/texture_mipmap_generation.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Sascha Willems
+/* Copyright (c) 2019-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -285,9 +285,12 @@ void TextureMipMapGeneration::load_texture_generate_mipmaps(std::string file_nam
 // Free all Vulkan resources used by a texture object
 void TextureMipMapGeneration::destroy_texture(Texture texture)
 {
-	vkDestroyImageView(get_device().get_handle(), texture.view, nullptr);
-	vkDestroyImage(get_device().get_handle(), texture.image, nullptr);
-	vkFreeMemory(get_device().get_handle(), texture.device_memory, nullptr);
+	if (has_device())
+	{
+		vkDestroyImageView(get_device().get_handle(), texture.view, nullptr);
+		vkDestroyImage(get_device().get_handle(), texture.image, nullptr);
+		vkFreeMemory(get_device().get_handle(), texture.device_memory, nullptr);
+	}
 }
 
 void TextureMipMapGeneration::load_assets()

--- a/samples/performance/hpp_pipeline_cache/hpp_pipeline_cache.cpp
+++ b/samples/performance/hpp_pipeline_cache/hpp_pipeline_cache.cpp
@@ -40,7 +40,10 @@ HPPPipelineCache::~HPPPipelineCache()
 		get_device().get_handle().destroyPipelineCache(pipeline_cache);
 	}
 
-	vkb::fs::write_temp(get_device().get_resource_cache().serialize(), "hpp_cache.data");
+	if (has_device())
+	{
+		vkb::fs::write_temp(get_device().get_resource_cache().serialize(), "hpp_cache.data");
+	}
 }
 
 bool HPPPipelineCache::prepare(const vkb::ApplicationOptions &options)

--- a/samples/performance/pipeline_cache/pipeline_cache.cpp
+++ b/samples/performance/pipeline_cache/pipeline_cache.cpp
@@ -70,7 +70,10 @@ PipelineCache::~PipelineCache()
 		vkDestroyPipelineCache(get_device().get_handle(), pipeline_cache, nullptr);
 	}
 
-	vkb::fs::write_temp(get_device().get_resource_cache().serialize(), "cache.data");
+	if (has_device())
+	{
+		vkb::fs::write_temp(get_device().get_resource_cache().serialize(), "cache.data");
+	}
 }
 
 bool PipelineCache::prepare(const vkb::ApplicationOptions &options)


### PR DESCRIPTION
## Description

This PR updates the iOS build and CI to support future standardization of FindVulkan.cmake where there may be fewer project customizations present for iOS build targets. With these changes the project will build and run for iOS and iOS Simulator with no project-specific FindVulkan.cmake present in the tree, instead relying on the cmake's standard version of the module. 

~~However, one downside in this scenario is the Vulkan Validation Layer would not be found for iOS and samples that rely on it would not run (e.g. _shader_debugprintf_).  In addition, iOS debug builds would run but would not benefit from validation messages~~  _(now fixed by item 4 below)_.  A separate effort is pushing project additions to the upstream FindVulkan.cmake to allow eventual migration to the standard cmake version. **_In the mean time the project FindVulkan.cmake will remain in place and this PR will not result in iOS regressions in any scenario._**

The specific items that have changed are:

1. A new **ios.cmake** toochain file has been introduced that sets common iOS cmake build variables and assists cmake's FindVulkan module in locating the Vulkan iOS frameworks.  Thanks to @fgiancane8 for this idea and initial code.  Co-Authored-By: Giancane, Francesco <fgiancan@qti.qualcomm.com>
2. Updated CI command and End-user build docs for iOS and iOS Simulator using the new **ios.cmake** toolchain file.
3. The `Vulkan_Target_SDK` cmake variable is now defined locally within **Vulkan-Samples/app/CmakeLists.txt**  vs. depending on its definition within the project's FindVulkan.cmake.  This approach makes more sense since this was a project-specific customization of FindVulkan.cmake and is the only location in the project build system (outside of FindVulkan.cmake itself) where this variable is used.  Note the purpose of this variable is to locate the directory where Vulkan icd and layer json files can be found - required for packaging an iOS app bundle.
4. The `Vulkan_Layer_VALIDATION` cmake variable is now defined within the iOS-specific section in **Vulkan-Samples/bldsys/cmake/global_options.cmake** if it's not already defined or found by FindVulkan.cmake.  This acts as a fail-safe fallback that avoids any regressions in finding the validation layer for iOS within the project.

I have also taken the opportunity to address ~~three~~ four other related items here:

5. Prevent Apple (macOS, iOS, iOS Simulator) builds from compiling the shaders for every new build instance.  Because Apple platforms always require the **VULKAN_SDK**, the current project build logic will define the shader compilers and force a build of the shaders.  This is not optimal since the project already provides pre-compiled shaders and the extra build steps on Apple platforms adds complexity and time to the project build for end-users.  This could also affect CI but I believe other steps have already been taken by @SaschaWillems to prevent that (at least for slang, not sure about other shader langs).  Note on Windows platforms the end-user has control over this by choosing to run with the SDK installed or not.  On Apple platforms the end-user has no choice since the SDK must be installed to provide the Vulkan libraries needed at runtime.
6. Change `VK_LAYER_KHRONOS_validation` to be Optional for debug builds vs. Required.  This applies to all platforms but allows debug builds to run even when the validation layer is not available.  This is important for several use cases:  a) Windows users who do not install the SDK, and b) on the iOS Simulator where the VVL library is not built for that target.  I debated this change before making it, but I believe it is correct given that Windows build docs do not mention or require installation of the SDK, and the default build config for Visual Studio is debug.  I am interested in feedback from maintainers on this regarding project intentions:  i.e. Required forces a runtime error that prevents samples from running in debug mode, or Optional allows execution with a runtime warning message instead.  I chose the latter.
7. Updated Vulkan SDK to 1.4.341.1 for iOS CI builds.  This matches the project and I thought this would be a good time to update given the other iOS CI changes.
8. Updated some samples (_texture_loading_, _texture_mipmap_generation_, _hpp_pipeline_cache_, _pipeline_cache_) to guard against an undefined device on exit.  These samples assume the device is defined and attempt cleanup without checking first, which can result in a crash on exit when the sample does not run successfully.  I found this in testing item 6 above, when running in debug mode with `VK_LAYER_KHRONOS_validation` set to Required.

Fixes iOS build issues associated with pull request #1490.  See additional discussion there.

Tested on Windows 11 and macOS Sequoia with macOS x86_64, iOS arm64, and iOS Simulator x86_64 targets.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
