### PR TITLE
Fix usage of vkCreateDebugUtilsMessengerEXT/vk::Instance::createDebugUtilsMessengerEXT.

### DIFF
--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -247,7 +247,7 @@ inline Instance<bindingType>::Instance(std::string const                        
 	                                   .enabledExtensionCount   = static_cast<uint32_t>(enabled_extensions_cstr.size()),
 	                                   .ppEnabledExtensionNames = enabled_extensions_cstr.data()};
 
-	vkb::StructureChainBuilder<vkb::BindingType::Cpp, vk::InstanceCreateInfo> scb;
+	vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> scb;
 	scb.set_anchor_struct(create_info);
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -247,8 +247,7 @@ inline Instance<bindingType>::Instance(std::string const                        
 	                                   .enabledExtensionCount   = static_cast<uint32_t>(enabled_extensions_cstr.size()),
 	                                   .ppEnabledExtensionNames = enabled_extensions_cstr.data()};
 
-	vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> scb;
-	scb.set_anchor_struct(create_info);
+	vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> scb(create_info);
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
 		extend_instance_create_info(scb);

--- a/framework/structure_chain_builder.h
+++ b/framework/structure_chain_builder.h
@@ -25,9 +25,9 @@ namespace vkb
 template <vkb::BindingType bindingType, typename AnchorStructType>
 class StructureChainBuilder
 {
-  public:
-	StructureChainBuilder();
+	static_assert((offsetof(AnchorStructType, sType) == 0) && (offsetof(AnchorStructType, pNext) == sizeof(void *)));
 
+  public:
 	template <typename T>
 	T &add_chain_data(T const &data_to_add = {});        // Adds data to the structure chain builder that is not part of the structure chain itself, but is used by the
 	                                                     // structures in the chain (e.g. pointed to by a member of a struct in the structure chain)
@@ -67,13 +67,6 @@ T &StructureChainBuilder<bindingType, AnchorStructType>::add_chain_data(T const 
 }
 
 template <vkb::BindingType bindingType, typename AnchorStructType>
-inline StructureChainBuilder<bindingType, AnchorStructType>::StructureChainBuilder()
-{
-	static_assert((offsetof(AnchorStructType, sType) == 0) && (offsetof(AnchorStructType, pNext) == sizeof(void *)));
-	structure_chain.push_back(std::make_unique<std::any>(std::make_any<AnchorStructType>()));
-}
-
-template <vkb::BindingType bindingType, typename AnchorStructType>
 template <typename StructType>
 inline StructType &StructureChainBuilder<bindingType, AnchorStructType>::add_struct(StructType const &struct_to_add)
 {
@@ -92,6 +85,11 @@ template <vkb::BindingType bindingType, typename AnchorStructType>
 template <typename StructType>
 inline StructType &StructureChainBuilder<bindingType, AnchorStructType>::add_struct_impl(StructType const &struct_to_add)
 {
+	if (structure_chain.empty())
+	{
+		structure_chain.push_back(std::make_unique<std::any>(std::make_any<AnchorStructType>()));
+	}
+
 #if !defined(NDEBUG)
 	auto it = std::ranges::find_if(structure_chain, [](auto const &chain_element) {
 		return std::any_cast<StructType>(chain_element.get()) != nullptr;
@@ -115,7 +113,7 @@ inline StructType const *StructureChainBuilder<bindingType, AnchorStructType>::g
 	}
 	else
 	{
-		return reinterpret_cast<StructType const *>(get_struct_impl<vk::CppType<StructType>::Type>(skip));
+		return reinterpret_cast<StructType const *>(get_struct_impl<typename vk::CppType<StructType>::Type>(skip));
 	}
 }
 
@@ -146,7 +144,7 @@ inline void StructureChainBuilder<bindingType, AnchorStructType>::set_anchor_str
 	}
 	else
 	{
-		return reinterpret_cast<StructureChainBuilder<vkb::BindingType::Cpp, typename vk::CppType<AnchorStructType>::Type> *>(this)->add_anchor_struct(
+		reinterpret_cast<StructureChainBuilder<vkb::BindingType::Cpp, typename vk::CppType<AnchorStructType>::Type> *>(this)->set_anchor_struct(
 		    reinterpret_cast<typename vk::CppType<AnchorStructType>::Type const &>(anchor_struct));
 	}
 }
@@ -154,9 +152,16 @@ inline void StructureChainBuilder<bindingType, AnchorStructType>::set_anchor_str
 template <vkb::BindingType bindingType, typename AnchorStructType>
 inline void StructureChainBuilder<bindingType, AnchorStructType>::set_anchor_struct_impl(AnchorStructType const &anchor_struct)
 {
-	void const *pNext                                                     = std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext;
-	*std::any_cast<AnchorStructType>(structure_chain.front().get())       = anchor_struct;
-	std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext = pNext;
+	if (structure_chain.empty())
+	{
+		structure_chain.push_back(std::make_unique<std::any>(std::make_any<AnchorStructType>(anchor_struct)));
+	}
+	else
+	{
+		void const *pNext                                                     = std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext;
+		*std::any_cast<AnchorStructType>(structure_chain.front().get())       = anchor_struct;
+		std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext = pNext;
+	}
 }
 
 }        // namespace vkb

--- a/framework/structure_chain_builder.h
+++ b/framework/structure_chain_builder.h
@@ -28,6 +28,8 @@ class StructureChainBuilder
 	static_assert((offsetof(AnchorStructType, sType) == 0) && (offsetof(AnchorStructType, pNext) == sizeof(void *)));
 
   public:
+	StructureChainBuilder(AnchorStructType const &anchor_struct);
+
 	template <typename T>
 	T &add_chain_data(T const &data_to_add = {});        // Adds data to the structure chain builder that is not part of the structure chain itself, but is used by the
 	                                                     // structures in the chain (e.g. pointed to by a member of a struct in the structure chain)
@@ -38,14 +40,11 @@ class StructureChainBuilder
 	template <typename StructType>
 	StructType const *get_struct(size_t skip = 0) const;
 
-	void set_anchor_struct(AnchorStructType const &anchor_struct);
-
   private:
 	template <typename StructType>
 	StructType &add_struct_impl(StructType const &struct_to_add);
 	template <typename StructType>
 	StructType const *get_struct_impl(size_t skip) const;
-	void              set_anchor_struct_impl(AnchorStructType const &anchor_struct);
 
   private:
 	std::vector<std::unique_ptr<std::any>> structure_chain;
@@ -59,8 +58,14 @@ template <typename AnchorStructType>
 using StructureChainBuilderCpp = StructureChainBuilder<vkb::BindingType::Cpp, AnchorStructType>;
 
 template <vkb::BindingType bindingType, typename AnchorStructType>
+inline StructureChainBuilder<bindingType, AnchorStructType>::StructureChainBuilder(AnchorStructType const &anchor_struct)
+{
+	structure_chain.push_back(std::make_unique<std::any>(std::make_any<AnchorStructType>(anchor_struct)));
+}
+
+template <vkb::BindingType bindingType, typename AnchorStructType>
 template <typename T>
-T &StructureChainBuilder<bindingType, AnchorStructType>::add_chain_data(T const &data_to_add)
+inline T &StructureChainBuilder<bindingType, AnchorStructType>::add_chain_data(T const &data_to_add)
 {
 	chain_data.push_back(std::make_unique<std::any>(std::make_any<T>(data_to_add)));
 	return *std::any_cast<T>(chain_data.back().get());
@@ -85,11 +90,6 @@ template <vkb::BindingType bindingType, typename AnchorStructType>
 template <typename StructType>
 inline StructType &StructureChainBuilder<bindingType, AnchorStructType>::add_struct_impl(StructType const &struct_to_add)
 {
-	if (structure_chain.empty())
-	{
-		structure_chain.push_back(std::make_unique<std::any>(std::make_any<AnchorStructType>()));
-	}
-
 #if !defined(NDEBUG)
 	auto it = std::ranges::find_if(structure_chain, [](auto const &chain_element) {
 		return std::any_cast<StructType>(chain_element.get()) != nullptr;
@@ -133,35 +133,6 @@ inline StructType const *StructureChainBuilder<bindingType, AnchorStructType>::g
 		});
 	}
 	return (it != structure_chain.end()) ? std::any_cast<StructType>(it->get()) : nullptr;
-}
-
-template <vkb::BindingType bindingType, typename AnchorStructType>
-inline void StructureChainBuilder<bindingType, AnchorStructType>::set_anchor_struct(AnchorStructType const &anchor_struct)
-{
-	if constexpr (bindingType == vkb::BindingType::Cpp)
-	{
-		set_anchor_struct_impl(anchor_struct);
-	}
-	else
-	{
-		reinterpret_cast<StructureChainBuilder<vkb::BindingType::Cpp, typename vk::CppType<AnchorStructType>::Type> *>(this)->set_anchor_struct(
-		    reinterpret_cast<typename vk::CppType<AnchorStructType>::Type const &>(anchor_struct));
-	}
-}
-
-template <vkb::BindingType bindingType, typename AnchorStructType>
-inline void StructureChainBuilder<bindingType, AnchorStructType>::set_anchor_struct_impl(AnchorStructType const &anchor_struct)
-{
-	if (structure_chain.empty())
-	{
-		structure_chain.push_back(std::make_unique<std::any>(std::make_any<AnchorStructType>(anchor_struct)));
-	}
-	else
-	{
-		void const *pNext                                                     = std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext;
-		*std::any_cast<AnchorStructType>(structure_chain.front().get())       = anchor_struct;
-		std::any_cast<AnchorStructType>(structure_chain.front().get())->pNext = pNext;
-	}
 }
 
 }        // namespace vkb

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -198,8 +198,6 @@ class VulkanSample : public vkb::Application
 	virtual void draw_renderpass(vkb::core::CommandBuffer<bindingType> &command_buffer, vkb::rendering::RenderTarget<bindingType> &render_target);
 
 	virtual void                    extend_instance_create_info(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &scb) const;
