### PR TITLE
Update Android VVL download to 1.4.341.0 release

### DIFF
--- a/bldsys/cmake/template/gradle/app.build.gradle.in
+++ b/bldsys/cmake/template/gradle/app.build.gradle.in
@@ -2,7 +2,7 @@ plugins {
 	id 'com.android.application'
 }
 
-ext.vvl_version='1.4.321.0'
+ext.vvl_version='1.4.341.0'
 apply from: "./download_vvl.gradle"
 
 android {
@@ -68,7 +68,7 @@ android {
 		abortOnError false
 		checkReleaseBuilds false
 	}
-	
+
 	buildFeatures {
 		viewBinding true
 		prefab true

--- a/bldsys/cmake/template/gradle/download_vvl.gradle
+++ b/bldsys/cmake/template/gradle/download_vvl.gradle
@@ -36,7 +36,7 @@ apply plugin: 'com.android.application'
  */
 
 // get the validation layer version.
-def VVL_VER = "1.4.321.0"
+def VVL_VER = "1.4.341.0"
 if (ext.has("vvl_version")) {
     VVL_VER = ext.vvl_version
 }


### PR DESCRIPTION
## Description

We had a [bug report](https://github.com/ARM-software/libGPULayers/issues/166) for our libGPULayers project where attempting to inject a LGL layer on Android from outside of the application (e.g. using Android sysprops) would cause a crash in the VVL if the application had programmatically loaded the VVL from inside the application. 

I've not completely bisected it, but the crash consistently reproduces with 1.4.321 release binaries and no longer reproduces with the latest 1.4.341 upstream VVL Android release binaries so I propose updating the VVL download to pull the latest upstream release.