### PR TITLE
Add VKB_BUILD_SHADERS cmake option to control shader build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,5 +194,5 @@ jobs:
       - name: build_ios
         run: |
           source ~/VulkanSDK/iOS/setup-env.sh
-          cmake -H"." -B"build/ios" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_DEPLOYMENT_TARGET=16.3 -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
+          cmake -H"." -B"build/ios" -DVKB_BUILD_TESTS=ON -DVKB_BUILD_SAMPLES=ON -DVKB_BUILD_SHADERS=OFF -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_DEPLOYMENT_TARGET=16.3 -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
           cmake --build "build/ios" --target vulkan_samples --config ${{ matrix.build_type }} -- -allowProvisioningUpdates

--- a/bldsys/cmake/global_options.cmake
+++ b/bldsys/cmake/global_options.cmake
@@ -1,5 +1,5 @@
 #[[
- Copyright (c) 2019-2025, Arm Limited and Contributors
+ Copyright (c) 2019-2026, Arm Limited and Contributors
 
  SPDX-License-Identifier: Apache-2.0
 
@@ -120,6 +120,7 @@ set(VKB_VALIDATION_LAYERS_BEST_PRACTICES OFF CACHE BOOL "Enable best practices v
 set(VKB_VALIDATION_LAYERS_SYNCHRONIZATION OFF CACHE BOOL "Enable synchronization validation layers for every application (implicitly enables VKB_VALIDATION_LAYERS).")
 set(VKB_VULKAN_DEBUG ON CACHE BOOL "Enable VK_EXT_debug_utils or VK_EXT_debug_marker if supported.")
 set(VKB_BUILD_SAMPLES ON CACHE BOOL "Enable generation and building of Vulkan best practice samples.")
+set(VKB_BUILD_SHADERS ON CACHE BOOL "Enable shader compilation for all supported shading languages.")
 set(VKB_BUILD_TESTS OFF CACHE BOOL "Enable generation and building of Vulkan best practice tests.")
 set(VKB_WSI_SELECTION "XCB" CACHE STRING "Select WSI target (XCB, XLIB, WAYLAND, D2D)")
 set(VKB_CLANG_TIDY OFF CACHE STRING "Use CMake Clang Tidy integration")

--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -1,7 +1,7 @@
 #[[
- Copyright (c) 2019-2025, Arm Limited and Contributors
- Copyright (c) 2024-2025, Mobica Limited
- Copyright (c) 2024-2025, Sascha Willems
+ Copyright (c) 2019-2026, Arm Limited and Contributors
+ Copyright (c) 2024-2026, Mobica Limited
+ Copyright (c) 2024-2026, Sascha Willems
 
  SPDX-License-Identifier: Apache-2.0
 
@@ -197,7 +197,7 @@ endif()
     endif()
 
     # HLSL compilation via DXC
-    if(Vulkan_dxc_EXECUTABLE AND DEFINED SHADERS_HLSL)
+    if(VKB_BUILD_SHADERS AND Vulkan_dxc_EXECUTABLE AND DEFINED SHADERS_HLSL)
         set(OUTPUT_FILES "")
         set(HLSL_TARGET_NAME ${PROJECT_NAME}-HLSL)
         foreach(SHADER_FILE_HLSL ${TARGET_SHADERS_HLSL})
@@ -256,16 +256,7 @@ endif()
     endif()
 
     # Slang shader compilation
-    # Skip on MacOS/iOS due to CI/CD using potentially broken slang compiler versions from the SDK
-    # Might revisit once Slang shipped with the SDK is usable
-    set(SLANG_SKIP_COMPILE false)
-    if (($ENV{CI} MATCHES true) AND ((CMAKE_SYSTEM_NAME MATCHES "Darwin") OR (CMAKE_SYSTEM_NAME MATCHES "iOS")))
-        set(SLANG_SKIP_COMPILE true)
-    endif()
-    if(VKB_SKIP_SLANG_SHADER_COMPILATION)
-        set(SLANG_SKIP_COMPILE true)
-    endif()
-    if(NOT SLANG_SKIP_COMPILE AND Vulkan_slang_EXECUTABLE AND DEFINED SHADERS_SLANG)
+    if(VKB_BUILD_SHADERS AND NOT VKB_SKIP_SLANG_SHADER_COMPILATION AND Vulkan_slang_EXECUTABLE AND DEFINED SHADERS_SLANG)
         set(OUTPUT_FILES "")
         set(SLANG_TARGET_NAME ${PROJECT_NAME}-SLANG)
         foreach(SHADER_FILE_SLANG ${TARGET_SHADERS_SLANG})
@@ -297,7 +288,7 @@ endif()
     endif()
 
     # GLSL shader compilation
-    if(Vulkan_glslc_EXECUTABLE AND DEFINED SHADERS_GLSL)
+    if(VKB_BUILD_SHADERS AND Vulkan_glslc_EXECUTABLE AND DEFINED SHADERS_GLSL)
         set(GLSL_TARGET_NAME ${PROJECT_NAME}-GLSL)
         set(OUTPUT_FILES "")
         foreach(SHADER_FILE_GLSL ${TARGET_SHADERS_GLSL})
@@ -343,7 +334,7 @@ endif()
     endif()
 
     # spvasm shader compilation
-    if(Vulkan_spirvas_EXECUTABLE AND DEFINED SHADERS_SPVASM)
+    if(VKB_BUILD_SHADERS AND Vulkan_spirvas_EXECUTABLE AND DEFINED SHADERS_SPVASM)
         set(SPVASM_TARGET_NAME ${PROJECT_NAME}-SPVASM)
         set(OUTPUT_FILES "")
         foreach(SHADER_FILE_SPVASM ${TARGET_SHADERS_SPVASM})


### PR DESCRIPTION
## Description

This PR adds a new `VKB_BUILD_SHADERS` cmake option (default `ON`) to control whether shaders are built for the project.  Currently shaders are always built even though they are already available in pre-built form as part of the project.  This seems wasteful unless the end-user actually wants to modify shaders and rebuild.  In addition, this adds to build time for a project that already has long build duration (~9 minutes).

As part of this PR, this new option is used to turn off shader compilation for iOS CI builds.  iOS is unique in that it requires the SDK to be available during CI for packaging and app bundle creation reasons.  A side-effect of this is that shader compilers are therefore available to the iOS CI build and shaders are always built, which is wasteful.

This PR also removes a short term workaround that @SaschaWillems put in place disabling slang shader compilation for iOS CI builds.  This is no longer needed for several reasons: a) current iOS/macOS SDKs contain working slang compilers, and b) the new `VKB_BUILD_SHADERS` option is used to turn off shader compilation for iOS CI in this PR.

Some project build time comparisons (with SDK and/or shader compilers installed):

macOS Sequoia on x86_64 6C/12T using Xcode 26.3 debug build:
`VKB_BUILD_SHADERS=ON`: 490 seconds
`VKB_BUILD_SHADERS=OFF`: 413 seconds (14% improvement)

Windows 11 VS 2019 debug build (exact same machine as above but booted into Windows 11):
`VKB_BUILD_SHADERS=ON`: 517 seconds
`VKB_BUILD_SHADERS=OFF`: 480 seconds (7% improvement)

Note I have set the default value for `VKB_BUILD_SHADERS` to be `ON` for backwards compatibility, there may be a good argument to set the default value to `OFF`.  I will wait for feedback from maintainers on this point.

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
