### PR TITLE
chore: Add AI-Assisted Contributions and fix CLA pre-disclosure [skip ci]

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,19 +1,8 @@
 ////
-- Copyright (c) 2019-2024, Arm Limited and Contributors
+- SPDX-FileCopyrightText: 2019-2024, Arm Limited and Contributors
+- SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
 -
 - SPDX-License-Identifier: Apache-2.0
--
-- Licensed under the Apache License, Version 2.0 the "License";
-- you may not use this file except in compliance with the License.
-- You may obtain a copy of the License at
--
--     http://www.apache.org/licenses/LICENSE-2.0
--
-- Unless required by applicable law or agreed to in writing, software
-- distributed under the License is distributed on an "AS IS" BASIS,
-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-- See the License for the specific language governing permissions and
-- limitations under the License.
 -
 ////
 = Contributing
@@ -124,19 +113,9 @@ We also recommend that a file or class name and description of purpose be includ
 When contributing to an existing file you may add a new copyright year line under the existing ones.
 
 ....
-Copyright [yyyy] [name of copyright owner]
+SPDX-FileCopyrightText: [yyyy] [name of copyright owner]
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 ....
 
 == Code Style

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -156,7 +156,18 @@ It is recommended to use `clang-format-15`, which is compatible with the styles 
 . Make sure the sample code builds and runs on Windows, Linux, macOS and Android.
 If you cannot verify on all these target platforms, please note platform restrictions in the sample's README.
 . Verify the sample against a recent version of the Vulkan validation layers, either built from source or from the most recent available Vulkan SDK.
-. Submit a pull request via github for the contribution, including electronically signing the Khronos Contributor License Agreement (CLA) for the repository using CLA-Assistant.
+. Submit a pull request via GitHub for the contribution, including electronically signing the link:https://cla-assistant.io/KhronosGroup/Vulkan-Samples[Khronos Contributor License Agreement (CLA)] for the repository using CLA-Assistant.
+
+== AI-Assisted Contributions
+
+By submitting a Contribution to this repository, you additionally represent
+that, to the extent any of Your Contributions were developed with the
+assistance of artificial intelligence tools or AI-generated code, You have
+exercised sufficient review, judgment, and creative direction over such tools
+and resulting material to reasonably consider it Your original creation, and
+You are not aware of any third-party license, intellectual property claim, or
+other restriction arising from such use that is associated with any part of
+Your Contribution or use thereof.
 
 == Code Reviews
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,4 +1,7 @@
 ////
+- Copyright 2026 The Khronos Group, Inc. 
+- Copyright 2019-2026, Arm Limited and Contributors
+- 
 - SPDX-FileCopyrightText: 2019-2024, Arm Limited and Contributors
 - SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
 -


### PR DESCRIPTION
## Description

This PR adds a legal mandated AI Contributions block of text to the CONTRIBUTIONS file, and adds a link pointing to the CLA on cla-assistant. 