-	virtual void                    extend_debug_report_callback_create_info(vkb::StructureChainBuilder<bindingType, DebugReportCallbackCreateInfoType> &scb) const;
-	virtual void                    extend_debug_utils_messenger_create_info(vkb::StructureChainBuilder<bindingType, DebugUtilsMessengerCreateInfoType> &scb) const;
 	virtual uint32_t                get_api_version() const;
 	virtual InstanceCreateFlagsType get_instance_create_flags(std::vector<std::string> const &enabled_extensions) const;
 
@@ -341,8 +339,8 @@ class VulkanSample : public vkb::Application
 	static void set_viewport_and_scissor_impl(vkb::core::CommandBufferCpp const &command_buffer, vk::Extent2D const &extent);
 
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	vk::DebugReportCallbackCreateInfoEXT get_debug_report_callback_create_info() const;
-	vk::DebugUtilsMessengerCreateInfoEXT get_debug_utils_messenger_create_info() const;
+	vk::DebugReportCallbackCreateInfoEXT const &get_debug_report_callback_create_info() const;
+	vk::DebugUtilsMessengerCreateInfoEXT const &get_debug_utils_messenger_create_info() const;
 #endif
 
 	/**
@@ -836,14 +834,6 @@ inline void VulkanSample<bindingType>::extend_instance_create_info_impl(vkb::Str
 }
 
 template <vkb::BindingType bindingType>
-inline void VulkanSample<bindingType>::extend_debug_report_callback_create_info(vkb::StructureChainBuilder<bindingType, DebugReportCallbackCreateInfoType> &scb) const
-{}
-
-template <vkb::BindingType bindingType>
-inline void VulkanSample<bindingType>::extend_debug_utils_messenger_create_info(vkb::StructureChainBuilder<bindingType, DebugUtilsMessengerCreateInfoType> &scb) const
-{}
-
-template <vkb::BindingType bindingType>
 inline uint32_t VulkanSample<bindingType>::get_api_version() const
 {
 	return VK_API_VERSION_1_1;
@@ -904,18 +894,22 @@ inline vkb::core::Device<bindingType> &VulkanSample<bindingType>::get_device()
 
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
 template <vkb::BindingType bindingType>
-inline vk::DebugReportCallbackCreateInfoEXT VulkanSample<bindingType>::get_debug_report_callback_create_info() const
+inline vk::DebugReportCallbackCreateInfoEXT const &VulkanSample<bindingType>::get_debug_report_callback_create_info() const
 {
-	return {.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
-	        .pfnCallback = vkb::core::debug_callback};
+	static vk::DebugReportCallbackCreateInfoEXT debug_report_callback_create_info =
+	    {.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
+	     .pfnCallback = vkb::core::debug_callback};
+	return debug_report_callback_create_info;
 }
 
 template <vkb::BindingType bindingType>
-inline vk::DebugUtilsMessengerCreateInfoEXT VulkanSample<bindingType>::get_debug_utils_messenger_create_info() const
+inline vk::DebugUtilsMessengerCreateInfoEXT const &VulkanSample<bindingType>::get_debug_utils_messenger_create_info() const
 {
-	return {.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning,
-	        .messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance,
-	        .pfnUserCallback = vkb::core::debug_utils_messenger_callback};
+	static vk::DebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info =
+	    {.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning,
+	     .messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance,
+	     .pfnUserCallback = vkb::core::debug_utils_messenger_callback};
+	return debug_utils_messenger_create_info;
 }
 #endif
 
@@ -1236,51 +1230,17 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 		instance.reset(reinterpret_cast<vkb::core::InstanceCpp *>(create_instance().release()));
 	}
 
-	// initialize debug utils or report callback based on enabled extensions, if any
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	// initialize debug utils or report callback based on enabled extensions
 	if (instance->is_extension_enabled(VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
 	{
-		vkb::StructureChainBuilderCpp<vk::DebugUtilsMessengerCreateInfoEXT> scb;
-#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-		scb.set_anchor_struct(get_debug_utils_messenger_create_info());
-#endif
-
-		if constexpr (bindingType == BindingType::Cpp)
-		{
-			extend_debug_utils_messenger_create_info(scb);
-		}
-		else
-		{
-			extend_debug_utils_messenger_create_info(reinterpret_cast<vkb::StructureChainBuilderC<VkDebugUtilsMessengerCreateInfoEXT> &>(scb));
-		}
-
-		vk::DebugUtilsMessengerCreateInfoEXT const *debug_utils_messenger_create_info = scb.get_struct<vk::DebugUtilsMessengerCreateInfoEXT>();
-		if (debug_utils_messenger_create_info)
-		{
-			debug_utils_messenger = instance->get_handle().createDebugUtilsMessengerEXT(*debug_utils_messenger_create_info);
-		}
+		debug_utils_messenger = instance->get_handle().createDebugUtilsMessengerEXT(get_debug_utils_messenger_create_info());
 	}
 	else if (instance->is_extension_enabled(VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
 	{
-		vkb::StructureChainBuilderCpp<vk::DebugReportCallbackCreateInfoEXT> scb;
-#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-		scb.set_anchor_struct(get_debug_report_callback_create_info());
-#endif
-
-		if constexpr (bindingType == BindingType::Cpp)
-		{
-			extend_debug_report_callback_create_info(scb);
-		}
-		else
-		{
-			extend_debug_report_callback_create_info(reinterpret_cast<vkb::StructureChainBuilderC<VkDebugReportCallbackCreateInfoEXT> &>(scb));
-		}
-
-		vk::DebugReportCallbackCreateInfoEXT const *debug_report_callback_create_info = scb.get_struct<vk::DebugReportCallbackCreateInfoEXT>();
-		if (debug_report_callback_create_info)
-		{
-			debug_report_callback = instance->get_handle().createDebugReportCallbackEXT(*debug_report_callback_create_info);
-		}
+		debug_report_callback = instance->get_handle().createDebugReportCallbackEXT(get_debug_report_callback_create_info());
 	}
+#endif
 
 	// Getting a valid vulkan surface from the platform
 	surface = static_cast<vk::SurfaceKHR>(window->create_surface(reinterpret_cast<vkb::core::InstanceC &>(*instance)));

--- a/framework/vulkan_sample.h
+++ b/framework/vulkan_sample.h
@@ -197,11 +197,11 @@ class VulkanSample : public vkb::Application
 	 */
 	virtual void draw_renderpass(vkb::core::CommandBuffer<bindingType> &command_buffer, vkb::rendering::RenderTarget<bindingType> &render_target);
 
