### PR TITLE
Revised: Update iOS build to support future standarization of FindVulkan.cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,9 +187,9 @@ jobs:
       - name: retrieve VulkanSDK
         if: steps.VulkanSDK.outputs.cache-hit != 'true'
         run: |
-          wget https://sdk.lunarg.com/sdk/download/1.4.304.1/mac/vulkansdk-macos-1.4.304.1.zip
-          unzip vulkansdk-macos-1.4.304.1.zip
-          sudo InstallVulkan-1.4.304.1.app/Contents/MacOS/InstallVulkan-1.4.304.1 --root ~/VulkanSDK --accept-licenses --default-answer --confirm-command install com.lunarg.vulkan.ios
+          wget https://sdk.lunarg.com/sdk/download/1.4.341.1/mac/vulkansdk-macos-1.4.341.1.zip
+          unzip vulkansdk-macos-1.4.341.1.zip
+          sudo vulkansdk-macOS-1.4.341.1.app/Contents/MacOS/vulkansdk-macOS-1.4.341.1 --root ~/VulkanSDK --accept-licenses --default-answer --confirm-command install com.lunarg.vulkan.ios
 
       - name: build_ios
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright (c) 2020-2025, Arm Limited and Contributors
-# Copyright (c) 2024-2025, Mobica Limited
-# Copyright (c) 2024-2025, Sascha Willems
+# Copyright (c) 2020-2026, Arm Limited and Contributors
+# Copyright (c) 2024-2026, Mobica Limited
+# Copyright (c) 2024-2026, Sascha Willems
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -40,6 +40,11 @@ project(vulkan_samples)
 if(VKB_GENERATE_ANTORA_SITE)
     add_subdirectory(antora)
 else ()
+# On IOS we define CMAKE_FIND_ROOT_PATH to allow find_package(Vulkan) to locate the Vulkan frameworks for iOS
+if(IOS)
+	set(CMAKE_FIND_ROOT_PATH "$ENV{VULKAN_SDK}")
+endif()
+
 # search for Vulkan SDK
 find_package(Vulkan)
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2025, Arm Limited and Contributors
+# Copyright (c) 2019-2026, Arm Limited and Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -137,6 +137,7 @@ if(IOS)
     endif ()
     # Vulkan cache variables already defined by main project CMakeLists and updated on Apple platforms by global_options.cmake
     if(Vulkan_LIBRARY AND ${Vulkan_VERSION} VERSION_GREATER_EQUAL 1.3.278)
+        get_filename_component(Vulkan_Target_SDK "$ENV{VULKAN_SDK}/.." REALPATH)
         target_sources(${PROJECT_NAME} PRIVATE
                 ${Vulkan_Target_SDK}/iOS/share/vulkan
         )

--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -1,5 +1,5 @@
 #[[
- Copyright (c) 2019-2025, Arm Limited and Contributors
+ Copyright (c) 2019-2026, Arm Limited and Contributors
 
  SPDX-License-Identifier: Apache-2.0
 
@@ -78,10 +78,10 @@ if(APPLE)
 		else()
 			message(FATAL_ERROR "Can't find MoltenVK library. Please install the Vulkan SDK or MoltenVK project and set VULKAN_SDK.")
 		endif()
-	#elseif(OTHER_VULKAN_DRIVER)
-		# handle any special processing here for other Vulkan driver (e.g. KosmicKrisp) for standalone usage on macOS or deployment to iOS
-		# would likely require extensions to CMake find_package() OPTIONAL_COMPONENTS and library variables to identify & use other driver
-	#else()
+	elseif(IOS AND NOT Vulkan_Layer_VALIDATION)
+		# if building for iOS devices (not iOS Simulator as above) and Vulkan_Layer_VALIDATION is not defined or found, search in the Vulkan SDK
+		find_library(Vulkan_Layer_VALIDATION NAMES VkLayer_khronos_validation HINTS "$ENV{VULKAN_SDK}/lib")
+	else()
 		# if not using standalone driver, retain find_package() results for Vulkan driver, Vulkan loader, and Validation Layer library variables
 		# no need to override with _HPP_VULKAN_LIBRARY in this case since Vulkan DynamicLoader will find/load Vulkan library on macOS & iOS
 	endif()


### PR DESCRIPTION
## Description

Simplifies and replaces closed PR #1500.

This PR updates the iOS build and CI to support **future standardization of FindVulkan.cmake** where there may be fewer or no project customizations present for iOS build targets. With these changes the project will build and run for iOS and iOS Simulator _with_ OR _without_ the project-specific FindVulkan.cmake present in the tree, i.e. it only depends on the capabilities of cmake's standard version of the module without project-specific iOS customizations.  This will permit eventual migration away from the project-specific FindVulkan.cmake.  However, in the mean time the project FindVulkan.cmake will remain in place and this PR will not result in any iOS regressions, nor require any doc updates.

The specific items that have changed are:

1. The `CMAKE_FIND_ROOT_PATH` variable is defined for iOS builds in the main **CMakeLists** file.  This is to allow the standard non-customized FindVulkan.cmake to locate the iOS frameworks from the SDK.  This is the key change that makes this PR work properly.  While this adds one small item to the main CMakeLists file, it avoids a more complex approach using an iOS toolchain file (see closed PR #1500) which is overkill for the solution.
2. The `Vulkan_Target_SDK` cmake variable is now defined locally within **Vulkan-Samples/app/CMakeLists.txt** vs. depending on its definition within the project's FindVulkan.cmake. This approach makes more sense since this was a project-specific customization of FindVulkan.cmake and is the only location in the project build system (outside of FindVulkan.cmake itself) where this variable is used. Note the purpose of this variable is to locate the directory where Vulkan icd and layer json files can be found - required for packaging an iOS app bundle.
3.  The `Vulkan_Layer_VALIDATION` cmake variable is now located and defined within the iOS-specific section in **Vulkan-Samples/bldsys/cmake/global_options.cmake** if it's not already defined or found by FindVulkan.cmake. This acts as a fail-safe fallback that avoids any regressions in finding the validation layer for iOS within the project.
4. Updates the Vulkan SDK to 1.4.341.1 for iOS CI builds. This matches the project and I thought this would be a good time to update given the other iOS build changes.

Fixes iOS build issues associated with pull request #1490. See additional discussion there.

Tested on macOS Sequoia with iOS arm64 and iOS Simulator x86_64 targets.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
