### PR TITLE
Add missing constructor implementation of vkb::core::PhysicalDeviceC

### DIFF
--- a/framework/core/physical_device.h
+++ b/framework/core/physical_device.h
@@ -163,6 +163,7 @@ class PhysicalDevice
 	template <typename FeatureType>
 	FeatureType get_extension_features_impl();
 	uint32_t    get_memory_type_impl(uint32_t bits, vk::MemoryPropertyFlags properties, vk::Bool32 *memory_type_found = nullptr) const;
+	void        init();
 	template <typename FeatureType>
 	void request_required_feature_impl(vk::Bool32 FeatureType::*flag, std::string const &featureName, std::string const &flagName);
 
@@ -187,15 +188,28 @@ using PhysicalDeviceCpp = PhysicalDevice<vkb::BindingType::Cpp>;
 #define REQUEST_OPTIONAL_FEATURE(gpu, Feature, flag) gpu.request_optional_feature<Feature>(&Feature::flag, #Feature, #flag)
 #define REQUEST_REQUIRED_FEATURE(gpu, Feature, flag) gpu.request_required_feature<Feature>(&Feature::flag, #Feature, #flag)
 
-template <vkb::BindingType bindingType>
-inline PhysicalDevice<bindingType>::PhysicalDevice(vkb::core::Instance<bindingType> &instance, PhysicalDeviceType physical_device) :
+template <>
+inline PhysicalDeviceC::PhysicalDevice(vkb::core::InstanceC &instance, VkPhysicalDevice physical_device) :
+    instance{reinterpret_cast<vkb::core::InstanceCpp &>(instance)}, handle{physical_device}
+{
+	init();
+}
+
+template <>
+inline PhysicalDeviceCpp::PhysicalDevice(vkb::core::InstanceCpp &instance, vk::PhysicalDevice physical_device) :
     instance{instance}, handle{physical_device}
 {
-	features                = physical_device.getFeatures();
-	properties              = physical_device.getProperties();
-	memory_properties       = physical_device.getMemoryProperties();
-	queue_family_properties = physical_device.getQueueFamilyProperties();
-	device_extensions       = physical_device.enumerateDeviceExtensionProperties();
+	init();
+}
+
+template <vkb::BindingType bindingType>
+inline void PhysicalDevice<bindingType>::init()
+{
+	features                = handle.getFeatures();
+	properties              = handle.getProperties();
+	memory_properties       = handle.getMemoryProperties();
+	queue_family_properties = handle.getQueueFamilyProperties();
+	device_extensions       = handle.enumerateDeviceExtensionProperties();
 
 	LOGI("Found GPU: {}", properties.deviceName.data());
 

--- a/framework/core/physical_device.h
+++ b/framework/core/physical_device.h
@@ -189,14 +189,14 @@ using PhysicalDeviceCpp = PhysicalDevice<vkb::BindingType::Cpp>;
 #define REQUEST_REQUIRED_FEATURE(gpu, Feature, flag) gpu.request_required_feature<Feature>(&Feature::flag, #Feature, #flag)
 
 template <>
-inline PhysicalDeviceC::PhysicalDevice(vkb::core::InstanceC &instance, VkPhysicalDevice physical_device) :
+inline PhysicalDevice<vkb::BindingType::C>::PhysicalDevice(vkb::core::InstanceC &instance, VkPhysicalDevice physical_device) :
     instance{reinterpret_cast<vkb::core::InstanceCpp &>(instance)}, handle{physical_device}
 {
 	init();
 }
 
 template <>
-inline PhysicalDeviceCpp::PhysicalDevice(vkb::core::InstanceCpp &instance, vk::PhysicalDevice physical_device) :
+inline PhysicalDevice<vkb::BindingType::Cpp>::PhysicalDevice(vkb::core::InstanceCpp &instance, vk::PhysicalDevice physical_device) :
     instance{instance}, handle{physical_device}
 {
 	init();


### PR DESCRIPTION
## Description

Build tested on Win11 with VS2022. Run tested on Win11 with NVidia GPU.

Fixes #1532

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