-	virtual void                                     extend_instance_create_info(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &create_info) const;
-	virtual uint32_t                                 get_api_version() const;
-	virtual DebugReportCallbackCreateInfoType const *get_debug_report_callback_create_info() const;
-	virtual DebugUtilsMessengerCreateInfoType const *get_debug_utils_messenger_create_info() const;
-	virtual InstanceCreateFlagsType                  get_instance_create_flags(std::vector<std::string> const &enabled_extensions) const;
+	virtual void                    extend_instance_create_info(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &scb) const;
+	virtual void                    extend_debug_report_callback_create_info(vkb::StructureChainBuilder<bindingType, DebugReportCallbackCreateInfoType> &scb) const;
+	virtual void                    extend_debug_utils_messenger_create_info(vkb::StructureChainBuilder<bindingType, DebugUtilsMessengerCreateInfoType> &scb) const;
+	virtual uint32_t                get_api_version() const;
+	virtual InstanceCreateFlagsType get_instance_create_flags(std::vector<std::string> const &enabled_extensions) const;
 
 	/**
 	 * @brief Override this to customise the creation of the swapchain and render_context
@@ -339,6 +339,11 @@ class VulkanSample : public vkb::Application
 	void        render_impl(vkb::core::CommandBufferCpp &command_buffer);
 	void        request_layer_settings_impl(std::vector<vk::LayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderCpp<vk::InstanceCreateInfo> &scb) const;
 	static void set_viewport_and_scissor_impl(vkb::core::CommandBufferCpp const &command_buffer, vk::Extent2D const &extent);
+
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+	vk::DebugReportCallbackCreateInfoEXT get_debug_report_callback_create_info() const;
+	vk::DebugUtilsMessengerCreateInfoEXT get_debug_utils_messenger_create_info() const;
+#endif
 
 	/**
 	 * @brief Get sample-specific device extensions.
@@ -780,16 +785,11 @@ inline void VulkanSample<bindingType>::extend_instance_create_info_impl(vkb::Str
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
 	if (contains(create_info->enabledExtensionCount, create_info->ppEnabledExtensionNames, VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
 	{
-		vk::DebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info{.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning,
-		                                                                       .messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance,
-		                                                                       .pfnUserCallback = vkb::core::debug_utils_messenger_callback};
-		scb.add_struct(debug_utils_messenger_create_info);
+		scb.add_struct(get_debug_utils_messenger_create_info());
 	}
 	else if (contains(create_info->enabledExtensionCount, create_info->ppEnabledExtensionNames, VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
 	{
-		vk::DebugReportCallbackCreateInfoEXT debug_report_callback_create_info{.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
-		                                                                       .pfnCallback = vkb::core::debug_callback};
-		scb.add_struct(debug_report_callback_create_info);
+		scb.add_struct(get_debug_report_callback_create_info());
 	}
 #endif
 
@@ -836,48 +836,17 @@ inline void VulkanSample<bindingType>::extend_instance_create_info_impl(vkb::Str
 }
 
 template <vkb::BindingType bindingType>
+inline void VulkanSample<bindingType>::extend_debug_report_callback_create_info(vkb::StructureChainBuilder<bindingType, DebugReportCallbackCreateInfoType> &scb) const
+{}
+
+template <vkb::BindingType bindingType>
+inline void VulkanSample<bindingType>::extend_debug_utils_messenger_create_info(vkb::StructureChainBuilder<bindingType, DebugUtilsMessengerCreateInfoType> &scb) const
+{}
+
+template <vkb::BindingType bindingType>
 inline uint32_t VulkanSample<bindingType>::get_api_version() const
 {
 	return VK_API_VERSION_1_1;
-}
-
-template <vkb::BindingType bindingType>
-inline typename VulkanSample<bindingType>::DebugReportCallbackCreateInfoType const *VulkanSample<bindingType>::get_debug_report_callback_create_info() const
-{
-#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	static vk::DebugReportCallbackCreateInfoEXT debug_report_callback_create_info{.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
-	                                                                              .pfnCallback = vkb::core::debug_callback};
-	if constexpr (bindingType == vkb::BindingType::Cpp)
-	{
-		return &debug_report_callback_create_info;
-	}
-	else
-	{
-		return reinterpret_cast<VkDebugReportCallbackCreateInfoEXT *>(&debug_report_callback_create_info);
-	}
-#else
-	return nullptr;
-#endif
-}
-
-template <vkb::BindingType bindingType>
-inline typename VulkanSample<bindingType>::DebugUtilsMessengerCreateInfoType const *VulkanSample<bindingType>::get_debug_utils_messenger_create_info() const
-{
-#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-	static vk::DebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info{.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning,
-	                                                                              .messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance,
-	                                                                              .pfnUserCallback = vkb::core::debug_utils_messenger_callback};
-	if constexpr (bindingType == vkb::BindingType::Cpp)
-	{
-		return &debug_utils_messenger_create_info;
-	}
-	else
-	{
-		return reinterpret_cast<VkDebugUtilsMessengerCreateInfoEXT *>(&debug_utils_messenger_create_info);
-	}
-#else
-	return nullptr;
-#endif
 }
 
 template <vkb::BindingType bindingType>
@@ -932,6 +901,23 @@ inline vkb::core::Device<bindingType> &VulkanSample<bindingType>::get_device()
 		return reinterpret_cast<vkb::core::DeviceC &>(*device);
 	}
 }
+
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+template <vkb::BindingType bindingType>
+inline vk::DebugReportCallbackCreateInfoEXT VulkanSample<bindingType>::get_debug_report_callback_create_info() const
+{
+	return {.flags       = vk::DebugReportFlagBitsEXT::eError | vk::DebugReportFlagBitsEXT::eWarning | vk::DebugReportFlagBitsEXT::ePerformanceWarning,
+	        .pfnCallback = vkb::core::debug_callback};
+}
+
+template <vkb::BindingType bindingType>
+inline vk::DebugUtilsMessengerCreateInfoEXT VulkanSample<bindingType>::get_debug_utils_messenger_create_info() const
+{
+	return {.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning,
+	        .messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance,
+	        .pfnUserCallback = vkb::core::debug_utils_messenger_callback};
+}
+#endif
 
 template <vkb::BindingType bindingType>
 inline std::unordered_map<const char *, bool> const &VulkanSample<bindingType>::get_device_extensions() const
@@ -1253,32 +1239,46 @@ inline bool VulkanSample<bindingType>::prepare(const ApplicationOptions &options
 	// initialize debug utils or report callback based on enabled extensions, if any
 	if (instance->is_extension_enabled(VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
 	{
-		auto const *debug_utils_messenger_create_info = get_debug_utils_messenger_create_info();
+		vkb::StructureChainBuilderCpp<vk::DebugUtilsMessengerCreateInfoEXT> scb;
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+		scb.set_anchor_struct(get_debug_utils_messenger_create_info());
+#endif
+
+		if constexpr (bindingType == BindingType::Cpp)
+		{
+			extend_debug_utils_messenger_create_info(scb);
+		}
+		else
+		{
+			extend_debug_utils_messenger_create_info(reinterpret_cast<vkb::StructureChainBuilderC<VkDebugUtilsMessengerCreateInfoEXT> &>(scb));
+		}
+
+		vk::DebugUtilsMessengerCreateInfoEXT const *debug_utils_messenger_create_info = scb.get_struct<vk::DebugUtilsMessengerCreateInfoEXT>();
 		if (debug_utils_messenger_create_info)
 		{
-			if constexpr (bindingType == BindingType::Cpp)
-			{
-				debug_utils_messenger = instance->get_handle().createDebugUtilsMessengerEXT(*debug_utils_messenger_create_info);
-			}
-			else
-			{
-				debug_utils_messenger = instance->get_handle().createDebugUtilsMessengerEXT(*reinterpret_cast<vk::DebugUtilsMessengerCreateInfoEXT const *>(debug_utils_messenger_create_info));
-			}
+			debug_utils_messenger = instance->get_handle().createDebugUtilsMessengerEXT(*debug_utils_messenger_create_info);
 		}
 	}
 	else if (instance->is_extension_enabled(VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
 	{
-		auto const *debug_report_callback_create_info = get_debug_report_callback_create_info();
+		vkb::StructureChainBuilderCpp<vk::DebugReportCallbackCreateInfoEXT> scb;
+#if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
+		scb.set_anchor_struct(get_debug_report_callback_create_info());
+#endif
+
+		if constexpr (bindingType == BindingType::Cpp)
+		{
+			extend_debug_report_callback_create_info(scb);
+		}
+		else
+		{
+			extend_debug_report_callback_create_info(reinterpret_cast<vkb::StructureChainBuilderC<VkDebugReportCallbackCreateInfoEXT> &>(scb));
+		}
+
+		vk::DebugReportCallbackCreateInfoEXT const *debug_report_callback_create_info = scb.get_struct<vk::DebugReportCallbackCreateInfoEXT>();
 		if (debug_report_callback_create_info)
 		{
-			if constexpr (bindingType == BindingType::Cpp)
-			{
-				debug_report_callback = instance->get_handle().createDebugReportCallbackEXT(*debug_report_callback_create_info);
-			}
-			else
-			{
-				debug_report_callback = instance->get_handle().createDebugReportCallbackEXT(*reinterpret_cast<vk::DebugReportCallbackCreateInfoEXT const *>(debug_report_callback_create_info));
-			}
+			debug_report_callback = instance->get_handle().createDebugReportCallbackEXT(*debug_report_callback_create_info);
 		}
 	}
 

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -458,27 +458,38 @@ bool ShaderDebugPrintf::prepare(const vkb::ApplicationOptions &options)
 	return true;
 }
 
+VkDebugUtilsMessengerCreateInfoEXT ShaderDebugPrintf::get_debug_utils_messenger_create_info() const
+{
+	return {.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
+	        .pNext           = nullptr,
+	        .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
+	        .messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+	        .pfnUserCallback = debug_utils_message_callback,
+	        .pUserData       = nullptr};
+}
+
 void ShaderDebugPrintf::extend_instance_create_info(vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const
 {
 	ApiVulkanSample::extend_instance_create_info(scb);
 
 	// Register a sample specific debug utils callback in addition to the one registered by the base class
-	VkDebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info{.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
-	                                                                     .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
-	                                                                     .messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
-	                                                                     .pfnUserCallback = debug_utils_message_callback};
-	scb.add_struct(debug_utils_messenger_create_info);
+	scb.add_struct(get_debug_utils_messenger_create_info());
 }
 
-VkDebugUtilsMessengerCreateInfoEXT const *ShaderDebugPrintf::get_debug_utils_messenger_create_info() const
+void ShaderDebugPrintf::extend_debug_utils_messenger_create_info(vkb::StructureChainBuilderC<VkDebugUtilsMessengerCreateInfoEXT> &scb) const
 {
+	ApiVulkanSample::extend_debug_utils_messenger_create_info(scb);
+
 	// Register a sample specific debug utils callback in addition to the one registered by the base class
-	static VkDebugUtilsMessengerCreateInfoEXT local_debug_utils_messenger_create_info{.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
-	                                                                                  .pNext           = ApiVulkanSample::get_debug_utils_messenger_create_info(),
-	                                                                                  .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
-	                                                                                  .messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
-	                                                                                  .pfnUserCallback = debug_utils_message_callback};
-	return &local_debug_utils_messenger_create_info;
+#if 0
+	scb.add_struct(get_debug_utils_messenger_create_info());
+#else
+	// for some unknown reason, this VkDebugUtilsMessengerCreateInfoEXT needs to be the first one!
+	// That is, we need to replace the current anchor with this one, and add the current anchor as the second struct in the chain.
+	VkDebugUtilsMessengerCreateInfoEXT tmp = *scb.get_struct<VkDebugUtilsMessengerCreateInfoEXT>();
+	scb.set_anchor_struct(get_debug_utils_messenger_create_info());
+	scb.add_struct(tmp);
+#endif
 }
 
 void ShaderDebugPrintf::render(float delta_time)

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -481,15 +481,11 @@ void ShaderDebugPrintf::extend_debug_utils_messenger_create_info(vkb::StructureC
 	ApiVulkanSample::extend_debug_utils_messenger_create_info(scb);
 
 	// Register a sample specific debug utils callback in addition to the one registered by the base class
-#if 0
-	scb.add_struct(get_debug_utils_messenger_create_info());
-#else
 	// for some unknown reason, this VkDebugUtilsMessengerCreateInfoEXT needs to be the first one!
 	// That is, we need to replace the current anchor with this one, and add the current anchor as the second struct in the chain.
 	VkDebugUtilsMessengerCreateInfoEXT tmp = *scb.get_struct<VkDebugUtilsMessengerCreateInfoEXT>();
 	scb.set_anchor_struct(get_debug_utils_messenger_create_info());
 	scb.add_struct(tmp);
-#endif
 }
 
 void ShaderDebugPrintf::render(float delta_time)

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.cpp
@@ -61,6 +61,8 @@ ShaderDebugPrintf::~ShaderDebugPrintf()
 		vkDestroyDescriptorSetLayout(get_device().get_handle(), descriptor_set_layout, nullptr);
 
 		vkDestroySampler(get_device().get_handle(), textures.skysphere.sampler, nullptr);
+
+		vkDestroyDebugUtilsMessengerEXT(get_instance().get_handle(), debug_utils_messenger, nullptr);
 	}
 }
 
@@ -440,6 +442,12 @@ bool ShaderDebugPrintf::prepare(const vkb::ApplicationOptions &options)
 		return false;
 	}
 
+	// Register a sample specific debug utils callback in addition to the one registered by the base class
+	if (get_instance().is_extension_enabled(VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
+	{
+		vkCreateDebugUtilsMessengerEXT(get_instance().get_handle(), &get_debug_utils_messenger_create_info(), nullptr, &debug_utils_messenger);
+	}
+
 	camera.type = vkb::CameraType::LookAt;
 	camera.set_position(glm::vec3(0.0f, 0.0f, -6.0f));
 	camera.set_rotation(glm::vec3(0.0f, 180.0f, 0.0f));
@@ -458,14 +466,16 @@ bool ShaderDebugPrintf::prepare(const vkb::ApplicationOptions &options)
 	return true;
 }
 
-VkDebugUtilsMessengerCreateInfoEXT ShaderDebugPrintf::get_debug_utils_messenger_create_info() const
+VkDebugUtilsMessengerCreateInfoEXT const &ShaderDebugPrintf::get_debug_utils_messenger_create_info() const
 {
-	return {.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
-	        .pNext           = nullptr,
-	        .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
-	        .messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
-	        .pfnUserCallback = debug_utils_message_callback,
-	        .pUserData       = nullptr};
+	static VkDebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info =
+	    {.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
+	     .pNext           = nullptr,
+	     .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
+	     .messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+	     .pfnUserCallback = debug_utils_message_callback,
+	     .pUserData       = nullptr};
+	return debug_utils_messenger_create_info;
 }
 
 void ShaderDebugPrintf::extend_instance_create_info(vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const
@@ -474,18 +484,6 @@ void ShaderDebugPrintf::extend_instance_create_info(vkb::StructureChainBuilderC<
 
 	// Register a sample specific debug utils callback in addition to the one registered by the base class
 	scb.add_struct(get_debug_utils_messenger_create_info());
-}
-
-void ShaderDebugPrintf::extend_debug_utils_messenger_create_info(vkb::StructureChainBuilderC<VkDebugUtilsMessengerCreateInfoEXT> &scb) const
-{
-	ApiVulkanSample::extend_debug_utils_messenger_create_info(scb);
-
-	// Register a sample specific debug utils callback in addition to the one registered by the base class
-	// for some unknown reason, this VkDebugUtilsMessengerCreateInfoEXT needs to be the first one!
-	// That is, we need to replace the current anchor with this one, and add the current anchor as the second struct in the chain.
-	VkDebugUtilsMessengerCreateInfoEXT tmp = *scb.get_struct<VkDebugUtilsMessengerCreateInfoEXT>();
-	scb.set_anchor_struct(get_debug_utils_messenger_create_info());
-	scb.add_struct(tmp);
 }
 
 void ShaderDebugPrintf::render(float delta_time)

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.h
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.h
@@ -80,30 +80,32 @@ class ShaderDebugPrintf : public ApiVulkanSample
 
 	ShaderDebugPrintf();
 	~ShaderDebugPrintf();
-	void                                              request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
-	void                                              request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
-	void                                              request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
-	void                                              request_validation_feature_enables(std::vector<ValidationFeatureEnableType> &requested_layer_settings) const override;
-	void                                              build_command_buffers() override;
-	void                                              load_assets();
-	void                                              setup_descriptor_pool();
-	void                                              setup_descriptor_set_layout();
-	void                                              setup_descriptor_sets();
-	void                                              prepare_pipelines();
-	void                                              prepare_uniform_buffers();
-	void                                              update_uniform_buffers();
-	void                                              draw();
-	bool                                              prepare(const vkb::ApplicationOptions &options) override;
-	virtual void                                      extend_instance_create_info(vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
-	virtual VkDebugUtilsMessengerCreateInfoEXT const *get_debug_utils_messenger_create_info() const override;
-	virtual void                                      render(float delta_time) override;
-	virtual void                                      on_update_ui_overlay(vkb::Drawer &drawer) override;
-	virtual bool                                      resize(const uint32_t width, const uint32_t height) override;
+	void         request_gpu_features(vkb::core::PhysicalDeviceC &gpu) override;
+	void         request_instance_extensions(std::unordered_map<std::string, vkb::RequestMode> &requested_extensions) const override;
+	void         request_layer_settings(std::vector<VkLayerSettingEXT> &requested_layer_settings, vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
+	void         request_validation_feature_enables(std::vector<ValidationFeatureEnableType> &requested_layer_settings) const override;
+	void         build_command_buffers() override;
+	void         load_assets();
+	void         setup_descriptor_pool();
+	void         setup_descriptor_set_layout();
+	void         setup_descriptor_sets();
+	void         prepare_pipelines();
+	void         prepare_uniform_buffers();
+	void         update_uniform_buffers();
+	void         draw();
+	bool         prepare(const vkb::ApplicationOptions &options) override;
+	virtual void extend_instance_create_info(vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
+	virtual void extend_debug_utils_messenger_create_info(vkb::StructureChainBuilderC<VkDebugUtilsMessengerCreateInfoEXT> &scb) const override;
+	virtual void render(float delta_time) override;
+	virtual void on_update_ui_overlay(vkb::Drawer &drawer) override;
+	virtual bool resize(const uint32_t width, const uint32_t height) override;
 
   private:
 	// from vkb::VulkanSample
 	virtual uint32_t get_api_version() const override;
 	virtual void     request_layers(std::unordered_map<std::string, vkb::RequestMode> &requested_layers) const override;
+
+	VkDebugUtilsMessengerCreateInfoEXT get_debug_utils_messenger_create_info() const;
 };
 
 std::unique_ptr<vkb::Application> create_shader_debugprintf();

--- a/samples/extensions/shader_debugprintf/shader_debugprintf.h
+++ b/samples/extensions/shader_debugprintf/shader_debugprintf.h
@@ -95,7 +95,6 @@ class ShaderDebugPrintf : public ApiVulkanSample
 	void         draw();
 	bool         prepare(const vkb::ApplicationOptions &options) override;
 	virtual void extend_instance_create_info(vkb::StructureChainBuilderC<VkInstanceCreateInfo> &scb) const override;
-	virtual void extend_debug_utils_messenger_create_info(vkb::StructureChainBuilderC<VkDebugUtilsMessengerCreateInfoEXT> &scb) const override;
 	virtual void render(float delta_time) override;
 	virtual void on_update_ui_overlay(vkb::Drawer &drawer) override;
 	virtual bool resize(const uint32_t width, const uint32_t height) override;
@@ -105,7 +104,10 @@ class ShaderDebugPrintf : public ApiVulkanSample
 	virtual uint32_t get_api_version() const override;
 	virtual void     request_layers(std::unordered_map<std::string, vkb::RequestMode> &requested_layers) const override;
 
-	VkDebugUtilsMessengerCreateInfoEXT get_debug_utils_messenger_create_info() const;
+	VkDebugUtilsMessengerCreateInfoEXT const &get_debug_utils_messenger_create_info() const;
+
+  private:
+	VkDebugUtilsMessengerEXT debug_utils_messenger{VK_NULL_HANDLE};
 };
 
 std::unique_ptr<vkb::Application> create_shader_debugprintf();


### PR DESCRIPTION
## Description

Using `VkDebugUtilsMessengerCreateInfoEXT` needs special consideration, depending on where it is used.
- `VkDebugUtilsMessengerCreateInfoEXT` is specified to extend `VkInstanceCreateInfo`, and multiple instances of it in that extension chain are allowed. That is, with multiple `VkDebugUtilsMessengerCreateInfoEXT`s in that chain, multiple callbacks are created on instance creation, but just for a very short period of time.
- `VkDebugUtilsMessengerCreateInfoEXT` is not specified to extend itself! That is, with multiple instances of it in the pNext-chain for vkCreateDebugUtilsMessengerEXT, just the very first `VkDebugUtilsMessengerCreateInfoEXT` in that chain is used to create a callback. Actually, I would have expected that the validation layers would fire a warning with such a usage.

The sample `shader_debugprintf` used an additional `VkDebugUtilsMessengerCreateInfoEXT` for both, Instance and DebugUtilsMessenger creation. Now, a separate local DebugUtilsMessenger is created to have both callbacks, the one from the sample and the one from the framework, alive.

Build tested on Win11 with VS2022. Run tested on Win11 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
