### PR TITLE
Introduce StructureChainBuilder

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -49,6 +49,7 @@ set(FRAMEWORK_FILES
     hpp_resource_record.h
     hpp_resource_replay.h
     hpp_semaphore_pool.h
+    structure_chain_builder.h
     # Source Files
     drawer.cpp
     spirv_reflection.cpp

--- a/framework/common/helpers.h
+++ b/framework/common/helpers.h
@@ -41,9 +41,14 @@
 
 namespace vkb
 {
+inline bool contains(uint32_t range_count, char const *const *range, char const *value)
+{
+	return std::any_of(range, range + range_count, [value](char const *range_value) { return strcmp(range_value, value) == 0; });
+}
+
 inline bool contains(std::vector<std::string> const &range, char const *value)
 {
-	return std::ranges::find_if(range, [value](std::string const &range_value) { return range_value == value; }) != range.end();
+	return std::ranges::any_of(range, [value](std::string const &range_value) { return range_value == value; });
 }
 
 template <typename T>

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "common/helpers.h"
+#include "structure_chain_builder.h"
 #include <vulkan/vulkan.hpp>
 
 namespace vkb
@@ -39,11 +40,6 @@ typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCrea
 		return 0;
 	}
 }
-
-void const *get_default_pNext(std::vector<std::string> const &, std::vector<std::string> const &)
-{
-	return nullptr;
-}
 }        // namespace
 
 /**
@@ -57,6 +53,7 @@ class Instance
 {
   public:
 	using InstanceCreateFlagsType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCreateFlags, VkInstanceCreateFlags>::type;
+	using InstanceCreateInfoType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCreateInfo, VkInstanceCreateInfo>::type;
 	using InstanceType            = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Instance, VkInstance>::type;
 
   public:
@@ -66,17 +63,17 @@ class Instance
 	 * @param api_version The Vulkan API version that the instance will be using
 	 * @param requested_layers The requested layers to be enabled
 	 * @param requested_extensions The requested extensions to be enabled
-	 * @param get_pNext A function pointer returning the pNext pointer for the InstanceCreateInfo
 	 * @param get_create_flags A function pointer returning the InstanceCreateFlags for the InstanceCreateInfo
+	 * @param extend_instance_create_info A function pointer to extend the InstanceCreateInfo with additional structures in the pNext chain
 	 * @throws runtime_error if a required layer or extension is not available
 	 */
 	Instance(
-	    std::string const                                                                                     &application_name,
-	    uint32_t                                                                                               api_version          = VK_API_VERSION_1_1,
-	    std::unordered_map<std::string, vkb::RequestMode> const                                               &requested_layers     = {},
-	    std::unordered_map<std::string, vkb::RequestMode> const                                               &requested_extensions = {},
-	    std::function<void const *(std::vector<std::string> const &, std::vector<std::string> const &)> const &get_pNext            = get_default_pNext,
-	    std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const                        &get_create_flags     = get_default_create_flags);
+	    std::string const                                                                            &application_name,
+	    uint32_t                                                                                      api_version                 = VK_API_VERSION_1_1,
+	    std::unordered_map<std::string, vkb::RequestMode> const                                      &requested_layers            = {},
+	    std::unordered_map<std::string, vkb::RequestMode> const                                      &requested_extensions        = {},
+	    std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const               &get_create_flags            = get_default_create_flags,
+	    std::function<void(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &)> const &extend_instance_create_info = [](vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> const &) {});
 
 	Instance(vk::Instance instance, std::vector<char const *> const &externally_enabled_extensions = {}, bool needsToInitializeDispatcher = false);
 	Instance(VkInstance instance, std::vector<char const *> const &externally_enabled_extensions = {});
@@ -158,12 +155,12 @@ inline bool
 }        // namespace
 
 template <vkb::BindingType bindingType>
