### PR TITLE
fix(wayland): get surface extent from window instead of surface prope…

### DIFF
--- a/framework/rendering/render_context.h
+++ b/framework/rendering/render_context.h
@@ -604,8 +604,18 @@ inline bool RenderContext<bindingType>::handle_surface_changes(bool force_update
 	}
 
 	vk::SurfaceCapabilitiesKHR surface_properties = device.get_gpu().get_handle().getSurfaceCapabilitiesKHR(swapchain->get_surface());
+	vk::Extent2D               cur_extent;
 
-	if (surface_properties.currentExtent.width == 0xFFFFFFFF)
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+	// On Wayland, currentExtent is typically {0xFFFFFFFF, 0xFFFFFFFF}, meaning
+	// the application determines the surface size. We need to get the size from
+	// the window instead.
+	cur_extent = vk::Extent2D{window.get_extent().width, window.get_extent().height};
+#else
+	cur_extent = surface_properties.currentExtent;
+#endif
+
+	if (cur_extent.width == 0xFFFFFFFF || cur_extent.height == 0xFFFFFFFF)
 	{
 		return false;
 	}
@@ -613,14 +623,14 @@ inline bool RenderContext<bindingType>::handle_surface_changes(bool force_update
 	// Only recreate the swapchain if the dimensions have changed;
 	// handle_surface_changes() is called on VK_SUBOPTIMAL_KHR,
 	// which might not be due to a surface resize
-	if (surface_properties.currentExtent.width != surface_extent.width || surface_properties.currentExtent.height != surface_extent.height || force_update)
+	if (cur_extent.width != surface_extent.width || cur_extent.height != surface_extent.height || force_update)
 	{
 		// Recreate swapchain
 		device.get_handle().waitIdle();
 
-		update_swapchain_impl(surface_properties.currentExtent, pre_transform);
+		update_swapchain_impl(cur_extent, pre_transform);
 
-		surface_extent = surface_properties.currentExtent;
+		surface_extent = cur_extent;
 
 		return true;
 	}


### PR DESCRIPTION
…rties

On Wayland, VkSurfaceCapabilitiesKHR::currentExtent typically returns {0xFFFFFFFF, 0xFFFFFFFF}, indicating that the application determines the surface size rather than the compositor.
This patch fixes the issue by getting the actual surface extent from the platform window on Wayland, ensuring the swapchain is properly recreated with the correct dimensions.

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc)

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [x] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [x] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [x] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [x] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
