### PR TITLE
Migrate iOS app framework to required UIKit scene-based lifecycle

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2025, Arm Limited and Contributors
+# Copyright (c) 2019-2026, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -49,6 +49,8 @@ elseif(IOS)
 			${CMAKE_CURRENT_SOURCE_DIR}/ios/main.mm
 			${CMAKE_CURRENT_SOURCE_DIR}/ios/AppDelegate.h
 			${CMAKE_CURRENT_SOURCE_DIR}/ios/AppDelegate.m
+			${CMAKE_CURRENT_SOURCE_DIR}/ios/SceneDelegate.h
+			${CMAKE_CURRENT_SOURCE_DIR}/ios/SceneDelegate.m
 			${CMAKE_CURRENT_SOURCE_DIR}/ios/ViewController.h
 			${CMAKE_CURRENT_SOURCE_DIR}/ios/ViewController.mm
 	)

--- a/app/ios/AppDelegate.m
+++ b/app/ios/AppDelegate.m
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024, Holochip Inc.
+/* Copyright (c) 2024-2026, Holochip Inc.
 *
 * SPDX-License-Identifier: Apache-2.0
 *
@@ -29,27 +29,9 @@
     return YES;
 }
 
-
-- (void)applicationWillResignActive:(UIApplication *)application {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+- (void)applicationWillTerminate:(UIApplication *)application {
+	// Called when the application is about to terminate. Save data if appropriate.
 }
-
-
-- (void)applicationDidEnterBackground:(UIApplication *)application {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-}
-
-
-- (void)applicationWillEnterForeground:(UIApplication *)application {
-    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-}
-
-
-- (void)applicationDidBecomeActive:(UIApplication *)application {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-}
-
 
 @end
 #endif

--- a/app/ios/Info.plist
+++ b/app/ios/Info.plist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2024, Holochip Inc.
+Copyright (c) 2024-2026, Holochip Inc.
 
 SPDX-License-Identifier: Apache-2.0
 

--- a/app/ios/Info.plist
+++ b/app/ios/Info.plist
@@ -47,6 +47,25 @@ limitations under the License.
     <string>Storyboard</string>
     <key>UILaunchStoryboardName</key>
     <string>launch</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Storyboard</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/app/ios/SceneDelegate.h
+++ b/app/ios/SceneDelegate.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2026, Holochip Inc.
+/* Copyright (c) 2026, Holochip Inc.
 *
 * SPDX-License-Identifier: Apache-2.0
 *
@@ -15,21 +15,11 @@
 * limitations under the License.
 */
 
-#include <TargetConditionals.h>
-#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
-#else
-#include <AppKit/AppKit.h>
-#endif
 
-#if TARGET_OS_IOS
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
 
-#else
-@interface AppDelegate : NSResponder <NSApplicationDelegate>
-
-@property (strong, nonatomic) NSWindow *window;
-#endif
+@property (strong, nonatomic) UIWindow *window;
 
 @end
 