-inline Instance<bindingType>::Instance(std::string const                                                                                     &application_name,
-                                       uint32_t                                                                                               api_version,
-                                       std::unordered_map<std::string, vkb::RequestMode> const                                               &requested_layers,
-                                       std::unordered_map<std::string, vkb::RequestMode> const                                               &requested_extensions,
-                                       std::function<void const *(std::vector<std::string> const &, std::vector<std::string> const &)> const &get_pNext,
-                                       std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const                        &get_create_flags)
+inline Instance<bindingType>::Instance(std::string const                                                                            &application_name,
+                                       uint32_t                                                                                      api_version,
+                                       std::unordered_map<std::string, vkb::RequestMode> const                                      &requested_layers,
+                                       std::unordered_map<std::string, vkb::RequestMode> const                                      &requested_extensions,
+                                       std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const               &get_create_flags,
+                                       std::function<void(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &)> const &extend_instance_create_info)
 {
 	// check API version
 	LOGI("Requesting Vulkan API version {}.{}", VK_VERSION_MAJOR(api_version), VK_VERSION_MINOR(api_version));
@@ -243,16 +240,26 @@ inline Instance<bindingType>::Instance(std::string const                        
 
 	vk::ApplicationInfo app_info{.pApplicationName = application_name.c_str(), .pEngineName = "Vulkan Samples", .apiVersion = api_version};
 
-	vk::InstanceCreateInfo create_info{.pNext                   = get_pNext(enabled_layers, enabled_extensions),
-	                                   .flags                   = static_cast<vk::InstanceCreateFlags>(get_create_flags(enabled_extensions)),
+	vk::InstanceCreateInfo create_info{.flags                   = static_cast<vk::InstanceCreateFlags>(get_create_flags(enabled_extensions)),
 	                                   .pApplicationInfo        = &app_info,
 	                                   .enabledLayerCount       = static_cast<uint32_t>(enabled_layers_cstr.size()),
 	                                   .ppEnabledLayerNames     = enabled_layers_cstr.data(),
 	                                   .enabledExtensionCount   = static_cast<uint32_t>(enabled_extensions_cstr.size()),
 	                                   .ppEnabledExtensionNames = enabled_extensions_cstr.data()};
 
+	vkb::StructureChainBuilder<vkb::BindingType::Cpp, vk::InstanceCreateInfo> scb;
+	scb.set_anchor_struct(create_info);
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		extend_instance_create_info(scb);
+	}
+	else
+	{
+		extend_instance_create_info(reinterpret_cast<vkb::StructureChainBuilder<vkb::BindingType::C, VkInstanceCreateInfo> &>(scb));
+	}
+
 	// Create the Vulkan instance
-	handle = vk::createInstance(create_info);
+	handle = vk::createInstance(*scb.get_struct<vk::InstanceCreateInfo>());
 
 	// initialize the Vulkan-Hpp default dispatcher on the instance
 	VULKAN_HPP_DEFAULT_DISPATCHER.init(handle);

--- a/framework/structure_chain_builder.h
+++ b/framework/structure_chain_builder.h
@@ -1,0 +1,162 @@
+/* Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <any>
+#include <vulkan/vulkan.hpp>
+
+namespace vkb
+{
+template <vkb::BindingType bindingType, typename AnchorStructType>
+class StructureChainBuilder
+{
+  public:
+	StructureChainBuilder();
+
+	template <typename T>
+	T &add_chain_data(T const &data_to_add = {});        // Adds data to the structure chain builder that is not part of the structure chain itself, but is used by the
+	                                                     // structures in the chain (e.g. pointed to by a member of a struct in the structure chain)
+
+	template <typename StructType>
+	StructType &add_struct(StructType const &struct_to_add = {});
+
+	template <typename StructType>
+	StructType const *get_struct(size_t skip = 0) const;
+
+	void set_anchor_struct(AnchorStructType const &anchor_struct);
+
+  private:
+	template <typename StructType>
+	StructType &add_struct_impl(StructType const &struct_to_add);
+	template <typename StructType>
+	StructType const *get_struct_impl(size_t skip) const;
+	void              set_anchor_struct_impl(AnchorStructType const &anchor_struct);
+
+  private:
+	std::vector<std::unique_ptr<std::any>> structure_chain;
+	std::vector<std::unique_ptr<std::any>> chain_data;        // data used with the structure chain, stored separately to ensure correct destruction order (the structs
+	                                                          // in the structure chain may contain pointers to data owned by the chain_data)
+};
+
+template <typename AnchorStructType>
+using StructureChainBuilderC = StructureChainBuilder<vkb::BindingType::C, AnchorStructType>;
+template <typename AnchorStructType>
+using StructureChainBuilderCpp = StructureChainBuilder<vkb::BindingType::Cpp, AnchorStructType>;
+
+template <vkb::BindingType bindingType, typename AnchorStructType>
+template <typename T>
+T &StructureChainBuilder<bindingType, AnchorStructType>::add_chain_data(T const &data_to_add)
+{
+	chain_data.push_back(std::make_unique<std::any>(std::make_any<T>(data_to_add)));
+	return *std::any_cast<T>(chain_data.back().get());
+}
+
+template <vkb::BindingType bindingType, typename AnchorStructType>
+inline StructureChainBuilder<bindingType, AnchorStructType>::StructureChainBuilder()
+{
+	static_assert((offsetof(AnchorStructType, sType) == 0) && (offsetof(AnchorStructType, pNext) == sizeof(void *)));
+	structure_chain.push_back(std::make_unique<std::any>(std::make_any<AnchorStructType>()));
+}
+
+template <vkb::BindingType bindingType, typename AnchorStructType>
+template <typename StructType>
+inline StructType &StructureChainBuilder<bindingType, AnchorStructType>::add_struct(StructType const &struct_to_add)
+{
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		return add_struct_impl(struct_to_add);
+	}
+	else
+	{
+		return reinterpret_cast<StructureChainBuilder<vkb::BindingType::Cpp, typename vk::CppType<AnchorStructType>::Type> *>(this)->add_struct(
+		    reinterpret_cast<typename vk::CppType<StructType>::Type const &>(struct_to_add));
+	}
+}
+
+template <vkb::BindingType bindingType, typename AnchorStructType>
+template <typename StructType>
+inline StructType &StructureChainBuilder<bindingType, AnchorStructType>::add_struct_impl(StructType const &struct_to_add)
+{
+#if !defined(NDEBUG)
+	auto it = std::ranges::find_if(structure_chain, [](auto const &chain_element) {
+		return std::any_cast<StructType>(chain_element.get()) != nullptr;
+	});
+	assert(it == structure_chain.end() || StructType::allowDuplicate);        // If the struct type already exists in the structure chain, it must allow duplicates
+#endif
+
+	structure_chain.push_back(std::make_unique<std::any>(std::make_any<StructType>(struct_to_add)));
+	std::any_cast<StructType>(structure_chain.back().get())->pNext        = std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext;
+	std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext = std::any_cast<StructType>(structure_chain.back().get());
+	return *std::any_cast<StructType>(structure_chain.back().get());
+}
+
+template <vkb::BindingType bindingType, typename AnchorStructType>
+template <typename StructType>
+inline StructType const *StructureChainBuilder<bindingType, AnchorStructType>::get_struct(size_t skip) const
+{
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		return get_struct_impl<StructType>(skip);
+	}
+	else
+	{
+		return reinterpret_cast<StructType const *>(get_struct_impl<vk::CppType<StructType>::Type>(skip));
+	}
+}
+
+template <vkb::BindingType bindingType, typename AnchorStructType>
+template <typename StructType>
+inline StructType const *StructureChainBuilder<bindingType, AnchorStructType>::get_struct_impl(size_t skip) const
+{
+	assert(!skip || StructType::allowDuplicate);        // If skip is non-zero, the struct type must allow duplicates in the structure chain
+
+	auto it = std::ranges::find_if(structure_chain, [](auto const &chain_element) {
+		return std::any_cast<StructType>(chain_element.get()) != nullptr;
+	});
+	for (size_t i = 0; (i < skip) && (it != structure_chain.end()); ++i)
+	{
+		it = std::find_if(std::next(it), structure_chain.end(), [](auto const &chain_element) {
+			return std::any_cast<StructType>(chain_element.get()) != nullptr;
+		});
+	}
+	return (it != structure_chain.end()) ? std::any_cast<StructType>(it->get()) : nullptr;
+}
+
+template <vkb::BindingType bindingType, typename AnchorStructType>
+inline void StructureChainBuilder<bindingType, AnchorStructType>::set_anchor_struct(AnchorStructType const &anchor_struct)
+{
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		set_anchor_struct_impl(anchor_struct);
+	}
+	else
+	{
+		return reinterpret_cast<StructureChainBuilder<vkb::BindingType::Cpp, typename vk::CppType<AnchorStructType>::Type> *>(this)->add_anchor_struct(
+		    reinterpret_cast<typename vk::CppType<AnchorStructType>::Type const &>(anchor_struct));
+	}
+}
+
+template <vkb::BindingType bindingType, typename AnchorStructType>
+inline void StructureChainBuilder<bindingType, AnchorStructType>::set_anchor_struct_impl(AnchorStructType const &anchor_struct)
+{
+	void const *pNext                                                     = std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext;
+	*std::any_cast<AnchorStructType>(structure_chain.front().get())       = anchor_struct;
+	std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext = pNext;
+}
+
+}        // namespace vkb

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -135,11 +135,14 @@ class VulkanSample : public vkb::Application
 
 	using SceneType = typename std::conditional<bindingType == BindingType::Cpp, vkb::scene_graph::HPPScene, vkb::sg::Scene>::type;
 	using StatsType = typename std::conditional<bindingType == BindingType::Cpp, vkb::stats::HPPStats, vkb::Stats>::type;
+	template <typename AnchorStructType>
+	using StructureChainBuilderType = typename std::conditional<bindingType == BindingType::Cpp, vkb::StructureChainBuilder<BindingType::Cpp, AnchorStructType>, vkb::StructureChainBuilder<BindingType::C, AnchorStructType>>::type;
 
 	using Extent2DType                      = typename std::conditional<bindingType == BindingType::Cpp, vk::Extent2D, VkExtent2D>::type;
 	using DebugReportCallbackCreateInfoType = typename std::conditional<bindingType == BindingType::Cpp, vk::DebugReportCallbackCreateInfoEXT, VkDebugReportCallbackCreateInfoEXT>::type;
 	using DebugUtilsMessengerCreateInfoType = typename std::conditional<bindingType == BindingType::Cpp, vk::DebugUtilsMessengerCreateInfoEXT, VkDebugUtilsMessengerCreateInfoEXT>::type;
 	using InstanceCreateFlagsType           = typename std::conditional<bindingType == BindingType::Cpp, vk::InstanceCreateFlags, VkInstanceCreateFlags>::type;
+	using InstanceCreateInfoType            = typename std::conditional<bindingType == BindingType::Cpp, vk::InstanceCreateInfo, VkInstanceCreateInfo>::type;
 	using LayerSettingType                  = typename std::conditional<bindingType == BindingType::Cpp, vk::LayerSettingEXT, VkLayerSettingEXT>::type;
 	using PhysicalDeviceType                = typename std::conditional<bindingType == BindingType::Cpp, vk::PhysicalDevice, VkPhysicalDevice>::type;
 	using SurfaceFormatType                 = typename std::conditional<bindingType == BindingType::Cpp, vk::SurfaceFormatKHR, VkSurfaceFormatKHR>::type;
@@ -198,11 +201,11 @@ class VulkanSample : public vkb::Application
 	 */
 	virtual void draw_renderpass(vkb::core::CommandBuffer<bindingType> &command_buffer, vkb::rendering::RenderTarget<bindingType> &render_target);
 
+	virtual void                                     extend_instance_create_info(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &create_info) const;
 	virtual uint32_t                                 get_api_version() const;
 	virtual DebugReportCallbackCreateInfoType const *get_debug_report_callback_create_info() const;
 	virtual DebugUtilsMessengerCreateInfoType const *get_debug_utils_messenger_create_info() const;
 	virtual InstanceCreateFlagsType                  get_instance_create_flags(std::vector<std::string> const &enabled_extensions) const;
-	virtual void const                              *get_instance_create_info_extensions(std::vector<std::string> const &enabled_layers, std::vector<std::string> const &enabled_extensions) const;
 
 	/**
 	 * @brief Override this to customise the creation of the swapchain and render_context
@@ -222,7 +225,7 @@ class VulkanSample : public vkb::Application
 
 	virtual void request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const;
 	virtual void request_layers(std::unordered_map<std::string, vkb::RequestMode> &requested_layers) const;
-	virtual void request_layer_settings(std::vector<LayerSettingType> &requested_layer_settings) const;
+	virtual void request_layer_settings(std::vector<LayerSettingType> &requested_layer_settings, StructureChainBuilderType<InstanceCreateInfoType> &scb) const;
 	virtual void request_validation_feature_enables(std::vector<ValidationFeatureEnableType> &requested_validation_feature_enables) const;
 
 	/**
@@ -336,8 +339,9 @@ class VulkanSample : public vkb::Application
 	size_t      determine_physical_device_score_impl(vk::PhysicalDevice const &gpu) const;
 	void        draw_impl(vkb::core::CommandBufferCpp &command_buffer, vkb::rendering::RenderTargetCpp &render_target);
 	void        draw_renderpass_impl(vkb::core::CommandBufferCpp &command_buffer, vkb::rendering::RenderTargetCpp &render_target);
+	void        extend_instance_create_info_impl(vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> &create_info) const;
 	void        render_impl(vkb::core::CommandBufferCpp &command_buffer);
-	void        request_layer_settings_impl(std::vector<vk::LayerSettingEXT> &requested_layer_settings) const;
+	void        request_layer_settings_impl(std::vector<vk::LayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> &scb) const;
 	static void set_viewport_and_scissor_impl(vkb::core::CommandBufferCpp const &command_buffer, vk::Extent2D const &extent);
 
 	/**
@@ -494,7 +498,6 @@ inline std::unique_ptr<vkb::core::Instance<bindingType>> VulkanSample<bindingTyp
 	    get_api_version(),
 	    requested_layers,
 	    requested_extensions,
-	    [this](std::vector<std::string> const &enabled_layers, std::vector<std::string> const &enabled_extensions) { return get_instance_create_info_extensions(enabled_layers, enabled_extensions); },
 	    [this](std::vector<std::string> const &enabled_extensions) {
 		    if constexpr (bindingType == BindingType::Cpp)
 		    {
@@ -504,7 +507,8 @@ inline std::unique_ptr<vkb::core::Instance<bindingType>> VulkanSample<bindingTyp
 		    {
 			    return static_cast<VkInstanceCreateFlags>(get_instance_create_flags(enabled_extensions));
 		    }
-	    });
+	    },
+	    [this](vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &scb) { return extend_instance_create_info(scb); });
 }
 
 template <vkb::BindingType bindingType>
@@ -703,19 +707,27 @@ inline void VulkanSample<bindingType>::finish()
 }
 
 template <vkb::BindingType bindingType>
-inline uint32_t VulkanSample<bindingType>::get_api_version() const
+inline void VulkanSample<bindingType>::extend_instance_create_info(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &scb) const
 {
-	return VK_API_VERSION_1_1;
+	if constexpr (bindingType == vkb::BindingType::Cpp)
+	{
+		extend_instance_create_info_impl(scb);
+	}
+	else
+	{
+		extend_instance_create_info_impl(reinterpret_cast<vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> &>(scb));
+	}
 }
 
 inline bool enable_layer_setting(vk::LayerSettingEXT const        &requested_layer_setting,
-                                 std::vector<std::string> const   &enabled_layers,
+                                 uint32_t                          enabled_layers_count,
+                                 char const *const                *enabled_layers,
                                  std::vector<vk::LayerSettingEXT> &enabled_layer_settings)
 {
 	// We are checking if the layer is available.
 	// Vulkan does not provide a reflection API for layer settings. Layer settings are described in each layer JSON manifest.
-	bool is_available = std::ranges::any_of(
-	    enabled_layers, [&requested_layer_setting](auto const &enabled_layer) { return enabled_layer == requested_layer_setting.pLayerName; });
+	bool is_available = std::any_of(
+	    enabled_layers, enabled_layers + enabled_layers_count, [&requested_layer_setting](auto const &enabled_layer) { return strcmp(enabled_layer, requested_layer_setting.pLayerName) == 0; });
 
 #if defined(PLATFORM__MACOS)
 	// On Apple the MoltenVK driver configuration layer is implicitly enabled and available, and cannot be explicitly added or checked via enabled_layers.
@@ -755,25 +767,97 @@ inline bool enable_layer_setting(vk::LayerSettingEXT const        &requested_lay
 }
 
 inline bool enable_layer_setting(VkLayerSettingEXT const          &requested_layer_setting,
-                                 std::vector<std::string> const   &enabled_layers,
+                                 uint32_t                          enabled_layers_count,
+                                 char const *const                *enabled_layers,
                                  std::vector<vk::LayerSettingEXT> &enabled_layer_settings)
 {
-	return enable_layer_setting(reinterpret_cast<vk::LayerSettingEXT const &>(requested_layer_setting), enabled_layers, enabled_layer_settings);
+	return enable_layer_setting(
+	    reinterpret_cast<vk::LayerSettingEXT const &>(requested_layer_setting), enabled_layers_count, enabled_layers, enabled_layer_settings);
+}
+
+template <vkb::BindingType bindingType>
+inline void VulkanSample<bindingType>::extend_instance_create_info_impl(vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> &scb) const
+{
+	vk::InstanceCreateInfo const *create_info = scb.get_struct<vk::InstanceCreateInfo>();
+	assert(create_info);
+
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	if (contains(create_info->enabledExtensionCount, create_info->ppEnabledExtensionNames, VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
+	{
+		vk::DebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info{.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning,
+		                                                                       .messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance,
+		                                                                       .pfnUserCallback = vkb::core::debug_utils_messenger_callback};
+		scb.add_struct(debug_utils_messenger_create_info);
+	}
+	else if (contains(create_info->enabledExtensionCount, create_info->ppEnabledExtensionNames, VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
+	{
+		vk::DebugReportCallbackCreateInfoEXT debug_report_callback_create_info{.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
+		                                                                       .pfnCallback = vkb::core::debug_callback};
+		scb.add_struct(debug_report_callback_create_info);
+	}
+#endif
+
+	if (contains(create_info->enabledExtensionCount, create_info->ppEnabledExtensionNames, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME))
+	{
+		std::vector<vk::LayerSettingEXT> requested_layer_settings;
+		if constexpr (bindingType == vkb::BindingType::Cpp)
+		{
+			request_layer_settings(requested_layer_settings, scb);
+		}
+		else
+		{
+			request_layer_settings(reinterpret_cast<std::vector<VkLayerSettingEXT> &>(requested_layer_settings),
+			                       reinterpret_cast<vkb::StructureChainBuilderC<VkInstanceCreateInfo> &>(scb));
+		}
+
+		std::vector<vk::LayerSettingEXT> enabled_layer_settings;
+		for (auto const &layer_setting : requested_layer_settings)
+		{
+			enable_layer_setting(layer_setting, create_info->enabledLayerCount, create_info->ppEnabledLayerNames, enabled_layer_settings);
+		}
+
+		if (!enabled_layer_settings.empty())
+		{
+			// If layer settings are defined, then activate the sample's required layer settings during instance creation
+			vk::LayerSettingsCreateInfoEXT layer_settings_create_info_ext{.settingCount = static_cast<uint32_t>(enabled_layer_settings.size()),
+			                                                              .pSettings    = scb.add_chain_data(enabled_layer_settings).data()};
+			scb.add_struct(layer_settings_create_info_ext);
+		}
+	}
+	else if (contains(create_info->enabledExtensionCount, create_info->ppEnabledExtensionNames, VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME))
+	{
+		std::vector<ValidationFeatureEnableType> requested_validation_feature_enables;
+		request_validation_feature_enables(requested_validation_feature_enables);
+
+		if (!requested_validation_feature_enables.empty())
+		{
+			vk::ValidationFeaturesEXT validation_features_ext{
+			    .enabledValidationFeatureCount = static_cast<uint32_t>(requested_validation_feature_enables.size()),
+			    .pEnabledValidationFeatures    = reinterpret_cast<vk::ValidationFeatureEnableEXT const *>(scb.add_chain_data(requested_validation_feature_enables).data())};
+			scb.add_struct(validation_features_ext);
+		};
+	}
+}
+
+template <vkb::BindingType bindingType>
+inline uint32_t VulkanSample<bindingType>::get_api_version() const
+{
+	return VK_API_VERSION_1_1;
 }
 
 template <vkb::BindingType bindingType>
 inline typename VulkanSample<bindingType>::DebugReportCallbackCreateInfoType const *VulkanSample<bindingType>::get_debug_report_callback_create_info() const
 {
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	static vk::DebugReportCallbackCreateInfoEXT debug_report_callback_createInfo{.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
-	                                                                             .pfnCallback = vkb::core::debug_callback};
+	static vk::DebugReportCallbackCreateInfoEXT debug_report_callback_create_info{.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
+	                                                                              .pfnCallback = vkb::core::debug_callback};
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
-		return &debug_report_callback_createInfo;
+		return &debug_report_callback_create_info;
 	}
 	else
 	{
-		return reinterpret_cast<VkDebugReportCallbackCreateInfoEXT *>(&debug_report_callback_createInfo);
+		return reinterpret_cast<VkDebugReportCallbackCreateInfoEXT *>(&debug_report_callback_create_info);
 	}
 #else
 	return nullptr;
@@ -819,61 +903,6 @@ inline typename VulkanSample<bindingType>::InstanceCreateFlagsType VulkanSample<
 	{
 		return static_cast<VkInstanceCreateFlags>(flags);
 	}
-}
-
-template <vkb::BindingType bindingType>
-inline void const *VulkanSample<bindingType>::get_instance_create_info_extensions(std::vector<std::string> const &enabled_layers,
-                                                                                  std::vector<std::string> const &enabled_extensions) const
-{
-	void const *pNext = nullptr;
-
-	if (contains(enabled_extensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
-	{
-		pNext = get_debug_utils_messenger_create_info();
-	}
-	else if (contains(enabled_extensions, VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
-	{
-		pNext = get_debug_report_callback_create_info();
-	}
-
-	if (contains(enabled_extensions, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME))
-	{
-		std::vector<LayerSettingType> requested_layer_settings;
-		request_layer_settings(requested_layer_settings);
-
-		static std::vector<vk::LayerSettingEXT> enabled_layer_settings;
-		// since enabled_layer_settings is static, clear on every get_instance_create_info_extensions() call to support batch mode
-		enabled_layer_settings.clear();
-		for (auto const &layer_setting : requested_layer_settings)
-		{
-			enable_layer_setting(layer_setting, enabled_layers, enabled_layer_settings);
-		}
-
-		if (!enabled_layer_settings.empty())
-		{
-			// If layer settings are defined, then activate the sample's required layer settings during instance creation
-			static vk::LayerSettingsCreateInfoEXT layer_settings_create_info_ext{.pNext        = pNext,
-			                                                                     .settingCount = static_cast<uint32_t>(enabled_layer_settings.size()),
-			                                                                     .pSettings    = enabled_layer_settings.data()};
-			pNext = &layer_settings_create_info_ext;
-		}
-	}
-	else if (contains(enabled_extensions, VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME))
-	{
-		static std::vector<ValidationFeatureEnableType> requested_validation_feature_enables;
-		request_validation_feature_enables(requested_validation_feature_enables);
-
-		if (!requested_validation_feature_enables.empty())
-		{
-			static vk::ValidationFeaturesEXT validation_features_ext{
-			    .pNext                         = pNext,
-			    .enabledValidationFeatureCount = static_cast<uint32_t>(requested_validation_feature_enables.size()),
-			    .pEnabledValidationFeatures    = reinterpret_cast<vk::ValidationFeatureEnableEXT const *>(requested_validation_feature_enables.data())};
-			pNext = &validation_features_ext;
-		}
-	}
-
-	return pNext;
 }
 
 template <vkb::BindingType bindingType>
@@ -1445,50 +1474,44 @@ inline void VulkanSample<bindingType>::request_layers(std::unordered_map<std::st
 }
 
 template <vkb::BindingType bindingType>
-inline void VulkanSample<bindingType>::request_layer_settings(std::vector<LayerSettingType> &requested_layer_settings) const
+inline void VulkanSample<bindingType>::request_layer_settings(std::vector<LayerSettingType> &requested_layer_settings, StructureChainBuilderType<InstanceCreateInfoType> &scb) const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
-		request_layer_settings_impl(requested_layer_settings);
+		request_layer_settings_impl(requested_layer_settings, scb);
 	}
 	else
 	{
-		request_layer_settings_impl(reinterpret_cast<std::vector<vk::LayerSettingEXT> &>(requested_layer_settings));
+		request_layer_settings_impl(reinterpret_cast<std::vector<vk::LayerSettingEXT> &>(requested_layer_settings), reinterpret_cast<vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> &>(scb));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void VulkanSample<bindingType>::request_layer_settings_impl(std::vector<vk::LayerSettingEXT> &requested_layer_settings) const
+inline void VulkanSample<bindingType>::request_layer_settings_impl(std::vector<vk::LayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> &scb) const
 {
 #if defined(VKB_VALIDATION_LAYERS_GPU_ASSISTED)
-	static const vk::Bool32 setting_validate_gpuav = true;
-	requested_layer_settings.push_back({"VK_LAYER_KHRONOS_validation", "gpuav_enable", vk::LayerSettingTypeEXT::eBool32, 1, &setting_validate_gpuav});
+	requested_layer_settings.push_back({"VK_LAYER_KHRONOS_validation", "gpuav_enable", vk::LayerSettingTypeEXT::eBool32, 1, &scb.add_chain_data<vk::Bool32>(true)});
 #endif
 
 #if defined(VKB_VALIDATION_LAYERS_BEST_PRACTICES)
-	static const vk::Bool32 setting_validate_best_practices        = true;
-	static const vk::Bool32 setting_validate_best_practices_amd    = true;
-	static const vk::Bool32 setting_validate_best_practices_arm    = true;
-	static const vk::Bool32 setting_validate_best_practices_img    = true;
-	static const vk::Bool32 setting_validate_best_practices_nvidia = true;
+	std::array<vk::Bool32, 5> &best_practices_values = scb.add_chain_data<std::array<vk::Bool32, 5>>({true, true, true, true, true});
 	requested_layer_settings.push_back(
-	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices", vk::LayerSettingTypeEXT::eBool32, 1, &setting_validate_best_practices});
+	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices", vk::LayerSettingTypeEXT::eBool32, 1, &best_practices_values[0]});
 	requested_layer_settings.push_back(
-	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices_amd", vk::LayerSettingTypeEXT::eBool32, 1, &setting_validate_best_practices_amd});
+	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices_amd", vk::LayerSettingTypeEXT::eBool32, 1, &best_practices_values[1]});
 	requested_layer_settings.push_back(
-	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices_arm", vk::LayerSettingTypeEXT::eBool32, 1, &setting_validate_best_practices_arm});
+	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices_arm", vk::LayerSettingTypeEXT::eBool32, 1, &best_practices_values[2]});
 	requested_layer_settings.push_back(
-	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices_img", vk::LayerSettingTypeEXT::eBool32, 1, &setting_validate_best_practices_img});
+	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices_img", vk::LayerSettingTypeEXT::eBool32, 1, &best_practices_values[3]});
 	requested_layer_settings.push_back(
-	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices_nvidia", vk::LayerSettingTypeEXT::eBool32, 1, &setting_validate_best_practices_nvidia});
+	    {"VK_LAYER_KHRONOS_validation", "validate_best_practices_nvidia", vk::LayerSettingTypeEXT::eBool32, 1, &best_practices_values[4]});
 #endif
 
 #if defined(VKB_VALIDATION_LAYERS_SYNCHRONIZATION)
-	static const vk::Bool32 setting_validate_sync            = true;
-	static const vk::Bool32 setting_validate_sync_heuristics = true;
-	requested_layer_settings.push_back({"VK_LAYER_KHRONOS_validation", "validate_sync", vk::LayerSettingTypeEXT::eBool32, 1, &setting_validate_sync});
+	std::array<vk::Bool32, 2> &synchronization_values = scb.add_chain_data<std::array<vk::Bool32, 2>>({true, true});
+	requested_layer_settings.push_back({"VK_LAYER_KHRONOS_validation", "validate_sync", vk::LayerSettingTypeEXT::eBool32, 1, &synchronization_values[0]});
 	requested_layer_settings.push_back(
-	    {"VK_LAYER_KHRONOS_validation", "syncval_shader_accesses_heuristic", vk::LayerSettingTypeEXT::eBool32, 1, &setting_validate_sync_heuristics});
+	    {"VK_LAYER_KHRONOS_validation", "syncval_shader_accesses_heuristic", vk::LayerSettingTypeEXT::eBool32, 1, &synchronization_values[1]});
 #endif
 }
 

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.cpp
@@ -533,13 +533,10 @@ void DescriptorIndexing::request_instance_extensions(std::unordered_map<std::str
 	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
 }
 
-void DescriptorIndexing::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const
+void DescriptorIndexing::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const
 {
-	// Make this static so layer setting reference remains valid after leaving the current scope
-	static const int32_t useMetalArgumentBuffers = 1;
-
-	ApiVulkanSample::request_layer_settings(requested_layer_settings);
-	requested_layer_settings.push_back({"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &useMetalArgumentBuffers});
+	ApiVulkanSample::request_layer_settings(requested_layer_settings, scb);
+	requested_layer_settings.push_back({"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &scb.add_chain_data<int32_t>(1)});
 }
 #endif
 

--- a/samples/extensions/descriptor_indexing/descriptor_indexing.h
+++ b/samples/extensions/descriptor_indexing/descriptor_indexing.h
@@ -35,7 +35,7 @@ class DescriptorIndexing : public ApiVulkanSample
 	bool prepare(const vkb::ApplicationOptions &options) override;
 #if defined(PLATFORM__MACOS)
 	void request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
-	void request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
+	void request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
 #endif
 
 	void create_bindless_descriptors();

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -120,13 +120,11 @@ void ShaderDebugPrintf::request_instance_extensions(std::unordered_map<std::stri
 	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
 }
 
-void ShaderDebugPrintf::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const
+void ShaderDebugPrintf::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const
 {
-	// Make this static so layer setting reference remains valid after leaving the current scope
-	static const VkBool32 printf_enable = VK_TRUE;
-
-	ApiVulkanSample::request_layer_settings(requested_layer_settings);
-	requested_layer_settings.push_back({validation_layer_name, "printf_enable", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &printf_enable});
+	ApiVulkanSample::request_layer_settings(requested_layer_settings, scb);
+	requested_layer_settings.push_back(
+	    {validation_layer_name, "printf_enable", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &scb.add_chain_data<VkBool32>(VK_TRUE)});
 }
 
 void ShaderDebugPrintf::request_validation_feature_enables(std::vector<VkValidationFeatureEnableEXT> &requested_layer_settings) const
@@ -458,6 +456,18 @@ bool ShaderDebugPrintf::prepare(const vkb::ApplicationOptions &options)
 	build_command_buffers();
 	prepared = true;
 	return true;
+}
+
+void ShaderDebugPrintf::extend_instance_create_info(vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const
+{
+	ApiVulkanSample::extend_instance_create_info(scb);
+
+	// Register a sample specific debug utils callback in addition to the one registered by the base class
+	VkDebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info{.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
+	                                                                     .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
+	                                                                     .messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+	                                                                     .pfnUserCallback = debug_utils_message_callback};
+	scb.add_struct(debug_utils_messenger_create_info);
 }
 
 VkDebugUtilsMessengerCreateInfoEXT const *ShaderDebugPrintf::get_debug_utils_messenger_create_info() const

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.h
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.h
@@ -82,7 +82,7 @@ class ShaderDebugPrintf : public ApiVulkanSample
 	~ShaderDebugPrintf();
 	void                                              request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
 	void                                              request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
-	void                                              request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
+	void                                              request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
 	void                                              request_validation_feature_enables(std::vector<ValidationFeatureEnableType> &requested_layer_settings) const override;
 	void                                              build_command_buffers() override;
 	void                                              load_assets();
@@ -94,6 +94,7 @@ class ShaderDebugPrintf : public ApiVulkanSample
 	void                                              update_uniform_buffers();
 	void                                              draw();
 	bool                                              prepare(const vkb::ApplicationOptions &options) override;
+	virtual void                                      extend_instance_create_info(vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
 	virtual VkDebugUtilsMessengerCreateInfoEXT const *get_debug_utils_messenger_create_info() const override;
 	virtual void                                      render(float delta_time) override;
 	virtual void                                      on_update_ui_overlay(vkb::Drawer &drawer) override;

--- a/samples/performance/layout_transitions/layout_transitions.cpp
+++ b/samples/performance/layout_transitions/layout_transitions.cpp
@@ -84,13 +84,10 @@ void LayoutTransitions::request_instance_extensions(std::unordered_map<std::stri
 	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
 }
 
-void LayoutTransitions::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const
+void LayoutTransitions::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const
 {
-	// Make this static so layer setting reference remains valid after leaving the current scope
-	static const int32_t disableMetalArgumentBuffers = 0;
-
-	vkb::VulkanSampleC::request_layer_settings(requested_layer_settings);
-	requested_layer_settings.push_back({"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &disableMetalArgumentBuffers});
+	vkb::VulkanSampleC::request_layer_settings(requested_layer_settings, scb);
+	requested_layer_settings.push_back({"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &scb.add_chain_data<int32_t>(0)});
 }
 #endif
 

--- a/samples/performance/layout_transitions/layout_transitions.h
+++ b/samples/performance/layout_transitions/layout_transitions.h
@@ -35,7 +35,8 @@ class LayoutTransitions : public vkb::VulkanSampleC
 	bool prepare(const vkb::ApplicationOptions &options) override;
 #if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
 	void request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
-	void request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
+	void request_layer_settings(std::vector<VkLayerSettingEXT>                    &requested_layer_settings,
+	                            vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
 #endif
 
   private:

--- a/samples/performance/pipeline_barriers/pipeline_barriers.cpp
+++ b/samples/performance/pipeline_barriers/pipeline_barriers.cpp
@@ -119,13 +119,11 @@ void PipelineBarriers::request_instance_extensions(std::unordered_map<std::strin
 	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
 }
 
-void PipelineBarriers::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const
+void PipelineBarriers::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings, vbk::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const
 {
-	// Make this static so layer setting reference remains valid after leaving the current scope
-	static const int32_t disableMetalArgumentBuffers = 0;
-
-	vkb::VulkanSampleC::request_layer_settings(requested_layer_settings);
-	requested_layer_settings.push_back({"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &disableMetalArgumentBuffers});
+	vkb::VulkanSampleC::request_layer_settings(requested_layer_settings, scb);
+	requested_layer_settings.push_back(
+	    {"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &scb.add_chain_data<int32_t>(0)});
 }
 #endif
 

--- a/samples/performance/pipeline_barriers/pipeline_barriers.h
+++ b/samples/performance/pipeline_barriers/pipeline_barriers.h
@@ -35,7 +35,8 @@ class PipelineBarriers : public vkb::VulkanSampleC
 	bool prepare(const vkb::ApplicationOptions &options) override;
 #if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
 	void request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
-	void request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
+	void request_layer_settings(std::vector<VkLayerSettingEXT>                    &requested_layer_settings,
+	                            vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
 #endif
 
   private:

--- a/samples/performance/subpasses/subpasses.cpp
+++ b/samples/performance/subpasses/subpasses.cpp
@@ -176,13 +176,12 @@ void Subpasses::request_instance_extensions(std::unordered_map<std::string, vkb:
 	requested_extensions[VK_EXT_LAYER_SETTINGS_EXTENSION_NAME] = vkb::RequestMode::Optional;
 }
 
-void Subpasses::request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const
+void Subpasses::request_layer_settings(std::vector<VkLayerSettingEXT>                    &requested_layer_settings,
+                                       vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const
 {
-	// Make this static so layer setting reference remains valid after leaving the current scope
-	static const int32_t disableMetalArgumentBuffers = 0;
-
-	vkb::VulkanSampleC::request_layer_settings(requested_layer_settings);
-	requested_layer_settings.push_back({"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &disableMetalArgumentBuffers});
+	vkb::VulkanSampleC::request_layer_settings(requested_layer_settings, scb);
+	requested_layer_settings.push_back(
+	    {"MoltenVK", "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", VK_LAYER_SETTING_TYPE_INT32_EXT, 1, &scb.add_chain_data<int32_t>(0)});
 }
 #endif
 

--- a/samples/performance/subpasses/subpasses.h
+++ b/samples/performance/subpasses/subpasses.h
@@ -36,7 +36,8 @@ class Subpasses : public vkb::VulkanSampleC
 	bool prepare(const vkb::ApplicationOptions &options) override;
 #if defined(PLATFORM__MACOS) && TARGET_OS_IOS && TARGET_OS_SIMULATOR
 	void request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
-	void request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings) const override;
+	void request_layer_settings(std::vector<VkLayerSettingEXT>                    &requested_layer_settings,
+	                            vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
 #endif
 
 	void update(float delta_time) override;


### PR DESCRIPTION
## Description

In order to remove the need for all those static variables on structure chaining, I would like to introduce this helper class `vkb::StructureChainBuilder`.
It gathers all the structures to chain together, manages the chaining via the `pNext`-pointer, and gathers any memory pointed to by some of the structures chained here. In addition, it checks, that the struct to chain really extends the anchor struct, and in case of multiple allowed same structs, checks if that allowed.
Demonstrate its usage with vk::InstanceCreateInfo.

Build tested on Win11 with VS2022. Run tested on Win10 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
