### PR TITLE
Fix potential deadlock in timeline_semaphore sample

### DIFF
--- a/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
+++ b/samples/extensions/timeline_semaphore/timeline_semaphore.cpp
@@ -262,10 +262,10 @@ void TimelineSemaphore::signal_next_frame()
 }
 
 // Waits for the timeline to reach MAX_STAGES for the current frame
-void TimelineSemaphore::wait_for_next_frame()
+void TimelineSemaphore::wait_for_next_frame(const uint64_t nextFrame)
 {
 	// MAX_STAGES is used as it provides a boundary value between the stages of this frame and the next
-	const uint64_t waitValue = (timeline.frame + 1) * Timeline::MAX_STAGES;
+	const uint64_t waitValue = nextFrame * Timeline::MAX_STAGES;
 
 	VkSemaphoreWaitInfo waitInfo;
 	waitInfo.sType          = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
@@ -307,13 +307,17 @@ void TimelineSemaphore::do_compute_work()
 		submit_info.signalSemaphoreCount = 1;
 		submit_info.pSignalSemaphores    = &timeline.semaphore;
 
+		// Define next frame prior to queue submit to prevent potential deadlock in wait_for_next_frame(). This can happen due to incorrect
+		// waitValue caused by signalling the main thread to advance the frame before completion of wait_for_next_frame() in worker threads
+		uint64_t nextFrame = timeline.frame + 1;
+
 		// If the threads are being killed, we need to skip the queue submission to allow the program to exit gracefully
 		if (compute_worker.alive)
 		{
 			VK_CHECK(vkQueueSubmit(compute.queue, 1, &submit_info, VK_NULL_HANDLE));
 		}
 
-		wait_for_next_frame();
+		wait_for_next_frame(nextFrame);
 	}
 }
 
@@ -485,13 +489,17 @@ void TimelineSemaphore::do_graphics_work()
 			wait_on_timeline(Timeline::draw);
 		}
 
+		// Define next frame prior to queue submit to prevent potential deadlock in wait_for_next_frame(). This can happen due to incorrect
+		// waitValue caused by signalling the main thread to advance the frame before completion of wait_for_next_frame() in worker threads
+		uint64_t nextFrame = timeline.frame + 1;
+
 		// If the threads are being killed, we need to skip the queue submission to allow the program to exit gracefully
 		if (graphics_worker.alive)
 		{
 			VK_CHECK(vkQueueSubmit(graphics.queue, 1, &submit_info, VK_NULL_HANDLE));
 		}
 
-		wait_for_next_frame();
+		wait_for_next_frame(nextFrame);
 	}
 }
 

--- a/samples/extensions/timeline_semaphore/timeline_semaphore.h
+++ b/samples/extensions/timeline_semaphore/timeline_semaphore.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, Arm Limited and Contributors
+/* Copyright (c) 2021-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -104,7 +104,7 @@ class TimelineSemaphore : public ApiVulkanSample
 	void     signal_timeline(const Timeline::Stages stage);
 	void     wait_on_timeline(const Timeline::Stages stage);
 	void     signal_next_frame();
-	void     wait_for_next_frame();
+	void     wait_for_next_frame(const uint64_t nextFrame);
 	uint64_t get_timeline_stage_value(const Timeline::Stages stage);
 
 	// Compute Work


### PR DESCRIPTION
## Description

This fixes a deadlock in the _timeline_semaphore_ sample where there can be a race condition in the setting of timeline wait condition variable `waitValue` based on the current frame.  This can happen when a worker thread signals the main thread to advance the frame before completion of `wait_for_next_frame()` in either worker thread.  To fix this, `nextFrame` is defined within the worker threads **_before_** queue submit, and then passed into `wait_for_next_frame(nextFrame)` after queue submit to avoid the race condition.

Fixes #1525

Tested on Windows 11 and macOS Sequoia x86_64.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [ ] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [x] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
