### PR TITLE
Simplify unique extent check in RenderTarget<bindingType>::init functions

### DIFF
--- a/framework/rendering/render_target.h
+++ b/framework/rendering/render_target.h
@@ -25,7 +25,6 @@
 #include "core/hpp_image.h"
 #include "core/hpp_image_view.h"
 #include "core/image.h"
-#include <vulkan/vulkan_hash.hpp>        // provides std::hash specializations for Vulkan handle types, used in std::unordered_map and std::unordered_set
 
 namespace vkb
 {
@@ -233,23 +232,20 @@ inline RenderTarget<bindingType>::RenderTarget(std::vector<ImageType> &&images)
 template <vkb::BindingType bindingType>
 inline void RenderTarget<bindingType>::init(std::vector<vkb::core::HPPImage> &&images_)
 {
+	assert(!images_.empty());
+
 	device = &images_.back().get_device();
 	images = std::move(images_);
 
 	// Returns the image extent as a vk::Extent2D structure from a vk::Extent3D
 	auto get_image_extent = [](const vkb::core::HPPImage &image) { return vk::Extent2D{image.get_extent().width, image.get_extent().height}; };
 
-	// Constructs a set of unique image extents given a vector of images
-	std::unordered_set<vk::Extent2D> unique_extent;
-	std::ranges::transform(images, std::inserter(unique_extent, unique_extent.end()), get_image_extent);
-
-	// Allow only one extent size for a render target
-	if (unique_extent.size() != 1)
+	extent = get_image_extent(images.front());
+	if (std::ranges::find_if(images,
+	                         [extent = this->extent, &get_image_extent](const vkb::core::HPPImage &image) { return get_image_extent(image) != extent; }) != images.end())
 	{
 		throw vkb::common::HPPVulkanException{vk::Result::eErrorInitializationFailed, "Extent size is not unique"};
 	}
-
-	extent = *unique_extent.begin();
 
 	for (auto &image : images)
 	{
@@ -282,6 +278,8 @@ inline RenderTarget<bindingType>::RenderTarget(std::vector<ImageViewType> &&imag
 template <vkb::BindingType bindingType>
 inline void RenderTarget<bindingType>::init(std::vector<vkb::core::HPPImageView> &&image_views)
 {
+	assert(!image_views.empty());
+
 	device = &image_views.back().get_image().get_device();
 	views  = std::move(image_views);
 
@@ -292,15 +290,13 @@ inline void RenderTarget<bindingType>::init(std::vector<vkb::core::HPPImageView>
 		return vk::Extent2D{mip0_extent.width >> mip_level, mip0_extent.height >> mip_level};
 	};
 
-	// Constructs a set of unique image extents given a vector of image views;
 	// allow only one extent size for a render target
-	std::unordered_set<vk::Extent2D> unique_extent;
-	std::ranges::transform(views, std::inserter(unique_extent, unique_extent.end()), get_view_extent);
-	if (unique_extent.size() != 1)
+	extent = get_view_extent(views.front());
+	if (std::ranges::find_if(views,
+	                         [extent = this->extent, &get_view_extent](const vkb::core::HPPImageView &view) { return get_view_extent(view) != extent; }) != views.end())
 	{
 		throw vkb::common::HPPVulkanException{vk::Result::eErrorInitializationFailed, "Extent size is not unique"};
 	}
-	extent = *unique_extent.begin();
 
 	for (auto &view : views)
 	{


### PR DESCRIPTION
## Description

With #1517, we reduced the extent check in the `RenderTarget<bindingType>::init` functions from sorting the extents to counting the unique extents. But we actually just want to check if all extents are identical. And that can be easily done with this call to `std::ranges::find_if`. And this works regardless of whether `VULKAN_HPP_HAS_SPACESHIP_OPERATOR` is defined or not.

The previous approach nicely showed, how `vulkan_hash.hpp` can be used to use vulkan structs as the key in a `std::unordered_set`, but it's actually not needed.

Build tested on Win11 with VS2022. Run tested on Win11 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
