### PR TITLE
Move call to ApiVulkanSample::submit_frame to after submitting both graphics command buffers

### DIFF
--- a/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
+++ b/samples/extensions/fragment_shading_rate_dynamic/fragment_shading_rate_dynamic.cpp
@@ -1053,9 +1053,7 @@ void FragmentShadingRateDynamic::draw()
 	submit_info.pCommandBuffers      = &draw_cmd_buffers[current_buffer];
 	submit_info.signalSemaphoreCount = 2;
 	submit_info.pSignalSemaphores    = semaphores.data();
-
 	VK_CHECK(vkQueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE));
-	ApiVulkanSample::submit_frame();
 
 	const std::array<VkPipelineStageFlags, 2> small_wait_mask = {VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 	                                                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT};
@@ -1088,6 +1086,8 @@ void FragmentShadingRateDynamic::draw()
 	VK_CHECK(vkQueueSubmit(queue, 1, &compute_submit_info, compute_fence));
 	VK_CHECK(vkWaitForFences(get_device().get_handle(), 1, &compute_fence, VK_TRUE, UINT64_MAX));
 	VK_CHECK(vkResetFences(get_device().get_handle(), 1, &compute_fence));
+
+	ApiVulkanSample::submit_frame();
 
 	vkDestroySemaphore(get_device().get_handle(), semaphore, VK_NULL_HANDLE);
 	vkDestroySemaphore(get_device().get_handle(), small_semaphore, VK_NULL_HANDLE);


### PR DESCRIPTION
## Description

Fixes validation layer error
```
vkQueueSubmit(): pSubmits[0] performs a layout transition on presentable VkImage 0x50000000005, but the image has not been acquired from VkSwapchainKHR 0x40000000004 (either never or since the last present operation).
The Vulkan spec states: Use of a presentable image must occur only after the image is returned by vkAcquireNextImageKHR, and before it is released by vkQueuePresentKHR. This includes transitioning the image layout and rendering commands (https://docs.vulkan.org/refpages/latest/refpages/source/VkSwapchainKHR.html#_description)
```

Build tested on Win11 with VS2026. Run tested on Win11 with NVidia GPU.

Note: the left upper part of the window shows a smaller view of the graphics window, its size depends on the "Subpass size reduction" control, hiding parts or all of the GUI. Is that intended?

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [ ] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [x] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [x] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [x] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