--- a/app/ios/SceneDelegate.h
+++ b/app/ios/SceneDelegate.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2026, Holochip Inc.
+/* Copyright (c) 2026, Stephen Saunders
 *
 * SPDX-License-Identifier: Apache-2.0
 *

--- a/app/ios/SceneDelegate.m
+++ b/app/ios/SceneDelegate.m
@@ -1,0 +1,65 @@
+/* Copyright (c) 2026, Holochip Inc.
+*
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 the "License";
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import "SceneDelegate.h"
+#import "ViewController.h"
+
+@interface SceneDelegate ()
+
+@end
+
+@implementation SceneDelegate
+
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+	UIWindowScene *windowScene = (UIWindowScene *)scene;
+
+	self.window = [[UIWindow alloc] initWithWindowScene:windowScene];
+	self.window.rootViewController = [[ViewController alloc] init];
+
+	[self.window makeKeyAndVisible];
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene {
+	// Called as the scene transitions from the background to the foreground.
+	// Use this method to undo the changes made on entering the background.
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene {
+	// Called when the scene has moved from an inactive state to an active state.
+	// Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene {
+	// Called when the scene will move from an active state to an inactive state.
+	// This may occur due to temporary interruptions (ex. an incoming phone call).
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene {
+	// Called as the scene transitions from the foreground to the background.
+	// Use this method to save data, release shared resources, and store enough scene-specific state information
+	// to restore the scene back to its current state.
+}
+
+- (void)sceneDidDisconnect:(UIScene *)scene {
+	// Called as the scene is being released by the system.
+	// This occurs shortly after the scene enters the background, or when its session is discarded.
+	// Release any resources associated with this scene that can be re-created the next time the scene connects.
+	// The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+}
+
+@end

--- a/app/ios/SceneDelegate.m
+++ b/app/ios/SceneDelegate.m
@@ -1,4 +1,4 @@
-/* Copyright (c) 2026, Holochip Inc.
+/* Copyright (c) 2026, Stephen Saunders
 *
 * SPDX-License-Identifier: Apache-2.0
 *

--- a/app/ios/ViewController.mm
+++ b/app/ios/ViewController.mm
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024, Holochip Inc.
+/* Copyright (c) 2024-2026, Holochip Inc.
 *
 * SPDX-License-Identifier: Apache-2.0
 *
@@ -45,6 +45,10 @@ int platform_main(const vkb::PlatformContext &);
         NSString *s = args[i];
         argv[i] = s.UTF8String;
     }
+
+	// Allocate and add a Metal-compatible sub-view for Vulkan to use
+	self.vulkan_view = [[VulkanView alloc] initWithFrame:self.view.bounds];
+	[self.view addSubview:self.vulkan_view];
 
 	self.vulkan_view.contentScaleFactor = UIScreen.mainScreen.nativeScale;
 

--- a/app/ios/ViewController.mm
+++ b/app/ios/ViewController.mm
@@ -20,6 +20,7 @@
 #include "core/platform/entrypoint.hpp"
 #include "platform/ios/ios_platform.h"
 #include "platform/ios/ios_window.h"
+#include "platform/input_events.h"
 
 int platform_main(const vkb::PlatformContext &);
 
@@ -28,15 +29,15 @@ int platform_main(const vkb::PlatformContext &);
     std::unique_ptr<vkb::PlatformContext> context;
     vkb::IosPlatformContext* _context;
     vkb::ExitCode _code;
+	UITouch* _activeTouch;
 }
 @property (retain, nonatomic) IBOutlet VulkanView *vulkan_view;
 
 @end
 
 @implementation ViewController
-- (void)viewDidLoad {
+- (void) viewDidLoad {
     [super viewDidLoad];
-
 
     // Convert incoming args to "C" argc/argv strings
     NSArray *args = [[NSProcessInfo processInfo] arguments];
@@ -62,7 +63,7 @@ int platform_main(const vkb::PlatformContext &);
    [_displayLink addToRunLoop: NSRunLoop.currentRunLoop forMode: NSDefaultRunLoopMode];
 }
 
-- (void)viewDidLayoutSubviews {
+- (void) viewDidLayoutSubviews {
 	[super viewDidLayoutSubviews];
 	
 	// Update the Vulkan sub-view to match parent view dimensions following rotation events
@@ -84,4 +85,63 @@ int platform_main(const vkb::PlatformContext &);
 		}
     }
 }
+
+-(CGPoint) getTouchLocalPoint:(UITouch*) touch {
+	CGPoint point = [touch locationInView:self.vulkan_view];
+	point.x *= self.vulkan_view.contentScaleFactor;
+	point.y *= self.vulkan_view.contentScaleFactor;
+	return point;
+}
+
+// Handle touch events for selection and dragging within the display and GUI overlay
+-(void) touchesBegan:(NSSet*) touches withEvent:(UIEvent*) theEvent {
+	if (_activeTouch == nil) {
+		_activeTouch = [touches anyObject];
+
+		auto point = [self getTouchLocalPoint:_activeTouch];
+		((vkb::IosPlatform*)_context->userPlatform)->input_event(vkb::TouchInputEvent{
+			0, 1,
+			vkb::TouchAction::Down,
+			static_cast<float>(point.x),
+			static_cast<float>(point.y)});
+	}
+}
+
+-(void) touchesMoved:(NSSet*) touches withEvent:(UIEvent*) theEvent {
+	if (_activeTouch && [touches containsObject:_activeTouch]) {
+		auto point = [self getTouchLocalPoint:_activeTouch];
+		((vkb::IosPlatform*)_context->userPlatform)->input_event(vkb::TouchInputEvent{
+			0, 1,
+			vkb::TouchAction::Move,
+			static_cast<float>(point.x),
+			static_cast<float>(point.y)});
+	}
+}
+
+-(void) touchesEnded:(NSSet*) touches withEvent:(UIEvent*) theEvent {
+	if (_activeTouch && [touches containsObject:_activeTouch]) {
+		auto point = [self getTouchLocalPoint:_activeTouch];
+		((vkb::IosPlatform*)_context->userPlatform)->input_event(vkb::TouchInputEvent{
+			0, 1,
+			vkb::TouchAction::Up,
+			static_cast<float>(point.x),
+			static_cast<float>(point.y)});
+
+		_activeTouch = nil;
+	}
+}
+
+-(void) touchesCancelled:(NSSet*) touches withEvent:(UIEvent*) theEvent {
+	if (_activeTouch && [touches containsObject:_activeTouch]) {
+		auto point = [self getTouchLocalPoint:_activeTouch];
+		((vkb::IosPlatform*)_context->userPlatform)->input_event(vkb::TouchInputEvent{
+			0, 1,
+			vkb::TouchAction::Cancel,
+			static_cast<float>(point.x),
+			static_cast<float>(point.y)});
+
+		_activeTouch = nil;
+	}
+}
+
 @end

--- a/app/ios/ViewController.mm
+++ b/app/ios/ViewController.mm
@@ -62,6 +62,13 @@ int platform_main(const vkb::PlatformContext &);
    [_displayLink addToRunLoop: NSRunLoop.currentRunLoop forMode: NSDefaultRunLoopMode];
 }
 
+- (void)viewDidLayoutSubviews {
+	[super viewDidLayoutSubviews];
+	
+	// Update the Vulkan sub-view to match parent view dimensions following rotation events
+	self.vulkan_view.layer.frame = self.view.bounds;
+}
+
 -(void) renderLoop {
     if(!_displayLink.isPaused && [UIApplication sharedApplication].applicationState == UIApplicationStateActive) {
 		if(_code == vkb::ExitCode::Success) {


### PR DESCRIPTION
## Description

Apple is requiring iOS apps to adopt their new UIKit scene-based lifecycle. iOS 26 is the final version that will support the old-style application-based lifecycle. Users of the Vulkan-Samples project on iOS and the iOS Simulator currently receive deprecation warnings that apps built with the old-style lifecycle will not run in future iOS versions.

I thought I would get a start on this before the dead end arrives and the project will not run. The attached code updates the Vulkan-Sample iOS app to adopt UIKit's SceneDelegate class and scene management concepts. This was made easier since I just completed and submitted similar changes to @SaschaWillems Vulkan examples project.  The iOS app in the Vulkan-Samples project should now work without any deprecation warnings.

As a bonus, I also added UI touchscreen input to the iOS app for selection and dragging.  This means you can change options in the overlay GUI, and activate camara rotation for samples.

Tested using Xcode 26.3 on macOS Sequoia 15.7.4 targetting:

iOS 18.6.2 on a real iPhone 16, and
iOS 26.2 on an iPhone 17 Pro running on iOS Simulator.

Note that I added two new files for this work: **SceneDelegate.h** and **SceneDelegate.m**.  To keep things simple, I replicated the license headers from the equivalent **AppDelegate** files, but assigned them to me instead.  ~~I personally don't need the license to refer to me, and am happy to attribute to Holochip if that's acceptable.~~  I hope @gpx1000 is okay with this.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
