### PR TITLE
Fix slang-compilation by avoiding SV_VertexID in one pixel-stage

### DIFF
--- a/shaders/fragment_shader_barycentric/slang/object.frag.slang
+++ b/shaders/fragment_shader_barycentric/slang/object.frag.slang
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, Mobica Limited
+/* Copyright (c) 2023-2026, Mobica Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/shaders/fragment_shader_barycentric/slang/object.frag.slang
+++ b/shaders/fragment_shader_barycentric/slang/object.frag.slang
@@ -24,7 +24,7 @@ struct VSOutput
 [[vk::binding(1, 0)]] Sampler2D samplerColorMap;
 
 [shader("fragment")]
-float4 main(VSOutput input, float3 baryCoords: SV_Barycentrics, noperspective float3 baryCoordsAffine: SV_Barycentrics, uint vertexIndex: SV_VertexID, uniform int type)
+float4 main(VSOutput input, float3 baryCoords: SV_Barycentrics, noperspective float3 baryCoordsAffine: SV_Barycentrics, uniform int type)
 {
     float3 vColor0 = GetAttributeAtVertex(input.Color, 0);
     float3 vColor1 = GetAttributeAtVertex(input.Color, 1);


### PR DESCRIPTION
- surfaces with `1.4.350.0/x86_64/bin/slangc` (`2026.8`)
- trivially fixed by removing the unused `uint vertexIndex: SV_VertexID`

```
error[E30702]: system value semantic 'SV_VertexID' cannot be used as input in 'pixel' shader stage
  -->.../Vulkan-Samples/shaders/fragment_shader_barycentric/slang/object.frag.slang:27:126
   |
27 | float4 main(VSOutput input, float3 baryCoords: SV_Barycentrics, noperspective float3 baryCoordsAffine: SV_Barycentrics, uint vertexIndex: SV_VertexID, uniform int type)
```