### PR TITLE
Limit line length in framework/core to 120.

### DIFF
--- a/framework/core/.clang-format
+++ b/framework/core/.clang-format
@@ -1,0 +1,111 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     4
+IndentWrappedFunctionNames: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 8
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          ForIndentation
+---
+Language: ObjC
+DisableFormat: true
+...

--- a/framework/core/acceleration_structure.cpp
+++ b/framework/core/acceleration_structure.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, Sascha Willems
+/* Copyright (c) 2021-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -23,12 +23,9 @@ namespace vkb
 {
 namespace core
 {
-AccelerationStructure::AccelerationStructure(vkb::core::DeviceC            &device,
-                                             VkAccelerationStructureTypeKHR type) :
-    device{device},
-    type{type}
-{
-}
+AccelerationStructure::AccelerationStructure(vkb::core::DeviceC &device, VkAccelerationStructureTypeKHR type) :
+    device{device}, type{type}
+{}
 
 AccelerationStructure::~AccelerationStructure()
 {
@@ -53,17 +50,20 @@ uint64_t AccelerationStructure::add_triangle_geometry(vkb::core::BufferC &vertex
                                                       uint64_t            transform_buffer_data_address)
 {
 	VkAccelerationStructureGeometryKHR geometry{};
-	geometry.sType                                          = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
-	geometry.geometryType                                   = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
-	geometry.flags                                          = flags;
-	geometry.geometry.triangles.sType                       = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
-	geometry.geometry.triangles.vertexFormat                = vertex_format;
-	geometry.geometry.triangles.maxVertex                   = max_vertex;
-	geometry.geometry.triangles.vertexStride                = vertex_stride;
-	geometry.geometry.triangles.indexType                   = index_type;
-	geometry.geometry.triangles.vertexData.deviceAddress    = vertex_buffer_data_address == 0 ? vertex_buffer.get_device_address() : vertex_buffer_data_address;
-	geometry.geometry.triangles.indexData.deviceAddress     = index_buffer_data_address == 0 ? index_buffer.get_device_address() : index_buffer_data_address;
-	geometry.geometry.triangles.transformData.deviceAddress = transform_buffer_data_address == 0 ? transform_buffer.get_device_address() : transform_buffer_data_address;
+	geometry.sType                           = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+	geometry.geometryType                    = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
+	geometry.flags                           = flags;
+	geometry.geometry.triangles.sType        = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
+	geometry.geometry.triangles.vertexFormat = vertex_format;
+	geometry.geometry.triangles.maxVertex    = max_vertex;
+	geometry.geometry.triangles.vertexStride = vertex_stride;
+	geometry.geometry.triangles.indexType    = index_type;
+	geometry.geometry.triangles.vertexData.deviceAddress =
+	    vertex_buffer_data_address == 0 ? vertex_buffer.get_device_address() : vertex_buffer_data_address;
+	geometry.geometry.triangles.indexData.deviceAddress =
+	    index_buffer_data_address == 0 ? index_buffer.get_device_address() : index_buffer_data_address;
+	geometry.geometry.triangles.transformData.deviceAddress =
+	    transform_buffer_data_address == 0 ? transform_buffer.get_device_address() : transform_buffer_data_address;
 
 	uint64_t index = geometries.size();
 	geometries.insert({index, {geometry, triangle_count, transform_offset}});
@@ -74,38 +74,47 @@ void AccelerationStructure::update_triangle_geometry(uint64_t                   
                                                      std::unique_ptr<vkb::core::BufferC> &vertex_buffer,
                                                      std::unique_ptr<vkb::core::BufferC> &index_buffer,
                                                      std::unique_ptr<vkb::core::BufferC> &transform_buffer,
-                                                     uint32_t triangle_count, uint32_t max_vertex,
-                                                     VkDeviceSize vertex_stride, uint32_t transform_offset,
-                                                     VkFormat vertex_format, VkGeometryFlagsKHR flags,
-                                                     uint64_t vertex_buffer_data_address,
-                                                     uint64_t index_buffer_data_address,
-                                                     uint64_t transform_buffer_data_address)
+                                                     uint32_t                             triangle_count,
+                                                     uint32_t                             max_vertex,
+                                                     VkDeviceSize                         vertex_stride,
+                                                     uint32_t                             transform_offset,
+                                                     VkFormat                             vertex_format,
+                                                     VkGeometryFlagsKHR                   flags,
+                                                     uint64_t                             vertex_buffer_data_address,
+                                                     uint64_t                             index_buffer_data_address,
+                                                     uint64_t                             transform_buffer_data_address)
 {
-	VkAccelerationStructureGeometryKHR *geometry             = &geometries[triangleUUID].geometry;
-	geometry->sType                                          = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
-	geometry->geometryType                                   = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
-	geometry->flags                                          = flags;
-	geometry->geometry.triangles.sType                       = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
-	geometry->geometry.triangles.vertexFormat                = vertex_format;
-	geometry->geometry.triangles.maxVertex                   = max_vertex;
-	geometry->geometry.triangles.vertexStride                = vertex_stride;
-	geometry->geometry.triangles.indexType                   = VK_INDEX_TYPE_UINT32;
-	geometry->geometry.triangles.vertexData.deviceAddress    = vertex_buffer_data_address == 0 ? vertex_buffer->get_device_address() : vertex_buffer_data_address;
-	geometry->geometry.triangles.indexData.deviceAddress     = index_buffer_data_address == 0 ? index_buffer->get_device_address() : index_buffer_data_address;
-	geometry->geometry.triangles.transformData.deviceAddress = transform_buffer_data_address == 0 ? transform_buffer->get_device_address() : transform_buffer_data_address;
-	geometries[triangleUUID].primitive_count                 = triangle_count;
-	geometries[triangleUUID].transform_offset                = transform_offset;
-	geometries[triangleUUID].updated                         = true;
+	VkAccelerationStructureGeometryKHR *geometry = &geometries[triangleUUID].geometry;
+	geometry->sType                              = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+	geometry->geometryType                       = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
+	geometry->flags                              = flags;
+	geometry->geometry.triangles.sType           = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
+	geometry->geometry.triangles.vertexFormat    = vertex_format;
+	geometry->geometry.triangles.maxVertex       = max_vertex;
+	geometry->geometry.triangles.vertexStride    = vertex_stride;
+	geometry->geometry.triangles.indexType       = VK_INDEX_TYPE_UINT32;
+	geometry->geometry.triangles.vertexData.deviceAddress =
+	    vertex_buffer_data_address == 0 ? vertex_buffer->get_device_address() : vertex_buffer_data_address;
+	geometry->geometry.triangles.indexData.deviceAddress =
+	    index_buffer_data_address == 0 ? index_buffer->get_device_address() : index_buffer_data_address;
+	geometry->geometry.triangles.transformData.deviceAddress =
+	    transform_buffer_data_address == 0 ? transform_buffer->get_device_address() : transform_buffer_data_address;
+	geometries[triangleUUID].primitive_count  = triangle_count;
+	geometries[triangleUUID].transform_offset = transform_offset;
+	geometries[triangleUUID].updated          = true;
 }
 
-uint64_t AccelerationStructure::add_instance_geometry(std::unique_ptr<vkb::core::BufferC> &instance_buffer, uint32_t instance_count, uint32_t transform_offset, VkGeometryFlagsKHR flags)
+uint64_t AccelerationStructure::add_instance_geometry(std::unique_ptr<vkb::core::BufferC> &instance_buffer,
+                                                      uint32_t                             instance_count,
+                                                      uint32_t                             transform_offset,
+                                                      VkGeometryFlagsKHR                   flags)
 {
 	VkAccelerationStructureGeometryKHR geometry{};
-	geometry.sType                                 = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
-	geometry.geometryType                          = VK_GEOMETRY_TYPE_INSTANCES_KHR;
-	geometry.flags                                 = flags;
-	geometry.geometry.instances.sType              = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
-	geometry.geometry.instances.arrayOfPointers    = VK_FALSE;
+	geometry.sType                              = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+	geometry.geometryType                       = VK_GEOMETRY_TYPE_INSTANCES_KHR;
+	geometry.flags                              = flags;
+	geometry.geometry.instances.sType           = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
+	geometry.geometry.instances.arrayOfPointers = VK_FALSE;
 	geometry.geometry.instances.data.deviceAddress = instance_buffer->get_device_address();
 
 	uint64_t index = geometries.size();
@@ -115,22 +124,25 @@ uint64_t AccelerationStructure::add_instance_geometry(std::unique_ptr<vkb::core:
 
 void AccelerationStructure::update_instance_geometry(uint64_t                             instance_UID,
                                                      std::unique_ptr<vkb::core::BufferC> &instance_buffer,
-                                                     uint32_t instance_count, uint32_t transform_offset,
-                                                     VkGeometryFlagsKHR flags)
+                                                     uint32_t                             instance_count,
+                                                     uint32_t                             transform_offset,
+                                                     VkGeometryFlagsKHR                   flags)
 {
-	VkAccelerationStructureGeometryKHR *geometry    = &geometries[instance_UID].geometry;
-	geometry->sType                                 = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
-	geometry->geometryType                          = VK_GEOMETRY_TYPE_INSTANCES_KHR;
-	geometry->flags                                 = flags;
-	geometry->geometry.instances.sType              = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
-	geometry->geometry.instances.arrayOfPointers    = VK_FALSE;
+	VkAccelerationStructureGeometryKHR *geometry = &geometries[instance_UID].geometry;
+	geometry->sType                              = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+	geometry->geometryType                       = VK_GEOMETRY_TYPE_INSTANCES_KHR;
+	geometry->flags                              = flags;
+	geometry->geometry.instances.sType           = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
+	geometry->geometry.instances.arrayOfPointers = VK_FALSE;
 	geometry->geometry.instances.data.deviceAddress = instance_buffer->get_device_address();
 	geometries[instance_UID].primitive_count        = instance_count;
 	geometries[instance_UID].transform_offset       = transform_offset;
 	geometries[instance_UID].updated                = true;
 }
 
-void AccelerationStructure::build(VkQueue queue, VkBuildAccelerationStructureFlagsKHR flags, VkBuildAccelerationStructureModeKHR mode)
+void AccelerationStructure::build(VkQueue                              queue,
+                                  VkBuildAccelerationStructureFlagsKHR flags,
+                                  VkBuildAccelerationStructureModeKHR  mode)
 {
 	assert(!geometries.empty());
 
@@ -170,28 +182,28 @@ void AccelerationStructure::build(VkQueue queue, VkBuildAccelerationStructureFla
 
 	// Get required build sizes
 	build_sizes_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
-	vkGetAccelerationStructureBuildSizesKHR(
-	    device.get_handle(),
-	    VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
-	    &build_geometry_info,
-	    primitive_counts.data(),
-	    &build_sizes_info);
+	vkGetAccelerationStructureBuildSizesKHR(device.get_handle(),
+	                                        VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
+	                                        &build_geometry_info,
+	                                        primitive_counts.data(),
+	                                        &build_sizes_info);
 
 	// Create a buffer for the acceleration structure
 	if (!buffer || buffer->get_size() != build_sizes_info.accelerationStructureSize)
 	{
-		buffer = std::make_unique<vkb::core::BufferC>(
-		    device,
-		    build_sizes_info.accelerationStructureSize,
-		    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
-		    VMA_MEMORY_USAGE_GPU_ONLY);
+		buffer = std::make_unique<vkb::core::BufferC>(device,
+		                                              build_sizes_info.accelerationStructureSize,
+		                                              VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR |
+		                                                  VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+		                                              VMA_MEMORY_USAGE_GPU_ONLY);
 
 		VkAccelerationStructureCreateInfoKHR acceleration_structure_create_info{};
 		acceleration_structure_create_info.sType  = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR;
 		acceleration_structure_create_info.buffer = buffer->get_handle();
 		acceleration_structure_create_info.size   = build_sizes_info.accelerationStructureSize;
 		acceleration_structure_create_info.type   = type;
-		VkResult result                           = vkCreateAccelerationStructureKHR(device.get_handle(), &acceleration_structure_create_info, nullptr, &handle);
+		VkResult result                           = vkCreateAccelerationStructureKHR(
+            device.get_handle(), &acceleration_structure_create_info, nullptr, &handle);
 
 		if (result != VK_SUCCESS)
 		{
@@ -201,9 +213,9 @@ void AccelerationStructure::build(VkQueue queue, VkBuildAccelerationStructureFla
 
 	// Get the acceleration structure's handle
 	VkAccelerationStructureDeviceAddressInfoKHR acceleration_device_address_info{};
-	acceleration_device_address_info.sType                 = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
+	acceleration_device_address_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
 	acceleration_device_address_info.accelerationStructure = handle;
-	device_address                                         = vkGetAccelerationStructureDeviceAddressKHR(device.get_handle(), &acceleration_device_address_info);
+	device_address = vkGetAccelerationStructureDeviceAddressKHR(device.get_handle(), &acceleration_device_address_info);
 
 	// Create a scratch buffer as a temporary storage for the acceleration structure build
 	scratch_buffer = std::make_unique<vkb::core::BufferC>(
@@ -219,11 +231,7 @@ void AccelerationStructure::build(VkQueue queue, VkBuildAccelerationStructureFla
 	// Build the acceleration structure on the device via a one-time command buffer submission
 	VkCommandBuffer command_buffer       = device.create_command_buffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 	auto            as_build_range_infos = &*acceleration_structure_build_range_infos.data();
-	vkCmdBuildAccelerationStructuresKHR(
-	    command_buffer,
-	    1,
-	    &build_geometry_info,
-	    &as_build_range_infos);
+	vkCmdBuildAccelerationStructuresKHR(command_buffer, 1, &build_geometry_info, &as_build_range_infos);
 	device.flush_command_buffer(command_buffer, queue);
 	scratch_buffer.reset();
 }

--- a/framework/core/acceleration_structure.h
+++ b/framework/core/acceleration_structure.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, Sascha Willems
+/* Copyright (c) 2021-2026, Sascha Willems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -40,8 +40,7 @@ class AccelerationStructure
 	 * @param device A valid Vulkan device
 	 * @param type The type of the acceleration structure (top- or bottom-level)
 	 */
-	AccelerationStructure(vkb::core::DeviceC            &device,
-	                      VkAccelerationStructureTypeKHR type);
+	AccelerationStructure(vkb::core::DeviceC &device, VkAccelerationStructureTypeKHR type);
 
 	~AccelerationStructure();
 
@@ -76,15 +75,16 @@ class AccelerationStructure
 	                               uint64_t            index_buffer_data_address     = 0,
 	                               uint64_t            transform_buffer_data_address = 0);
 
-	void update_triangle_geometry(uint64_t triangleUUID, std::unique_ptr<vkb::core::BufferC> &vertex_buffer,
+	void update_triangle_geometry(uint64_t                             triangleUUID,
+	                              std::unique_ptr<vkb::core::BufferC> &vertex_buffer,
 	                              std::unique_ptr<vkb::core::BufferC> &index_buffer,
 	                              std::unique_ptr<vkb::core::BufferC> &transform_buffer,
 	                              uint32_t                             triangle_count,
 	                              uint32_t                             max_vertex,
 	                              VkDeviceSize                         vertex_stride,
-	                              uint32_t                             transform_offset              = 0,
-	                              VkFormat                             vertex_format                 = VK_FORMAT_R32G32B32_SFLOAT,
-	                              VkGeometryFlagsKHR                   flags                         = VK_GEOMETRY_OPAQUE_BIT_KHR,
+	                              uint32_t                             transform_offset = 0,
+	                              VkFormat                             vertex_format    = VK_FORMAT_R32G32B32_SFLOAT,
+	                              VkGeometryFlagsKHR                   flags            = VK_GEOMETRY_OPAQUE_BIT_KHR,
 	                              uint64_t                             vertex_buffer_data_address    = 0,
 	                              uint64_t                             index_buffer_data_address     = 0,
 	                              uint64_t                             transform_buffer_data_address = 0);
@@ -102,10 +102,11 @@ class AccelerationStructure
 	                               uint32_t                             transform_offset = 0,
 	                               VkGeometryFlagsKHR                   flags            = VK_GEOMETRY_OPAQUE_BIT_KHR);
 
-	void update_instance_geometry(uint64_t instance_UID, std::unique_ptr<vkb::core::BufferC> &instance_buffer,
-	                              uint32_t           instance_count,
-	                              uint32_t           transform_offset = 0,
-	                              VkGeometryFlagsKHR flags            = VK_GEOMETRY_OPAQUE_BIT_KHR);
+	void update_instance_geometry(uint64_t                             instance_UID,
+	                              std::unique_ptr<vkb::core::BufferC> &instance_buffer,
+	                              uint32_t                             instance_count,
+	                              uint32_t                             transform_offset = 0,
+	                              VkGeometryFlagsKHR                   flags            = VK_GEOMETRY_OPAQUE_BIT_KHR);
 
 	/**
 	 * @brief Builds the acceleration structure on the device (requires at least one geometry to be added)

--- a/framework/core/allocated.h
+++ b/framework/core/allocated.h
@@ -61,9 +61,11 @@ void init(const DeviceType &device)
 	allocator_info.device           = static_cast<VkDevice>(device.get_handle());
 	allocator_info.instance         = static_cast<VkInstance>(device.get_gpu().get_instance().get_handle());
 
-	bool can_get_memory_requirements = device.get_gpu().is_extension_supported(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-	bool has_dedicated_allocation    = device.get_gpu().is_extension_supported(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
-	if (can_get_memory_requirements && has_dedicated_allocation && device.is_extension_enabled(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME))
+	bool can_get_memory_requirements =
+	    device.get_gpu().is_extension_supported(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+	bool has_dedicated_allocation = device.get_gpu().is_extension_supported(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
+	if (can_get_memory_requirements && has_dedicated_allocation &&
+	    device.is_extension_enabled(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME))
 	{
 		allocator_info.flags |= VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
 	}
@@ -74,7 +76,8 @@ void init(const DeviceType &device)
 		allocator_info.flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
 	}
 
-	if (device.get_gpu().is_extension_supported(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME) && device.is_extension_enabled(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME))
+	if (device.get_gpu().is_extension_supported(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME) &&
+	    device.is_extension_enabled(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME))
 	{
 		allocator_info.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT;
 	}
@@ -85,7 +88,8 @@ void init(const DeviceType &device)
 		allocator_info.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT;
 	}
 
-	if (device.get_gpu().is_extension_supported(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME) && device.is_extension_enabled(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME))
+	if (device.get_gpu().is_extension_supported(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME) &&
+	    device.is_extension_enabled(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME))
 	{
 		allocator_info.flags |= VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT;
 	}
@@ -126,12 +130,16 @@ class Allocated : public vkb::core::VulkanResource<bindingType, HandleType>
   public:
 	using ParentType = vkb::core::VulkanResource<bindingType, HandleType>;
 
-	using BufferType           = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Buffer, VkBuffer>::type;
-	using BufferCreateInfoType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferCreateInfo, VkBufferCreateInfo>::type;
-	using DeviceMemoryType     = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceMemory, VkDeviceMemory>::type;
-	using DeviceSizeType       = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceSize, VkDeviceSize>::type;
-	using ImageCreateInfoType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageCreateInfo, VkImageCreateInfo>::type;
-	using ImageType            = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Image, VkImage>::type;
+	using BufferType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Buffer, VkBuffer>::type;
+	using BufferCreateInfoType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferCreateInfo, VkBufferCreateInfo>::type;
+	using DeviceMemoryType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceMemory, VkDeviceMemory>::type;
+	using DeviceSizeType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceSize, VkDeviceSize>::type;
+	using ImageCreateInfoType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageCreateInfo, VkImageCreateInfo>::type;
+	using ImageType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Image, VkImage>::type;
 
   public:
 	Allocated()                  = delete;
@@ -398,14 +406,13 @@ inline Allocated<bindingType, HandleType>::Allocated(Allocated &&other) noexcept
     mapped_data(std::exchange(other.mapped_data, {})),
     coherent(std::exchange(other.coherent, {})),
     persistent(std::exchange(other.persistent, {}))
-{
-}
+{}
 
 template <vkb::BindingType bindingType, typename HandleType>
 template <typename... Args>
-inline Allocated<bindingType, HandleType>::Allocated(const VmaAllocationCreateInfo &allocation_create_info, Args &&...args) :
-    ParentType{std::forward<Args>(args)...},
-    allocation_create_info(allocation_create_info)
+inline Allocated<bindingType, HandleType>::Allocated(const VmaAllocationCreateInfo &allocation_create_info,
+                                                     Args &&...args) :
+    ParentType{std::forward<Args>(args)...}, allocation_create_info(allocation_create_info)
 {}
 
 template <vkb::BindingType bindingType, typename HandleType>
@@ -428,7 +435,8 @@ inline void Allocated<bindingType, HandleType>::clear()
 }
 
 template <vkb::BindingType bindingType, typename HandleType>
-inline typename Allocated<bindingType, HandleType>::BufferType Allocated<bindingType, HandleType>::create_buffer(BufferCreateInfoType const &create_info, DeviceSizeType alignment)
+inline typename Allocated<bindingType, HandleType>::BufferType
+    Allocated<bindingType, HandleType>::create_buffer(BufferCreateInfoType const &create_info, DeviceSizeType alignment)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -436,12 +444,14 @@ inline typename Allocated<bindingType, HandleType>::BufferType Allocated<binding
 	}
 	else
 	{
-		return static_cast<VkBuffer>(create_buffer_impl(reinterpret_cast<vk::BufferCreateInfo const &>(create_info), alignment));
+		return static_cast<VkBuffer>(
+		    create_buffer_impl(reinterpret_cast<vk::BufferCreateInfo const &>(create_info), alignment));
 	}
 }
 
 template <vkb::BindingType bindingType, typename HandleType>
-inline vk::Buffer Allocated<bindingType, HandleType>::create_buffer_impl(vk::BufferCreateInfo const &create_info, DeviceSizeType alignment)
+inline vk::Buffer Allocated<bindingType, HandleType>::create_buffer_impl(vk::BufferCreateInfo const &create_info,
+                                                                         DeviceSizeType              alignment)
 {
 	vk::Buffer        buffer = VK_NULL_HANDLE;
 	VmaAllocationInfo allocation_info{};
@@ -449,24 +459,22 @@ inline vk::Buffer Allocated<bindingType, HandleType>::create_buffer_impl(vk::Buf
 	auto result = VK_SUCCESS;
 	if (alignment == 0)
 	{
-		result = vmaCreateBuffer(
-		    get_memory_allocator(),
-		    reinterpret_cast<VkBufferCreateInfo const *>(&create_info),
-		    &allocation_create_info,
-		    reinterpret_cast<VkBuffer *>(&buffer),
-		    &allocation,
-		    &allocation_info);
+		result = vmaCreateBuffer(get_memory_allocator(),
+		                         reinterpret_cast<VkBufferCreateInfo const *>(&create_info),
+		                         &allocation_create_info,
+		                         reinterpret_cast<VkBuffer *>(&buffer),
+		                         &allocation,
+		                         &allocation_info);
 	}
 	else
 	{
-		result = vmaCreateBufferWithAlignment(
-		    get_memory_allocator(),
-		    reinterpret_cast<VkBufferCreateInfo const *>(&create_info),
-		    &allocation_create_info,
-		    alignment,
-		    reinterpret_cast<VkBuffer *>(&buffer),
-		    &allocation,
-		    &allocation_info);
+		result = vmaCreateBufferWithAlignment(get_memory_allocator(),
+		                                      reinterpret_cast<VkBufferCreateInfo const *>(&create_info),
+		                                      &allocation_create_info,
+		                                      alignment,
+		                                      reinterpret_cast<VkBuffer *>(&buffer),
+		                                      &allocation,
+		                                      &allocation_info);
 	}
 
 	if (result != VK_SUCCESS)
@@ -478,7 +486,8 @@ inline vk::Buffer Allocated<bindingType, HandleType>::create_buffer_impl(vk::Buf
 }
 
 template <vkb::BindingType bindingType, typename HandleType>
-inline typename Allocated<bindingType, HandleType>::ImageType Allocated<bindingType, HandleType>::create_image(ImageCreateInfoType const &create_info)
+inline typename Allocated<bindingType, HandleType>::ImageType
+    Allocated<bindingType, HandleType>::create_image(ImageCreateInfoType const &create_info)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -573,7 +582,8 @@ inline void Allocated<bindingType, HandleType>::flush(DeviceSizeType offset, Dev
 	{
 		if constexpr (bindingType == vkb::BindingType::Cpp)
 		{
-			vmaFlushAllocation(get_memory_allocator(), allocation, static_cast<VkDeviceSize>(offset), static_cast<VkDeviceSize>(size));
+			vmaFlushAllocation(
+			    get_memory_allocator(), allocation, static_cast<VkDeviceSize>(offset), static_cast<VkDeviceSize>(size));
 		}
 		else
 		{
@@ -589,7 +599,8 @@ inline const uint8_t *Allocated<bindingType, HandleType>::get_data() const
 }
 
 template <vkb::BindingType bindingType, typename HandleType>
-inline typename Allocated<bindingType, HandleType>::DeviceMemoryType Allocated<bindingType, HandleType>::get_memory() const
+inline typename Allocated<bindingType, HandleType>::DeviceMemoryType
+    Allocated<bindingType, HandleType>::get_memory() const
 {
 	VmaAllocationInfo alloc_info;
 	vmaGetAllocationInfo(get_memory_allocator(), allocation, &alloc_info);
@@ -604,7 +615,8 @@ inline typename Allocated<bindingType, HandleType>::DeviceMemoryType Allocated<b
 }
 
 template <vkb::BindingType bindingType, typename HandleType>
-inline typename Allocated<bindingType, HandleType>::DeviceSizeType Allocated<bindingType, HandleType>::get_memory_offset() const
+inline typename Allocated<bindingType, HandleType>::DeviceSizeType
+    Allocated<bindingType, HandleType>::get_memory_offset() const
 {
 	VmaAllocationInfo alloc_info;
 	vmaGetAllocationInfo(get_memory_allocator(), allocation, &alloc_info);

--- a/framework/core/buffer.h
+++ b/framework/core/buffer.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
- * Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -37,14 +37,21 @@ template <vkb::BindingType bindingType>
 struct BufferBuilder
     : public vkb::allocated::BuilderBase<bindingType,
                                          BufferBuilder<bindingType>,
-                                         typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferCreateInfo, VkBufferCreateInfo>::type>
+                                         typename std::conditional<bindingType == vkb::BindingType::Cpp,
+                                                                   vk::BufferCreateInfo,
+                                                                   VkBufferCreateInfo>::type>
 {
   public:
-	using BufferCreateFlagsType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferCreateFlags, VkBufferCreateFlags>::type;
-	using BufferCreateInfoType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferCreateInfo, VkBufferCreateInfo>::type;
-	using BufferUsageFlagsType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferUsageFlags, VkBufferUsageFlags>::type;
-	using DeviceSizeType        = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceSize, VkDeviceSize>::type;
-	using SharingModeType       = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::SharingMode, VkSharingMode>::type;
+	using BufferCreateFlagsType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::BufferCreateFlags, VkBufferCreateFlags>::type;
+	using BufferCreateInfoType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferCreateInfo, VkBufferCreateInfo>::type;
+	using BufferUsageFlagsType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferUsageFlags, VkBufferUsageFlags>::type;
+	using DeviceSizeType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceSize, VkDeviceSize>::type;
+	using SharingModeType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::SharingMode, VkSharingMode>::type;
 
   private:
 	using ParentType = vkb::allocated::BuilderBase<bindingType, BufferBuilder<bindingType>, BufferCreateInfoType>;
@@ -72,8 +79,7 @@ using BufferBuilderCpp = BufferBuilder<vkb::BindingType::Cpp>;
 template <>
 inline BufferBuilder<vkb::BindingType::Cpp>::BufferBuilder(vk::DeviceSize size) :
     ParentType(BufferCreateInfoType{.size = size})
-{
-}
+{}
 
 template <>
 inline BufferBuilder<vkb::BindingType::C>::BufferBuilder(VkDeviceSize size) :
@@ -116,19 +122,23 @@ inline BufferBuilder<bindingType> &BufferBuilder<bindingType>::with_alignment(De
 /*=========================================================*/
 
 template <vkb::BindingType bindingType>
-class Buffer
-    : public vkb::allocated::Allocated<bindingType, typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Buffer, VkBuffer>::type>
+class Buffer : public vkb::allocated::Allocated<
+                   bindingType,
+                   typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Buffer, VkBuffer>::type>
 {
   public:
-	using BufferType           = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Buffer, VkBuffer>::type;
-	using BufferUsageFlagsType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferUsageFlags, VkBufferUsageFlags>::type;
-	using DeviceSizeType       = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceSize, VkDeviceSize>::type;
+	using BufferType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Buffer, VkBuffer>::type;
+	using BufferUsageFlagsType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferUsageFlags, VkBufferUsageFlags>::type;
+	using DeviceSizeType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceSize, VkDeviceSize>::type;
 
   private:
 	using ParentType = vkb::allocated::Allocated<bindingType, BufferType>;
 
   public:
-	static Buffer<bindingType> create_staging_buffer(vkb::core::Device<bindingType> &device, DeviceSizeType size, const void *data);
+	static Buffer<bindingType>
+	    create_staging_buffer(vkb::core::Device<bindingType> &device, DeviceSizeType size, const void *data);
 
 	template <typename T>
 	static Buffer create_staging_buffer(vkb::core::Device<bindingType> &device, std::vector<T> const &data);
@@ -156,8 +166,9 @@ class Buffer
 	       DeviceSizeType                  size,
 	       BufferUsageFlagsType            buffer_usage,
 	       VmaMemoryUsage                  memory_usage,
-	       VmaAllocationCreateFlags        flags                = VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT,
-	       const std::vector<uint32_t>    &queue_family_indices = {});
+	       VmaAllocationCreateFlags        flags = VMA_ALLOCATION_CREATE_MAPPED_BIT |
+	                                        VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT,
+	       const std::vector<uint32_t> &queue_family_indices = {});
 
 	Buffer(vkb::core::Device<bindingType> &device, BufferBuilder<bindingType> const &builder);
 
@@ -174,7 +185,8 @@ class Buffer
 	DeviceSizeType get_size() const;
 
   private:
-	static Buffer<vkb::BindingType::Cpp> create_staging_buffer_impl(vkb::core::DeviceCpp &device, vk::DeviceSize size, const void *data);
+	static Buffer<vkb::BindingType::Cpp>
+	    create_staging_buffer_impl(vkb::core::DeviceCpp &device, vk::DeviceSize size, const void *data);
 
   private:
 	vk::DeviceSize size = 0;
@@ -185,13 +197,16 @@ using BufferCpp = Buffer<vkb::BindingType::Cpp>;
 
 template <vkb::BindingType bindingType>
 template <typename T>
-inline Buffer<bindingType> Buffer<bindingType>::create_staging_buffer(vkb::core::Device<bindingType> &device, const T &data)
+inline Buffer<bindingType> Buffer<bindingType>::create_staging_buffer(vkb::core::Device<bindingType> &device,
+                                                                      const T                        &data)
 {
 	return create_staging_buffer(device, sizeof(T), &data);
 }
 
 template <vkb::BindingType bindingType>
-inline Buffer<bindingType> Buffer<bindingType>::create_staging_buffer(vkb::core::Device<bindingType> &device, DeviceSizeType size, const void *data)
+inline Buffer<bindingType> Buffer<bindingType>::create_staging_buffer(vkb::core::Device<bindingType> &device,
+                                                                      DeviceSizeType                  size,
+                                                                      const void                     *data)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -199,13 +214,15 @@ inline Buffer<bindingType> Buffer<bindingType>::create_staging_buffer(vkb::core:
 	}
 	else
 	{
-		BufferCpp buffer = create_staging_buffer_impl(reinterpret_cast<vkb::core::DeviceCpp &>(device), static_cast<vk::DeviceSize>(size), data);
+		BufferCpp buffer = create_staging_buffer_impl(
+		    reinterpret_cast<vkb::core::DeviceCpp &>(device), static_cast<vk::DeviceSize>(size), data);
 		return std::move(*reinterpret_cast<BufferC *>(&buffer));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline BufferCpp Buffer<bindingType>::create_staging_buffer_impl(vkb::core::DeviceCpp &device, vk::DeviceSize size, const void *data)
+inline BufferCpp
+    Buffer<bindingType>::create_staging_buffer_impl(vkb::core::DeviceCpp &device, vk::DeviceSize size, const void *data)
 {
 	BufferBuilderCpp builder(size);
 	builder.with_vma_flags(VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT)
@@ -220,7 +237,8 @@ inline BufferCpp Buffer<bindingType>::create_staging_buffer_impl(vkb::core::Devi
 
 template <vkb::BindingType bindingType>
 template <typename T>
-inline Buffer<bindingType> Buffer<bindingType>::create_staging_buffer(vkb::core::Device<bindingType> &device, std::vector<T> const &data)
+inline Buffer<bindingType> Buffer<bindingType>::create_staging_buffer(vkb::core::Device<bindingType> &device,
+                                                                      std::vector<T> const           &data)
 {
 	return create_staging_buffer(device, data.size() * sizeof(T), data.data());
 }
@@ -268,7 +286,8 @@ inline uint64_t Buffer<bindingType>::get_device_address() const
 	}
 	else
 	{
-		return static_cast<vk::Device>(this->get_device().get_handle()).getBufferAddressKHR({.buffer = static_cast<vk::Buffer>(this->get_handle())});
+		return static_cast<vk::Device>(this->get_device().get_handle())
+		    .getBufferAddressKHR({.buffer = static_cast<vk::Buffer>(this->get_handle())});
 	}
 }
 

--- a/framework/core/command_buffer.h
+++ b/framework/core/command_buffer.h
@@ -44,46 +44,74 @@ class HPPQueryPool;
  */
 template <vkb::BindingType bindingType>
 class CommandBuffer
-    : public vkb::core::VulkanResource<bindingType, typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBuffer, VkCommandBuffer>::type>
+    : public vkb::core::VulkanResource<
+          bindingType,
+          typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBuffer, VkCommandBuffer>::type>
 {
-	using ParentType =
-	    vkb::core::VulkanResource<bindingType, typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBuffer, VkCommandBuffer>::type>;
+	using ParentType = vkb::core::VulkanResource<
+	    bindingType,
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBuffer, VkCommandBuffer>::type>;
 
   public:
-	using BufferImageCopyType    = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferImageCopy, VkBufferImageCopy>::type;
-	using ClearAttachmentType    = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ClearAttachment, VkClearAttachment>::type;
-	using ClearRectType          = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ClearRect, VkClearRect>::type;
-	using ClearValueType         = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ClearValue, VkClearValue>::type;
-	using CommandBufferLevelType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBufferLevel, VkCommandBufferLevel>::type;
-	using CommandBufferType      = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBuffer, VkCommandBuffer>::type;
-	using CommandBufferUsageFlagsType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBufferUsageFlags, VkCommandBufferUsageFlags>::type;
-	using DeviceSizeType   = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceSize, VkDeviceSize>::type;
-	using ImageBlitType    = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageBlit, VkImageBlit>::type;
-	using ImageCopyType    = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageCopy, VkImageCopy>::type;
-	using ImageLayoutType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageLayout, VkImageLayout>::type;
-	using ImageResolveType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageResolve, VkImageResolve>::type;
-	using IndexTypeType    = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::IndexType, VkIndexType>::type;
-	using PipelineStagFlagBitsType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::PipelineStageFlagBits, VkPipelineStageFlagBits>::type;
-	using QueryControlFlagsType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::QueryControlFlags, VkQueryControlFlags>::type;
-	using Rect2DType            = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Rect2D, VkRect2D>::type;
-	using ResultType            = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Result, VkResult>::type;
-	using SubpassContentsType   = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::SubpassContents, VkSubpassContents>::type;
-	using ViewportType          = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Viewport, VkViewport>::type;
+	using BufferImageCopyType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferImageCopy, VkBufferImageCopy>::type;
+	using ClearAttachmentType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ClearAttachment, VkClearAttachment>::type;
+	using ClearRectType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ClearRect, VkClearRect>::type;
+	using ClearValueType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ClearValue, VkClearValue>::type;
+	using CommandBufferLevelType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBufferLevel, VkCommandBufferLevel>::type;
+	using CommandBufferType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBuffer, VkCommandBuffer>::type;
+	using CommandBufferUsageFlagsType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBufferUsageFlags, VkCommandBufferUsageFlags>::type;
+	using DeviceSizeType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceSize, VkDeviceSize>::type;
+	using ImageBlitType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageBlit, VkImageBlit>::type;
+	using ImageCopyType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageCopy, VkImageCopy>::type;
+	using ImageLayoutType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageLayout, VkImageLayout>::type;
+	using ImageResolveType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageResolve, VkImageResolve>::type;
+	using IndexTypeType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::IndexType, VkIndexType>::type;
+	using PipelineStagFlagBitsType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::PipelineStageFlagBits, VkPipelineStageFlagBits>::type;
+	using QueryControlFlagsType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::QueryControlFlags, VkQueryControlFlags>::type;
+	using Rect2DType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Rect2D, VkRect2D>::type;
+	using ResultType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Result, VkResult>::type;
+	using SubpassContentsType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::SubpassContents, VkSubpassContents>::type;
+	using ViewportType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Viewport, VkViewport>::type;
 
-	using BufferMemoryBarrierType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::common::HPPBufferMemoryBarrier, vkb::BufferMemoryBarrier>::type;
-	using FramebufferType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPFramebuffer, vkb::Framebuffer>::type;
-	using ImageMemoryBarrierType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::common::HPPImageMemoryBarrier, vkb::ImageMemoryBarrier>::type;
-	using ImageType          = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPImage, vkb::core::Image>::type;
-	using ImageViewType      = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPImageView, vkb::core::ImageView>::type;
-	using LoadStoreInfoType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::common::HPPLoadStoreInfo, vkb::LoadStoreInfo>::type;
-	using PipelineLayoutType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPPipelineLayout, vkb::PipelineLayout>::type;
-	using QueryPoolType      = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPQueryPool, vkb::QueryPool>::type;
-	using RenderPassType     = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPRenderPass, vkb::RenderPass>::type;
-	using SamplerType        = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPSampler, vkb::core::Sampler>::type;
+	using BufferMemoryBarrierType = typename std::conditional<bindingType == vkb::BindingType::Cpp,
+	                                                          vkb::common::HPPBufferMemoryBarrier,
+	                                                          vkb::BufferMemoryBarrier>::type;
+	using FramebufferType         = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPFramebuffer, vkb::Framebuffer>::type;
+	using ImageMemoryBarrierType = typename std::conditional<bindingType == vkb::BindingType::Cpp,
+	                                                         vkb::common::HPPImageMemoryBarrier,
+	                                                         vkb::ImageMemoryBarrier>::type;
+	using ImageType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPImage, vkb::core::Image>::type;
+	using ImageViewType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPImageView, vkb::core::ImageView>::type;
+	using LoadStoreInfoType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vkb::common::HPPLoadStoreInfo, vkb::LoadStoreInfo>::type;
+	using PipelineLayoutType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPPipelineLayout, vkb::PipelineLayout>::type;
+	using QueryPoolType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPQueryPool, vkb::QueryPool>::type;
+	using RenderPassType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPRenderPass, vkb::RenderPass>::type;
+	using SamplerType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPSampler, vkb::core::Sampler>::type;
 
   public:
 	CommandBuffer(vkb::core::CommandPool<bindingType> &command_pool, CommandBufferLevelType level);
@@ -111,56 +139,88 @@ class CommandBuffer
 	 * @param framebuffer
 	 * @param subpass_index
 	 */
-	void begin(CommandBufferUsageFlagsType flags, const RenderPassType *render_pass, const FramebufferType *framebuffer, uint32_t subpass_index);
+	void begin(CommandBufferUsageFlagsType flags,
+	           const RenderPassType       *render_pass,
+	           const FramebufferType      *framebuffer,
+	           uint32_t                    subpass_index);
 
-	void                   begin_query(QueryPoolType const &query_pool, uint32_t query, QueryControlFlagsType flags);
-	void                   begin_render_pass(vkb::rendering::RenderTarget<bindingType> const                          &render_target,
-	                                         std::vector<LoadStoreInfoType> const                                     &load_store_infos,
-	                                         std::vector<ClearValueType> const                                        &clear_values,
-	                                         std::vector<std::unique_ptr<vkb::rendering::Subpass<bindingType>>> const &subpasses,
-	                                         SubpassContentsType                                                       contents = VK_SUBPASS_CONTENTS_INLINE);
-	void                   begin_render_pass(vkb::rendering::RenderTarget<bindingType> const &render_target,
-	                                         RenderPassType const                            &render_pass,
-	                                         FramebufferType const                           &framebuffer,
-	                                         std::vector<ClearValueType> const               &clear_values,
-	                                         SubpassContentsType                              contents = vk::SubpassContents::eInline);
-	void                   bind_buffer(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset, DeviceSizeType range, uint32_t set, uint32_t binding, uint32_t array_element);
-	void                   bind_image(ImageViewType const &image_view, SamplerType const &sampler, uint32_t set, uint32_t binding, uint32_t array_element);
-	void                   bind_image(ImageViewType const &image_view, uint32_t set, uint32_t binding, uint32_t array_element);
-	void                   bind_index_buffer(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset, IndexTypeType index_type);
-	void                   bind_input(ImageViewType const &image_view, uint32_t set, uint32_t binding, uint32_t array_element);
-	void                   bind_lighting(vkb::rendering::LightingState<bindingType> &lighting_state, uint32_t set, uint32_t binding);
-	void                   bind_pipeline_layout(PipelineLayoutType &pipeline_layout);
-	void                   bind_vertex_buffers(uint32_t                                                                         first_binding,
-	                                           std::vector<std::reference_wrapper<const vkb::core::Buffer<bindingType>>> const &buffers,
-	                                           std::vector<DeviceSizeType> const                                               &offsets);
-	void                   blit_image(ImageType const &src_img, ImageType const &dst_img, std::vector<ImageBlitType> const &regions);
-	void                   buffer_memory_barrier(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset, DeviceSizeType size, BufferMemoryBarrierType const &memory_barrier);
-	void                   clear(ClearAttachmentType const &info, ClearRectType const &rect);
-	void                   copy_buffer(vkb::core::Buffer<bindingType> const &src_buffer, vkb::core::Buffer<bindingType> const &dst_buffer, DeviceSizeType size);
-	void                   copy_buffer_to_image(vkb::core::Buffer<bindingType> const &buffer, ImageType const &image, std::vector<BufferImageCopyType> const &regions);
-	void                   copy_image(ImageType const &src_img, ImageType const &dst_img, std::vector<ImageCopyType> const &regions);
-	void                   copy_image_to_buffer(ImageType const                        &image,
-	                                            ImageLayoutType                         image_layout,
-	                                            vkb::core::Buffer<bindingType> const   &buffer,
-	                                            std::vector<BufferImageCopyType> const &regions);
-	void                   dispatch(uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);
-	void                   dispatch_indirect(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset);
-	void                   draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex, uint32_t first_instance);
-	void                   draw_indexed(uint32_t index_count, uint32_t instance_count, uint32_t first_index, int32_t vertex_offset, uint32_t first_instance);
-	void                   draw_indexed_indirect(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset, uint32_t draw_count, uint32_t stride);
-	void                   end();
-	void                   end_query(QueryPoolType const &query_pool, uint32_t query);
-	void                   end_render_pass();
-	void                   execute_commands(vkb::core::CommandBuffer<bindingType> &secondary_command_buffer);
-	void                   execute_commands(std::vector<std::shared_ptr<vkb::core::CommandBuffer<bindingType>>> &secondary_command_buffers);
+	void begin_query(QueryPoolType const &query_pool, uint32_t query, QueryControlFlagsType flags);
+	void begin_render_pass(vkb::rendering::RenderTarget<bindingType> const                          &render_target,
+	                       std::vector<LoadStoreInfoType> const                                     &load_store_infos,
+	                       std::vector<ClearValueType> const                                        &clear_values,
+	                       std::vector<std::unique_ptr<vkb::rendering::Subpass<bindingType>>> const &subpasses,
+	                       SubpassContentsType contents = VK_SUBPASS_CONTENTS_INLINE);
+	void begin_render_pass(vkb::rendering::RenderTarget<bindingType> const &render_target,
+	                       RenderPassType const                            &render_pass,
+	                       FramebufferType const                           &framebuffer,
+	                       std::vector<ClearValueType> const               &clear_values,
+	                       SubpassContentsType                              contents = vk::SubpassContents::eInline);
+	void bind_buffer(vkb::core::Buffer<bindingType> const &buffer,
+	                 DeviceSizeType                        offset,
+	                 DeviceSizeType                        range,
+	                 uint32_t                              set,
+	                 uint32_t                              binding,
+	                 uint32_t                              array_element);
+	void bind_image(ImageViewType const &image_view,
+	                SamplerType const   &sampler,
+	                uint32_t             set,
+	                uint32_t             binding,
+	                uint32_t             array_element);
+	void bind_image(ImageViewType const &image_view, uint32_t set, uint32_t binding, uint32_t array_element);
+	void bind_index_buffer(vkb::core::Buffer<bindingType> const &buffer,
+	                       DeviceSizeType                        offset,
+	                       IndexTypeType                         index_type);
+	void bind_input(ImageViewType const &image_view, uint32_t set, uint32_t binding, uint32_t array_element);
+	void bind_lighting(vkb::rendering::LightingState<bindingType> &lighting_state, uint32_t set, uint32_t binding);
+	void bind_pipeline_layout(PipelineLayoutType &pipeline_layout);
+	void bind_vertex_buffers(uint32_t first_binding,
+	                         std::vector<std::reference_wrapper<const vkb::core::Buffer<bindingType>>> const &buffers,
+	                         std::vector<DeviceSizeType> const                                               &offsets);
+	void blit_image(ImageType const &src_img, ImageType const &dst_img, std::vector<ImageBlitType> const &regions);
+	void buffer_memory_barrier(vkb::core::Buffer<bindingType> const &buffer,
+	                           DeviceSizeType                        offset,
+	                           DeviceSizeType                        size,
+	                           BufferMemoryBarrierType const        &memory_barrier);
+	void clear(ClearAttachmentType const &info, ClearRectType const &rect);
+	void copy_buffer(vkb::core::Buffer<bindingType> const &src_buffer,
+	                 vkb::core::Buffer<bindingType> const &dst_buffer,
+	                 DeviceSizeType                        size);
+	void copy_buffer_to_image(vkb::core::Buffer<bindingType> const   &buffer,
+	                          ImageType const                        &image,
+	                          std::vector<BufferImageCopyType> const &regions);
+	void copy_image(ImageType const &src_img, ImageType const &dst_img, std::vector<ImageCopyType> const &regions);
+	void copy_image_to_buffer(ImageType const                        &image,
+	                          ImageLayoutType                         image_layout,
+	                          vkb::core::Buffer<bindingType> const   &buffer,
+	                          std::vector<BufferImageCopyType> const &regions);
+	void dispatch(uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);
+	void dispatch_indirect(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset);
+	void draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex, uint32_t first_instance);
+	void draw_indexed(uint32_t index_count,
+	                  uint32_t instance_count,
+	                  uint32_t first_index,
+	                  int32_t  vertex_offset,
+	                  uint32_t first_instance);
+	void draw_indexed_indirect(vkb::core::Buffer<bindingType> const &buffer,
+	                           DeviceSizeType                        offset,
+	                           uint32_t                              draw_count,
+	                           uint32_t                              stride);
+	void end();
+	void end_query(QueryPoolType const &query_pool, uint32_t query);
+	void end_render_pass();
+	void execute_commands(vkb::core::CommandBuffer<bindingType> &secondary_command_buffer);
+	void execute_commands(
+	    std::vector<std::shared_ptr<vkb::core::CommandBuffer<bindingType>>> &secondary_command_buffers);
 	CommandBufferLevelType get_level() const;
-	RenderPassType        &get_render_pass(vkb::rendering::RenderTarget<bindingType> const                          &render_target,
-	                                       std::vector<LoadStoreInfoType> const                                     &load_store_infos,
-	                                       std::vector<std::unique_ptr<vkb::rendering::Subpass<bindingType>>> const &subpasses);
-	void                   image_memory_barrier(ImageViewType const &image_view, ImageMemoryBarrierType const &memory_barrier) const;
-	void                   image_memory_barrier(vkb::rendering::RenderTarget<bindingType> &render_target, uint32_t view_index, ImageMemoryBarrierType const &memory_barrier) const;
-	void                   next_subpass();
+	RenderPassType  &
+        get_render_pass(vkb::rendering::RenderTarget<bindingType> const                          &render_target,
+	                     std::vector<LoadStoreInfoType> const                                     &load_store_infos,
+	                     std::vector<std::unique_ptr<vkb::rendering::Subpass<bindingType>>> const &subpasses);
+	void image_memory_barrier(ImageViewType const &image_view, ImageMemoryBarrierType const &memory_barrier) const;
+	void image_memory_barrier(vkb::rendering::RenderTarget<bindingType> &render_target,
+	                          uint32_t                                   view_index,
+	                          ImageMemoryBarrierType const              &memory_barrier) const;
+	void next_subpass();
 
 	/**
 	 * @brief Records byte data into the command buffer to be pushed as push constants to each draw call
@@ -177,7 +237,8 @@ class CommandBuffer
 	ResultType reset(vkb::CommandBufferResetMode reset_mode);
 
 	void reset_query_pool(QueryPoolType const &query_pool, uint32_t first_query, uint32_t query_count);
-	void resolve_image(ImageType const &src_img, ImageType const &dst_img, std::vector<ImageResolveType> const &regions);
+	void
+	    resolve_image(ImageType const &src_img, ImageType const &dst_img, std::vector<ImageResolveType> const &regions);
 	void set_blend_constants(std::array<float, 4> const &blend_constants);
 	void set_color_blend_state(vkb::rendering::ColorBlendState<bindingType> const &state_info);
 	void set_depth_bias(float depth_bias_constant_factor, float depth_bias_clamp, float depth_bias_slope_factor);
@@ -197,7 +258,9 @@ class CommandBuffer
 	void set_vertex_input_state(vkb::rendering::VertexInputState<bindingType> const &state_info);
 	void set_viewport(uint32_t first_viewport, std::vector<ViewportType> const &viewports);
 	void set_viewport_state(vkb::rendering::ViewportState const &state_info);
-	void update_buffer(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset, std::vector<uint8_t> const &data);
+	void update_buffer(vkb::core::Buffer<bindingType> const &buffer,
+	                   DeviceSizeType                        offset,
+	                   std::vector<uint8_t> const           &data);
 	void write_timestamp(PipelineStagFlagBitsType pipeline_stage, QueryPoolType const &query_pool, uint32_t query);
 
   private:
@@ -217,34 +280,39 @@ class CommandBuffer
 	bool is_render_size_optimal(const vk::Extent2D &extent, const vk::Rect2D &render_area);
 
   private:
-	void                      begin_impl(vk::CommandBufferUsageFlags flags, vkb::core::CommandBuffer<bindingType> *primary_cmd_buf);
-	void                      begin_impl(vk::CommandBufferUsageFlags      flags,
-	                                     vkb::core::HPPRenderPass const  *render_pass,
-	                                     vkb::core::HPPFramebuffer const *framebuffer,
-	                                     uint32_t                         subpass_index);
-	void                      begin_render_pass_impl(vkb::rendering::RenderTargetCpp const &render_target,
-	                                                 vkb::core::HPPRenderPass const        &render_pass,
-	                                                 vkb::core::HPPFramebuffer const       &framebuffer,
-	                                                 std::vector<vk::ClearValue> const     &clear_values,
-	                                                 vk::SubpassContents                    contents);
-	void                      bind_vertex_buffers_impl(uint32_t                                                               first_binding,
-	                                                   std::vector<std::reference_wrapper<const vkb::core::BufferCpp>> const &buffers,
-	                                                   std::vector<vk::DeviceSize> const                                     &offsets);
-	void                      buffer_memory_barrier_impl(vkb::core::BufferCpp const                &buffer,
-	                                                     vk::DeviceSize                             offset,
-	                                                     vk::DeviceSize                             size,
-	                                                     vkb::common::HPPBufferMemoryBarrier const &memory_barrier);
-	void                      copy_buffer_impl(vkb::core::BufferCpp const &src_buffer, vkb::core::BufferCpp const &dst_buffer, vk::DeviceSize size);
-	void                      execute_commands_impl(std::vector<std::shared_ptr<vkb::core::CommandBuffer<vkb::BindingType::Cpp>>> &secondary_command_buffers);
-	void                      flush_impl(vkb::core::DeviceCpp &device, vk::PipelineBindPoint pipeline_bind_point);
-	void                      flush_descriptor_state_impl(vk::PipelineBindPoint pipeline_bind_point);
-	void                      flush_pipeline_state_impl(vkb::core::DeviceCpp &device, vk::PipelineBindPoint pipeline_bind_point);
-	vkb::core::HPPRenderPass &get_render_pass_impl(vkb::core::DeviceCpp                                           &device,
-	                                               vkb::rendering::RenderTargetCpp const                          &render_target,
-	                                               std::vector<vkb::common::HPPLoadStoreInfo> const               &load_store_infos,
-	                                               std::vector<std::unique_ptr<vkb::rendering::SubpassCpp>> const &subpasses);
-	void                      image_memory_barrier_impl(vkb::core::HPPImageView const &image_view, vkb::common::HPPImageMemoryBarrier const &memory_barrier) const;
-	vk::Result                reset_impl(vkb::CommandBufferResetMode reset_mode);
+	void begin_impl(vk::CommandBufferUsageFlags flags, vkb::core::CommandBuffer<bindingType> *primary_cmd_buf);
+	void begin_impl(vk::CommandBufferUsageFlags      flags,
+	                vkb::core::HPPRenderPass const  *render_pass,
+	                vkb::core::HPPFramebuffer const *framebuffer,
+	                uint32_t                         subpass_index);
+	void begin_render_pass_impl(vkb::rendering::RenderTargetCpp const &render_target,
+	                            vkb::core::HPPRenderPass const        &render_pass,
+	                            vkb::core::HPPFramebuffer const       &framebuffer,
+	                            std::vector<vk::ClearValue> const     &clear_values,
+	                            vk::SubpassContents                    contents);
+	void bind_vertex_buffers_impl(uint32_t                                                               first_binding,
+	                              std::vector<std::reference_wrapper<const vkb::core::BufferCpp>> const &buffers,
+	                              std::vector<vk::DeviceSize> const                                     &offsets);
+	void buffer_memory_barrier_impl(vkb::core::BufferCpp const                &buffer,
+	                                vk::DeviceSize                             offset,
+	                                vk::DeviceSize                             size,
+	                                vkb::common::HPPBufferMemoryBarrier const &memory_barrier);
+	void copy_buffer_impl(vkb::core::BufferCpp const &src_buffer,
+	                      vkb::core::BufferCpp const &dst_buffer,
+	                      vk::DeviceSize              size);
+	void execute_commands_impl(
+	    std::vector<std::shared_ptr<vkb::core::CommandBuffer<vkb::BindingType::Cpp>>> &secondary_command_buffers);
+	void flush_impl(vkb::core::DeviceCpp &device, vk::PipelineBindPoint pipeline_bind_point);
+	void flush_descriptor_state_impl(vk::PipelineBindPoint pipeline_bind_point);
+	void flush_pipeline_state_impl(vkb::core::DeviceCpp &device, vk::PipelineBindPoint pipeline_bind_point);
+	vkb::core::HPPRenderPass        &
+        get_render_pass_impl(vkb::core::DeviceCpp                                           &device,
+	                                vkb::rendering::RenderTargetCpp const                          &render_target,
+	                                std::vector<vkb::common::HPPLoadStoreInfo> const               &load_store_infos,
+	                                std::vector<std::unique_ptr<vkb::rendering::SubpassCpp>> const &subpasses);
+	void       image_memory_barrier_impl(vkb::core::HPPImageView const            &image_view,
+	                                     vkb::common::HPPImageMemoryBarrier const &memory_barrier) const;
+	vk::Result reset_impl(vkb::CommandBufferResetMode reset_mode);
 
   private:
 	vkb::core::CommandPoolCpp                                              &command_pool;
@@ -279,10 +347,15 @@ namespace vkb
 namespace core
 {
 template <vkb::BindingType bindingType>
-inline vkb::core::CommandBuffer<bindingType>::CommandBuffer(vkb::core::CommandPool<bindingType> &command_pool_, CommandBufferLevelType level_) :
-    vkb::core::VulkanResource<bindingType, CommandBufferType>(nullptr, &command_pool_.get_device()), level(static_cast<vk::CommandBufferLevel>(level_)), command_pool(reinterpret_cast<vkb::core::CommandPoolCpp &>(command_pool_)), max_push_constants_size(command_pool_.get_device().get_gpu().get_properties().limits.maxPushConstantsSize)
+inline vkb::core::CommandBuffer<bindingType>::CommandBuffer(vkb::core::CommandPool<bindingType> &command_pool_,
+                                                            CommandBufferLevelType               level_) :
+    vkb::core::VulkanResource<bindingType, CommandBufferType>(nullptr, &command_pool_.get_device()),
+    level(static_cast<vk::CommandBufferLevel>(level_)),
+    command_pool(reinterpret_cast<vkb::core::CommandPoolCpp &>(command_pool_)),
+    max_push_constants_size(command_pool_.get_device().get_gpu().get_properties().limits.maxPushConstantsSize)
 {
-	vk::CommandBufferAllocateInfo allocate_info{.commandPool = command_pool.get_handle(), .level = level, .commandBufferCount = 1};
+	vk::CommandBufferAllocateInfo allocate_info{
+	    .commandPool = command_pool.get_handle(), .level = level, .commandBufferCount = 1};
 
 	this->set_handle(this->get_device().get_resource().allocateCommandBuffers(allocate_info).front());
 }
@@ -312,13 +385,18 @@ inline void CommandBuffer<bindingType>::begin(CommandBufferUsageFlagsType       
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::begin_impl(vk::CommandBufferUsageFlags flags, vkb::core::CommandBuffer<bindingType> *primary_cmd_buf)
+inline void CommandBuffer<bindingType>::begin_impl(vk::CommandBufferUsageFlags            flags,
+                                                   vkb::core::CommandBuffer<bindingType> *primary_cmd_buf)
 {
 	if (level == vk::CommandBufferLevel::eSecondary)
 	{
-		assert(primary_cmd_buf && "A primary command buffer pointer must be provided when calling begin from a secondary one");
+		assert(primary_cmd_buf &&
+		       "A primary command buffer pointer must be provided when calling begin from a secondary one");
 
-		return begin_impl(flags, primary_cmd_buf->current_render_pass, primary_cmd_buf->current_framebuffer, primary_cmd_buf->pipeline_state.get_subpass_index());
+		return begin_impl(flags,
+		                  primary_cmd_buf->current_render_pass,
+		                  primary_cmd_buf->current_framebuffer,
+		                  primary_cmd_buf->pipeline_state.get_subpass_index());
 	}
 	else
 	{
@@ -362,7 +440,8 @@ inline void CommandBuffer<bindingType>::begin_impl(vk::CommandBufferUsageFlags  
 
 	if (level == vk::CommandBufferLevel::eSecondary)
 	{
-		assert((render_pass && framebuffer) && "Render pass and framebuffer must be provided when calling begin from a secondary one");
+		assert((render_pass && framebuffer) &&
+		       "Render pass and framebuffer must be provided when calling begin from a secondary one");
 
 		current_render_pass = render_pass;
 		current_framebuffer = framebuffer;
@@ -378,7 +457,9 @@ inline void CommandBuffer<bindingType>::begin_impl(vk::CommandBufferUsageFlags  
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::begin_query(QueryPoolType const &query_pool, uint32_t query, QueryControlFlagsType flags)
+inline void CommandBuffer<bindingType>::begin_query(QueryPoolType const  &query_pool,
+                                                    uint32_t              query,
+                                                    QueryControlFlagsType flags)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -386,16 +467,19 @@ inline void CommandBuffer<bindingType>::begin_query(QueryPoolType const &query_p
 	}
 	else
 	{
-		this->get_resource().beginQuery(static_cast<vk::QueryPool const>(query_pool.get_handle()), query, static_cast<vk::QueryControlFlags>(flags));
+		this->get_resource().beginQuery(static_cast<vk::QueryPool const>(query_pool.get_handle()),
+		                                query,
+		                                static_cast<vk::QueryControlFlags>(flags));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::begin_render_pass(vkb::rendering::RenderTarget<bindingType> const                          &render_target,
-                                                          std::vector<LoadStoreInfoType> const                                     &load_store_infos,
-                                                          std::vector<ClearValueType> const                                        &clear_values,
-                                                          std::vector<std::unique_ptr<vkb::rendering::Subpass<bindingType>>> const &subpasses,
-                                                          SubpassContentsType                                                       contents)
+inline void CommandBuffer<bindingType>::begin_render_pass(
+    vkb::rendering::RenderTarget<bindingType> const                          &render_target,
+    std::vector<LoadStoreInfoType> const                                     &load_store_infos,
+    std::vector<ClearValueType> const                                        &clear_values,
+    std::vector<std::unique_ptr<vkb::rendering::Subpass<bindingType>>> const &subpasses,
+    SubpassContentsType                                                       contents)
 {
 	// Reset state
 	pipeline_state.reset();
@@ -409,11 +493,12 @@ inline void CommandBuffer<bindingType>::begin_render_pass(vkb::rendering::Render
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::begin_render_pass(vkb::rendering::RenderTarget<bindingType> const &render_target,
-                                                          RenderPassType const                            &render_pass,
-                                                          FramebufferType const                           &framebuffer,
-                                                          std::vector<ClearValueType> const               &clear_values,
-                                                          SubpassContentsType                              contents)
+inline void
+    CommandBuffer<bindingType>::begin_render_pass(vkb::rendering::RenderTarget<bindingType> const &render_target,
+                                                  RenderPassType const                            &render_pass,
+                                                  FramebufferType const                           &framebuffer,
+                                                  std::vector<ClearValueType> const               &clear_values,
+                                                  SubpassContentsType                              contents)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -452,7 +537,8 @@ inline void CommandBuffer<bindingType>::begin_render_pass_impl(vkb::rendering::R
 	if (!is_render_size_optimal(framebuffer_extent, begin_info.renderArea))
 	{
 		// Only prints the warning if the framebuffer or render area are different since the last time the render size was not optimal
-		if ((framebuffer_extent != last_framebuffer_extent) || (begin_info.renderArea.extent != last_render_area_extent))
+		if ((framebuffer_extent != last_framebuffer_extent) ||
+		    (begin_info.renderArea.extent != last_render_area_extent))
 		{
 			LOGW("Render target extent is not an optimal size, this may result in reduced performance.");
 		}
@@ -470,8 +556,12 @@ inline void CommandBuffer<bindingType>::begin_render_pass_impl(vkb::rendering::R
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::bind_buffer(
-    vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset, DeviceSizeType range, uint32_t set, uint32_t binding, uint32_t array_element)
+inline void CommandBuffer<bindingType>::bind_buffer(vkb::core::Buffer<bindingType> const &buffer,
+                                                    DeviceSizeType                        offset,
+                                                    DeviceSizeType                        range,
+                                                    uint32_t                              set,
+                                                    uint32_t                              binding,
+                                                    uint32_t                              array_element)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -479,8 +569,12 @@ inline void CommandBuffer<bindingType>::bind_buffer(
 	}
 	else
 	{
-		resource_binding_state.bind_buffer(
-		    reinterpret_cast<vkb::core::Buffer<vkb::BindingType::Cpp> const &>(buffer), offset, range, set, binding, array_element);
+		resource_binding_state.bind_buffer(reinterpret_cast<vkb::core::Buffer<vkb::BindingType::Cpp> const &>(buffer),
+		                                   offset,
+		                                   range,
+		                                   set,
+		                                   binding,
+		                                   array_element);
 	}
 }
 
@@ -503,7 +597,10 @@ inline void CommandBuffer<bindingType>::bind_image(
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::bind_image(ImageViewType const &image_view, uint32_t set, uint32_t binding, uint32_t array_element)
+inline void CommandBuffer<bindingType>::bind_image(ImageViewType const &image_view,
+                                                   uint32_t             set,
+                                                   uint32_t             binding,
+                                                   uint32_t             array_element)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -511,12 +608,15 @@ inline void CommandBuffer<bindingType>::bind_image(ImageViewType const &image_vi
 	}
 	else
 	{
-		resource_binding_state.bind_image(reinterpret_cast<vkb::core::HPPImageView const &>(image_view), set, binding, array_element);
+		resource_binding_state.bind_image(
+		    reinterpret_cast<vkb::core::HPPImageView const &>(image_view), set, binding, array_element);
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::bind_index_buffer(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset, IndexTypeType index_type)
+inline void CommandBuffer<bindingType>::bind_index_buffer(vkb::core::Buffer<bindingType> const &buffer,
+                                                          DeviceSizeType                        offset,
+                                                          IndexTypeType                         index_type)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -524,12 +624,16 @@ inline void CommandBuffer<bindingType>::bind_index_buffer(vkb::core::Buffer<bind
 	}
 	else
 	{
-		this->get_resource().bindIndexBuffer(buffer.get_resource(), static_cast<vk::DeviceSize>(offset), static_cast<vk::IndexType>(index_type));
+		this->get_resource().bindIndexBuffer(
+		    buffer.get_resource(), static_cast<vk::DeviceSize>(offset), static_cast<vk::IndexType>(index_type));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::bind_input(ImageViewType const &image_view, uint32_t set, uint32_t binding, uint32_t array_element)
+inline void CommandBuffer<bindingType>::bind_input(ImageViewType const &image_view,
+                                                   uint32_t             set,
+                                                   uint32_t             binding,
+                                                   uint32_t             array_element)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -537,14 +641,22 @@ inline void CommandBuffer<bindingType>::bind_input(ImageViewType const &image_vi
 	}
 	else
 	{
-		resource_binding_state.bind_input(reinterpret_cast<vkb::core::HPPImageView const &>(image_view), set, binding, array_element);
+		resource_binding_state.bind_input(
+		    reinterpret_cast<vkb::core::HPPImageView const &>(image_view), set, binding, array_element);
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::bind_lighting(vkb::rendering::LightingState<bindingType> &lighting_state, uint32_t set, uint32_t binding)
+inline void CommandBuffer<bindingType>::bind_lighting(vkb::rendering::LightingState<bindingType> &lighting_state,
+                                                      uint32_t                                    set,
+                                                      uint32_t                                    binding)
 {
-	bind_buffer(lighting_state.light_buffer.get_buffer(), lighting_state.light_buffer.get_offset(), lighting_state.light_buffer.get_size(), set, binding, 0);
+	bind_buffer(lighting_state.light_buffer.get_buffer(),
+	            lighting_state.light_buffer.get_offset(),
+	            lighting_state.light_buffer.get_size(),
+	            set,
+	            binding,
+	            0);
 
 	set_specialization_constant(0, to_u32(lighting_state.directional_lights.size()));
 	set_specialization_constant(1, to_u32(lighting_state.point_lights.size()));
@@ -565,9 +677,10 @@ inline void CommandBuffer<bindingType>::bind_pipeline_layout(PipelineLayoutType 
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::bind_vertex_buffers(uint32_t                                                                         first_binding,
-                                                            std::vector<std::reference_wrapper<const vkb::core::Buffer<bindingType>>> const &buffers,
-                                                            std::vector<DeviceSizeType> const                                               &offsets)
+inline void CommandBuffer<bindingType>::bind_vertex_buffers(
+    uint32_t                                                                         first_binding,
+    std::vector<std::reference_wrapper<const vkb::core::Buffer<bindingType>>> const &buffers,
+    std::vector<DeviceSizeType> const                                               &offsets)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -575,24 +688,30 @@ inline void CommandBuffer<bindingType>::bind_vertex_buffers(uint32_t            
 	}
 	else
 	{
-		bind_vertex_buffers_impl(first_binding,
-		                         reinterpret_cast<std::vector<std::reference_wrapper<vkb::core::BufferCpp const>> const &>(buffers),
-		                         reinterpret_cast<std::vector<vk::DeviceSize> const &>(offsets));
+		bind_vertex_buffers_impl(
+		    first_binding,
+		    reinterpret_cast<std::vector<std::reference_wrapper<vkb::core::BufferCpp const>> const &>(buffers),
+		    reinterpret_cast<std::vector<vk::DeviceSize> const &>(offsets));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::bind_vertex_buffers_impl(uint32_t                                                               first_binding,
-                                                                 std::vector<std::reference_wrapper<const vkb::core::BufferCpp>> const &buffers,
-                                                                 std::vector<vk::DeviceSize> const                                     &offsets)
+inline void CommandBuffer<bindingType>::bind_vertex_buffers_impl(
+    uint32_t                                                               first_binding,
+    std::vector<std::reference_wrapper<const vkb::core::BufferCpp>> const &buffers,
+    std::vector<vk::DeviceSize> const                                     &offsets)
 {
 	std::vector<vk::Buffer> buffer_handles(buffers.size(), nullptr);
-	std::transform(buffers.begin(), buffers.end(), buffer_handles.begin(), [](auto const &buffer) { return buffer.get().get_handle(); });
+	std::transform(buffers.begin(), buffers.end(), buffer_handles.begin(), [](auto const &buffer) {
+		return buffer.get().get_handle();
+	});
 	this->get_resource().bindVertexBuffers(first_binding, buffer_handles, offsets);
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::blit_image(ImageType const &src_img, ImageType const &dst_img, std::vector<ImageBlitType> const &regions)
+inline void CommandBuffer<bindingType>::blit_image(ImageType const                  &src_img,
+                                                   ImageType const                  &dst_img,
+                                                   std::vector<ImageBlitType> const &regions)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -634,10 +753,11 @@ inline void CommandBuffer<bindingType>::buffer_memory_barrier(vkb::core::Buffer<
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::buffer_memory_barrier_impl(vkb::core::BufferCpp const                &buffer,
-                                                                   vk::DeviceSize                             offset,
-                                                                   vk::DeviceSize                             size,
-                                                                   vkb::common::HPPBufferMemoryBarrier const &memory_barrier)
+inline void
+    CommandBuffer<bindingType>::buffer_memory_barrier_impl(vkb::core::BufferCpp const                &buffer,
+                                                           vk::DeviceSize                             offset,
+                                                           vk::DeviceSize                             size,
+                                                           vkb::common::HPPBufferMemoryBarrier const &memory_barrier)
 {
 	vk::BufferMemoryBarrier buffer_memory_barrier{.srcAccessMask = memory_barrier.src_access_mask,
 	                                              .dstAccessMask = memory_barrier.dst_access_mask,
@@ -645,7 +765,8 @@ inline void CommandBuffer<bindingType>::buffer_memory_barrier_impl(vkb::core::Bu
 	                                              .offset        = offset,
 	                                              .size          = size};
 
-	this->get_resource().pipelineBarrier(memory_barrier.src_stage_mask, memory_barrier.dst_stage_mask, {}, {}, buffer_memory_barrier, {});
+	this->get_resource().pipelineBarrier(
+	    memory_barrier.src_stage_mask, memory_barrier.dst_stage_mask, {}, {}, buffer_memory_barrier, {});
 }
 
 template <vkb::BindingType bindingType>
@@ -657,7 +778,8 @@ inline void CommandBuffer<bindingType>::clear(ClearAttachmentType const &attachm
 	}
 	else
 	{
-		this->get_resource().clearAttachments(reinterpret_cast<vk::ClearAttachment const &>(attachment), reinterpret_cast<vk::ClearRect const &>(rect));
+		this->get_resource().clearAttachments(reinterpret_cast<vk::ClearAttachment const &>(attachment),
+		                                      reinterpret_cast<vk::ClearRect const &>(rect));
 	}
 }
 
@@ -679,8 +801,9 @@ inline void CommandBuffer<bindingType>::copy_buffer(vkb::core::Buffer<bindingTyp
 }
 
 template <vkb::BindingType bindingType>
-inline void
-    CommandBuffer<bindingType>::copy_buffer_impl(vkb::core::BufferCpp const &src_buffer, vkb::core::BufferCpp const &dst_buffer, vk::DeviceSize size)
+inline void CommandBuffer<bindingType>::copy_buffer_impl(vkb::core::BufferCpp const &src_buffer,
+                                                         vkb::core::BufferCpp const &dst_buffer,
+                                                         vk::DeviceSize              size)
 {
 	vk::BufferCopy copy_region{.size = size};
 	this->get_resource().copyBuffer(src_buffer.get_handle(), dst_buffer.get_handle(), copy_region);
@@ -693,7 +816,8 @@ inline void CommandBuffer<bindingType>::copy_buffer_to_image(vkb::core::Buffer<b
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
-		this->get_resource().copyBufferToImage(buffer.get_handle(), image.get_handle(), vk::ImageLayout::eTransferDstOptimal, regions);
+		this->get_resource().copyBufferToImage(
+		    buffer.get_handle(), image.get_handle(), vk::ImageLayout::eTransferDstOptimal, regions);
 	}
 	else
 	{
@@ -705,11 +829,17 @@ inline void CommandBuffer<bindingType>::copy_buffer_to_image(vkb::core::Buffer<b
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::copy_image(ImageType const &src_img, ImageType const &dst_img, std::vector<ImageCopyType> const &regions)
+inline void CommandBuffer<bindingType>::copy_image(ImageType const                  &src_img,
+                                                   ImageType const                  &dst_img,
+                                                   std::vector<ImageCopyType> const &regions)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
-		this->get_resource().copyImage(src_img.get_handle(), vk::ImageLayout::eTransferSrcOptimal, dst_img.get_handle(), vk::ImageLayout::eTransferDstOptimal, regions);
+		this->get_resource().copyImage(src_img.get_handle(),
+		                               vk::ImageLayout::eTransferSrcOptimal,
+		                               dst_img.get_handle(),
+		                               vk::ImageLayout::eTransferDstOptimal,
+		                               regions);
 	}
 	else
 	{
@@ -748,7 +878,8 @@ inline void CommandBuffer<bindingType>::dispatch(uint32_t group_count_x, uint32_
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::dispatch_indirect(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset)
+inline void CommandBuffer<bindingType>::dispatch_indirect(vkb::core::Buffer<bindingType> const &buffer,
+                                                          DeviceSizeType                        offset)
 {
 	flush(vk::PipelineBindPoint::eCompute);
 	if constexpr (bindingType == vkb::BindingType::Cpp)
@@ -762,7 +893,10 @@ inline void CommandBuffer<bindingType>::dispatch_indirect(vkb::core::Buffer<bind
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex, uint32_t first_instance)
+inline void CommandBuffer<bindingType>::draw(uint32_t vertex_count,
+                                             uint32_t instance_count,
+                                             uint32_t first_vertex,
+                                             uint32_t first_instance)
 {
 	flush(vk::PipelineBindPoint::eGraphics);
 	this->get_resource().draw(vertex_count, instance_count, first_vertex, first_instance);
@@ -777,7 +911,10 @@ inline void CommandBuffer<bindingType>::draw_indexed(
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::draw_indexed_indirect(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset, uint32_t draw_count, uint32_t stride)
+inline void CommandBuffer<bindingType>::draw_indexed_indirect(vkb::core::Buffer<bindingType> const &buffer,
+                                                              DeviceSizeType                        offset,
+                                                              uint32_t                              draw_count,
+                                                              uint32_t                              stride)
 {
 	flush(vk::PipelineBindPoint::eGraphics);
 	if constexpr (bindingType == vkb::BindingType::Cpp)
@@ -786,7 +923,8 @@ inline void CommandBuffer<bindingType>::draw_indexed_indirect(vkb::core::Buffer<
 	}
 	else
 	{
-		this->get_resource().drawIndexedIndirect(buffer.get_resource(), static_cast<vk::DeviceSize>(offset), draw_count, stride);
+		this->get_resource().drawIndexedIndirect(
+		    buffer.get_resource(), static_cast<vk::DeviceSize>(offset), draw_count, stride);
 	}
 }
 
@@ -829,13 +967,15 @@ inline typename CommandBuffer<bindingType>::CommandBufferLevelType CommandBuffer
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::execute_commands(vkb::core::CommandBuffer<bindingType> &secondary_command_buffer)
+inline void
+    CommandBuffer<bindingType>::execute_commands(vkb::core::CommandBuffer<bindingType> &secondary_command_buffer)
 {
 	this->get_resource().executeCommands(secondary_command_buffer.get_resource());
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::execute_commands(std::vector<std::shared_ptr<vkb::core::CommandBuffer<bindingType>>> &secondary_command_buffers)
+inline void CommandBuffer<bindingType>::execute_commands(
+    std::vector<std::shared_ptr<vkb::core::CommandBuffer<bindingType>>> &secondary_command_buffers)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -843,12 +983,14 @@ inline void CommandBuffer<bindingType>::execute_commands(std::vector<std::shared
 	}
 	else
 	{
-		execute_commands_impl(reinterpret_cast<std::vector<std::shared_ptr<vkb::core::CommandBufferCpp>> &>(secondary_command_buffers));
+		execute_commands_impl(
+		    reinterpret_cast<std::vector<std::shared_ptr<vkb::core::CommandBufferCpp>> &>(secondary_command_buffers));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::execute_commands_impl(std::vector<std::shared_ptr<vkb::core::CommandBuffer<vkb::BindingType::Cpp>>> &secondary_command_buffers)
+inline void CommandBuffer<bindingType>::execute_commands_impl(
+    std::vector<std::shared_ptr<vkb::core::CommandBuffer<vkb::BindingType::Cpp>>> &secondary_command_buffers)
 {
 	std::vector<vk::CommandBuffer> sec_cmd_buf_handles(secondary_command_buffers.size(), nullptr);
 	std::transform(secondary_command_buffers.begin(),
@@ -859,10 +1001,10 @@ inline void CommandBuffer<bindingType>::execute_commands_impl(std::vector<std::s
 }
 
 template <vkb::BindingType bindingType>
-inline typename vkb::core::CommandBuffer<bindingType>::RenderPassType &
-    CommandBuffer<bindingType>::get_render_pass(vkb::rendering::RenderTarget<bindingType> const                          &render_target,
-                                                std::vector<LoadStoreInfoType> const                                     &load_store_infos,
-                                                std::vector<std::unique_ptr<vkb::rendering::Subpass<bindingType>>> const &subpasses)
+inline typename vkb::core::CommandBuffer<bindingType>::RenderPassType &CommandBuffer<bindingType>::get_render_pass(
+    vkb::rendering::RenderTarget<bindingType> const                          &render_target,
+    std::vector<LoadStoreInfoType> const                                     &load_store_infos,
+    std::vector<std::unique_ptr<vkb::rendering::Subpass<bindingType>>> const &subpasses)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -870,20 +1012,20 @@ inline typename vkb::core::CommandBuffer<bindingType>::RenderPassType &
 	}
 	else
 	{
-		return reinterpret_cast<vkb::RenderPass &>(
-		    get_render_pass_impl(reinterpret_cast<vkb::core::DeviceCpp &>(this->get_device()),
-		                         reinterpret_cast<vkb::rendering::RenderTargetCpp const &>(render_target),
-		                         reinterpret_cast<std::vector<vkb::common::HPPLoadStoreInfo> const &>(load_store_infos),
-		                         reinterpret_cast<std::vector<std::unique_ptr<vkb::rendering::SubpassCpp>> const &>(subpasses)));
+		return reinterpret_cast<vkb::RenderPass &>(get_render_pass_impl(
+		    reinterpret_cast<vkb::core::DeviceCpp &>(this->get_device()),
+		    reinterpret_cast<vkb::rendering::RenderTargetCpp const &>(render_target),
+		    reinterpret_cast<std::vector<vkb::common::HPPLoadStoreInfo> const &>(load_store_infos),
+		    reinterpret_cast<std::vector<std::unique_ptr<vkb::rendering::SubpassCpp>> const &>(subpasses)));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline vkb::core::HPPRenderPass &
-    CommandBuffer<bindingType>::get_render_pass_impl(vkb::core::DeviceCpp                                           &device,
-                                                     vkb::rendering::RenderTargetCpp const                          &render_target,
-                                                     std::vector<vkb::common::HPPLoadStoreInfo> const               &load_store_infos,
-                                                     std::vector<std::unique_ptr<vkb::rendering::SubpassCpp>> const &subpasses)
+inline vkb::core::HPPRenderPass &CommandBuffer<bindingType>::get_render_pass_impl(
+    vkb::core::DeviceCpp                                           &device,
+    vkb::rendering::RenderTargetCpp const                          &render_target,
+    std::vector<vkb::common::HPPLoadStoreInfo> const               &load_store_infos,
+    std::vector<std::unique_ptr<vkb::rendering::SubpassCpp>> const &subpasses)
 {
 	// Create render pass
 	assert(subpasses.size() > 0 && "Cannot create a render pass without any subpass");
@@ -903,11 +1045,14 @@ inline vkb::core::HPPRenderPass &
 		++subpass_info_it;
 	}
 
-	return device.get_resource_cache().request_render_pass(render_target.get_attachments(), load_store_infos, subpass_infos);
+	return device.get_resource_cache().request_render_pass(
+	    render_target.get_attachments(), load_store_infos, subpass_infos);
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::image_memory_barrier(vkb::rendering::RenderTarget<bindingType> &render_target, uint32_t view_index, ImageMemoryBarrierType const &memory_barrier) const
+inline void CommandBuffer<bindingType>::image_memory_barrier(vkb::rendering::RenderTarget<bindingType> &render_target,
+                                                             uint32_t                                   view_index,
+                                                             ImageMemoryBarrierType const &memory_barrier) const
 {
 	auto const &image_view = render_target.get_views()[view_index];
 
@@ -925,7 +1070,8 @@ inline void CommandBuffer<bindingType>::image_memory_barrier(vkb::rendering::Ren
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::image_memory_barrier(ImageViewType const &image_view, ImageMemoryBarrierType const &memory_barrier) const
+inline void CommandBuffer<bindingType>::image_memory_barrier(ImageViewType const          &image_view,
+                                                             ImageMemoryBarrierType const &memory_barrier) const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -939,8 +1085,8 @@ inline void CommandBuffer<bindingType>::image_memory_barrier(ImageViewType const
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::image_memory_barrier_impl(vkb::core::HPPImageView const            &image_view,
-                                                                  vkb::common::HPPImageMemoryBarrier const &memory_barrier) const
+inline void CommandBuffer<bindingType>::image_memory_barrier_impl(
+    vkb::core::HPPImageView const &image_view, vkb::common::HPPImageMemoryBarrier const &memory_barrier) const
 {
 	// Adjust barrier's subresource range for depth images
 	auto subresource_range = image_view.get_subresource_range();
@@ -998,7 +1144,10 @@ inline void CommandBuffer<bindingType>::push_constants(const std::vector<uint8_t
 
 	if (push_constant_size > max_push_constants_size)
 	{
-		LOGE("Push constant limit of {} exceeded (pushing {} bytes for a total of {} bytes)", max_push_constants_size, values.size(), push_constant_size);
+		LOGE("Push constant limit of {} exceeded (pushing {} bytes for a total of {} bytes)",
+		     max_push_constants_size,
+		     values.size(),
+		     push_constant_size);
 		throw std::runtime_error("Push constant limit exceeded.");
 	}
 	else
@@ -1025,7 +1174,8 @@ inline void CommandBuffer<bindingType>::push_constants(const T &value)
 }
 
 template <vkb::BindingType bindingType>
-inline typename CommandBuffer<bindingType>::ResultType CommandBuffer<bindingType>::reset(vkb::CommandBufferResetMode reset_mode)
+inline typename CommandBuffer<bindingType>::ResultType
+    CommandBuffer<bindingType>::reset(vkb::CommandBufferResetMode reset_mode)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1040,7 +1190,8 @@ inline typename CommandBuffer<bindingType>::ResultType CommandBuffer<bindingType
 template <vkb::BindingType bindingType>
 inline vk::Result CommandBuffer<bindingType>::reset_impl(vkb::CommandBufferResetMode reset_mode)
 {
-	assert(reset_mode == command_pool.get_reset_mode() && "Command buffer reset mode must match the one used by the pool to allocate it");
+	assert(reset_mode == command_pool.get_reset_mode() &&
+	       "Command buffer reset mode must match the one used by the pool to allocate it");
 	if (reset_mode == vkb::CommandBufferResetMode::ResetIndividually)
 	{
 		this->get_resource().reset(vk::CommandBufferResetFlagBits::eReleaseResources);
@@ -1050,7 +1201,9 @@ inline vk::Result CommandBuffer<bindingType>::reset_impl(vkb::CommandBufferReset
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::reset_query_pool(QueryPoolType const &query_pool, uint32_t first_query, uint32_t query_count)
+inline void CommandBuffer<bindingType>::reset_query_pool(QueryPoolType const &query_pool,
+                                                         uint32_t             first_query,
+                                                         uint32_t             query_count)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1058,17 +1211,23 @@ inline void CommandBuffer<bindingType>::reset_query_pool(QueryPoolType const &qu
 	}
 	else
 	{
-		this->get_resource().resetQueryPool(static_cast<vk::QueryPool>(query_pool.get_handle()), first_query, query_count);
+		this->get_resource().resetQueryPool(
+		    static_cast<vk::QueryPool>(query_pool.get_handle()), first_query, query_count);
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::resolve_image(ImageType const &src_img, ImageType const &dst_img, std::vector<ImageResolveType> const &regions)
+inline void CommandBuffer<bindingType>::resolve_image(ImageType const                     &src_img,
+                                                      ImageType const                     &dst_img,
+                                                      std::vector<ImageResolveType> const &regions)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
-		this->get_resource().resolveImage(
-		    src_img.get_handle(), vk::ImageLayout::eTransferSrcOptimal, dst_img.get_handle(), vk::ImageLayout::eTransferDstOptimal, regions);
+		this->get_resource().resolveImage(src_img.get_handle(),
+		                                  vk::ImageLayout::eTransferSrcOptimal,
+		                                  dst_img.get_handle(),
+		                                  vk::ImageLayout::eTransferDstOptimal,
+		                                  regions);
 	}
 	else
 	{
@@ -1087,7 +1246,8 @@ inline void CommandBuffer<bindingType>::set_blend_constants(std::array<float, 4>
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::set_color_blend_state(vkb::rendering::ColorBlendState<bindingType> const &state_info)
+inline void
+    CommandBuffer<bindingType>::set_color_blend_state(vkb::rendering::ColorBlendState<bindingType> const &state_info)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1100,7 +1260,9 @@ inline void CommandBuffer<bindingType>::set_color_blend_state(vkb::rendering::Co
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::set_depth_bias(float depth_bias_constant_factor, float depth_bias_clamp, float depth_bias_slope_factor)
+inline void CommandBuffer<bindingType>::set_depth_bias(float depth_bias_constant_factor,
+                                                       float depth_bias_clamp,
+                                                       float depth_bias_slope_factor)
 {
 	this->get_resource().setDepthBias(depth_bias_constant_factor, depth_bias_clamp, depth_bias_slope_factor);
 }
@@ -1112,7 +1274,8 @@ inline void CommandBuffer<bindingType>::set_depth_bounds(float min_depth_bounds,
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::set_depth_stencil_state(vkb::rendering::DepthStencilState<bindingType> const &state_info)
+inline void CommandBuffer<bindingType>::set_depth_stencil_state(
+    vkb::rendering::DepthStencilState<bindingType> const &state_info)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1120,12 +1283,14 @@ inline void CommandBuffer<bindingType>::set_depth_stencil_state(vkb::rendering::
 	}
 	else
 	{
-		pipeline_state.set_depth_stencil_state(reinterpret_cast<vkb::rendering::DepthStencilStateCpp const &>(state_info));
+		pipeline_state.set_depth_stencil_state(
+		    reinterpret_cast<vkb::rendering::DepthStencilStateCpp const &>(state_info));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::set_input_assembly_state(vkb::rendering::InputAssemblyState<bindingType> const &state_info)
+inline void CommandBuffer<bindingType>::set_input_assembly_state(
+    vkb::rendering::InputAssemblyState<bindingType> const &state_info)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1133,7 +1298,8 @@ inline void CommandBuffer<bindingType>::set_input_assembly_state(vkb::rendering:
 	}
 	else
 	{
-		pipeline_state.set_input_assembly_state(reinterpret_cast<vkb::rendering::InputAssemblyStateCpp const &>(state_info));
+		pipeline_state.set_input_assembly_state(
+		    reinterpret_cast<vkb::rendering::InputAssemblyStateCpp const &>(state_info));
 	}
 }
 
@@ -1144,7 +1310,8 @@ inline void CommandBuffer<bindingType>::set_line_width(float line_width)
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::set_multisample_state(vkb::rendering::MultisampleState<bindingType> const &state_info)
+inline void
+    CommandBuffer<bindingType>::set_multisample_state(vkb::rendering::MultisampleState<bindingType> const &state_info)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1157,7 +1324,8 @@ inline void CommandBuffer<bindingType>::set_multisample_state(vkb::rendering::Mu
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::set_rasterization_state(vkb::rendering::RasterizationState<bindingType> const &state_info)
+inline void CommandBuffer<bindingType>::set_rasterization_state(
+    vkb::rendering::RasterizationState<bindingType> const &state_info)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1165,7 +1333,8 @@ inline void CommandBuffer<bindingType>::set_rasterization_state(vkb::rendering::
 	}
 	else
 	{
-		pipeline_state.set_rasterization_state(reinterpret_cast<vkb::rendering::RasterizationStateCpp const &>(state_info));
+		pipeline_state.set_rasterization_state(
+		    reinterpret_cast<vkb::rendering::RasterizationStateCpp const &>(state_info));
 	}
 }
 
@@ -1197,7 +1366,8 @@ inline void CommandBuffer<bindingType>::set_specialization_constant(uint32_t con
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::set_specialization_constant(uint32_t constant_id, std::vector<uint8_t> const &data)
+inline void CommandBuffer<bindingType>::set_specialization_constant(uint32_t                    constant_id,
+                                                                    std::vector<uint8_t> const &data)
 {
 	pipeline_state.set_specialization_constant(constant_id, data);
 }
@@ -1209,7 +1379,8 @@ inline void CommandBuffer<bindingType>::set_update_after_bind(bool update_after_
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::set_vertex_input_state(vkb::rendering::VertexInputState<bindingType> const &state_info)
+inline void
+    CommandBuffer<bindingType>::set_vertex_input_state(vkb::rendering::VertexInputState<bindingType> const &state_info)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1217,12 +1388,14 @@ inline void CommandBuffer<bindingType>::set_vertex_input_state(vkb::rendering::V
 	}
 	else
 	{
-		pipeline_state.set_vertex_input_state(reinterpret_cast<vkb::rendering::VertexInputStateCpp const &>(state_info));
+		pipeline_state.set_vertex_input_state(
+		    reinterpret_cast<vkb::rendering::VertexInputStateCpp const &>(state_info));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::set_viewport(uint32_t first_viewport, std::vector<ViewportType> const &viewports)
+inline void CommandBuffer<bindingType>::set_viewport(uint32_t                         first_viewport,
+                                                     std::vector<ViewportType> const &viewports)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1230,7 +1403,8 @@ inline void CommandBuffer<bindingType>::set_viewport(uint32_t first_viewport, st
 	}
 	else
 	{
-		this->get_resource().setViewport(first_viewport, reinterpret_cast<std::vector<vk::Viewport> const &>(viewports));
+		this->get_resource().setViewport(first_viewport,
+		                                 reinterpret_cast<std::vector<vk::Viewport> const &>(viewports));
 	}
 }
 
@@ -1241,7 +1415,9 @@ inline void CommandBuffer<bindingType>::set_viewport_state(vkb::rendering::Viewp
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::update_buffer(vkb::core::Buffer<bindingType> const &buffer, DeviceSizeType offset, std::vector<uint8_t> const &data)
+inline void CommandBuffer<bindingType>::update_buffer(vkb::core::Buffer<bindingType> const &buffer,
+                                                      DeviceSizeType                        offset,
+                                                      std::vector<uint8_t> const           &data)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1249,12 +1425,15 @@ inline void CommandBuffer<bindingType>::update_buffer(vkb::core::Buffer<bindingT
 	}
 	else
 	{
-		this->get_resource().template updateBuffer<uint8_t>(buffer.get_resource(), static_cast<vk::DeviceSize>(offset), data);
+		this->get_resource().template updateBuffer<uint8_t>(
+		    buffer.get_resource(), static_cast<vk::DeviceSize>(offset), data);
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::write_timestamp(PipelineStagFlagBitsType pipeline_stage, QueryPoolType const &query_pool, uint32_t query)
+inline void CommandBuffer<bindingType>::write_timestamp(PipelineStagFlagBitsType pipeline_stage,
+                                                        QueryPoolType const     &query_pool,
+                                                        uint32_t                 query)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -1262,7 +1441,8 @@ inline void CommandBuffer<bindingType>::write_timestamp(PipelineStagFlagBitsType
 	}
 	else
 	{
-		this->get_resource().writeTimestamp(static_cast<vk::PipelineStageFlagBits>(pipeline_stage), query_pool.get_handle(), query);
+		this->get_resource().writeTimestamp(
+		    static_cast<vk::PipelineStageFlagBits>(pipeline_stage), query_pool.get_handle(), query);
 	}
 }
 
@@ -1280,7 +1460,8 @@ inline void CommandBuffer<bindingType>::flush(vk::PipelineBindPoint pipeline_bin
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::flush_impl(vkb::core::DeviceCpp &device, vk::PipelineBindPoint pipeline_bind_point)
+inline void CommandBuffer<bindingType>::flush_impl(vkb::core::DeviceCpp &device,
+                                                   vk::PipelineBindPoint pipeline_bind_point)
 {
 	flush_pipeline_state_impl(device, pipeline_bind_point);
 	flush_push_constants();
@@ -1306,7 +1487,8 @@ inline void CommandBuffer<bindingType>::flush_descriptor_state_impl(vk::Pipeline
 
 		if (descriptor_set_layout_it != descriptor_set_layout_binding_state.end())
 		{
-			if (descriptor_set_layout_it->second->get_handle() != pipeline_layout.get_descriptor_set_layout(descriptor_set_id).get_handle())
+			if (descriptor_set_layout_it->second->get_handle() !=
+			    pipeline_layout.get_descriptor_set_layout(descriptor_set_id).get_handle())
 			{
 				update_descriptor_sets.emplace(descriptor_set_id);
 			}
@@ -1314,7 +1496,8 @@ inline void CommandBuffer<bindingType>::flush_descriptor_state_impl(vk::Pipeline
 	}
 
 	// Validate that the bound descriptor set layouts exist in the pipeline layout
-	for (auto set_it = descriptor_set_layout_binding_state.begin(); set_it != descriptor_set_layout_binding_state.end();)
+	for (auto set_it = descriptor_set_layout_binding_state.begin();
+	     set_it != descriptor_set_layout_binding_state.end();)
 	{
 		if (!pipeline_layout.has_descriptor_set_layout(set_it->first))
 		{
@@ -1338,7 +1521,8 @@ inline void CommandBuffer<bindingType>::flush_descriptor_state_impl(vk::Pipeline
 			auto    &resource_set      = resource_set_it.second;
 
 			// Don't update resource set if it's not in the update list OR its state hasn't changed
-			if (!resource_set.is_dirty() && (update_descriptor_sets.find(descriptor_set_id) == update_descriptor_sets.end()))
+			if (!resource_set.is_dirty() &&
+			    (update_descriptor_sets.find(descriptor_set_id) == update_descriptor_sets.end()))
 			{
 				continue;
 			}
@@ -1385,7 +1569,8 @@ inline void CommandBuffer<bindingType>::flush_descriptor_state_impl(vk::Pipeline
 						// Get buffer info
 						if (buffer != nullptr && vkb::common::is_buffer_descriptor_type(binding_info->descriptorType))
 						{
-							vk::DescriptorBufferInfo buffer_info{resource_info.buffer->get_handle(), resource_info.offset, resource_info.range};
+							vk::DescriptorBufferInfo buffer_info{
+							    resource_info.buffer->get_handle(), resource_info.offset, resource_info.range};
 
 							if (vkb::common::is_dynamic_buffer_descriptor_type(binding_info->descriptorType))
 							{
@@ -1400,7 +1585,8 @@ inline void CommandBuffer<bindingType>::flush_descriptor_state_impl(vk::Pipeline
 						else if (image_view != nullptr || sampler != nullptr)
 						{
 							// Can be null for input attachments
-							vk::DescriptorImageInfo image_info{sampler ? sampler->get_handle() : nullptr, image_view->get_handle()};
+							vk::DescriptorImageInfo image_info{sampler ? sampler->get_handle() : nullptr,
+							                                   image_view->get_handle()};
 
 							if (image_view != nullptr)
 							{
@@ -1411,7 +1597,10 @@ inline void CommandBuffer<bindingType>::flush_descriptor_state_impl(vk::Pipeline
 										image_info.imageLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
 										break;
 									case vk::DescriptorType::eInputAttachment:
-										image_info.imageLayout = vkb::common::is_depth_format(image_view->get_format()) ? vk::ImageLayout::eDepthStencilReadOnlyOptimal : vk::ImageLayout::eShaderReadOnlyOptimal;
+										image_info.imageLayout =
+										    vkb::common::is_depth_format(image_view->get_format()) ?
+										        vk::ImageLayout::eDepthStencilReadOnlyOptimal :
+										        vk::ImageLayout::eShaderReadOnlyOptimal;
 										break;
 									case vk::DescriptorType::eStorageImage:
 										image_info.imageLayout = vk::ImageLayout::eGeneral;
@@ -1425,8 +1614,10 @@ inline void CommandBuffer<bindingType>::flush_descriptor_state_impl(vk::Pipeline
 						}
 					}
 
-					assert((!update_after_bind || (buffer_infos.count(binding_index) > 0 || (image_infos.count(binding_index) > 0))) &&
-					       "binding index with no buffer or image infos can't be checked for adding to bindings_to_update");
+					assert((!update_after_bind ||
+					        (buffer_infos.count(binding_index) > 0 || (image_infos.count(binding_index) > 0))) &&
+					       "binding index with no buffer or image infos can't be checked for adding to "
+					       "bindings_to_update");
 				}
 			}
 
@@ -1434,13 +1625,18 @@ inline void CommandBuffer<bindingType>::flush_descriptor_state_impl(vk::Pipeline
 			    descriptor_set_layout, buffer_infos, image_infos, update_after_bind, command_pool.get_thread_index());
 
 			// Bind descriptor set
-			this->get_resource().bindDescriptorSets(pipeline_bind_point, pipeline_layout.get_handle(), descriptor_set_id, descriptor_set_handle, dynamic_offsets);
+			this->get_resource().bindDescriptorSets(pipeline_bind_point,
+			                                        pipeline_layout.get_handle(),
+			                                        descriptor_set_id,
+			                                        descriptor_set_handle,
+			                                        dynamic_offsets);
 		}
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline void CommandBuffer<bindingType>::flush_pipeline_state_impl(vkb::core::DeviceCpp &device, vk::PipelineBindPoint pipeline_bind_point)
+inline void CommandBuffer<bindingType>::flush_pipeline_state_impl(vkb::core::DeviceCpp &device,
+                                                                  vk::PipelineBindPoint pipeline_bind_point)
 {
 	// Create a new pipeline only if the graphics state changed
 	if (!pipeline_state.is_dirty())
@@ -1480,11 +1676,13 @@ inline void CommandBuffer<bindingType>::flush_push_constants()
 
 	auto const &pipeline_layout = pipeline_state.get_pipeline_layout();
 
-	vk::ShaderStageFlags shader_stage = pipeline_layout.get_push_constant_range_stage(to_u32(stored_push_constants.size()));
+	vk::ShaderStageFlags shader_stage =
+	    pipeline_layout.get_push_constant_range_stage(to_u32(stored_push_constants.size()));
 
 	if (shader_stage)
 	{
-		this->get_resource().template pushConstants<uint8_t>(pipeline_layout.get_handle(), shader_stage, 0, stored_push_constants);
+		this->get_resource().template pushConstants<uint8_t>(
+		    pipeline_layout.get_handle(), shader_stage, 0, stored_push_constants);
 	}
 	else
 	{
@@ -1495,11 +1693,13 @@ inline void CommandBuffer<bindingType>::flush_push_constants()
 }
 
 template <vkb::BindingType bindingType>
-inline bool CommandBuffer<bindingType>::is_render_size_optimal(const vk::Extent2D &framebuffer_extent, const vk::Rect2D &render_area)
+inline bool CommandBuffer<bindingType>::is_render_size_optimal(const vk::Extent2D &framebuffer_extent,
+                                                               const vk::Rect2D   &render_area)
 {
 	auto render_area_granularity = current_render_pass->get_render_area_granularity();
 
-	return ((render_area.offset.x % render_area_granularity.width == 0) && (render_area.offset.y % render_area_granularity.height == 0) &&
+	return ((render_area.offset.x % render_area_granularity.width == 0) &&
+	        (render_area.offset.y % render_area_granularity.height == 0) &&
 	        ((render_area.extent.width % render_area_granularity.width == 0) ||
 	         (render_area.offset.x + render_area.extent.width == framebuffer_extent.width)) &&
 	        ((render_area.extent.height % render_area_granularity.height == 0) ||

--- a/framework/core/command_pool.h
+++ b/framework/core/command_pool.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
- * Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -60,15 +60,17 @@ template <vkb::BindingType bindingType>
 class CommandPool : private vkb::core::CommandPoolBase
 {
   public:
-	using CommandBufferLevelType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBufferLevel, VkCommandBufferLevel>::type;
-	using CommandPoolType        = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandPool, VkCommandPool>::type;
+	using CommandBufferLevelType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBufferLevel, VkCommandBufferLevel>::type;
+	using CommandPoolType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandPool, VkCommandPool>::type;
 
   public:
 	CommandPool(vkb::core::Device<bindingType>           &device,
 	            uint32_t                                  queue_family_index,
 	            vkb::rendering::RenderFrame<bindingType> *render_frame = nullptr,
 	            size_t                                    thread_index = 0,
-	            vkb::CommandBufferResetMode               reset_mode   = vkb::CommandBufferResetMode::ResetIndividually);
+	            vkb::CommandBufferResetMode               reset_mode = vkb::CommandBufferResetMode::ResetIndividually);
 	CommandPool(CommandPool<bindingType> const &)            = delete;
 	CommandPool(CommandPool<bindingType> &&other)            = default;
 	CommandPool &operator=(CommandPool<bindingType> const &) = delete;
@@ -81,8 +83,9 @@ class CommandPool : private vkb::core::CommandPoolBase
 	vkb::rendering::RenderFrame<bindingType>              *get_render_frame();
 	vkb::CommandBufferResetMode                            get_reset_mode() const;
 	size_t                                                 get_thread_index() const;
-	std::shared_ptr<vkb::core::CommandBuffer<bindingType>> request_command_buffer(CommandBufferLevelType level = DefaultCommandBufferLevelValue<CommandBufferLevelType>::value);
-	void                                                   reset_pool();
+	std::shared_ptr<vkb::core::CommandBuffer<bindingType>> request_command_buffer(
+	    CommandBufferLevelType level = DefaultCommandBufferLevelValue<CommandBufferLevelType>::value);
+	void reset_pool();
 };
 
 using CommandPoolC   = CommandPool<vkb::BindingType::C>;
@@ -159,7 +162,8 @@ inline size_t CommandPool<bindingType>::get_thread_index() const
 }
 
 template <vkb::BindingType bindingType>
-std::shared_ptr<vkb::core::CommandBuffer<bindingType>> CommandPool<bindingType>::request_command_buffer(CommandBufferLevelType level)
+std::shared_ptr<vkb::core::CommandBuffer<bindingType>>
+    CommandPool<bindingType>::request_command_buffer(CommandBufferLevelType level)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -167,8 +171,8 @@ std::shared_ptr<vkb::core::CommandBuffer<bindingType>> CommandPool<bindingType>:
 	}
 	else
 	{
-		std::shared_ptr<vkb::core::CommandBufferCpp> command_buffer =
-		    CommandPoolBase::request_command_buffer(reinterpret_cast<vkb::core::CommandPoolCpp &>(*this), static_cast<vk::CommandBufferLevel>(level));
+		std::shared_ptr<vkb::core::CommandBufferCpp> command_buffer = CommandPoolBase::request_command_buffer(
+		    reinterpret_cast<vkb::core::CommandPoolCpp &>(*this), static_cast<vk::CommandBufferLevel>(level));
 		return *reinterpret_cast<std::shared_ptr<CommandBufferC> *>(&command_buffer);
 	}
 }

--- a/framework/core/command_pool_base.cpp
+++ b/framework/core/command_pool_base.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -105,7 +105,8 @@ size_t CommandPoolBase::get_thread_index() const
 	return thread_index;
 }
 
-std::shared_ptr<vkb::core::CommandBufferCpp> CommandPoolBase::request_command_buffer(vkb::core::CommandPoolCpp &commandPool, vk::CommandBufferLevel level)
+std::shared_ptr<vkb::core::CommandBufferCpp>
+    CommandPoolBase::request_command_buffer(vkb::core::CommandPoolCpp &commandPool, vk::CommandBufferLevel level)
 {
 	if (static_cast<vk::CommandBufferLevel>(level) == vk::CommandBufferLevel::ePrimary)
 	{

--- a/framework/core/command_pool_base.h
+++ b/framework/core/command_pool_base.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -65,7 +65,8 @@ class CommandPoolBase
 	vkb::rendering::RenderFrameCpp              *get_render_frame();
 	vkb::CommandBufferResetMode                  get_reset_mode() const;
 	size_t                                       get_thread_index() const;
-	std::shared_ptr<vkb::core::CommandBufferCpp> request_command_buffer(vkb::core::CommandPoolCpp &commandPool, vk::CommandBufferLevel level);
+	std::shared_ptr<vkb::core::CommandBufferCpp> request_command_buffer(vkb::core::CommandPoolCpp &commandPool,
+	                                                                    vk::CommandBufferLevel     level);
 	void                                         reset_pool();
 
   private:
@@ -78,7 +79,7 @@ class CommandPoolBase
 	uint32_t                                                  active_primary_command_buffer_count = 0;
 	std::vector<std::shared_ptr<vkb::core::CommandBufferCpp>> secondary_command_buffers;
 	uint32_t                                                  active_secondary_command_buffer_count = 0;
-	vkb::CommandBufferResetMode                               reset_mode                            = vkb::CommandBufferResetMode::ResetPool;
+	vkb::CommandBufferResetMode                               reset_mode = vkb::CommandBufferResetMode::ResetPool;
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/debug.cpp
+++ b/framework/core/debug.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, Arm Limited and Contributors
+/* Copyright (c) 2021-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,8 +25,10 @@
 
 namespace vkb
 {
-void DebugUtilsExtDebugUtils::set_debug_name(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-                                             const char *name) const
+void DebugUtilsExtDebugUtils::set_debug_name(VkDevice     device,
+                                             VkObjectType object_type,
+                                             uint64_t     object_handle,
+                                             const char  *name) const
 {
 	VkDebugUtilsObjectNameInfoEXT name_info{};
 	name_info.sType        = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
@@ -38,8 +40,12 @@ void DebugUtilsExtDebugUtils::set_debug_name(VkDevice device, VkObjectType objec
 	vkSetDebugUtilsObjectNameEXT(device, &name_info);
 }
 
-void DebugUtilsExtDebugUtils::set_debug_tag(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-                                            uint64_t tag_name, const void *tag_data, size_t tag_data_size) const
+void DebugUtilsExtDebugUtils::set_debug_tag(VkDevice     device,
+                                            VkObjectType object_type,
+                                            uint64_t     object_handle,
+                                            uint64_t     tag_name,
+                                            const void  *tag_data,
+                                            size_t       tag_data_size) const
 {
 	VkDebugUtilsObjectTagInfoEXT tag_info{};
 	tag_info.sType        = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_TAG_INFO_EXT;
@@ -53,8 +59,7 @@ void DebugUtilsExtDebugUtils::set_debug_tag(VkDevice device, VkObjectType object
 	vkSetDebugUtilsObjectTagEXT(device, &tag_info);
 }
 
-void DebugUtilsExtDebugUtils::cmd_begin_label(VkCommandBuffer command_buffer,
-                                              const char *name, glm::vec4 color) const
+void DebugUtilsExtDebugUtils::cmd_begin_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color) const
 {
 	VkDebugUtilsLabelEXT label_info{};
 	label_info.sType      = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
@@ -71,8 +76,7 @@ void DebugUtilsExtDebugUtils::cmd_end_label(VkCommandBuffer command_buffer) cons
 	vkCmdEndDebugUtilsLabelEXT(command_buffer);
 }
 
-void DebugUtilsExtDebugUtils::cmd_insert_label(VkCommandBuffer command_buffer,
-                                               const char *name, glm::vec4 color) const
+void DebugUtilsExtDebugUtils::cmd_insert_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color) const
 {
 	VkDebugUtilsLabelEXT label_info{};
 	label_info.sType      = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
@@ -119,8 +123,10 @@ static const std::unordered_map<VkObjectType, VkDebugReportObjectTypeEXT> VK_OBJ
     {VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT},
 };
 
-void DebugMarkerExtDebugUtils::set_debug_name(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-                                              const char *name) const
+void DebugMarkerExtDebugUtils::set_debug_name(VkDevice     device,
+                                              VkObjectType object_type,
+                                              uint64_t     object_handle,
+                                              const char  *name) const
 {
 	VkDebugMarkerObjectNameInfoEXT name_info{};
 	name_info.sType       = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
@@ -132,8 +138,12 @@ void DebugMarkerExtDebugUtils::set_debug_name(VkDevice device, VkObjectType obje
 	vkDebugMarkerSetObjectNameEXT(device, &name_info);
 }
 
-void DebugMarkerExtDebugUtils::set_debug_tag(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-                                             uint64_t tag_name, const void *tag_data, size_t tag_data_size) const
+void DebugMarkerExtDebugUtils::set_debug_tag(VkDevice     device,
+                                             VkObjectType object_type,
+                                             uint64_t     object_handle,
+                                             uint64_t     tag_name,
+                                             const void  *tag_data,
+                                             size_t       tag_data_size) const
 {
 	VkDebugMarkerObjectTagInfoEXT tag_info{};
 	tag_info.sType      = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT;
@@ -147,8 +157,7 @@ void DebugMarkerExtDebugUtils::set_debug_tag(VkDevice device, VkObjectType objec
 	vkDebugMarkerSetObjectTagEXT(device, &tag_info);
 }
 
-void DebugMarkerExtDebugUtils::cmd_begin_label(VkCommandBuffer command_buffer,
-                                               const char *name, glm::vec4 color) const
+void DebugMarkerExtDebugUtils::cmd_begin_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color) const
 {
 	VkDebugMarkerMarkerInfoEXT marker_info{};
 	marker_info.sType       = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
@@ -165,8 +174,7 @@ void DebugMarkerExtDebugUtils::cmd_end_label(VkCommandBuffer command_buffer) con
 	vkCmdDebugMarkerEndEXT(command_buffer);
 }
 
-void DebugMarkerExtDebugUtils::cmd_insert_label(VkCommandBuffer command_buffer,
-                                                const char *name, glm::vec4 color) const
+void DebugMarkerExtDebugUtils::cmd_insert_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color) const
 {
 	VkDebugMarkerMarkerInfoEXT marker_info{};
 	marker_info.sType       = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
@@ -177,10 +185,11 @@ void DebugMarkerExtDebugUtils::cmd_insert_label(VkCommandBuffer command_buffer,
 	vkCmdDebugMarkerInsertEXT(command_buffer, &marker_info);
 }
 
-ScopedDebugLabel::ScopedDebugLabel(const DebugUtils &debug_utils, VkCommandBuffer command_buffer,
-                                   const char *name, glm::vec4 color) :
-    debug_utils{&debug_utils},
-    command_buffer{VK_NULL_HANDLE}
+ScopedDebugLabel::ScopedDebugLabel(const DebugUtils &debug_utils,
+                                   VkCommandBuffer   command_buffer,
+                                   const char       *name,
+                                   glm::vec4         color) :
+    debug_utils{&debug_utils}, command_buffer{VK_NULL_HANDLE}
 {
 	if (name && *name != '\0')
 	{
@@ -193,8 +202,7 @@ ScopedDebugLabel::ScopedDebugLabel(const DebugUtils &debug_utils, VkCommandBuffe
 
 ScopedDebugLabel::ScopedDebugLabel(const vkb::core::CommandBufferC &command_buffer, const char *name, glm::vec4 color) :
     ScopedDebugLabel{command_buffer.get_device().get_debug_utils(), command_buffer.get_handle(), name, color}
-{
-}
+{}
 
 ScopedDebugLabel::~ScopedDebugLabel()
 {

--- a/framework/core/debug.h
+++ b/framework/core/debug.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, Arm Limited and Contributors
+/* Copyright (c) 2021-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -41,20 +41,23 @@ class DebugUtils
 	/**
 	 * @brief Sets the debug name for a Vulkan object.
 	 */
-	virtual void set_debug_name(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-	                            const char *name) const = 0;
+	virtual void
+	    set_debug_name(VkDevice device, VkObjectType object_type, uint64_t object_handle, const char *name) const = 0;
 
 	/**
 	 * @brief Tags the given Vulkan object with some data.
 	 */
-	virtual void set_debug_tag(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-	                           uint64_t tag_name, const void *tag_data, size_t tag_data_size) const = 0;
+	virtual void set_debug_tag(VkDevice     device,
+	                           VkObjectType object_type,
+	                           uint64_t     object_handle,
+	                           uint64_t     tag_name,
+	                           const void  *tag_data,
+	                           size_t       tag_data_size) const = 0;
 
 	/**
 	 * @brief Inserts a command to begin a new debug label/marker scope.
 	 */
-	virtual void cmd_begin_label(VkCommandBuffer command_buffer,
-	                             const char *name, glm::vec4 color = {}) const = 0;
+	virtual void cmd_begin_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color = {}) const = 0;
 
 	/**
 	 * @brief Inserts a command to end the current debug label/marker scope.
@@ -64,8 +67,7 @@ class DebugUtils
 	/**
 	 * @brief Inserts a (non-scoped) debug label/marker in the command buffer.
 	 */
-	virtual void cmd_insert_label(VkCommandBuffer command_buffer,
-	                              const char *name, glm::vec4 color = {}) const = 0;
+	virtual void cmd_insert_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color = {}) const = 0;
 };
 
 /**
@@ -76,19 +78,23 @@ class DebugUtilsExtDebugUtils final : public DebugUtils
   public:
 	~DebugUtilsExtDebugUtils() override = default;
 
-	void set_debug_name(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-	                    const char *name) const override;
+	void set_debug_name(VkDevice     device,
+	                    VkObjectType object_type,
+	                    uint64_t     object_handle,
+	                    const char  *name) const override;
 
-	void set_debug_tag(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-	                   uint64_t tag_name, const void *tag_data, size_t tag_data_size) const override;
+	void set_debug_tag(VkDevice     device,
+	                   VkObjectType object_type,
+	                   uint64_t     object_handle,
+	                   uint64_t     tag_name,
+	                   const void  *tag_data,
+	                   size_t       tag_data_size) const override;
 
-	void cmd_begin_label(VkCommandBuffer command_buffer,
-	                     const char *name, glm::vec4 color) const override;
+	void cmd_begin_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color) const override;
 
 	void cmd_end_label(VkCommandBuffer command_buffer) const override;
 
-	void cmd_insert_label(VkCommandBuffer command_buffer,
-	                      const char *name, glm::vec4 color) const override;
+	void cmd_insert_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color) const override;
 };
 
 /**
@@ -99,19 +105,23 @@ class DebugMarkerExtDebugUtils final : public DebugUtils
   public:
 	~DebugMarkerExtDebugUtils() override = default;
 
-	void set_debug_name(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-	                    const char *name) const override;
+	void set_debug_name(VkDevice     device,
+	                    VkObjectType object_type,
+	                    uint64_t     object_handle,
+	                    const char  *name) const override;
 
-	void set_debug_tag(VkDevice device, VkObjectType object_type, uint64_t object_handle,
-	                   uint64_t tag_name, const void *tag_data, size_t tag_data_size) const override;
+	void set_debug_tag(VkDevice     device,
+	                   VkObjectType object_type,
+	                   uint64_t     object_handle,
+	                   uint64_t     tag_name,
+	                   const void  *tag_data,
+	                   size_t       tag_data_size) const override;
 
-	void cmd_begin_label(VkCommandBuffer command_buffer,
-	                     const char *name, glm::vec4 color) const override;
+	void cmd_begin_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color) const override;
 
 	void cmd_end_label(VkCommandBuffer command_buffer) const override;
 
-	void cmd_insert_label(VkCommandBuffer command_buffer,
-	                      const char *name, glm::vec4 color) const override;
+	void cmd_insert_label(VkCommandBuffer command_buffer, const char *name, glm::vec4 color) const override;
 };
 
 /**
@@ -125,19 +135,16 @@ class DummyDebugUtils final : public DebugUtils
 	inline void set_debug_name(VkDevice, VkObjectType, uint64_t, const char *) const override
 	{}
 
-	inline void set_debug_tag(VkDevice, VkObjectType, uint64_t,
-	                          uint64_t, const void *, size_t) const override
+	inline void set_debug_tag(VkDevice, VkObjectType, uint64_t, uint64_t, const void *, size_t) const override
 	{}
 
-	inline void cmd_begin_label(VkCommandBuffer,
-	                            const char *, glm::vec4) const override
+	inline void cmd_begin_label(VkCommandBuffer, const char *, glm::vec4) const override
 	{}
 
 	inline void cmd_end_label(VkCommandBuffer) const override
 	{}
 
-	inline void cmd_insert_label(VkCommandBuffer,
-	                             const char *, glm::vec4) const override
+	inline void cmd_insert_label(VkCommandBuffer, const char *, glm::vec4) const override
 	{}
 };
 
@@ -150,8 +157,10 @@ class DummyDebugUtils final : public DebugUtils
 class ScopedDebugLabel final
 {
   public:
-	ScopedDebugLabel(const DebugUtils &debug_utils, VkCommandBuffer command_buffer,
-	                 const char *name, glm::vec4 color = {});
+	ScopedDebugLabel(const DebugUtils &debug_utils,
+	                 VkCommandBuffer   command_buffer,
+	                 const char       *name,
+	                 glm::vec4         color = {});
 
 	ScopedDebugLabel(const vkb::core::CommandBufferC &command_buffer, const char *name, glm::vec4 color = {});
 

--- a/framework/core/descriptor_pool.cpp
+++ b/framework/core/descriptor_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,8 +25,7 @@ namespace vkb
 DescriptorPool::DescriptorPool(vkb::core::DeviceC        &device,
                                const DescriptorSetLayout &descriptor_set_layout,
                                uint32_t                   pool_size) :
-    device{device},
-    descriptor_set_layout{&descriptor_set_layout}
+    device{device}, descriptor_set_layout{&descriptor_set_layout}
 {
 	const auto &bindings = descriptor_set_layout.get_bindings();
 

--- a/framework/core/descriptor_set.cpp
+++ b/framework/core/descriptor_set.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -37,7 +37,8 @@ DescriptorSet::DescriptorSet(vkb::core::DeviceC                       &device,
 	prepare();
 }
 
-void DescriptorSet::reset(const BindingMap<VkDescriptorBufferInfo> &new_buffer_infos, const BindingMap<VkDescriptorImageInfo> &new_image_infos)
+void DescriptorSet::reset(const BindingMap<VkDescriptorBufferInfo> &new_buffer_infos,
+                          const BindingMap<VkDescriptorImageInfo>  &new_image_infos)
 {
 	if (!new_buffer_infos.empty() || !new_image_infos.empty())
 	{
@@ -82,14 +83,28 @@ void DescriptorSet::prepare()
 
 				size_t buffer_range_limit = static_cast<size_t>(buffer_info.range);
 
-				if ((binding_info->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER || binding_info->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) && buffer_range_limit > uniform_buffer_range_limit)
+				if ((binding_info->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER ||
+				     binding_info->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) &&
+				    buffer_range_limit > uniform_buffer_range_limit)
 				{
-					LOGE("Set {} binding {} cannot be updated: buffer size {} exceeds the uniform buffer range limit {}", descriptor_set_layout.get_index(), binding_index, buffer_info.range, uniform_buffer_range_limit);
+					LOGE(
+					    "Set {} binding {} cannot be updated: buffer size {} exceeds the uniform buffer range limit {}",
+					    descriptor_set_layout.get_index(),
+					    binding_index,
+					    buffer_info.range,
+					    uniform_buffer_range_limit);
 					buffer_range_limit = uniform_buffer_range_limit;
 				}
-				else if ((binding_info->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER || binding_info->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) && buffer_range_limit > storage_buffer_range_limit)
+				else if ((binding_info->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER ||
+				          binding_info->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) &&
+				         buffer_range_limit > storage_buffer_range_limit)
 				{
-					LOGE("Set {} binding {} cannot be updated: buffer size {} exceeds the storage buffer range limit {}", descriptor_set_layout.get_index(), binding_index, buffer_info.range, storage_buffer_range_limit);
+					LOGE(
+					    "Set {} binding {} cannot be updated: buffer size {} exceeds the storage buffer range limit {}",
+					    descriptor_set_layout.get_index(),
+					    binding_index,
+					    buffer_info.range,
+					    storage_buffer_range_limit);
 					buffer_range_limit = storage_buffer_range_limit;
 				}
 
@@ -196,11 +211,8 @@ void DescriptorSet::update(const std::vector<uint32_t> &bindings_to_update)
 	// Perform the Vulkan call to update the DescriptorSet by executing the write operations
 	if (!write_operations.empty())
 	{
-		vkUpdateDescriptorSets(device.get_handle(),
-		                       to_u32(write_operations.size()),
-		                       write_operations.data(),
-		                       0,
-		                       nullptr);
+		vkUpdateDescriptorSets(
+		    device.get_handle(), to_u32(write_operations.size()), write_operations.data(), 0, nullptr);
 	}
 
 	// Store the bindings from the write operations that were executed by vkUpdateDescriptorSets (and their hash)
@@ -213,11 +225,8 @@ void DescriptorSet::update(const std::vector<uint32_t> &bindings_to_update)
 
 void DescriptorSet::apply_writes() const
 {
-	vkUpdateDescriptorSets(device.get_handle(),
-	                       to_u32(write_descriptor_sets.size()),
-	                       write_descriptor_sets.data(),
-	                       0,
-	                       nullptr);
+	vkUpdateDescriptorSets(
+	    device.get_handle(), to_u32(write_descriptor_sets.size()), write_descriptor_sets.data(), 0, nullptr);
 }
 
 DescriptorSet::DescriptorSet(DescriptorSet &&other) :

--- a/framework/core/descriptor_set_layout.cpp
+++ b/framework/core/descriptor_set_layout.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -70,9 +70,12 @@ inline VkDescriptorType find_descriptor_type(ShaderResourceType resource_type, b
 	}
 }
 
-inline bool validate_binding(const VkDescriptorSetLayoutBinding &binding, const std::vector<VkDescriptorType> &blacklist)
+inline bool validate_binding(const VkDescriptorSetLayoutBinding  &binding,
+                             const std::vector<VkDescriptorType> &blacklist)
 {
-	return !(std::ranges::find_if(blacklist, [binding](const VkDescriptorType &type) { return type == binding.descriptorType; }) != blacklist.end());
+	return !(std::ranges::find_if(blacklist, [binding](const VkDescriptorType &type) {
+		         return type == binding.descriptorType;
+	         }) != blacklist.end());
 }
 
 inline bool validate_flags(vkb::core::PhysicalDeviceC const                &gpu,
@@ -100,9 +103,7 @@ DescriptorSetLayout::DescriptorSetLayout(vkb::core::DeviceC                &devi
                                          const uint32_t                     set_index,
                                          const std::vector<ShaderModule *> &shader_modules,
                                          const std::vector<ShaderResource> &resource_set) :
-    device{device},
-    set_index{set_index},
-    shader_modules{shader_modules}
+    device{device}, set_index{set_index}, shader_modules{shader_modules}
 {
 	// NOTE: `shader_modules` is passed in mainly for hashing their handles in `request_resource`.
 	//        This way, different pipelines (with different shaders / shader variants) will get
@@ -111,8 +112,7 @@ DescriptorSetLayout::DescriptorSetLayout(vkb::core::DeviceC                &devi
 	for (auto &resource : resource_set)
 	{
 		// Skip shader resources whitout a binding point
-		if (resource.type == ShaderResourceType::Input ||
-		    resource.type == ShaderResourceType::Output ||
+		if (resource.type == ShaderResourceType::Input || resource.type == ShaderResourceType::Output ||
 		    resource.type == ShaderResourceType::PushConstant ||
 		    resource.type == ShaderResourceType::SpecializationConstant)
 		{
@@ -158,15 +158,19 @@ DescriptorSetLayout::DescriptorSetLayout(vkb::core::DeviceC                &devi
 	create_info.pBindings    = bindings.data();
 
 	// Handle update-after-bind extensions
-	VkDescriptorSetLayoutBindingFlagsCreateInfoEXT binding_flags_create_info{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT};
-	if (std::ranges::find_if(resource_set,
-	                         [](const ShaderResource &shader_resource) { return shader_resource.mode == ShaderResourceMode::UpdateAfterBind; }) != resource_set.end())
+	VkDescriptorSetLayoutBindingFlagsCreateInfoEXT binding_flags_create_info{
+	    VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT};
+	if (std::ranges::find_if(resource_set, [](const ShaderResource &shader_resource) {
+		    return shader_resource.mode == ShaderResourceMode::UpdateAfterBind;
+	    }) != resource_set.end())
 	{
 		// Spec states you can't have ANY dynamic resources if you have one of the bindings set to update-after-bind
-		if (std::ranges::find_if(resource_set,
-		                         [](const ShaderResource &shader_resource) { return shader_resource.mode == ShaderResourceMode::Dynamic; }) != resource_set.end())
+		if (std::ranges::find_if(resource_set, [](const ShaderResource &shader_resource) {
+			    return shader_resource.mode == ShaderResourceMode::Dynamic;
+		    }) != resource_set.end())
 		{
-			throw std::runtime_error("Cannot create descriptor set layout, dynamic resources are not allowed if at least one resource is update-after-bind.");
+			throw std::runtime_error("Cannot create descriptor set layout, dynamic resources are not allowed if at "
+			                         "least one resource is update-after-bind.");
 		}
 
 		if (!validate_flags(device.get_gpu(), bindings, binding_flags))
@@ -178,7 +182,10 @@ DescriptorSetLayout::DescriptorSetLayout(vkb::core::DeviceC                &devi
 		binding_flags_create_info.pBindingFlags = binding_flags.data();
 
 		create_info.pNext = &binding_flags_create_info;
-		create_info.flags |= std::ranges::find(binding_flags, VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT) != binding_flags.end() ? VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT : 0;
+		create_info.flags |=
+		    std::ranges::find(binding_flags, VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT) != binding_flags.end() ?
+		        VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT :
+		        0;
 	}
 
 	// Create the Vulkan descriptor set layout handle

--- a/framework/core/device.h
+++ b/framework/core/device.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -44,36 +44,55 @@ using CommandPoolC   = CommandPool<vkb::BindingType::C>;
 using CommandPoolCpp = CommandPool<vkb::BindingType::Cpp>;
 
 template <vkb::BindingType bindingType>
-class Device
-    : public vkb::core::VulkanResource<bindingType, typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Device, VkDevice>::type>
+class Device : public vkb::core::VulkanResource<
+                   bindingType,
+                   typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Device, VkDevice>::type>
 {
   public:
-	using Bool32Type                 = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Bool32, VkBool32>::type;
-	using BufferCopyType             = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferCopy, VkBufferCopy>::type;
-	using CommandBufferLevelType     = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBufferLevel, VkCommandBufferLevel>::type;
-	using CommandBufferType          = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBuffer, VkCommandBuffer>::type;
-	using CommandPoolCreateFlagsType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandPoolCreateFlags, VkCommandPoolCreateFlags>::type;
-	using CommandPoolType            = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandPool, VkCommandPool>::type;
-	using DeviceMemoryType           = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceMemory, VkDeviceMemory>::type;
-	using DeviceType                 = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Device, VkDevice>::type;
-	using Extent2DType               = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Extent2D, VkExtent2D>::type;
-	using FenceType                  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Fence, VkFence>::type;
-	using FormatType                 = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Format, VkFormat>::type;
-	using ImageType                  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Image, VkImage>::type;
-	using ImageUsageFlagsType        = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageUsageFlags, VkImageUsageFlags>::type;
-	using MemoryPropertyFlagsType    = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::MemoryPropertyFlags, VkMemoryPropertyFlags>::type;
-	using QueueFamilyPropertiesType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::QueueFamilyProperties, VkQueueFamilyProperties>::type;
-	using QueueFlagBitsType          = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::QueueFlagBits, VkQueueFlagBits>::type;
-	using QueueFlagsType             = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::QueueFlags, VkQueueFlags>::type;
-	using QueueType                  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Queue, VkQueue>::type;
-	using ResultType                 = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Result, VkResult>::type;
-	using SemaphoreType              = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Semaphore, VkSemaphore>::type;
-	using SurfaceType                = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::SurfaceKHR, VkSurfaceKHR>::type;
+	using Bool32Type = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Bool32, VkBool32>::type;
+	using BufferCopyType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::BufferCopy, VkBufferCopy>::type;
+	using CommandBufferLevelType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBufferLevel, VkCommandBufferLevel>::type;
+	using CommandBufferType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandBuffer, VkCommandBuffer>::type;
+	using CommandPoolCreateFlagsType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::CommandPoolCreateFlags, VkCommandPoolCreateFlags>::type;
+	using CommandPoolType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::CommandPool, VkCommandPool>::type;
+	using DeviceMemoryType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::DeviceMemory, VkDeviceMemory>::type;
+	using DeviceType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Device, VkDevice>::type;
+	using Extent2DType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Extent2D, VkExtent2D>::type;
+	using FenceType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Fence, VkFence>::type;
+	using FormatType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Format, VkFormat>::type;
+	using ImageType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Image, VkImage>::type;
+	using ImageUsageFlagsType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ImageUsageFlags, VkImageUsageFlags>::type;
+	using MemoryPropertyFlagsType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::MemoryPropertyFlags, VkMemoryPropertyFlags>::type;
+	using QueueFamilyPropertiesType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::QueueFamilyProperties, VkQueueFamilyProperties>::type;
+	using QueueFlagBitsType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::QueueFlagBits, VkQueueFlagBits>::type;
+	using QueueFlagsType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::QueueFlags, VkQueueFlags>::type;
+	using QueueType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Queue, VkQueue>::type;
+	using ResultType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Result, VkResult>::type;
+	using SemaphoreType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Semaphore, VkSemaphore>::type;
+	using SurfaceType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::SurfaceKHR, VkSurfaceKHR>::type;
 
-	using DebugUtilsType    = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPDebugUtils, vkb::DebugUtils>::type;
-	using FencePoolType     = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::HPPFencePool, vkb::FencePool>::type;
-	using CoreQueueType     = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPQueue, vkb::Queue>::type;
-	using ResourceCacheType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::HPPResourceCache, vkb::ResourceCache>::type;
+	using DebugUtilsType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPDebugUtils, vkb::DebugUtils>::type;
+	using FencePoolType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::HPPFencePool, vkb::FencePool>::type;
+	using CoreQueueType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vkb::core::HPPQueue, vkb::Queue>::type;
+	using ResourceCacheType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vkb::HPPResourceCache, vkb::ResourceCache>::type;
 
   public:
 	/**
@@ -105,38 +124,60 @@ class Device
 	Device &operator=(const Device &) = delete;
 	Device &operator=(Device &&)      = delete;
 
-	void add_queue(size_t global_index, uint32_t family_index, QueueFamilyPropertiesType const &properties, Bool32Type can_present);
-	void copy_buffer(
-	    vkb::core::Buffer<bindingType> const &src, vkb::core::Buffer<bindingType> &dst, QueueType queue, BufferCopyType const *copy_region = nullptr);
-	CommandBufferType                      create_command_buffer(CommandBufferLevelType level, bool begin = false) const;
-	CommandPoolType                        create_command_pool(uint32_t queue_index, CommandPoolCreateFlagsType flags = 0);
-	std::pair<ImageType, DeviceMemoryType> create_image(
-	    FormatType format, Extent2DType const &extent, uint32_t mip_levels, ImageUsageFlagsType usage, MemoryPropertyFlagsType properties) const;
-	void                                 create_internal_command_pool();
-	void                                 create_internal_fence_pool();
-	void                                 flush_command_buffer(CommandBufferType command_buffer, QueueType queue, bool free = true, SemaphoreType signal_semaphore = VK_NULL_HANDLE) const;
-	vkb::core::CommandPool<bindingType> &get_command_pool() const;
-	DebugUtilsType const                &get_debug_utils() const;
-	FencePoolType                       &get_fence_pool() const;
-	PhysicalDevice<bindingType> const   &get_gpu() const;
-	CoreQueueType const                 &get_queue(uint32_t queue_family_index, uint32_t queue_index) const;
-	CoreQueueType const                 &get_queue_by_flags(QueueFlagsType queue_flags, uint32_t queue_index) const;
-	CoreQueueType const                 &get_queue_by_present(uint32_t queue_index) const;
-	ResourceCacheType                   &get_resource_cache();
-	bool                                 is_extension_enabled(const char *extension) const;
-	bool                                 is_image_format_supported(FormatType format) const;
-	void                                 wait_idle() const;
+	void              add_queue(size_t                           global_index,
+	                            uint32_t                         family_index,
+	                            QueueFamilyPropertiesType const &properties,
+	                            Bool32Type                       can_present);
+	void              copy_buffer(vkb::core::Buffer<bindingType> const &src,
+	                              vkb::core::Buffer<bindingType>       &dst,
+	                              QueueType                             queue,
+	                              BufferCopyType const                 *copy_region = nullptr);
+	CommandBufferType create_command_buffer(CommandBufferLevelType level, bool begin = false) const;
+	CommandPoolType   create_command_pool(uint32_t queue_index, CommandPoolCreateFlagsType flags = 0);
+	std::pair<ImageType, DeviceMemoryType> create_image(FormatType              format,
+	                                                    Extent2DType const     &extent,
+	                                                    uint32_t                mip_levels,
+	                                                    ImageUsageFlagsType     usage,
+	                                                    MemoryPropertyFlagsType properties) const;
+	void                                   create_internal_command_pool();
+	void                                   create_internal_fence_pool();
+	void                                   flush_command_buffer(CommandBufferType command_buffer,
+	                                                            QueueType         queue,
+	                                                            bool              free = true,
+	                                                            SemaphoreType     signal_semaphore = VK_NULL_HANDLE) const;
+	vkb::core::CommandPool<bindingType>   &get_command_pool() const;
+	DebugUtilsType const                  &get_debug_utils() const;
+	FencePoolType                         &get_fence_pool() const;
+	PhysicalDevice<bindingType> const     &get_gpu() const;
+	CoreQueueType const                   &get_queue(uint32_t queue_family_index, uint32_t queue_index) const;
+	CoreQueueType const                   &get_queue_by_flags(QueueFlagsType queue_flags, uint32_t queue_index) const;
+	CoreQueueType const                   &get_queue_by_present(uint32_t queue_index) const;
+	ResourceCacheType                     &get_resource_cache();
+	bool                                   is_extension_enabled(const char *extension) const;
+	bool                                   is_image_format_supported(FormatType format) const;
+	void                                   wait_idle() const;
 
   private:
-	void                                   copy_buffer_impl(vk::Device device, vkb::core::BufferCpp const &src, vkb::core::BufferCpp &dst, vk::Queue queue, vk::BufferCopy const *copy_region);
-	vk::CommandBuffer                      create_command_buffer_impl(vk::Device device, vk::CommandBufferLevel level, bool begin) const;
-	std::pair<vk::Image, vk::DeviceMemory> create_image_impl(
-	    vk::Device device, vk::Format format, vk::Extent2D const &extent, uint32_t mip_levels, vk::ImageUsageFlags usage, vk::MemoryPropertyFlags properties)
-	    const;
-	void flush_command_buffer_impl(
-	    vk::Device device, vk::CommandBuffer command_buffer, vk::Queue queue, bool free = true, vk::Semaphore signal_semaphore = nullptr) const;
+	void              copy_buffer_impl(vk::Device                  device,
+	                                   vkb::core::BufferCpp const &src,
+	                                   vkb::core::BufferCpp       &dst,
+	                                   vk::Queue                   queue,
+	                                   vk::BufferCopy const       *copy_region);
+	vk::CommandBuffer create_command_buffer_impl(vk::Device device, vk::CommandBufferLevel level, bool begin) const;
+	std::pair<vk::Image, vk::DeviceMemory> create_image_impl(vk::Device              device,
+	                                                         vk::Format              format,
+	                                                         vk::Extent2D const     &extent,
+	                                                         uint32_t                mip_levels,
+	                                                         vk::ImageUsageFlags     usage,
+	                                                         vk::MemoryPropertyFlags properties) const;
+	void                                   flush_command_buffer_impl(vk::Device        device,
+	                                                                 vk::CommandBuffer command_buffer,
+	                                                                 vk::Queue         queue,
+	                                                                 bool              free = true,
+	                                                                 vk::Semaphore     signal_semaphore = nullptr) const;
 	vkb::core::HPPQueue const &get_queue_by_flags_impl(vk::QueueFlags queue_flags, uint32_t queue_index) const;
-	void                       init(std::unordered_map<const char *, bool> const &requested_extensions, std::function<void(vkb::core::PhysicalDevice<bindingType> &)> request_gpu_features);
+	void                       init(std::unordered_map<const char *, bool> const                 &requested_extensions,
+	                                std::function<void(vkb::core::PhysicalDevice<bindingType> &)> request_gpu_features);
 
   private:
 	std::unique_ptr<vkb::core::CommandPoolCpp>    command_pool;
@@ -168,7 +209,11 @@ inline Device<vkb::BindingType::Cpp>::Device(vkb::core::PhysicalDeviceCpp       
                                              std::unique_ptr<vkb::core::HPPDebugUtils>         &&debug_utils,
                                              std::unordered_map<const char *, bool> const       &requested_extensions,
                                              std::function<void(vkb::core::PhysicalDeviceCpp &)> request_gpu_features) :
-    vkb::core::VulkanResourceCpp<vk::Device>{nullptr, this}, debug_utils{std::move(debug_utils)}, gpu{gpu}, resource_cache{*this}, surface(surface)
+    vkb::core::VulkanResourceCpp<vk::Device>{nullptr, this},
+    debug_utils{std::move(debug_utils)},
+    gpu{gpu},
+    resource_cache{*this},
+    surface(surface)
 {
 	init(requested_extensions, request_gpu_features);
 }
@@ -179,21 +224,32 @@ inline Device<vkb::BindingType::C>::Device(vkb::core::PhysicalDeviceC           
                                            std::unique_ptr<vkb::DebugUtils>                &&debug_utils,
                                            std::unordered_map<const char *, bool> const     &requested_extensions,
                                            std::function<void(vkb::core::PhysicalDeviceC &)> request_gpu_features) :
-    vkb::core::VulkanResourceC<VkDevice>{VK_NULL_HANDLE, this}, debug_utils{reinterpret_cast<vkb::core::HPPDebugUtils *>(debug_utils.release())}, gpu{reinterpret_cast<vkb::core::PhysicalDeviceCpp &>(gpu)}, resource_cache{*reinterpret_cast<vkb::core::DeviceCpp *>(this)}, surface(static_cast<vk::SurfaceKHR>(surface))
+    vkb::core::VulkanResourceC<VkDevice>{VK_NULL_HANDLE, this},
+    debug_utils{reinterpret_cast<vkb::core::HPPDebugUtils *>(debug_utils.release())},
+    gpu{reinterpret_cast<vkb::core::PhysicalDeviceCpp &>(gpu)},
+    resource_cache{*reinterpret_cast<vkb::core::DeviceCpp *>(this)},
+    surface(static_cast<vk::SurfaceKHR>(surface))
 {
 	init(requested_extensions, request_gpu_features);
 }
 
 template <>
-inline Device<vkb::BindingType::Cpp>::Device(vkb::core::PhysicalDeviceCpp &gpu, vk::Device &vulkan_device, vk::SurfaceKHR surface) :
+inline Device<vkb::BindingType::Cpp>::Device(vkb::core::PhysicalDeviceCpp &gpu,
+                                             vk::Device                   &vulkan_device,
+                                             vk::SurfaceKHR                surface) :
     VulkanResource{vulkan_device}, gpu{gpu}, surface{surface}, resource_cache{*this}
 {
 	debug_utils = std::make_unique<HPPDummyDebugUtils>();
 }
 
 template <>
-inline Device<vkb::BindingType::C>::Device(vkb::core::PhysicalDeviceC &gpu, VkDevice &vulkan_device, VkSurfaceKHR surface) :
-    VulkanResource{vulkan_device}, gpu{reinterpret_cast<vkb::core::PhysicalDeviceCpp &>(gpu)}, resource_cache{*reinterpret_cast<vkb::core::DeviceCpp *>(this)}, surface{static_cast<vk::SurfaceKHR>(surface)}
+inline Device<vkb::BindingType::C>::Device(vkb::core::PhysicalDeviceC &gpu,
+                                           VkDevice                   &vulkan_device,
+                                           VkSurfaceKHR                surface) :
+    VulkanResource{vulkan_device},
+    gpu{reinterpret_cast<vkb::core::PhysicalDeviceCpp &>(gpu)},
+    resource_cache{*reinterpret_cast<vkb::core::DeviceCpp *>(this)},
+    surface{static_cast<vk::SurfaceKHR>(surface)}
 {
 	debug_utils = std::make_unique<HPPDummyDebugUtils>();
 }
@@ -219,7 +275,10 @@ inline Device<bindingType>::~Device()
 }
 
 template <vkb::BindingType bindingType>
-inline void Device<bindingType>::add_queue(size_t global_index, uint32_t family_index, QueueFamilyPropertiesType const &properties, Bool32Type can_present)
+inline void Device<bindingType>::add_queue(size_t                           global_index,
+                                           uint32_t                         family_index,
+                                           QueueFamilyPropertiesType const &properties,
+                                           Bool32Type                       can_present)
 {
 	if (queues.size() <= global_index)
 	{
@@ -254,7 +313,8 @@ inline void Device<bindingType>::copy_buffer(vkb::core::Buffer<bindingType> cons
 	}
 	else
 	{
-		copy_buffer_impl(static_cast<vk::Device>(this->get_handle()), reinterpret_cast<vkb::core::BufferCpp const &>(src),
+		copy_buffer_impl(static_cast<vk::Device>(this->get_handle()),
+		                 reinterpret_cast<vkb::core::BufferCpp const &>(src),
 		                 reinterpret_cast<vkb::core::BufferCpp &>(dst),
 		                 static_cast<vk::Queue>(queue),
 		                 reinterpret_cast<vk::BufferCopy const *>(copy_region));
@@ -262,7 +322,8 @@ inline void Device<bindingType>::copy_buffer(vkb::core::Buffer<bindingType> cons
 }
 
 template <vkb::BindingType bindingType>
-inline typename Device<bindingType>::CommandBufferType Device<bindingType>::create_command_buffer(CommandBufferLevelType level, bool begin) const
+inline typename Device<bindingType>::CommandBufferType
+    Device<bindingType>::create_command_buffer(CommandBufferLevelType level, bool begin) const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -270,13 +331,14 @@ inline typename Device<bindingType>::CommandBufferType Device<bindingType>::crea
 	}
 	else
 	{
-		return static_cast<VkCommandBuffer>(
-		    create_command_buffer_impl(static_cast<vk::Device>(this->get_handle()), static_cast<vk::CommandBufferLevel>(level), begin));
+		return static_cast<VkCommandBuffer>(create_command_buffer_impl(
+		    static_cast<vk::Device>(this->get_handle()), static_cast<vk::CommandBufferLevel>(level), begin));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline typename Device<bindingType>::CommandPoolType Device<bindingType>::create_command_pool(uint32_t queue_index, CommandPoolCreateFlagsType flags)
+inline typename Device<bindingType>::CommandPoolType
+    Device<bindingType>::create_command_pool(uint32_t queue_index, CommandPoolCreateFlagsType flags)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -285,14 +347,19 @@ inline typename Device<bindingType>::CommandPoolType Device<bindingType>::create
 	}
 	else
 	{
-		vk::CommandPoolCreateInfo command_pool_info{.flags = static_cast<vk::CommandPoolCreateFlags>(flags), .queueFamilyIndex = queue_index};
+		vk::CommandPoolCreateInfo command_pool_info{.flags            = static_cast<vk::CommandPoolCreateFlags>(flags),
+		                                            .queueFamilyIndex = queue_index};
 		return static_cast<vk::Device>(this->get_handle()).createCommandPool(command_pool_info);
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline std::pair<typename Device<bindingType>::ImageType, typename Device<bindingType>::DeviceMemoryType> Device<bindingType>::create_image(
-    FormatType format, Extent2DType const &extent, uint32_t mip_levels, ImageUsageFlagsType usage, MemoryPropertyFlagsType properties) const
+inline std::pair<typename Device<bindingType>::ImageType, typename Device<bindingType>::DeviceMemoryType>
+    Device<bindingType>::create_image(FormatType              format,
+                                      Extent2DType const     &extent,
+                                      uint32_t                mip_levels,
+                                      ImageUsageFlagsType     usage,
+                                      MemoryPropertyFlagsType properties) const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -300,26 +367,29 @@ inline std::pair<typename Device<bindingType>::ImageType, typename Device<bindin
 	}
 	else
 	{
-		return static_cast<std::pair<VkImage, VkDeviceMemory>>(create_image_impl(static_cast<vk::Device>(this->get_handle()),
-		                                                                         static_cast<VkFormat>(format),
-		                                                                         static_cast<VkExtent2D>(extent),
-		                                                                         mip_levels,
-		                                                                         static_cast<VkImageUsageFlags>(usage),
-		                                                                         static_cast<VkMemoryPropertyFlags>(properties)));
+		return static_cast<std::pair<VkImage, VkDeviceMemory>>(
+		    create_image_impl(static_cast<vk::Device>(this->get_handle()),
+		                      static_cast<VkFormat>(format),
+		                      static_cast<VkExtent2D>(extent),
+		                      mip_levels,
+		                      static_cast<VkImageUsageFlags>(usage),
+		                      static_cast<VkMemoryPropertyFlags>(properties)));
 	}
 }
 
 template <vkb::BindingType bindingType>
 inline void Device<bindingType>::create_internal_command_pool()
 {
-	uint32_t familyIndex = get_queue_by_flags_impl(vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute, 0).get_family_index();
+	uint32_t familyIndex =
+	    get_queue_by_flags_impl(vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute, 0).get_family_index();
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
 		command_pool = std::make_unique<vkb::core::CommandPoolCpp>(*this, familyIndex);
 	}
 	else
 	{
-		command_pool = std::make_unique<vkb::core::CommandPoolCpp>(*reinterpret_cast<vkb::core::DeviceCpp *>(this), familyIndex);
+		command_pool =
+		    std::make_unique<vkb::core::CommandPoolCpp>(*reinterpret_cast<vkb::core::DeviceCpp *>(this), familyIndex);
 	}
 }
 
@@ -337,7 +407,10 @@ inline void Device<bindingType>::create_internal_fence_pool()
 }
 
 template <vkb::BindingType bindingType>
-inline void Device<bindingType>::flush_command_buffer(CommandBufferType command_buffer, QueueType queue, bool free, SemaphoreType signal_semaphore) const
+inline void Device<bindingType>::flush_command_buffer(CommandBufferType command_buffer,
+                                                      QueueType         queue,
+                                                      bool              free,
+                                                      SemaphoreType     signal_semaphore) const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -406,7 +479,8 @@ inline PhysicalDevice<bindingType> const &Device<bindingType>::get_gpu() const
 }
 
 template <vkb::BindingType bindingType>
-inline typename Device<bindingType>::CoreQueueType const &Device<bindingType>::get_queue(uint32_t queue_family_index, uint32_t queue_index) const
+inline typename Device<bindingType>::CoreQueueType const &Device<bindingType>::get_queue(uint32_t queue_family_index,
+                                                                                         uint32_t queue_index) const
 {
 	assert(queue_family_index < queues.size() && "Queue family index out of bounds");
 	assert(queue_index < queues[queue_family_index].size() && "Queue index out of bounds");
@@ -422,8 +496,8 @@ inline typename Device<bindingType>::CoreQueueType const &Device<bindingType>::g
 }
 
 template <vkb::BindingType bindingType>
-inline typename Device<bindingType>::CoreQueueType const &Device<bindingType>::get_queue_by_flags(QueueFlagsType required_queue_flags,
-                                                                                                  uint32_t       queue_index) const
+inline typename Device<bindingType>::CoreQueueType const &
+    Device<bindingType>::get_queue_by_flags(QueueFlagsType required_queue_flags, uint32_t queue_index) const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -431,16 +505,19 @@ inline typename Device<bindingType>::CoreQueueType const &Device<bindingType>::g
 	}
 	else
 	{
-		return reinterpret_cast<vkb::Queue const &>(get_queue_by_flags_impl(static_cast<vk::QueueFlags>(required_queue_flags), queue_index));
+		return reinterpret_cast<vkb::Queue const &>(
+		    get_queue_by_flags_impl(static_cast<vk::QueueFlags>(required_queue_flags), queue_index));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline typename Device<bindingType>::CoreQueueType const &Device<bindingType>::get_queue_by_present(uint32_t queue_index) const
+inline typename Device<bindingType>::CoreQueueType const &
+    Device<bindingType>::get_queue_by_present(uint32_t queue_index) const
 {
-	auto queueIt =
-	    std::ranges::find_if(queues,
-	                         [queue_index](const std::vector<vkb::core::HPPQueue> &queue_family) { return !queue_family.empty() && queue_index < queue_family[0].get_properties().queueCount && queue_family[0].support_present(); });
+	auto queueIt = std::ranges::find_if(queues, [queue_index](const std::vector<vkb::core::HPPQueue> &queue_family) {
+		return !queue_family.empty() && queue_index < queue_family[0].get_properties().queueCount &&
+		       queue_family[0].support_present();
+	});
 	if (queueIt != queues.end())
 	{
 		if constexpr (bindingType == vkb::BindingType::Cpp)
@@ -472,8 +549,9 @@ inline typename Device<bindingType>::ResourceCacheType &Device<bindingType>::get
 template <vkb::BindingType bindingType>
 inline bool Device<bindingType>::is_extension_enabled(const char *extension) const
 {
-	return std::ranges::find_if(enabled_extensions, [extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; }) !=
-	       enabled_extensions.end();
+	return std::ranges::find_if(enabled_extensions, [extension](const char *enabled_extension) {
+		       return strcmp(extension, enabled_extension) == 0;
+	       }) != enabled_extensions.end();
 }
 
 template <vkb::BindingType bindingType>
@@ -482,8 +560,12 @@ inline bool Device<bindingType>::is_image_format_supported(FormatType format) co
 	// as we want to check for an error (vk::Result::eErrorFormatNotSupported) we use the non-throwing version of getImageFormatProperties here
 	vk::ImageFormatProperties format_properties;
 	return vk::Result::eErrorFormatNotSupported !=
-	       gpu.get_handle().getImageFormatProperties(
-	           static_cast<vk::Format>(format), vk::ImageType::e2D, vk::ImageTiling::eOptimal, vk::ImageUsageFlagBits::eSampled, {}, &format_properties);
+	       gpu.get_handle().getImageFormatProperties(static_cast<vk::Format>(format),
+	                                                 vk::ImageType::e2D,
+	                                                 vk::ImageTiling::eOptimal,
+	                                                 vk::ImageUsageFlagBits::eSampled,
+	                                                 {},
+	                                                 &format_properties);
 }
 
 template <vkb::BindingType bindingType>
@@ -500,8 +582,11 @@ inline void Device<bindingType>::wait_idle() const
 }
 
 template <vkb::BindingType bindingType>
-inline void Device<bindingType>::copy_buffer_impl(
-    vk::Device device, vkb::core::BufferCpp const &src, vkb::core::BufferCpp &dst, vk::Queue queue, vk::BufferCopy const *copy_region)
+inline void Device<bindingType>::copy_buffer_impl(vk::Device                  device,
+                                                  vkb::core::BufferCpp const &src,
+                                                  vkb::core::BufferCpp       &dst,
+                                                  vk::Queue                   queue,
+                                                  vk::BufferCopy const       *copy_region)
 {
 	vk::CommandBuffer command_buffer = create_command_buffer_impl(device, vk::CommandBufferLevel::ePrimary, true);
 
@@ -521,12 +606,14 @@ inline void Device<bindingType>::copy_buffer_impl(
 }
 
 template <vkb::BindingType bindingType>
-inline vk::CommandBuffer Device<bindingType>::create_command_buffer_impl(vk::Device device, vk::CommandBufferLevel level, bool begin) const
+inline vk::CommandBuffer
+    Device<bindingType>::create_command_buffer_impl(vk::Device device, vk::CommandBufferLevel level, bool begin) const
 {
 	assert(command_pool && "No command pool exists in the device");
 
-	vk::CommandBufferAllocateInfo command_buffer_allocate_info{.commandPool = command_pool->get_handle(), .level = level, .commandBufferCount = 1};
-	vk::CommandBuffer             command_buffer = device.allocateCommandBuffers(command_buffer_allocate_info).front();
+	vk::CommandBufferAllocateInfo command_buffer_allocate_info{
+	    .commandPool = command_pool->get_handle(), .level = level, .commandBufferCount = 1};
+	vk::CommandBuffer command_buffer = device.allocateCommandBuffers(command_buffer_allocate_info).front();
 
 	// If requested, also start recording for the new command buffer
 	if (begin)
@@ -538,8 +625,13 @@ inline vk::CommandBuffer Device<bindingType>::create_command_buffer_impl(vk::Dev
 }
 
 template <vkb::BindingType bindingType>
-inline std::pair<vk::Image, vk::DeviceMemory> Device<bindingType>::create_image_impl(
-    vk::Device device, vk::Format format, vk::Extent2D const &extent, uint32_t mip_levels, vk::ImageUsageFlags usage, vk::MemoryPropertyFlags properties) const
+inline std::pair<vk::Image, vk::DeviceMemory>
+    Device<bindingType>::create_image_impl(vk::Device              device,
+                                           vk::Format              format,
+                                           vk::Extent2D const     &extent,
+                                           uint32_t                mip_levels,
+                                           vk::ImageUsageFlags     usage,
+                                           vk::MemoryPropertyFlags properties) const
 {
 	vk::ImageCreateInfo image_create_info{.imageType   = vk::ImageType::e2D,
 	                                      .format      = format,
@@ -554,8 +646,9 @@ inline std::pair<vk::Image, vk::DeviceMemory> Device<bindingType>::create_image_
 
 	vk::MemoryRequirements memory_requirements = device.getImageMemoryRequirements(image);
 
-	vk::MemoryAllocateInfo memory_allocation{.allocationSize  = memory_requirements.size,
-	                                         .memoryTypeIndex = gpu.get_memory_type(memory_requirements.memoryTypeBits, properties)};
+	vk::MemoryAllocateInfo memory_allocation{.allocationSize = memory_requirements.size,
+	                                         .memoryTypeIndex =
+	                                             gpu.get_memory_type(memory_requirements.memoryTypeBits, properties)};
 	vk::DeviceMemory       memory = device.allocateMemory(memory_allocation);
 	device.bindImageMemory(image, memory, 0);
 
@@ -563,8 +656,11 @@ inline std::pair<vk::Image, vk::DeviceMemory> Device<bindingType>::create_image_
 }
 
 template <vkb::BindingType bindingType>
-inline void Device<bindingType>::flush_command_buffer_impl(
-    vk::Device device, vk::CommandBuffer command_buffer, vk::Queue queue, bool free, vk::Semaphore signal_semaphore) const
+inline void Device<bindingType>::flush_command_buffer_impl(vk::Device        device,
+                                                           vk::CommandBuffer command_buffer,
+                                                           vk::Queue         queue,
+                                                           bool              free,
+                                                           vk::Semaphore     signal_semaphore) const
 {
 	if (command_buffer)
 	{
@@ -600,15 +696,16 @@ inline void Device<bindingType>::flush_command_buffer_impl(
 }
 
 template <vkb::BindingType bindingType>
-vkb::core::HPPQueue const &Device<bindingType>::get_queue_by_flags_impl(vk::QueueFlags required_queue_flags, uint32_t queue_index) const
+vkb::core::HPPQueue const &Device<bindingType>::get_queue_by_flags_impl(vk::QueueFlags required_queue_flags,
+                                                                        uint32_t       queue_index) const
 {
-	auto queueIt =
-	    std::ranges::find_if(queues,
-	                         [required_queue_flags, queue_index](const std::vector<vkb::core::HPPQueue> &queue) {
-		                         assert(!queue.empty());
-		                         vk::QueueFamilyProperties const &properties = queue[0].get_properties();
-		                         return ((properties.queueFlags & required_queue_flags) == required_queue_flags) && (queue_index < properties.queueCount);
-	                         });
+	auto queueIt = std::ranges::find_if(
+	    queues, [required_queue_flags, queue_index](const std::vector<vkb::core::HPPQueue> &queue) {
+		    assert(!queue.empty());
+		    vk::QueueFamilyProperties const &properties = queue[0].get_properties();
+		    return ((properties.queueFlags & required_queue_flags) == required_queue_flags) &&
+		           (queue_index < properties.queueCount);
+	    });
 
 	if (queueIt == queues.end())
 	{
@@ -619,7 +716,9 @@ vkb::core::HPPQueue const &Device<bindingType>::get_queue_by_flags_impl(vk::Queu
 }
 
 template <vkb::BindingType bindingType>
-inline void Device<bindingType>::init(std::unordered_map<const char *, bool> const &requested_extensions, std::function<void(vkb::core::PhysicalDevice<bindingType> &)> request_gpu_features)
+inline void
+    Device<bindingType>::init(std::unordered_map<const char *, bool> const                 &requested_extensions,
+                              std::function<void(vkb::core::PhysicalDevice<bindingType> &)> request_gpu_features)
 {
 	LOGI("Selected GPU: {}", *gpu.get_properties().deviceName);
 
@@ -636,7 +735,8 @@ inline void Device<bindingType>::init(std::unordered_map<const char *, bool> con
 
 		queue_priorities.push_back(std::vector<float>(queue_family_property.queueCount, 0.5f));
 		if (gpu.has_high_priority_graphics_queue() &&
-		    (vkb::common::get_queue_family_index(queue_family_properties, vk::QueueFlagBits::eGraphics) == queue_family_index))
+		    (vkb::common::get_queue_family_index(queue_family_properties, vk::QueueFlagBits::eGraphics) ==
+		     queue_family_index))
 		{
 			queue_priorities.back()[0] = 0.5f;
 		}
@@ -660,16 +760,16 @@ inline void Device<bindingType>::init(std::unordered_map<const char *, bool> con
 
 	// For performance queries, we also use host query reset since queryPool resets cannot
 	// live in the same command buffer as beginQuery
-	if (gpu.is_extension_supported("VK_KHR_performance_query") &&
-	    gpu.is_extension_supported("VK_EXT_host_query_reset"))
+	if (gpu.is_extension_supported("VK_KHR_performance_query") && gpu.is_extension_supported("VK_EXT_host_query_reset"))
 	{
 		auto perf_counter_features     = gpu.get_extension_features<vk::PhysicalDevicePerformanceQueryFeaturesKHR>();
 		auto host_query_reset_features = gpu.get_extension_features<vk::PhysicalDeviceHostQueryResetFeatures>();
 
 		if (perf_counter_features.performanceCounterQueryPools && host_query_reset_features.hostQueryReset)
 		{
-			gpu.add_extension_features<vk::PhysicalDevicePerformanceQueryFeaturesKHR>().performanceCounterQueryPools = VK_TRUE;
-			gpu.add_extension_features<vk::PhysicalDeviceHostQueryResetFeatures>().hostQueryReset                    = VK_TRUE;
+			gpu.add_extension_features<vk::PhysicalDevicePerformanceQueryFeaturesKHR>().performanceCounterQueryPools =
+			    VK_TRUE;
+			gpu.add_extension_features<vk::PhysicalDeviceHostQueryResetFeatures>().hostQueryReset = VK_TRUE;
 			enabled_extensions.push_back("VK_KHR_performance_query");
 			enabled_extensions.push_back("VK_EXT_host_query_reset");
 			LOGI("Performance query enabled");
@@ -754,12 +854,16 @@ inline void Device<bindingType>::init(std::unordered_map<const char *, bool> con
 		{
 			if constexpr (bindingType == BindingType::Cpp)
 			{
-				queues[queue_family_index].emplace_back(*this, queue_family_index, queue_family_property, present_supported, queue_index);
+				queues[queue_family_index].emplace_back(
+				    *this, queue_family_index, queue_family_property, present_supported, queue_index);
 			}
 			else
 			{
-				queues[queue_family_index].emplace_back(
-				    *reinterpret_cast<vkb::core::DeviceCpp *>(this), queue_family_index, queue_family_property, present_supported, queue_index);
+				queues[queue_family_index].emplace_back(*reinterpret_cast<vkb::core::DeviceCpp *>(this),
+				                                        queue_family_index,
+				                                        queue_family_property,
+				                                        present_supported,
+				                                        queue_index);
 			}
 		}
 	}
@@ -769,7 +873,8 @@ inline void Device<bindingType>::init(std::unordered_map<const char *, bool> con
 	if constexpr (bindingType == BindingType::Cpp)
 	{
 		command_pool = std::make_unique<vkb::core::CommandPoolCpp>(
-		    *this, get_queue_by_flags_impl(vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute, 0).get_family_index());
+		    *this,
+		    get_queue_by_flags_impl(vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute, 0).get_family_index());
 		fence_pool = std::make_unique<vkb::HPPFencePool>(*this);
 	}
 	else

--- a/framework/core/framebuffer.cpp
+++ b/framework/core/framebuffer.cpp
@@ -32,9 +32,10 @@ const VkExtent2D &Framebuffer::get_extent() const
 	return extent;
 }
 
-Framebuffer::Framebuffer(vkb::core::DeviceC &device, const vkb::rendering::RenderTargetC &render_target, const RenderPass &render_pass) :
-    device{device},
-    extent{render_target.get_extent()}
+Framebuffer::Framebuffer(vkb::core::DeviceC                  &device,
+                         const vkb::rendering::RenderTargetC &render_target,
+                         const RenderPass                    &render_pass) :
+    device{device}, extent{render_target.get_extent()}
 {
 	std::vector<VkImageView> attachments;
 
@@ -60,10 +61,7 @@ Framebuffer::Framebuffer(vkb::core::DeviceC &device, const vkb::rendering::Rende
 	}
 }
 
-Framebuffer::Framebuffer(Framebuffer &&other) :
-    device{other.device},
-    handle{other.handle},
-    extent{other.extent}
+Framebuffer::Framebuffer(Framebuffer &&other) : device{other.device}, handle{other.handle}, extent{other.extent}
 {
 	other.handle = VK_NULL_HANDLE;
 }

--- a/framework/core/framebuffer.h
+++ b/framework/core/framebuffer.h
@@ -41,7 +41,9 @@ using RenderTargetC = RenderTarget<vkb::BindingType::C>;
 class Framebuffer
 {
   public:
-	Framebuffer(vkb::core::DeviceC &device, const vkb::rendering::RenderTargetC &render_target, const RenderPass &render_pass);
+	Framebuffer(vkb::core::DeviceC                  &device,
+	            const vkb::rendering::RenderTargetC &render_target,
+	            const RenderPass                    &render_pass);
 
 	Framebuffer(const Framebuffer &) = delete;
 

--- a/framework/core/hpp_debug.cpp
+++ b/framework/core/hpp_debug.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -23,22 +23,37 @@ namespace vkb
 {
 namespace core
 {
-void HPPDebugUtilsExtDebugUtils::set_debug_name(vk::Device device, vk::ObjectType object_type, uint64_t object_handle, const char *name) const
+void HPPDebugUtilsExtDebugUtils::set_debug_name(vk::Device     device,
+                                                vk::ObjectType object_type,
+                                                uint64_t       object_handle,
+                                                const char    *name) const
 {
-	vk::DebugUtilsObjectNameInfoEXT name_info{.objectType = object_type, .objectHandle = object_handle, .pObjectName = name};
+	vk::DebugUtilsObjectNameInfoEXT name_info{
+	    .objectType = object_type, .objectHandle = object_handle, .pObjectName = name};
 	device.setDebugUtilsObjectNameEXT(name_info);
 }
 
-void HPPDebugUtilsExtDebugUtils::set_debug_tag(
-    vk::Device device, vk::ObjectType object_type, uint64_t object_handle, uint64_t tag_name, const void *tag_data, size_t tag_data_size) const
+void HPPDebugUtilsExtDebugUtils::set_debug_tag(vk::Device     device,
+                                               vk::ObjectType object_type,
+                                               uint64_t       object_handle,
+                                               uint64_t       tag_name,
+                                               const void    *tag_data,
+                                               size_t         tag_data_size) const
 {
-	vk::DebugUtilsObjectTagInfoEXT tag_info{.objectType = object_type, .objectHandle = object_handle, .tagName = tag_name, .tagSize = tag_data_size, .pTag = tag_data};
+	vk::DebugUtilsObjectTagInfoEXT tag_info{.objectType   = object_type,
+	                                        .objectHandle = object_handle,
+	                                        .tagName      = tag_name,
+	                                        .tagSize      = tag_data_size,
+	                                        .pTag         = tag_data};
 	device.setDebugUtilsObjectTagEXT(tag_info);
 }
 
-void HPPDebugUtilsExtDebugUtils::cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const
+void HPPDebugUtilsExtDebugUtils::cmd_begin_label(vk::CommandBuffer command_buffer,
+                                                 const char       *name,
+                                                 glm::vec4 const   color) const
 {
-	vk::DebugUtilsLabelEXT label_info{.pLabelName = name, .color = reinterpret_cast<std::array<float, 4> const &>(*&color[0])};
+	vk::DebugUtilsLabelEXT label_info{.pLabelName = name,
+	                                  .color      = reinterpret_cast<std::array<float, 4> const &>(*&color[0])};
 	command_buffer.beginDebugUtilsLabelEXT(label_info);
 }
 
@@ -47,29 +62,46 @@ void HPPDebugUtilsExtDebugUtils::cmd_end_label(vk::CommandBuffer command_buffer)
 	command_buffer.endDebugUtilsLabelEXT();
 }
 
-void HPPDebugUtilsExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const
+void HPPDebugUtilsExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buffer,
+                                                  const char       *name,
+                                                  glm::vec4 const   color) const
 {
-	vk::DebugUtilsLabelEXT label_info{.pLabelName = name, .color = reinterpret_cast<std::array<float, 4> const &>(*&color[0])};
+	vk::DebugUtilsLabelEXT label_info{.pLabelName = name,
+	                                  .color      = reinterpret_cast<std::array<float, 4> const &>(*&color[0])};
 	command_buffer.insertDebugUtilsLabelEXT(label_info);
 }
 
-void HPPDebugMarkerExtDebugUtils::set_debug_name(vk::Device device, vk::ObjectType object_type, uint64_t object_handle, const char *name) const
+void HPPDebugMarkerExtDebugUtils::set_debug_name(vk::Device     device,
+                                                 vk::ObjectType object_type,
+                                                 uint64_t       object_handle,
+                                                 const char    *name) const
 {
-	vk::DebugMarkerObjectNameInfoEXT name_info{.objectType = vk::debugReportObjectType(object_type), .object = object_handle, .pObjectName = name};
+	vk::DebugMarkerObjectNameInfoEXT name_info{
+	    .objectType = vk::debugReportObjectType(object_type), .object = object_handle, .pObjectName = name};
 	device.debugMarkerSetObjectNameEXT(name_info);
 }
 
-void HPPDebugMarkerExtDebugUtils::set_debug_tag(
-    vk::Device device, vk::ObjectType object_type, uint64_t object_handle, uint64_t tag_name, const void *tag_data, size_t tag_data_size) const
+void HPPDebugMarkerExtDebugUtils::set_debug_tag(vk::Device     device,
+                                                vk::ObjectType object_type,
+                                                uint64_t       object_handle,
+                                                uint64_t       tag_name,
+                                                const void    *tag_data,
+                                                size_t         tag_data_size) const
 {
-	vk::DebugMarkerObjectTagInfoEXT tag_info{
-	    .objectType = vk::debugReportObjectType(object_type), .object = object_handle, .tagName = tag_name, .tagSize = tag_data_size, .pTag = tag_data};
+	vk::DebugMarkerObjectTagInfoEXT tag_info{.objectType = vk::debugReportObjectType(object_type),
+	                                         .object     = object_handle,
+	                                         .tagName    = tag_name,
+	                                         .tagSize    = tag_data_size,
+	                                         .pTag       = tag_data};
 	device.debugMarkerSetObjectTagEXT(tag_info);
 }
 
-void HPPDebugMarkerExtDebugUtils::cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const
+void HPPDebugMarkerExtDebugUtils::cmd_begin_label(vk::CommandBuffer command_buffer,
+                                                  const char       *name,
+                                                  glm::vec4 const   color) const
 {
-	vk::DebugMarkerMarkerInfoEXT marker_info{.pMarkerName = name, .color = reinterpret_cast<std::array<float, 4> const &>(*&color[0])};
+	vk::DebugMarkerMarkerInfoEXT marker_info{.pMarkerName = name,
+	                                         .color       = reinterpret_cast<std::array<float, 4> const &>(*&color[0])};
 	command_buffer.debugMarkerBeginEXT(marker_info);
 }
 
@@ -78,9 +110,12 @@ void HPPDebugMarkerExtDebugUtils::cmd_end_label(vk::CommandBuffer command_buffer
 	command_buffer.debugMarkerEndEXT();
 }
 
-void HPPDebugMarkerExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const
+void HPPDebugMarkerExtDebugUtils::cmd_insert_label(vk::CommandBuffer command_buffer,
+                                                   const char       *name,
+                                                   glm::vec4 const   color) const
 {
-	vk::DebugMarkerMarkerInfoEXT marker_info{.pMarkerName = name, .color = reinterpret_cast<std::array<float, 4> const &>(*&color[0])};
+	vk::DebugMarkerMarkerInfoEXT marker_info{.pMarkerName = name,
+	                                         .color       = reinterpret_cast<std::array<float, 4> const &>(*&color[0])};
 	command_buffer.debugMarkerInsertEXT(marker_info);
 }
 
@@ -103,8 +138,7 @@ HPPScopedDebugLabel::HPPScopedDebugLabel(const vkb::core::CommandBufferCpp &comm
                                          std::string const                 &name,
                                          glm::vec4 const                    color) :
     HPPScopedDebugLabel{command_buffer.get_device().get_debug_utils(), command_buffer.get_handle(), name, color}
-{
-}
+{}
 
 HPPScopedDebugLabel::~HPPScopedDebugLabel()
 {

--- a/framework/core/hpp_debug.h
+++ b/framework/core/hpp_debug.h
@@ -40,18 +40,26 @@ class HPPDebugUtils
 	/**
 	 * @brief Sets the debug name for a Vulkan object.
 	 */
-	virtual void set_debug_name(vk::Device device, vk::ObjectType object_type, uint64_t object_handle, const char *name) const = 0;
+	virtual void set_debug_name(vk::Device     device,
+	                            vk::ObjectType object_type,
+	                            uint64_t       object_handle,
+	                            const char    *name) const = 0;
 
 	/**
 	 * @brief Tags the given Vulkan object with some data.
 	 */
-	virtual void set_debug_tag(
-	    vk::Device device, vk::ObjectType object_type, uint64_t object_handle, uint64_t tag_name, const void *tag_data, size_t tag_data_size) const = 0;
+	virtual void set_debug_tag(vk::Device     device,
+	                           vk::ObjectType object_type,
+	                           uint64_t       object_handle,
+	                           uint64_t       tag_name,
+	                           const void    *tag_data,
+	                           size_t         tag_data_size) const = 0;
 
 	/**
 	 * @brief Inserts a command to begin a new debug label/marker scope.
 	 */
-	virtual void cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color = {}) const = 0;
+	virtual void
+	    cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color = {}) const = 0;
 
 	/**
 	 * @brief Inserts a command to end the current debug label/marker scope.
@@ -61,7 +69,8 @@ class HPPDebugUtils
 	/**
 	 * @brief Inserts a (non-scoped) debug label/marker in the command buffer.
 	 */
-	virtual void cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color = {}) const = 0;
+	virtual void
+	    cmd_insert_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color = {}) const = 0;
 };
 
 /**
@@ -72,10 +81,17 @@ class HPPDebugUtilsExtDebugUtils final : public vkb::core::HPPDebugUtils
   public:
 	~HPPDebugUtilsExtDebugUtils() override = default;
 
-	void set_debug_name(vk::Device device, vk::ObjectType object_type, uint64_t object_handle, const char *name) const override;
+	void set_debug_name(vk::Device     device,
+	                    vk::ObjectType object_type,
+	                    uint64_t       object_handle,
+	                    const char    *name) const override;
 
-	void set_debug_tag(
-	    vk::Device device, vk::ObjectType object_type, uint64_t object_handle, uint64_t tag_name, const void *tag_data, size_t tag_data_size) const override;
+	void set_debug_tag(vk::Device     device,
+	                   vk::ObjectType object_type,
+	                   uint64_t       object_handle,
+	                   uint64_t       tag_name,
+	                   const void    *tag_data,
+	                   size_t         tag_data_size) const override;
 
 	void cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const override;
 
@@ -92,10 +108,17 @@ class HPPDebugMarkerExtDebugUtils final : public vkb::core::HPPDebugUtils
   public:
 	~HPPDebugMarkerExtDebugUtils() override = default;
 
-	void set_debug_name(vk::Device device, vk::ObjectType object_type, uint64_t object_handle, const char *name) const override;
+	void set_debug_name(vk::Device     device,
+	                    vk::ObjectType object_type,
+	                    uint64_t       object_handle,
+	                    const char    *name) const override;
 
-	void set_debug_tag(
-	    vk::Device device, vk::ObjectType object_type, uint64_t object_handle, uint64_t tag_name, const void *tag_data, size_t tag_data_size) const override;
+	void set_debug_tag(vk::Device     device,
+	                   vk::ObjectType object_type,
+	                   uint64_t       object_handle,
+	                   uint64_t       tag_name,
+	                   const void    *tag_data,
+	                   size_t         tag_data_size) const override;
 
 	void cmd_begin_label(vk::CommandBuffer command_buffer, const char *name, glm::vec4 const color) const override;
 
@@ -137,9 +160,14 @@ class HPPDummyDebugUtils final : public vkb::core::HPPDebugUtils
 class HPPScopedDebugLabel final
 {
   public:
-	HPPScopedDebugLabel(const vkb::core::HPPDebugUtils &debug_utils, vk::CommandBuffer command_buffer, std::string const &name, glm::vec4 const color = {});
+	HPPScopedDebugLabel(const vkb::core::HPPDebugUtils &debug_utils,
+	                    vk::CommandBuffer               command_buffer,
+	                    std::string const              &name,
+	                    glm::vec4 const                 color = {});
 
-	HPPScopedDebugLabel(const vkb::core::CommandBufferCpp &command_buffer, std::string const &name, glm::vec4 const color = {});
+	HPPScopedDebugLabel(const vkb::core::CommandBufferCpp &command_buffer,
+	                    std::string const                 &name,
+	                    glm::vec4 const                    color = {});
 
 	~HPPScopedDebugLabel();
 
@@ -149,10 +177,11 @@ class HPPScopedDebugLabel final
 };
 
 #if defined(VKB_DEBUG) || defined(VKB_VALIDATION_LAYERS)
-inline VKAPI_ATTR vk::Bool32 VKAPI_CALL debug_utils_messenger_callback(vk::DebugUtilsMessageSeverityFlagBitsEXT      message_severity,
-                                                                       vk::DebugUtilsMessageTypeFlagsEXT             message_type,
-                                                                       vk::DebugUtilsMessengerCallbackDataEXT const *callback_data,
-                                                                       void                                         *user_data)
+inline VKAPI_ATTR vk::Bool32 VKAPI_CALL
+                  debug_utils_messenger_callback(vk::DebugUtilsMessageSeverityFlagBitsEXT      message_severity,
+                                                 vk::DebugUtilsMessageTypeFlagsEXT             message_type,
+                                                 vk::DebugUtilsMessengerCallbackDataEXT const *callback_data,
+                                                 void                                         *user_data)
 {
 	// Log debug message
 	if (message_severity & vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning)

--- a/framework/core/hpp_descriptor_pool.h
+++ b/framework/core/hpp_descriptor_pool.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -39,9 +39,12 @@ class HPPDescriptorPool : private vkb::DescriptorPool
   public:
 	using vkb::DescriptorPool::reset;
 
-	HPPDescriptorPool(vkb::core::DeviceCpp &device, const vkb::core::HPPDescriptorSetLayout &descriptor_set_layout, uint32_t pool_size = MAX_SETS_PER_POOL) :
-	    vkb::DescriptorPool(
-	        reinterpret_cast<vkb::core::DeviceC &>(device), reinterpret_cast<vkb::DescriptorSetLayout const &>(descriptor_set_layout), pool_size)
+	HPPDescriptorPool(vkb::core::DeviceCpp                    &device,
+	                  const vkb::core::HPPDescriptorSetLayout &descriptor_set_layout,
+	                  uint32_t                                 pool_size = MAX_SETS_PER_POOL) :
+	    vkb::DescriptorPool(reinterpret_cast<vkb::core::DeviceC &>(device),
+	                        reinterpret_cast<vkb::DescriptorSetLayout const &>(descriptor_set_layout),
+	                        pool_size)
 	{}
 };
 }        // namespace core

--- a/framework/core/hpp_descriptor_set_layout.h
+++ b/framework/core/hpp_descriptor_set_layout.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -60,19 +60,20 @@ class HPPDescriptorSetLayout : private vkb::DescriptorSetLayout
 
 	std::unique_ptr<vk::DescriptorSetLayoutBinding> get_layout_binding(const uint32_t binding_index) const
 	{
-		return std::unique_ptr<vk::DescriptorSetLayoutBinding>(
-		    reinterpret_cast<vk::DescriptorSetLayoutBinding *>(vkb::DescriptorSetLayout::get_layout_binding(binding_index).release()));
+		return std::unique_ptr<vk::DescriptorSetLayoutBinding>(reinterpret_cast<vk::DescriptorSetLayoutBinding *>(
+		    vkb::DescriptorSetLayout::get_layout_binding(binding_index).release()));
 	}
 
 	std::unique_ptr<vk::DescriptorSetLayoutBinding> get_layout_binding(std::string const &name) const
 	{
-		return std::unique_ptr<vk::DescriptorSetLayoutBinding>(
-		    reinterpret_cast<vk::DescriptorSetLayoutBinding *>(vkb::DescriptorSetLayout::get_layout_binding(name).release()));
+		return std::unique_ptr<vk::DescriptorSetLayoutBinding>(reinterpret_cast<vk::DescriptorSetLayoutBinding *>(
+		    vkb::DescriptorSetLayout::get_layout_binding(name).release()));
 	}
 
 	vk::DescriptorBindingFlagsEXT get_layout_binding_flag(const uint32_t binding_index) const
 	{
-		return static_cast<vk::DescriptorBindingFlagsEXT>(vkb::DescriptorSetLayout::get_layout_binding_flag(binding_index));
+		return static_cast<vk::DescriptorBindingFlagsEXT>(
+		    vkb::DescriptorSetLayout::get_layout_binding_flag(binding_index));
 	}
 };
 }        // namespace core

--- a/framework/core/hpp_framebuffer.h
+++ b/framework/core/hpp_framebuffer.h
@@ -42,7 +42,9 @@ class HPPRenderPass;
 class HPPFramebuffer : private vkb::Framebuffer
 {
   public:
-	HPPFramebuffer(vkb::core::DeviceCpp &device, const vkb::rendering::RenderTargetCpp &render_target, const vkb::core::HPPRenderPass &render_pass) :
+	HPPFramebuffer(vkb::core::DeviceCpp                  &device,
+	               const vkb::rendering::RenderTargetCpp &render_target,
+	               const vkb::core::HPPRenderPass        &render_pass) :
 	    vkb::Framebuffer(reinterpret_cast<vkb::core::DeviceC &>(device),
 	                     reinterpret_cast<vkb::rendering::RenderTargetC const &>(render_target),
 	                     reinterpret_cast<vkb::RenderPass const &>(render_pass))

--- a/framework/core/hpp_image.h
+++ b/framework/core/hpp_image.h
@@ -36,20 +36,21 @@ struct HPPImageBuilder : public vkb::allocated::BuilderBaseCpp<HPPImageBuilder, 
 	using Parent = vkb::allocated::BuilderBaseCpp<HPPImageBuilder, vk::ImageCreateInfo>;
 
   public:
-	HPPImageBuilder(vk::Extent3D const &extent) :        // Better reasonable defaults than vk::ImageCreateInfo default ctor
-	    Parent(vk::ImageCreateInfo{.imageType = vk::ImageType::e2D, .format = vk::Format::eR8G8B8A8Unorm, .extent = extent, .mipLevels = 1, .arrayLayers = 1})
-	{
-	}
+	HPPImageBuilder(
+	    vk::Extent3D const &extent) :        // Better reasonable defaults than vk::ImageCreateInfo default ctor
+	    Parent(vk::ImageCreateInfo{.imageType   = vk::ImageType::e2D,
+	                               .format      = vk::Format::eR8G8B8A8Unorm,
+	                               .extent      = extent,
+	                               .mipLevels   = 1,
+	                               .arrayLayers = 1})
+	{}
 
-	HPPImageBuilder(vk::Extent2D const &extent) :
-	    HPPImageBuilder(vk::Extent3D{extent.width, extent.height, 1})
-	{
-	}
+	HPPImageBuilder(vk::Extent2D const &extent) : HPPImageBuilder(vk::Extent3D{extent.width, extent.height, 1})
+	{}
 
 	HPPImageBuilder(uint32_t width, uint32_t height = 1, uint32_t depth = 1) :
 	    HPPImageBuilder(vk::Extent3D{width, height, depth})
-	{
-	}
+	{}
 
 	HPPImageBuilder &with_format(vk::Format format)
 	{
@@ -127,8 +128,7 @@ class HPPImage : public vkb::allocated::AllocatedCpp<vk::Image>
 	         uint32_t                num_queue_families = 0,
 	         const uint32_t         *queue_families     = nullptr);
 
-	HPPImage(vkb::core::DeviceCpp  &device,
-	         HPPImageBuilder const &builder);
+	HPPImage(vkb::core::DeviceCpp &device, HPPImageBuilder const &builder);
 
 	HPPImage(const HPPImage &) = delete;
 

--- a/framework/core/hpp_image_core.cpp
+++ b/framework/core/hpp_image_core.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -79,7 +79,8 @@ HPPImage::HPPImage(vkb::core::DeviceCpp   &device,
 {}
 
 HPPImage::HPPImage(vkb::core::DeviceCpp &device, HPPImageBuilder const &builder) :
-    vkb::allocated::AllocatedCpp<vk::Image>{builder.get_allocation_create_info(), nullptr, &device}, create_info{builder.get_create_info()}
+    vkb::allocated::AllocatedCpp<vk::Image>{builder.get_allocation_create_info(), nullptr, &device},
+    create_info{builder.get_create_info()}
 {
 	get_handle()           = create_image(create_info);
 	subresource.arrayLayer = create_info.arrayLayers;

--- a/framework/core/hpp_image_view.cpp
+++ b/framework/core/hpp_image_view.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -39,11 +39,13 @@ HPPImageView::HPPImageView(vkb::core::HPPImage &img,
 		this->format = format = image->get_format();
 	}
 
-	subresource_range = vk::ImageSubresourceRange{.aspectMask     = (std::string(vk::componentName(format, 0)) == "D") ? vk::ImageAspectFlagBits::eDepth : vk::ImageAspectFlagBits::eColor,
-	                                              .baseMipLevel   = mip_level,
-	                                              .levelCount     = n_mip_levels == 0 ? image->get_subresource().mipLevel : n_mip_levels,
-	                                              .baseArrayLayer = array_layer,
-	                                              .layerCount     = n_array_layers == 0 ? image->get_subresource().arrayLayer : n_array_layers};
+	subresource_range = vk::ImageSubresourceRange{
+	    .aspectMask     = (std::string(vk::componentName(format, 0)) == "D") ? vk::ImageAspectFlagBits::eDepth :
+	                                                                           vk::ImageAspectFlagBits::eColor,
+	    .baseMipLevel   = mip_level,
+	    .levelCount     = n_mip_levels == 0 ? image->get_subresource().mipLevel : n_mip_levels,
+	    .baseArrayLayer = array_layer,
+	    .layerCount     = n_array_layers == 0 ? image->get_subresource().arrayLayer : n_array_layers};
 
 	vk::ImageViewCreateInfo image_view_create_info{
 	    .image = image->get_handle(), .viewType = view_type, .format = format, .subresourceRange = subresource_range};
@@ -56,7 +58,10 @@ HPPImageView::HPPImageView(vkb::core::HPPImage &img,
 }
 
 HPPImageView::HPPImageView(HPPImageView &&other) :
-    VulkanResource{std::move(other)}, image{other.image}, format{other.format}, subresource_range{other.subresource_range}
+    VulkanResource{std::move(other)},
+    image{other.image},
+    format{other.format},
+    subresource_range{other.subresource_range}
 {
 	// Remove old view from image set and add this new one
 	auto &views = image->get_views();
@@ -92,8 +97,10 @@ void HPPImageView::set_image(vkb::core::HPPImage &img)
 
 vk::ImageSubresourceLayers HPPImageView::get_subresource_layers() const
 {
-	return vk::ImageSubresourceLayers{
-	    subresource_range.aspectMask, subresource_range.baseMipLevel, subresource_range.baseArrayLayer, subresource_range.layerCount};
+	return vk::ImageSubresourceLayers{subresource_range.aspectMask,
+	                                  subresource_range.baseMipLevel,
+	                                  subresource_range.baseArrayLayer,
+	                                  subresource_range.layerCount};
 }
 
 vk::ImageSubresourceRange HPPImageView::get_subresource_range() const

--- a/framework/core/hpp_pipeline.h
+++ b/framework/core/hpp_pipeline.h
@@ -40,7 +40,9 @@ class HPPPipeline : private vkb::Pipeline
 class HPPComputePipeline : private vkb::ComputePipeline
 {
   public:
-	HPPComputePipeline(vkb::core::DeviceCpp &device, vk::PipelineCache pipeline_cache, vkb::rendering::PipelineStateCpp &pipeline_state) :
+	HPPComputePipeline(vkb::core::DeviceCpp             &device,
+	                   vk::PipelineCache                 pipeline_cache,
+	                   vkb::rendering::PipelineStateCpp &pipeline_state) :
 	    vkb::ComputePipeline(reinterpret_cast<vkb::core::DeviceC &>(device),
 	                         static_cast<VkPipelineCache>(pipeline_cache),
 	                         reinterpret_cast<vkb::rendering::PipelineStateC &>(pipeline_state))
@@ -55,7 +57,9 @@ class HPPComputePipeline : private vkb::ComputePipeline
 class HPPGraphicsPipeline : private vkb::GraphicsPipeline
 {
   public:
-	HPPGraphicsPipeline(vkb::core::DeviceCpp &device, vk::PipelineCache pipeline_cache, vkb::rendering::PipelineStateCpp &pipeline_state) :
+	HPPGraphicsPipeline(vkb::core::DeviceCpp             &device,
+	                    vk::PipelineCache                 pipeline_cache,
+	                    vkb::rendering::PipelineStateCpp &pipeline_state) :
 	    vkb::GraphicsPipeline(reinterpret_cast<vkb::core::DeviceC &>(device),
 	                          static_cast<VkPipelineCache>(pipeline_cache),
 	                          reinterpret_cast<vkb::rendering::PipelineStateC &>(pipeline_state))

--- a/framework/core/hpp_pipeline_layout.cpp
+++ b/framework/core/hpp_pipeline_layout.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,9 +24,9 @@ namespace vkb
 {
 namespace core
 {
-HPPPipelineLayout::HPPPipelineLayout(vkb::core::DeviceCpp &device, const std::vector<vkb::core::HPPShaderModule *> &shader_modules) :
-    device{device},
-    shader_modules{shader_modules}
+HPPPipelineLayout::HPPPipelineLayout(vkb::core::DeviceCpp                            &device,
+                                     const std::vector<vkb::core::HPPShaderModule *> &shader_modules) :
+    device{device}, shader_modules{shader_modules}
 {
 	// Collect and combine all the shader resources from each of the shader modules
 	// Collate them all into a map that is indexed by the name of the resource
@@ -37,7 +37,8 @@ HPPPipelineLayout::HPPPipelineLayout(vkb::core::DeviceCpp &device, const std::ve
 			std::string key = shader_resource.name;
 
 			// Since 'Input' and 'Output' resources can have the same name, we modify the key string
-			if (shader_resource.type == vkb::core::HPPShaderResourceType::Input || shader_resource.type == vkb::core::HPPShaderResourceType::Output)
+			if (shader_resource.type == vkb::core::HPPShaderResourceType::Input ||
+			    shader_resource.type == vkb::core::HPPShaderResourceType::Output)
 			{
 				key = std::to_string(static_cast<uint32_t>(shader_resource.stages)) + "_" + key;
 			}
@@ -81,8 +82,8 @@ HPPPipelineLayout::HPPPipelineLayout(vkb::core::DeviceCpp &device, const std::ve
 	// Create a descriptor set layout for each shader set in the shader modules
 	for (auto &shader_set_it : shader_sets)
 	{
-		descriptor_set_layouts.emplace_back(
-		    &device.get_resource_cache().request_descriptor_set_layout(shader_set_it.first, shader_modules, shader_set_it.second));
+		descriptor_set_layouts.emplace_back(&device.get_resource_cache().request_descriptor_set_layout(
+		    shader_set_it.first, shader_modules, shader_set_it.second));
 	}
 
 	// Collect all the descriptor set layout handles, maintaining set order
@@ -96,13 +97,15 @@ HPPPipelineLayout::HPPPipelineLayout(vkb::core::DeviceCpp &device, const std::ve
 	std::vector<vk::PushConstantRange> push_constant_ranges;
 	for (auto &push_constant_resource : get_resources(vkb::core::HPPShaderResourceType::PushConstant))
 	{
-		push_constant_ranges.push_back({push_constant_resource.stages, push_constant_resource.offset, push_constant_resource.size});
+		push_constant_ranges.push_back(
+		    {push_constant_resource.stages, push_constant_resource.offset, push_constant_resource.size});
 	}
 
-	vk::PipelineLayoutCreateInfo create_info{.setLayoutCount         = static_cast<uint32_t>(descriptor_set_layout_handles.size()),
-	                                         .pSetLayouts            = descriptor_set_layout_handles.data(),
-	                                         .pushConstantRangeCount = static_cast<uint32_t>(push_constant_ranges.size()),
-	                                         .pPushConstantRanges    = push_constant_ranges.data()};
+	vk::PipelineLayoutCreateInfo create_info{
+	    .setLayoutCount         = static_cast<uint32_t>(descriptor_set_layout_handles.size()),
+	    .pSetLayouts            = descriptor_set_layout_handles.data(),
+	    .pushConstantRangeCount = static_cast<uint32_t>(push_constant_ranges.size()),
+	    .pPushConstantRanges    = push_constant_ranges.data()};
 
 	// Create the Vulkan pipeline layout handle
 	handle = device.get_handle().createPipelineLayout(create_info);
@@ -130,8 +133,9 @@ HPPPipelineLayout::~HPPPipelineLayout()
 
 vkb::core::HPPDescriptorSetLayout const &HPPPipelineLayout::get_descriptor_set_layout(const uint32_t set_index) const
 {
-	auto it = std::ranges::find_if(descriptor_set_layouts,
-	                               [&set_index](auto const *descriptor_set_layout) { return descriptor_set_layout->get_index() == set_index; });
+	auto it = std::ranges::find_if(descriptor_set_layouts, [&set_index](auto const *descriptor_set_layout) {
+		return descriptor_set_layout->get_index() == set_index;
+	});
 	if (it == descriptor_set_layouts.end())
 	{
 		throw std::runtime_error("Couldn't find descriptor set layout at set index " + to_string(set_index));
@@ -150,7 +154,8 @@ vk::ShaderStageFlags HPPPipelineLayout::get_push_constant_range_stage(uint32_t s
 
 	for (auto &push_constant_resource : get_resources(vkb::core::HPPShaderResourceType::PushConstant))
 	{
-		if (push_constant_resource.offset <= offset && offset + size <= push_constant_resource.offset + push_constant_resource.size)
+		if (push_constant_resource.offset <= offset &&
+		    offset + size <= push_constant_resource.offset + push_constant_resource.size)
 		{
 			stages |= push_constant_resource.stages;
 		}
@@ -158,7 +163,8 @@ vk::ShaderStageFlags HPPPipelineLayout::get_push_constant_range_stage(uint32_t s
 	return stages;
 }
 
-std::vector<vkb::core::HPPShaderResource> HPPPipelineLayout::get_resources(const vkb::core::HPPShaderResourceType &type, vk::ShaderStageFlagBits stage) const
+std::vector<vkb::core::HPPShaderResource> HPPPipelineLayout::get_resources(const vkb::core::HPPShaderResourceType &type,
+                                                                           vk::ShaderStageFlagBits stage) const
 {
 	std::vector<vkb::core::HPPShaderResource> found_resources;
 
@@ -183,7 +189,8 @@ const std::vector<vkb::core::HPPShaderModule *> &HPPPipelineLayout::get_shader_m
 	return shader_modules;
 }
 
-const std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> &HPPPipelineLayout::get_shader_sets() const
+const std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> &
+    HPPPipelineLayout::get_shader_sets() const
 {
 	return shader_sets;
 }

--- a/framework/core/hpp_pipeline_layout.h
+++ b/framework/core/hpp_pipeline_layout.h
@@ -42,22 +42,27 @@ class HPPPipelineLayout
 	HPPPipelineLayout &operator=(const HPPPipelineLayout &) = delete;
 	HPPPipelineLayout &operator=(HPPPipelineLayout &&)      = delete;
 
-	vkb::core::HPPDescriptorSetLayout const                                       &get_descriptor_set_layout(const uint32_t set_index) const;
-	vk::PipelineLayout                                                             get_handle() const;
-	vk::ShaderStageFlags                                                           get_push_constant_range_stage(uint32_t size, uint32_t offset = 0) const;
-	std::vector<vkb::core::HPPShaderResource>                                      get_resources(const vkb::core::HPPShaderResourceType &type  = vkb::core::HPPShaderResourceType::All,
-	                                                                                             vk::ShaderStageFlagBits                 stage = vk::ShaderStageFlagBits::eAll) const;
+	vkb::core::HPPDescriptorSetLayout const &get_descriptor_set_layout(const uint32_t set_index) const;
+	vk::PipelineLayout                       get_handle() const;
+	vk::ShaderStageFlags                     get_push_constant_range_stage(uint32_t size, uint32_t offset = 0) const;
+	std::vector<vkb::core::HPPShaderResource>
+	    get_resources(const vkb::core::HPPShaderResourceType &type  = vkb::core::HPPShaderResourceType::All,
+	                  vk::ShaderStageFlagBits                 stage = vk::ShaderStageFlagBits::eAll) const;
 	const std::vector<vkb::core::HPPShaderModule *>                               &get_shader_modules() const;
 	const std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> &get_shader_sets() const;
-	bool                                                                           has_descriptor_set_layout(const uint32_t set_index) const;
+	bool has_descriptor_set_layout(const uint32_t set_index) const;
 
   private:
-	vkb::core::DeviceCpp                                                   &device;
-	vk::PipelineLayout                                                      handle;
-	std::vector<vkb::core::HPPShaderModule *>                               shader_modules;                // The shader modules that this pipeline layout uses
-	std::unordered_map<std::string, vkb::core::HPPShaderResource>           shader_resources;              // The shader resources that this pipeline layout uses, indexed by their name
-	std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>> shader_sets;                   // A map of each set and the resources it owns used by the pipeline layout
-	std::vector<vkb::core::HPPDescriptorSetLayout *>                        descriptor_set_layouts;        // The different descriptor set layouts for this pipeline layout
+	vkb::core::DeviceCpp &device;
+	vk::PipelineLayout    handle;
+	std::vector<vkb::core::HPPShaderModule *>
+	    shader_modules;        // The shader modules that this pipeline layout uses
+	std::unordered_map<std::string, vkb::core::HPPShaderResource>
+	    shader_resources;        // The shader resources that this pipeline layout uses, indexed by their name
+	std::unordered_map<uint32_t, std::vector<vkb::core::HPPShaderResource>>
+	    shader_sets;        // A map of each set and the resources it owns used by the pipeline layout
+	std::vector<vkb::core::HPPDescriptorSetLayout *>
+	    descriptor_set_layouts;        // The different descriptor set layouts for this pipeline layout
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/hpp_queue.cpp
+++ b/framework/core/hpp_queue.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -23,7 +23,11 @@ namespace vkb
 {
 namespace core
 {
-HPPQueue::HPPQueue(vkb::core::DeviceCpp &device, uint32_t family_index, vk::QueueFamilyProperties const &properties, vk::Bool32 can_present, uint32_t index) :
+HPPQueue::HPPQueue(vkb::core::DeviceCpp            &device,
+                   uint32_t                         family_index,
+                   vk::QueueFamilyProperties const &properties,
+                   vk::Bool32                       can_present,
+                   uint32_t                         index) :
     device{device}, family_index{family_index}, index{index}, can_present{can_present}, properties{properties}
 {
 	handle = device.get_handle().getQueue(family_index, index);

--- a/framework/core/hpp_queue.h
+++ b/framework/core/hpp_queue.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -39,7 +39,11 @@ using CommandBufferCpp = CommandBuffer<vkb::BindingType::Cpp>;
 class HPPQueue
 {
   public:
-	HPPQueue(vkb::core::DeviceCpp &device, uint32_t family_index, vk::QueueFamilyProperties const &properties, vk::Bool32 can_present, uint32_t index);
+	HPPQueue(vkb::core::DeviceCpp            &device,
+	         uint32_t                         family_index,
+	         vk::QueueFamilyProperties const &properties,
+	         vk::Bool32                       can_present,
+	         uint32_t                         index);
 
 	HPPQueue(const HPPQueue &) = default;
 

--- a/framework/core/hpp_sampler.cpp
+++ b/framework/core/hpp_sampler.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,8 +26,7 @@ HPPSampler::HPPSampler(vkb::core::DeviceCpp &device, const vk::SamplerCreateInfo
     vkb::core::VulkanResourceCpp<vk::Sampler>{device.get_handle().createSampler(info), &device}
 {}
 
-HPPSampler::HPPSampler(HPPSampler &&other) :
-    VulkanResource(std::move(other))
+HPPSampler::HPPSampler(HPPSampler &&other) : VulkanResource(std::move(other))
 {}
 
 HPPSampler::~HPPSampler()

--- a/framework/core/hpp_shader_module.h
+++ b/framework/core/hpp_shader_module.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -85,8 +85,7 @@ class HPPShaderSource : private vkb::ShaderSource
 {
   public:
 	HPPShaderSource() = default;
-	HPPShaderSource(const std::string &filename) :
-	    vkb::ShaderSource(filename)
+	HPPShaderSource(const std::string &filename) : vkb::ShaderSource(filename)
 	{}
 };
 

--- a/framework/core/hpp_swapchain.cpp
+++ b/framework/core/hpp_swapchain.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -69,14 +69,19 @@ vk::PresentModeKHR choose_present_mode(vk::PresentModeKHR                     re
 	if (present_mode_it == available_present_modes.end())
 	{
 		// If the requested present mode isn't found, then try to find a mode from the priority list
-		auto const chosen_present_mode_it =
-		    std::ranges::find_if(present_mode_priority_list,
-		                         [&available_present_modes](vk::PresentModeKHR present_mode) { return std::ranges::find(available_present_modes, present_mode) != available_present_modes.end(); });
+		auto const chosen_present_mode_it = std::ranges::find_if(
+		    present_mode_priority_list, [&available_present_modes](vk::PresentModeKHR present_mode) {
+			    return std::ranges::find(available_present_modes, present_mode) != available_present_modes.end();
+		    });
 
 		// If nothing found, always default to FIFO
-		vk::PresentModeKHR const chosen_present_mode = (chosen_present_mode_it != present_mode_priority_list.end()) ? *chosen_present_mode_it : vk::PresentModeKHR::eFifo;
+		vk::PresentModeKHR const chosen_present_mode = (chosen_present_mode_it != present_mode_priority_list.end()) ?
+		                                                   *chosen_present_mode_it :
+		                                                   vk::PresentModeKHR::eFifo;
 
-		LOGW("(HPPSwapchain) Present mode '{}' not supported. Selecting '{}'.", vk::to_string(request_present_mode), vk::to_string(chosen_present_mode));
+		LOGW("(HPPSwapchain) Present mode '{}' not supported. Selecting '{}'.",
+		     vk::to_string(request_present_mode),
+		     vk::to_string(chosen_present_mode));
 		return chosen_present_mode;
 	}
 	else
@@ -96,12 +101,15 @@ vk::SurfaceFormatKHR choose_surface_format(const vk::SurfaceFormatKHR           
 	// If the requested surface format isn't found, then try to request a format from the priority list
 	if (surface_format_it == available_surface_formats.end())
 	{
-		auto const chosen_surface_format_it =
-		    std::ranges::find_if(surface_format_priority_list,
-		                         [&available_surface_formats](vk::SurfaceFormatKHR surface_format) { return std::ranges::find(available_surface_formats, surface_format) != available_surface_formats.end(); });
+		auto const chosen_surface_format_it = std::ranges::find_if(
+		    surface_format_priority_list, [&available_surface_formats](vk::SurfaceFormatKHR surface_format) {
+			    return std::ranges::find(available_surface_formats, surface_format) != available_surface_formats.end();
+		    });
 
 		// If nothing found, default to the first available format
-		vk::SurfaceFormatKHR const &chosen_surface_format = (chosen_surface_format_it != surface_format_priority_list.end()) ? *chosen_surface_format_it : available_surface_formats[0];
+		vk::SurfaceFormatKHR const &chosen_surface_format =
+		    (chosen_surface_format_it != surface_format_priority_list.end()) ? *chosen_surface_format_it :
+		                                                                       available_surface_formats[0];
 
 		LOGW("(HPPSwapchain) Surface format ({}) not supported. Selecting ({}).",
 		     vk::to_string(requested_surface_format.format) + ", " + vk::to_string(requested_surface_format.colorSpace),
@@ -111,7 +119,8 @@ vk::SurfaceFormatKHR choose_surface_format(const vk::SurfaceFormatKHR           
 	else
 	{
 		LOGI("(HPPSwapchain) Surface format selected: {}",
-		     vk::to_string(requested_surface_format.format) + ", " + vk::to_string(requested_surface_format.colorSpace));
+		     vk::to_string(requested_surface_format.format) + ", " +
+		         vk::to_string(requested_surface_format.colorSpace));
 		return requested_surface_format;
 	}
 }
@@ -130,7 +139,9 @@ vk::SurfaceTransformFlagBitsKHR choose_transform(vk::SurfaceTransformFlagBitsKHR
 		return request_transform;
 	}
 
-	LOGW("(HPPSwapchain) Surface transform '{}' not supported. Selecting '{}'.", vk::to_string(request_transform), vk::to_string(current_transform));
+	LOGW("(HPPSwapchain) Surface transform '{}' not supported. Selecting '{}'.",
+	     vk::to_string(request_transform),
+	     vk::to_string(current_transform));
 	return current_transform;
 }
 
@@ -142,29 +153,35 @@ vk::CompositeAlphaFlagBitsKHR choose_composite_alpha(vk::CompositeAlphaFlagBitsK
 		return request_composite_alpha;
 	}
 
-	static const std::vector<vk::CompositeAlphaFlagBitsKHR> composite_alpha_priority_list = {vk::CompositeAlphaFlagBitsKHR::eOpaque,
-	                                                                                         vk::CompositeAlphaFlagBitsKHR::ePreMultiplied,
-	                                                                                         vk::CompositeAlphaFlagBitsKHR::ePostMultiplied,
-	                                                                                         vk::CompositeAlphaFlagBitsKHR::eInherit};
+	static const std::vector<vk::CompositeAlphaFlagBitsKHR> composite_alpha_priority_list = {
+	    vk::CompositeAlphaFlagBitsKHR::eOpaque,
+	    vk::CompositeAlphaFlagBitsKHR::ePreMultiplied,
+	    vk::CompositeAlphaFlagBitsKHR::ePostMultiplied,
+	    vk::CompositeAlphaFlagBitsKHR::eInherit};
 
 	auto const chosen_composite_alpha_it =
 	    std::find_if(composite_alpha_priority_list.begin(),
 	                 composite_alpha_priority_list.end(),
-	                 [&supported_composite_alpha](vk::CompositeAlphaFlagBitsKHR composite_alpha) { return composite_alpha & supported_composite_alpha; });
+	                 [&supported_composite_alpha](vk::CompositeAlphaFlagBitsKHR composite_alpha) {
+		                 return composite_alpha & supported_composite_alpha;
+	                 });
 	if (chosen_composite_alpha_it == composite_alpha_priority_list.end())
 	{
 		throw std::runtime_error("No compatible composite alpha found.");
 	}
 	else
 	{
-		LOGW("(HPPSwapchain) Composite alpha '{}' not supported. Selecting '{}.", vk::to_string(request_composite_alpha), vk::to_string(*chosen_composite_alpha_it));
+		LOGW("(HPPSwapchain) Composite alpha '{}' not supported. Selecting '{}.",
+		     vk::to_string(request_composite_alpha),
+		     vk::to_string(*chosen_composite_alpha_it));
 		return *chosen_composite_alpha_it;
 	}
 }
 
 bool validate_format_feature(vk::ImageUsageFlagBits image_usage, vk::FormatFeatureFlags supported_features)
 {
-	return (image_usage != vk::ImageUsageFlagBits::eStorage) || (supported_features & vk::FormatFeatureFlagBits::eStorageImage);
+	return (image_usage != vk::ImageUsageFlagBits::eStorage) ||
+	       (supported_features & vk::FormatFeatureFlagBits::eStorageImage);
 }
 
 std::set<vk::ImageUsageFlagBits> choose_image_usage(const std::set<vk::ImageUsageFlagBits> &requested_image_usage_flags,
@@ -188,11 +205,16 @@ std::set<vk::ImageUsageFlagBits> choose_image_usage(const std::set<vk::ImageUsag
 	{
 		// Pick the first format from list of defaults, if supported
 		static const std::vector<vk::ImageUsageFlagBits> image_usage_priority_list = {
-		    vk::ImageUsageFlagBits::eColorAttachment, vk::ImageUsageFlagBits::eStorage, vk::ImageUsageFlagBits::eSampled, vk::ImageUsageFlagBits::eTransferDst};
+		    vk::ImageUsageFlagBits::eColorAttachment,
+		    vk::ImageUsageFlagBits::eStorage,
+		    vk::ImageUsageFlagBits::eSampled,
+		    vk::ImageUsageFlagBits::eTransferDst};
 
-		auto const priority_list_it =
-		    std::ranges::find_if(image_usage_priority_list,
-		                         [&supported_image_usage, &supported_features](auto const image_usage) { return ((image_usage & supported_image_usage) && validate_format_feature(image_usage, supported_features)); });
+		auto const priority_list_it = std::ranges::find_if(
+		    image_usage_priority_list, [&supported_image_usage, &supported_features](auto const image_usage) {
+			    return ((image_usage & supported_image_usage) &&
+			            validate_format_feature(image_usage, supported_features));
+		    });
 		if (priority_list_it != image_usage_priority_list.end())
 		{
 			validated_image_usage_flags.insert(*priority_list_it);
@@ -275,7 +297,9 @@ HPPSwapchain::HPPSwapchain(HPPSwapchain &old_swapchain, const std::set<vk::Image
                  old_swapchain.requested_compression_fixed_rate}
 {}
 
-HPPSwapchain::HPPSwapchain(HPPSwapchain &old_swapchain, const vk::Extent2D &extent, const vk::SurfaceTransformFlagBitsKHR transform) :
+HPPSwapchain::HPPSwapchain(HPPSwapchain                         &old_swapchain,
+                           const vk::Extent2D                   &extent,
+                           const vk::SurfaceTransformFlagBitsKHR transform) :
     HPPSwapchain{old_swapchain,
                  old_swapchain.device,
                  old_swapchain.surface,
@@ -305,8 +329,7 @@ HPPSwapchain::HPPSwapchain(HPPSwapchain                               &old_swapc
                  old_swapchain.image_usage_flags,
                  requested_compression,
                  requested_compression_fixed_rate}
-{
-}
+{}
 
 HPPSwapchain::HPPSwapchain(vkb::core::DeviceCpp                       &device,
                            vk::SurfaceKHR                              surface,
@@ -319,7 +342,16 @@ HPPSwapchain::HPPSwapchain(vkb::core::DeviceCpp                       &device,
                            const std::set<vk::ImageUsageFlagBits>     &image_usage_flags,
                            const vk::ImageCompressionFlagsEXT          requested_compression,
                            const vk::ImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate) :
-    HPPSwapchain{*this, device, surface, present_mode, present_mode_priority_list, surface_format_priority_list, extent, image_count, transform, image_usage_flags}
+    HPPSwapchain{*this,
+                 device,
+                 surface,
+                 present_mode,
+                 present_mode_priority_list,
+                 surface_format_priority_list,
+                 extent,
+                 image_count,
+                 transform,
+                 image_usage_flags}
 {}
 
 HPPSwapchain::HPPSwapchain(HPPSwapchain                               &old_swapchain,
@@ -357,21 +389,31 @@ HPPSwapchain::HPPSwapchain(HPPSwapchain                               &old_swapc
 	}
 
 	// Choose best properties based on surface capabilities
-	vk::SurfaceCapabilitiesKHR const surface_capabilities = device.get_gpu().get_handle().getSurfaceCapabilitiesKHR(surface);
+	vk::SurfaceCapabilitiesKHR const surface_capabilities =
+	    device.get_gpu().get_handle().getSurfaceCapabilitiesKHR(surface);
 
-	properties.old_swapchain  = old_swapchain.get_handle();
-	properties.image_count    = choose_image_count(image_count, surface_capabilities.minImageCount, surface_capabilities.maxImageCount);
-	properties.extent         = choose_extent(extent, surface_capabilities.minImageExtent, surface_capabilities.maxImageExtent, surface_capabilities.currentExtent);
-	properties.surface_format = choose_surface_format(properties.surface_format, surface_formats, surface_format_priority_list);
-	properties.array_layers   = choose_image_array_layers(1U, surface_capabilities.maxImageArrayLayers);
+	properties.old_swapchain = old_swapchain.get_handle();
+	properties.image_count =
+	    choose_image_count(image_count, surface_capabilities.minImageCount, surface_capabilities.maxImageCount);
+	properties.extent = choose_extent(extent,
+	                                  surface_capabilities.minImageExtent,
+	                                  surface_capabilities.maxImageExtent,
+	                                  surface_capabilities.currentExtent);
+	properties.surface_format =
+	    choose_surface_format(properties.surface_format, surface_formats, surface_format_priority_list);
+	properties.array_layers = choose_image_array_layers(1U, surface_capabilities.maxImageArrayLayers);
 
-	vk::FormatProperties const format_properties = device.get_gpu().get_handle().getFormatProperties(properties.surface_format.format);
-	this->image_usage_flags                      = choose_image_usage(image_usage_flags, surface_capabilities.supportedUsageFlags, format_properties.optimalTilingFeatures);
+	vk::FormatProperties const format_properties =
+	    device.get_gpu().get_handle().getFormatProperties(properties.surface_format.format);
+	this->image_usage_flags = choose_image_usage(
+	    image_usage_flags, surface_capabilities.supportedUsageFlags, format_properties.optimalTilingFeatures);
 
-	properties.image_usage     = composite_image_flags(this->image_usage_flags);
-	properties.pre_transform   = choose_transform(transform, surface_capabilities.supportedTransforms, surface_capabilities.currentTransform);
-	properties.composite_alpha = choose_composite_alpha(vk::CompositeAlphaFlagBitsKHR::eInherit, surface_capabilities.supportedCompositeAlpha);
-	properties.present_mode    = choose_present_mode(present_mode, present_modes, present_mode_priority_list);
+	properties.image_usage = composite_image_flags(this->image_usage_flags);
+	properties.pre_transform =
+	    choose_transform(transform, surface_capabilities.supportedTransforms, surface_capabilities.currentTransform);
+	properties.composite_alpha =
+	    choose_composite_alpha(vk::CompositeAlphaFlagBitsKHR::eInherit, surface_capabilities.supportedCompositeAlpha);
+	properties.present_mode = choose_present_mode(present_mode, present_modes, present_mode_priority_list);
 
 	vk::SwapchainCreateInfoKHR create_info{.surface          = surface,
 	                                       .minImageCount    = properties.image_count,
@@ -407,7 +449,8 @@ HPPSwapchain::HPPSwapchain(HPPSwapchain                               &old_swapc
 	{
 		if (vk::ImageCompressionFlagBitsEXT::eDefault != requested_compression)
 		{
-			LOGW("(Swapchain) Compression cannot be controlled because VK_EXT_image_compression_control_swapchain is not enabled")
+			LOGW("(Swapchain) Compression cannot be controlled because VK_EXT_image_compression_control_swapchain is "
+			     "not enabled")
 
 			this->requested_compression            = vk::ImageCompressionFlagBitsEXT::eDefault;
 			this->requested_compression_fixed_rate = vk::ImageCompressionFixedRateFlagBitsEXT::eNone;
@@ -422,7 +465,8 @@ HPPSwapchain::HPPSwapchain(HPPSwapchain                               &old_swapc
 	    vk::ImageCompressionFlagBitsEXT::eFixedRateDefault == requested_compression)
 	{
 		// Check if fixed-rate compression was applied
-		const auto applied_compression_fixed_rate = vkb::common::query_applied_compression(device.get_handle(), images[0]).imageCompressionFixedRateFlags;
+		const auto applied_compression_fixed_rate =
+		    vkb::common::query_applied_compression(device.get_handle(), images[0]).imageCompressionFixedRateFlags;
 
 		if (applied_compression_fixed_rate != requested_compression_fixed_rate)
 		{
@@ -478,9 +522,11 @@ vk::SwapchainKHR HPPSwapchain::get_handle() const
 	return handle;
 }
 
-std::pair<vk::Result, uint32_t> HPPSwapchain::acquire_next_image(vk::Semaphore image_acquired_semaphore, vk::Fence fence) const
+std::pair<vk::Result, uint32_t> HPPSwapchain::acquire_next_image(vk::Semaphore image_acquired_semaphore,
+                                                                 vk::Fence     fence) const
 {
-	vk::ResultValue<uint32_t> rv = device.get_handle().acquireNextImageKHR(handle, std::numeric_limits<uint64_t>::max(), image_acquired_semaphore, fence);
+	vk::ResultValue<uint32_t> rv = device.get_handle().acquireNextImageKHR(
+	    handle, std::numeric_limits<uint64_t>::max(), image_acquired_semaphore, fence);
 	return std::make_pair(rv.result, rv.value);
 }
 

--- a/framework/core/hpp_swapchain.h
+++ b/framework/core/hpp_swapchain.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -80,36 +80,44 @@ class HPPSwapchain
 	/**
 	 * @brief Constructor to create a swapchain.
 	 */
-	HPPSwapchain(vkb::core::DeviceCpp                       &device,
-	             vk::SurfaceKHR                              surface,
-	             const vk::PresentModeKHR                    present_mode,
-	             const std::vector<vk::PresentModeKHR>      &present_mode_priority_list       = {vk::PresentModeKHR::eFifo, vk::PresentModeKHR::eMailbox},
-	             const std::vector<vk::SurfaceFormatKHR>    &surface_format_priority_list     = {{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
-	                                                                                             {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}},
-	             const vk::Extent2D                         &extent                           = {},
-	             const uint32_t                              image_count                      = 3,
-	             const vk::SurfaceTransformFlagBitsKHR       transform                        = vk::SurfaceTransformFlagBitsKHR::eIdentity,
-	             const std::set<vk::ImageUsageFlagBits>     &image_usage_flags                = {vk::ImageUsageFlagBits::eColorAttachment, vk::ImageUsageFlagBits::eTransferSrc},
-	             const vk::ImageCompressionFlagsEXT          requested_compression            = vk::ImageCompressionFlagBitsEXT::eDefault,
-	             const vk::ImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate = vk::ImageCompressionFixedRateFlagBitsEXT::eNone);
+	HPPSwapchain(vkb::core::DeviceCpp                    &device,
+	             vk::SurfaceKHR                           surface,
+	             const vk::PresentModeKHR                 present_mode,
+	             const std::vector<vk::PresentModeKHR>   &present_mode_priority_list = {vk::PresentModeKHR::eFifo,
+	                                                                                    vk::PresentModeKHR::eMailbox},
+	             const std::vector<vk::SurfaceFormatKHR> &surface_format_priority_list =
+	                 {{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
+	                  {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}},
+	             const vk::Extent2D                     &extent            = {},
+	             const uint32_t                          image_count       = 3,
+	             const vk::SurfaceTransformFlagBitsKHR   transform         = vk::SurfaceTransformFlagBitsKHR::eIdentity,
+	             const std::set<vk::ImageUsageFlagBits> &image_usage_flags = {vk::ImageUsageFlagBits::eColorAttachment,
+	                                                                          vk::ImageUsageFlagBits::eTransferSrc},
+	             const vk::ImageCompressionFlagsEXT requested_compression  = vk::ImageCompressionFlagBitsEXT::eDefault,
+	             const vk::ImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate =
+	                 vk::ImageCompressionFixedRateFlagBitsEXT::eNone);
 
 	/**
 	 * @brief Constructor to create a swapchain from the old swapchain
 	 *        by configuring all parameters.
 	 */
-	HPPSwapchain(HPPSwapchain                               &old_swapchain,
-	             vkb::core::DeviceCpp                       &device,
-	             vk::SurfaceKHR                              surface,
-	             const vk::PresentModeKHR                    present_mode,
-	             const std::vector<vk::PresentModeKHR>      &present_mode_priority_list       = {vk::PresentModeKHR::eFifo, vk::PresentModeKHR::eMailbox},
-	             const std::vector<vk::SurfaceFormatKHR>    &surface_format_priority_list     = {{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
-	                                                                                             {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}},
-	             const vk::Extent2D                         &extent                           = {},
-	             const uint32_t                              image_count                      = 3,
-	             const vk::SurfaceTransformFlagBitsKHR       transform                        = vk::SurfaceTransformFlagBitsKHR::eIdentity,
-	             const std::set<vk::ImageUsageFlagBits>     &image_usage_flags                = {vk::ImageUsageFlagBits::eColorAttachment, vk::ImageUsageFlagBits::eTransferSrc},
-	             const vk::ImageCompressionFlagsEXT          requested_compression            = vk::ImageCompressionFlagBitsEXT::eDefault,
-	             const vk::ImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate = vk::ImageCompressionFixedRateFlagBitsEXT::eNone);
+	HPPSwapchain(HPPSwapchain                            &old_swapchain,
+	             vkb::core::DeviceCpp                    &device,
+	             vk::SurfaceKHR                           surface,
+	             const vk::PresentModeKHR                 present_mode,
+	             const std::vector<vk::PresentModeKHR>   &present_mode_priority_list = {vk::PresentModeKHR::eFifo,
+	                                                                                    vk::PresentModeKHR::eMailbox},
+	             const std::vector<vk::SurfaceFormatKHR> &surface_format_priority_list =
+	                 {{vk::Format::eR8G8B8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear},
+	                  {vk::Format::eB8G8R8A8Srgb, vk::ColorSpaceKHR::eSrgbNonlinear}},
+	             const vk::Extent2D                     &extent            = {},
+	             const uint32_t                          image_count       = 3,
+	             const vk::SurfaceTransformFlagBitsKHR   transform         = vk::SurfaceTransformFlagBitsKHR::eIdentity,
+	             const std::set<vk::ImageUsageFlagBits> &image_usage_flags = {vk::ImageUsageFlagBits::eColorAttachment,
+	                                                                          vk::ImageUsageFlagBits::eTransferSrc},
+	             const vk::ImageCompressionFlagsEXT requested_compression  = vk::ImageCompressionFlagBitsEXT::eDefault,
+	             const vk::ImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate =
+	                 vk::ImageCompressionFixedRateFlagBitsEXT::eNone);
 
 	HPPSwapchain(const HPPSwapchain &) = delete;
 
@@ -127,7 +135,8 @@ class HPPSwapchain
 
 	vk::SwapchainKHR get_handle() const;
 
-	std::pair<vk::Result, uint32_t> acquire_next_image(vk::Semaphore image_acquired_semaphore, vk::Fence fence = nullptr) const;
+	std::pair<vk::Result, uint32_t> acquire_next_image(vk::Semaphore image_acquired_semaphore,
+	                                                   vk::Fence     fence = nullptr) const;
 
 	const vk::Extent2D &get_extent() const;
 
@@ -164,7 +173,8 @@ class HPPSwapchain
 
 	vk::ImageCompressionFlagsEXT requested_compression{vk::ImageCompressionFlagBitsEXT::eDefault};
 
-	vk::ImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate{vk::ImageCompressionFixedRateFlagBitsEXT::eNone};
+	vk::ImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate{
+	    vk::ImageCompressionFixedRateFlagBitsEXT::eNone};
 };
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/image.h
+++ b/framework/core/image.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -42,8 +42,7 @@ struct ImageBuilder : public vkb::allocated::BuilderBaseC<ImageBuilder, VkImageC
 	using Parent = vkb::allocated::BuilderBaseC<ImageBuilder, VkImageCreateInfo>;
 
   public:
-	ImageBuilder(VkExtent3D const &extent) :
-	    Parent(VkImageCreateInfo{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, nullptr})
+	ImageBuilder(VkExtent3D const &extent) : Parent(VkImageCreateInfo{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, nullptr})
 	{
 		VkImageCreateInfo &create_info = get_create_info();
 		create_info.extent             = extent;
@@ -56,8 +55,7 @@ struct ImageBuilder : public vkb::allocated::BuilderBaseC<ImageBuilder, VkImageC
 
 	ImageBuilder(uint32_t width, uint32_t height = 1, uint32_t depth = 1) :
 	    ImageBuilder(VkExtent3D{width, height, depth})
-	{
-	}
+	{}
 
 	ImageBuilder &with_format(VkFormat format)
 	{
@@ -134,19 +132,18 @@ class Image : public vkb::allocated::AllocatedC<VkImage>
 	      VkSampleCountFlagBits sample_count = VK_SAMPLE_COUNT_1_BIT);
 
 	// [[deprecated("Use the ImageBuilder ctor instead")]]
-	Image(
-	    vkb::core::DeviceC   &device,
-	    const VkExtent3D     &extent,
-	    VkFormat              format,
-	    VkImageUsageFlags     image_usage,
-	    VmaMemoryUsage        memory_usage       = VMA_MEMORY_USAGE_AUTO,
-	    VkSampleCountFlagBits sample_count       = VK_SAMPLE_COUNT_1_BIT,
-	    uint32_t              mip_levels         = 1,
-	    uint32_t              array_layers       = 1,
-	    VkImageTiling         tiling             = VK_IMAGE_TILING_OPTIMAL,
-	    VkImageCreateFlags    flags              = 0,
-	    uint32_t              num_queue_families = 0,
-	    const uint32_t       *queue_families     = nullptr);
+	Image(vkb::core::DeviceC   &device,
+	      const VkExtent3D     &extent,
+	      VkFormat              format,
+	      VkImageUsageFlags     image_usage,
+	      VmaMemoryUsage        memory_usage       = VMA_MEMORY_USAGE_AUTO,
+	      VkSampleCountFlagBits sample_count       = VK_SAMPLE_COUNT_1_BIT,
+	      uint32_t              mip_levels         = 1,
+	      uint32_t              array_layers       = 1,
+	      VkImageTiling         tiling             = VK_IMAGE_TILING_OPTIMAL,
+	      VkImageCreateFlags    flags              = 0,
+	      uint32_t              num_queue_families = 0,
+	      const uint32_t       *queue_families     = nullptr);
 
 	Image(vkb::core::DeviceC &device, ImageBuilder const &builder);
 

--- a/framework/core/image_core.cpp
+++ b/framework/core/image_core.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -104,11 +104,11 @@ Image::Image(vkb::core::DeviceC   &device,
               .with_sample_count(sample_count)
               .with_queue_families(num_queue_families, queue_families)
               .with_implicit_sharing_mode())
-{
-}
+{}
 
 Image::Image(vkb::core::DeviceC &device, ImageBuilder const &builder) :
-    vkb::allocated::AllocatedC<VkImage>{builder.get_allocation_create_info(), VK_NULL_HANDLE, &device}, create_info(builder.get_create_info())
+    vkb::allocated::AllocatedC<VkImage>{builder.get_allocation_create_info(), VK_NULL_HANDLE, &device},
+    create_info(builder.get_create_info())
 {
 	set_handle(create_image(create_info));
 	subresource.arrayLayer = create_info.arrayLayers;
@@ -119,8 +119,12 @@ Image::Image(vkb::core::DeviceC &device, ImageBuilder const &builder) :
 	}
 }
 
-Image::Image(
-    vkb::core::DeviceC &device, VkImage handle, const VkExtent3D &extent, VkFormat format, VkImageUsageFlags image_usage, VkSampleCountFlagBits sample_count) :
+Image::Image(vkb::core::DeviceC   &device,
+             VkImage               handle,
+             const VkExtent3D     &extent,
+             VkFormat              format,
+             VkImageUsageFlags     image_usage,
+             VkSampleCountFlagBits sample_count) :
     vkb::allocated::AllocatedC<VkImage>{handle, &device}
 {
 	create_info.extent     = extent;
@@ -132,9 +136,11 @@ Image::Image(
 	subresource.mipLevel = create_info.mipLevels = 1;
 }
 
-Image::Image(Image &&other) noexcept
-    :
-    vkb::allocated::AllocatedC<VkImage>{std::move(other)}, create_info{std::exchange(other.create_info, {})}, subresource{std::exchange(other.subresource, {})}, views(std::exchange(other.views, {}))
+Image::Image(Image &&other) noexcept :
+    vkb::allocated::AllocatedC<VkImage>{std::move(other)},
+    create_info{std::exchange(other.create_info, {})},
+    subresource{std::exchange(other.subresource, {})},
+    views(std::exchange(other.views, {}))
 {
 	// Update image views references to this image to avoid dangling pointers
 	for (auto &view : views)

--- a/framework/core/image_view.cpp
+++ b/framework/core/image_view.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2024, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,12 +24,14 @@ namespace vkb
 {
 namespace core
 {
-ImageView::ImageView(Image &img, VkImageViewType view_type, VkFormat format,
-                     uint32_t mip_level, uint32_t array_layer,
-                     uint32_t n_mip_levels, uint32_t n_array_layers) :
-    VulkanResource{VK_NULL_HANDLE, &img.get_device()},
-    image{&img},
-    format{format}
+ImageView::ImageView(Image          &img,
+                     VkImageViewType view_type,
+                     VkFormat        format,
+                     uint32_t        mip_level,
+                     uint32_t        array_layer,
+                     uint32_t        n_mip_levels,
+                     uint32_t        n_array_layers) :
+    VulkanResource{VK_NULL_HANDLE, &img.get_device()}, image{&img}, format{format}
 {
 	if (format == VK_FORMAT_UNDEFINED)
 	{

--- a/framework/core/image_view.h
+++ b/framework/core/image_view.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -30,9 +30,13 @@ class Image;
 class ImageView : public vkb::core::VulkanResourceC<VkImageView>
 {
   public:
-	ImageView(Image &image, VkImageViewType view_type, VkFormat format = VK_FORMAT_UNDEFINED,
-	          uint32_t base_mip_level = 0, uint32_t base_array_layer = 0,
-	          uint32_t n_mip_levels = 0, uint32_t n_array_layers = 0);
+	ImageView(Image          &image,
+	          VkImageViewType view_type,
+	          VkFormat        format           = VK_FORMAT_UNDEFINED,
+	          uint32_t        base_mip_level   = 0,
+	          uint32_t        base_array_layer = 0,
+	          uint32_t        n_mip_levels     = 0,
+	          uint32_t        n_array_layers   = 0);
 
 	ImageView(ImageView &) = delete;
 

--- a/framework/core/instance.h
+++ b/framework/core/instance.h
@@ -29,7 +29,8 @@ namespace core
 namespace
 {
 template <vkb::BindingType bindingType>
-typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCreateFlags, VkInstanceCreateFlags>::type get_default_create_flags(std::vector<std::string> const &)
+typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCreateFlags, VkInstanceCreateFlags>::type
+    get_default_create_flags(std::vector<std::string> const &)
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -52,9 +53,12 @@ template <vkb::BindingType bindingType>
 class Instance
 {
   public:
-	using InstanceCreateFlagsType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCreateFlags, VkInstanceCreateFlags>::type;
-	using InstanceCreateInfoType  = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCreateInfo, VkInstanceCreateInfo>::type;
-	using InstanceType            = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Instance, VkInstance>::type;
+	using InstanceCreateFlagsType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCreateFlags, VkInstanceCreateFlags>::type;
+	using InstanceCreateInfoType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::InstanceCreateInfo, VkInstanceCreateInfo>::type;
+	using InstanceType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Instance, VkInstance>::type;
 
   public:
 	/**
@@ -68,14 +72,19 @@ class Instance
 	 * @throws runtime_error if a required layer or extension is not available
 	 */
 	Instance(
-	    std::string const                                                                            &application_name,
-	    uint32_t                                                                                      api_version                 = VK_API_VERSION_1_1,
-	    std::unordered_map<std::string, vkb::RequestMode> const                                      &requested_layers            = {},
-	    std::unordered_map<std::string, vkb::RequestMode> const                                      &requested_extensions        = {},
-	    std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const               &get_create_flags            = get_default_create_flags,
-	    std::function<void(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &)> const &extend_instance_create_info = [](vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> const &) {});
+	    std::string const                                       &application_name,
+	    uint32_t                                                 api_version          = VK_API_VERSION_1_1,
+	    std::unordered_map<std::string, vkb::RequestMode> const &requested_layers     = {},
+	    std::unordered_map<std::string, vkb::RequestMode> const &requested_extensions = {},
+	    std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const &get_create_flags =
+	        get_default_create_flags,
+	    std::function<void(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &)> const
+	        &extend_instance_create_info =
+	            [](vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> const &) {});
 
-	Instance(vk::Instance instance, std::vector<char const *> const &externally_enabled_extensions = {}, bool needsToInitializeDispatcher = false);
+	Instance(vk::Instance                     instance,
+	         std::vector<char const *> const &externally_enabled_extensions = {},
+	         bool                             needsToInitializeDispatcher   = false);
 	Instance(VkInstance instance, std::vector<char const *> const &externally_enabled_extensions = {});
 
 	Instance(Instance const &) = delete;
@@ -110,12 +119,16 @@ inline bool enable_extension(std::string const                          &request
                              std::vector<vk::ExtensionProperties> const &available_extensions,
                              std::vector<std::string>                   &enabled_extensions)
 {
-	bool is_available = std::ranges::any_of(
-	    available_extensions, [&requested_extension](auto const &available_extension) { return requested_extension == available_extension.extensionName; });
+	bool is_available =
+	    std::ranges::any_of(available_extensions, [&requested_extension](auto const &available_extension) {
+		    return requested_extension == available_extension.extensionName;
+	    });
 	if (is_available)
 	{
 		bool is_already_enabled =
-		    std::ranges::any_of(enabled_extensions, [&requested_extension](auto const &enabled_extension) { return requested_extension == enabled_extension; });
+		    std::ranges::any_of(enabled_extensions, [&requested_extension](auto const &enabled_extension) {
+			    return requested_extension == enabled_extension;
+		    });
 		if (!is_already_enabled)
 		{
 			LOGI("Extension {} available, enabling it", requested_extension);
@@ -130,15 +143,17 @@ inline bool enable_extension(std::string const                          &request
 	return is_available;
 }
 
-inline bool
-    enable_layer(std::string const &requested_layer, std::vector<vk::LayerProperties> const &available_layers, std::vector<std::string> &enabled_layers)
+inline bool enable_layer(std::string const                      &requested_layer,
+                         std::vector<vk::LayerProperties> const &available_layers,
+                         std::vector<std::string>               &enabled_layers)
 {
-	bool is_available =
-	    std::ranges::any_of(available_layers, [&requested_layer](auto const &available_layer) { return requested_layer == available_layer.layerName; });
+	bool is_available = std::ranges::any_of(available_layers, [&requested_layer](auto const &available_layer) {
+		return requested_layer == available_layer.layerName;
+	});
 	if (is_available)
 	{
-		bool is_already_enabled =
-		    std::ranges::any_of(enabled_layers, [&requested_layer](auto const &enabled_layer) { return requested_layer == enabled_layer; });
+		bool is_already_enabled = std::ranges::any_of(
+		    enabled_layers, [&requested_layer](auto const &enabled_layer) { return requested_layer == enabled_layer; });
 		if (!is_already_enabled)
 		{
 			LOGI("Layer {} available, enabling it", requested_layer);
@@ -155,22 +170,28 @@ inline bool
 }        // namespace
 
 template <vkb::BindingType bindingType>
-inline Instance<bindingType>::Instance(std::string const                                                                            &application_name,
-                                       uint32_t                                                                                      api_version,
-                                       std::unordered_map<std::string, vkb::RequestMode> const                                      &requested_layers,
-                                       std::unordered_map<std::string, vkb::RequestMode> const                                      &requested_extensions,
-                                       std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const               &get_create_flags,
-                                       std::function<void(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &)> const &extend_instance_create_info)
+inline Instance<bindingType>::Instance(
+    std::string const                                                              &application_name,
+    uint32_t                                                                        api_version,
+    std::unordered_map<std::string, vkb::RequestMode> const                        &requested_layers,
+    std::unordered_map<std::string, vkb::RequestMode> const                        &requested_extensions,
+    std::function<InstanceCreateFlagsType(std::vector<std::string> const &)> const &get_create_flags,
+    std::function<void(vkb::StructureChainBuilder<bindingType, InstanceCreateInfoType> &)> const
+        &extend_instance_create_info)
 {
 	// check API version
 	LOGI("Requesting Vulkan API version {}.{}", VK_VERSION_MAJOR(api_version), VK_VERSION_MINOR(api_version));
 	if (api_version < VK_API_VERSION_1_1)
 	{
-		LOGE("Vulkan API version {}.{} is requested but version 1.1 or higher is required.", VK_VERSION_MAJOR(api_version), VK_VERSION_MINOR(api_version));
+		LOGE("Vulkan API version {}.{} is requested but version 1.1 or higher is required.",
+		     VK_VERSION_MAJOR(api_version),
+		     VK_VERSION_MINOR(api_version));
 		throw std::runtime_error("Requested Vulkan API version is too low.");
 	}
 	uint32_t instance_api_version = vk::enumerateInstanceVersion();
-	LOGI("Vulkan instance supports API version {}.{}", VK_VERSION_MAJOR(instance_api_version), VK_VERSION_MINOR(instance_api_version));
+	LOGI("Vulkan instance supports API version {}.{}",
+	     VK_VERSION_MAJOR(instance_api_version),
+	     VK_VERSION_MINOR(instance_api_version));
 	if (instance_api_version < api_version)
 	{
 		LOGE("Vulkan API version {}.{} is requested but only version {}.{} is supported.",
@@ -210,8 +231,9 @@ inline Instance<bindingType>::Instance(std::string const                        
 
 	if (contains(enabled_layers, "VK_LAYER_KHRONOS_validation"))
 	{
-		std::string const                    validation_layer_name               = "VK_LAYER_KHRONOS_validation";
-		std::vector<vk::ExtensionProperties> available_layer_instance_extensions = vk::enumerateInstanceExtensionProperties(validation_layer_name);
+		std::string const                    validation_layer_name = "VK_LAYER_KHRONOS_validation";
+		std::vector<vk::ExtensionProperties> available_layer_instance_extensions =
+		    vk::enumerateInstanceExtensionProperties(validation_layer_name);
 		available_extensions.insert(available_extensions.end(),
 		                            available_layer_instance_extensions.begin(),
 		                            available_layer_instance_extensions.end());
@@ -223,7 +245,8 @@ inline Instance<bindingType>::Instance(std::string const                        
 		{
 			if (requested_extension.second == vkb::RequestMode::Optional)
 			{
-				LOGW("Optional instance extension {} not available, some features may be disabled", requested_extension.first);
+				LOGW("Optional instance extension {} not available, some features may be disabled",
+				     requested_extension.first);
 			}
 			else
 			{
@@ -238,9 +261,11 @@ inline Instance<bindingType>::Instance(std::string const                        
 		enabled_extensions_cstr.push_back(extension.c_str());
 	}
 
-	vk::ApplicationInfo app_info{.pApplicationName = application_name.c_str(), .pEngineName = "Vulkan Samples", .apiVersion = api_version};
+	vk::ApplicationInfo app_info{
+	    .pApplicationName = application_name.c_str(), .pEngineName = "Vulkan Samples", .apiVersion = api_version};
 
-	vk::InstanceCreateInfo create_info{.flags                   = static_cast<vk::InstanceCreateFlags>(get_create_flags(enabled_extensions)),
+	vk::InstanceCreateInfo create_info{.flags =
+	                                       static_cast<vk::InstanceCreateFlags>(get_create_flags(enabled_extensions)),
 	                                   .pApplicationInfo        = &app_info,
 	                                   .enabledLayerCount       = static_cast<uint32_t>(enabled_layers_cstr.size()),
 	                                   .ppEnabledLayerNames     = enabled_layers_cstr.data(),
@@ -255,7 +280,8 @@ inline Instance<bindingType>::Instance(std::string const                        
 	}
 	else
 	{
-		extend_instance_create_info(reinterpret_cast<vkb::StructureChainBuilder<vkb::BindingType::C, VkInstanceCreateInfo> &>(scb));
+		extend_instance_create_info(
+		    reinterpret_cast<vkb::StructureChainBuilder<vkb::BindingType::C, VkInstanceCreateInfo> &>(scb));
 	}
 
 	// Create the Vulkan instance
@@ -269,7 +295,9 @@ inline Instance<bindingType>::Instance(std::string const                        
 }
 
 template <vkb::BindingType bindingType>
-inline Instance<bindingType>::Instance(vk::Instance instance, std::vector<char const *> const &externally_enabled_extensions, bool needsToInitializeDispatcher) :
+inline Instance<bindingType>::Instance(vk::Instance                     instance,
+                                       std::vector<char const *> const &externally_enabled_extensions,
+                                       bool                             needsToInitializeDispatcher) :
     handle{instance}
 {
 	if (needsToInitializeDispatcher)
@@ -279,7 +307,8 @@ inline Instance<bindingType>::Instance(vk::Instance instance, std::vector<char c
 #else
 		static vk::detail::DynamicLoader dl;
 #endif
-		PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr = dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
+		PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr =
+		    dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
 		VULKAN_HPP_DEFAULT_DISPATCHER.init(vkGetInstanceProcAddr);
 		VULKAN_HPP_DEFAULT_DISPATCHER.init(instance);
 	}
@@ -293,7 +322,8 @@ inline Instance<bindingType>::Instance(vk::Instance instance, std::vector<char c
 }
 
 template <vkb::BindingType bindingType>
-inline Instance<bindingType>::Instance(VkInstance instance, std::vector<char const *> const &externally_enabled_extensions) :
+inline Instance<bindingType>::Instance(VkInstance                       instance,
+                                       std::vector<char const *> const &externally_enabled_extensions) :
     Instance<bindingType>(static_cast<vk::Instance>(instance), externally_enabled_extensions, true)
 {}
 
@@ -322,7 +352,9 @@ inline typename Instance<bindingType>::InstanceType Instance<bindingType>::get_h
 template <vkb::BindingType bindingType>
 inline bool Instance<bindingType>::is_extension_enabled(char const *extension) const
 {
-	return std::ranges::any_of(enabled_extensions, [extension](std::string const &enabled_extension) { return enabled_extension == extension; });
+	return std::ranges::any_of(enabled_extensions, [extension](std::string const &enabled_extension) {
+		return enabled_extension == extension;
+	});
 }
 
 template <vkb::BindingType bindingType>

--- a/framework/core/physical_device.h
+++ b/framework/core/physical_device.h
@@ -41,27 +41,36 @@ template <vkb::BindingType bindingType>
 class PhysicalDevice
 {
   public:
-	using Bool32Type              = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Bool32, VkBool32>::type;
-	using FormatPropertiesType    = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::FormatProperties, VkFormatProperties>::type;
-	using FormatType              = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Format, VkFormat>::type;
-	using MemoryPropertyFlagsType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::MemoryPropertyFlags, VkMemoryPropertyFlags>::type;
-	using PerformanceCounterDescriptionKHRType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::PerformanceCounterDescriptionKHR, VkPerformanceCounterDescriptionKHR>::type;
-	using PerformanceCounterKHRType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::PerformanceCounterKHR, VkPerformanceCounterKHR>::type;
-	using PhysicalDeviceFeaturesType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::PhysicalDeviceFeatures, VkPhysicalDeviceFeatures>::type;
-	using PhysicalDeviceMemoryPropertiesType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::PhysicalDeviceMemoryProperties, VkPhysicalDeviceMemoryProperties>::type;
-	using PhysicalDevicePropertiesType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::PhysicalDeviceProperties, VkPhysicalDeviceProperties>::type;
-	using PhysicalDeviceType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::PhysicalDevice, VkPhysicalDevice>::type;
-	using QueueFamilyPropertiesType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::QueueFamilyProperties, VkQueueFamilyProperties>::type;
-	using QueryPoolPerformanceCreateInfoKHRType =
-	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::QueryPoolPerformanceCreateInfoKHR, VkQueryPoolPerformanceCreateInfoKHR>::type;
-	using StructureTypeType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::StructureType, VkStructureType>::type;
-	using SurfaceKHRType    = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::SurfaceKHR, VkSurfaceKHR>::type;
+	using Bool32Type = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Bool32, VkBool32>::type;
+	using FormatPropertiesType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::FormatProperties, VkFormatProperties>::type;
+	using FormatType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::Format, VkFormat>::type;
+	using MemoryPropertyFlagsType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::MemoryPropertyFlags, VkMemoryPropertyFlags>::type;
+	using PerformanceCounterDescriptionKHRType = typename std::conditional<bindingType == vkb::BindingType::Cpp,
+	                                                                       vk::PerformanceCounterDescriptionKHR,
+	                                                                       VkPerformanceCounterDescriptionKHR>::type;
+	using PerformanceCounterKHRType            = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::PerformanceCounterKHR, VkPerformanceCounterKHR>::type;
+	using PhysicalDeviceFeaturesType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::PhysicalDeviceFeatures, VkPhysicalDeviceFeatures>::type;
+	using PhysicalDeviceMemoryPropertiesType = typename std::conditional<bindingType == vkb::BindingType::Cpp,
+	                                                                     vk::PhysicalDeviceMemoryProperties,
+	                                                                     VkPhysicalDeviceMemoryProperties>::type;
+	using PhysicalDevicePropertiesType       = typename std::conditional<bindingType == vkb::BindingType::Cpp,
+                                                                   vk::PhysicalDeviceProperties,
+                                                                   VkPhysicalDeviceProperties>::type;
+	using PhysicalDeviceType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::PhysicalDevice, VkPhysicalDevice>::type;
+	using QueueFamilyPropertiesType = typename std::
+	    conditional<bindingType == vkb::BindingType::Cpp, vk::QueueFamilyProperties, VkQueueFamilyProperties>::type;
+	using QueryPoolPerformanceCreateInfoKHRType = typename std::conditional<bindingType == vkb::BindingType::Cpp,
+	                                                                        vk::QueryPoolPerformanceCreateInfoKHR,
+	                                                                        VkQueryPoolPerformanceCreateInfoKHR>::type;
+	using StructureTypeType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::StructureType, VkStructureType>::type;
+	using SurfaceKHRType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::SurfaceKHR, VkSurfaceKHR>::type;
 
   public:
 	PhysicalDevice(vkb::core::Instance<bindingType> &instance, PhysicalDeviceType physical_device);
@@ -108,15 +117,18 @@ class PhysicalDevice
 	template <typename T>
 	T get_extension_features();
 
-	PhysicalDeviceFeaturesType const             &get_features() const;
-	FormatPropertiesType                          get_format_properties(FormatType format) const;
-	PhysicalDeviceType                            get_handle() const;
-	vkb::core::Instance<bindingType>             &get_instance() const;
-	PhysicalDeviceMemoryPropertiesType const     &get_memory_properties() const;
-	uint32_t                                      get_memory_type(uint32_t bits, MemoryPropertyFlagsType properties, Bool32Type *memory_type_found = nullptr) const;
-	PhysicalDeviceFeaturesType                   &get_mutable_requested_features();
-	PhysicalDevicePropertiesType const           &get_properties() const;
-	uint32_t                                      get_queue_family_performance_query_passes(QueryPoolPerformanceCreateInfoKHRType const *perf_query_create_info) const;
+	PhysicalDeviceFeaturesType const         &get_features() const;
+	FormatPropertiesType                      get_format_properties(FormatType format) const;
+	PhysicalDeviceType                        get_handle() const;
+	vkb::core::Instance<bindingType>         &get_instance() const;
+	PhysicalDeviceMemoryPropertiesType const &get_memory_properties() const;
+	uint32_t                                  get_memory_type(uint32_t                bits,
+	                                                          MemoryPropertyFlagsType properties,
+	                                                          Bool32Type             *memory_type_found = nullptr) const;
+	PhysicalDeviceFeaturesType               &get_mutable_requested_features();
+	PhysicalDevicePropertiesType const       &get_properties() const;
+	uint32_t                                  get_queue_family_performance_query_passes(
+	                                     QueryPoolPerformanceCreateInfoKHRType const *perf_query_create_info) const;
 	std::vector<QueueFamilyPropertiesType> const &get_queue_family_properties() const;
 	PhysicalDeviceFeaturesType const             &get_requested_features() const;
 
@@ -138,7 +150,9 @@ class PhysicalDevice
 	 * @returns true if the requested feature is supported, otherwise false
 	 */
 	template <typename Feature>
-	Bool32Type request_optional_feature(Bool32Type Feature::*flag, std::string const &featureName, std::string const &flagName);
+	Bool32Type request_optional_feature(Bool32Type Feature::*flag,
+	                                    std::string const   &featureName,
+	                                    std::string const   &flagName);
 
 	/**
 	 * @brief Request a required features flag
@@ -147,7 +161,9 @@ class PhysicalDevice
 	 *        add_extension_features is called, otherwise a runtime_error is thrown.
 	 */
 	template <typename Feature>
-	void request_required_feature(Bool32Type Feature::*flag, std::string const &featureName, std::string const &flagName);
+	void request_required_feature(Bool32Type Feature::*flag,
+	                              std::string const   &featureName,
+	                              std::string const   &flagName);
 
 	/**
 	 * @brief Sets whether or not the first graphics queue should have higher priority than other queues.
@@ -162,41 +178,50 @@ class PhysicalDevice
 	FeatureType &add_extension_features_impl();
 	template <typename FeatureType>
 	FeatureType get_extension_features_impl();
-	uint32_t    get_memory_type_impl(uint32_t bits, vk::MemoryPropertyFlags properties, vk::Bool32 *memory_type_found = nullptr) const;
+	uint32_t    get_memory_type_impl(uint32_t                bits,
+	                                 vk::MemoryPropertyFlags properties,
+	                                 vk::Bool32             *memory_type_found = nullptr) const;
 	void        init();
 	template <typename FeatureType>
-	void request_required_feature_impl(vk::Bool32 FeatureType::*flag, std::string const &featureName, std::string const &flagName);
+	void request_required_feature_impl(vk::Bool32 FeatureType::*flag,
+	                                   std::string const       &featureName,
+	                                   std::string const       &flagName);
 
   private:
 	std::vector<vk::ExtensionProperties> device_extensions;        // The extensions that this GPU supports
 	std::map<vk::StructureType, std::shared_ptr<void>>
-	                                       extension_features;        // Holds the extension feature structures, we use a map to retain an order of requested structures
-	vk::PhysicalDeviceFeatures             features;                  // The features that this GPU supports
-	vk::PhysicalDevice                     handle;                    // Handle to the Vulkan physical device
-	bool                                   high_priority_graphics_queue = {};
-	vkb::core::InstanceCpp                &instance;                                          // Handle to the Vulkan instance
-	void                                  *last_requested_extension_feature = nullptr;        // The extension feature pointer
-	vk::PhysicalDeviceMemoryProperties     memory_properties;                                 // The GPU memory properties
-	vk::PhysicalDeviceProperties           properties;                                        // The GPU properties
-	std::vector<vk::QueueFamilyProperties> queue_family_properties;                           // The GPU queue family properties
-	vk::PhysicalDeviceFeatures             requested_features;                                // The features that will be requested to be enabled in the logical device
+	    extension_features;        // Holds the extension feature structures, we use a map to retain an order of requested structures
+	vk::PhysicalDeviceFeatures features;        // The features that this GPU supports
+	vk::PhysicalDevice         handle;          // Handle to the Vulkan physical device
+	bool                       high_priority_graphics_queue = {};
+	vkb::core::InstanceCpp    &instance;                                          // Handle to the Vulkan instance
+	void                      *last_requested_extension_feature = nullptr;        // The extension feature pointer
+	vk::PhysicalDeviceMemoryProperties     memory_properties;                     // The GPU memory properties
+	vk::PhysicalDeviceProperties           properties;                            // The GPU properties
+	std::vector<vk::QueueFamilyProperties> queue_family_properties;               // The GPU queue family properties
+	vk::PhysicalDeviceFeatures
+	    requested_features;        // The features that will be requested to be enabled in the logical device
 };
 
 using PhysicalDeviceC   = PhysicalDevice<vkb::BindingType::C>;
 using PhysicalDeviceCpp = PhysicalDevice<vkb::BindingType::Cpp>;
 
-#define REQUEST_OPTIONAL_FEATURE(gpu, Feature, flag) gpu.request_optional_feature<Feature>(&Feature::flag, #Feature, #flag)
-#define REQUEST_REQUIRED_FEATURE(gpu, Feature, flag) gpu.request_required_feature<Feature>(&Feature::flag, #Feature, #flag)
+#define REQUEST_OPTIONAL_FEATURE(gpu, Feature, flag) \
+	gpu.request_optional_feature<Feature>(&Feature::flag, #Feature, #flag)
+#define REQUEST_REQUIRED_FEATURE(gpu, Feature, flag) \
+	gpu.request_required_feature<Feature>(&Feature::flag, #Feature, #flag)
 
 template <>
-inline PhysicalDevice<vkb::BindingType::C>::PhysicalDevice(vkb::core::InstanceC &instance, VkPhysicalDevice physical_device) :
+inline PhysicalDevice<vkb::BindingType::C>::PhysicalDevice(vkb::core::InstanceC &instance,
+                                                           VkPhysicalDevice      physical_device) :
     instance{reinterpret_cast<vkb::core::InstanceCpp &>(instance)}, handle{physical_device}
 {
 	init();
 }
 
 template <>
-inline PhysicalDevice<vkb::BindingType::Cpp>::PhysicalDevice(vkb::core::InstanceCpp &instance, vk::PhysicalDevice physical_device) :
+inline PhysicalDevice<vkb::BindingType::Cpp>::PhysicalDevice(vkb::core::InstanceCpp &instance,
+                                                             vk::PhysicalDevice      physical_device) :
     instance{instance}, handle{physical_device}
 {
 	init();
@@ -245,7 +270,8 @@ inline FeatureType &PhysicalDevice<bindingType>::add_extension_features_impl()
 	// We cannot request extension features if the physical device properties 2 instance extension isn't enabled
 	if (!instance.is_extension_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
 	{
-		throw std::runtime_error("Couldn't request feature from device as " + std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) +
+		throw std::runtime_error("Couldn't request feature from device as " +
+		                         std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) +
 		                         " isn't enabled!");
 	}
 
@@ -336,7 +362,8 @@ inline FeatureType PhysicalDevice<bindingType>::get_extension_features_impl()
 	// We cannot request extension features if the physical device properties 2 instance extension isn't enabled
 	if (!instance.is_extension_enabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
 	{
-		throw std::runtime_error("Couldn't request feature from device as " + std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) +
+		throw std::runtime_error("Couldn't request feature from device as " +
+		                         std::string(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) +
 		                         " isn't enabled!");
 	}
 
@@ -345,13 +372,15 @@ inline FeatureType PhysicalDevice<bindingType>::get_extension_features_impl()
 }
 
 template <vkb::BindingType bindingType>
-inline typename PhysicalDevice<bindingType>::PhysicalDeviceFeaturesType const &PhysicalDevice<bindingType>::get_features() const
+inline typename PhysicalDevice<bindingType>::PhysicalDeviceFeaturesType const &
+    PhysicalDevice<bindingType>::get_features() const
 {
 	return features;
 }
 
 template <vkb::BindingType bindingType>
-inline typename PhysicalDevice<bindingType>::FormatPropertiesType PhysicalDevice<bindingType>::get_format_properties(FormatType format) const
+inline typename PhysicalDevice<bindingType>::FormatPropertiesType
+    PhysicalDevice<bindingType>::get_format_properties(FormatType format) const
 {
 	if constexpr (bindingType == BindingType::Cpp)
 	{
@@ -383,13 +412,16 @@ inline vkb::core::Instance<bindingType> &PhysicalDevice<bindingType>::get_instan
 }
 
 template <vkb::BindingType bindingType>
-inline typename PhysicalDevice<bindingType>::PhysicalDeviceMemoryPropertiesType const &PhysicalDevice<bindingType>::get_memory_properties() const
+inline typename PhysicalDevice<bindingType>::PhysicalDeviceMemoryPropertiesType const &
+    PhysicalDevice<bindingType>::get_memory_properties() const
 {
 	return memory_properties;
 }
 
 template <vkb::BindingType bindingType>
-inline uint32_t PhysicalDevice<bindingType>::get_memory_type(uint32_t bits, MemoryPropertyFlagsType properties, Bool32Type *memory_type_found) const
+inline uint32_t PhysicalDevice<bindingType>::get_memory_type(uint32_t                bits,
+                                                             MemoryPropertyFlagsType properties,
+                                                             Bool32Type             *memory_type_found) const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -397,12 +429,15 @@ inline uint32_t PhysicalDevice<bindingType>::get_memory_type(uint32_t bits, Memo
 	}
 	else
 	{
-		return get_memory_type_impl(bits, static_cast<vk::MemoryPropertyFlags>(properties), reinterpret_cast<vk::Bool32 *>(memory_type_found));
+		return get_memory_type_impl(
+		    bits, static_cast<vk::MemoryPropertyFlags>(properties), reinterpret_cast<vk::Bool32 *>(memory_type_found));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline uint32_t PhysicalDevice<bindingType>::get_memory_type_impl(uint32_t bits, vk::MemoryPropertyFlags properties, vk::Bool32 *memory_type_found) const
+inline uint32_t PhysicalDevice<bindingType>::get_memory_type_impl(uint32_t                bits,
+                                                                  vk::MemoryPropertyFlags properties,
+                                                                  vk::Bool32             *memory_type_found) const
 {
 	for (uint32_t i = 0; i < memory_properties.memoryTypeCount; i++)
 	{
@@ -432,20 +467,22 @@ inline uint32_t PhysicalDevice<bindingType>::get_memory_type_impl(uint32_t bits,
 }
 
 template <vkb::BindingType bindingType>
-inline typename PhysicalDevice<bindingType>::PhysicalDeviceFeaturesType &PhysicalDevice<bindingType>::get_mutable_requested_features()
+inline typename PhysicalDevice<bindingType>::PhysicalDeviceFeaturesType &
+    PhysicalDevice<bindingType>::get_mutable_requested_features()
 {
 	return requested_features;
 }
 
 template <vkb::BindingType bindingType>
-inline typename PhysicalDevice<bindingType>::PhysicalDevicePropertiesType const &PhysicalDevice<bindingType>::get_properties() const
+inline typename PhysicalDevice<bindingType>::PhysicalDevicePropertiesType const &
+    PhysicalDevice<bindingType>::get_properties() const
 {
 	return properties;
 }
 
 template <vkb::BindingType bindingType>
-uint32_t
-    PhysicalDevice<bindingType>::get_queue_family_performance_query_passes(QueryPoolPerformanceCreateInfoKHRType const *perf_query_create_info) const
+uint32_t PhysicalDevice<bindingType>::get_queue_family_performance_query_passes(
+    QueryPoolPerformanceCreateInfoKHRType const *perf_query_create_info) const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -453,12 +490,14 @@ uint32_t
 	}
 	else
 	{
-		return handle.getQueueFamilyPerformanceQueryPassesKHR(reinterpret_cast<vk::QueryPoolPerformanceCreateInfoKHR const &>(*perf_query_create_info));
+		return handle.getQueueFamilyPerformanceQueryPassesKHR(
+		    reinterpret_cast<vk::QueryPoolPerformanceCreateInfoKHR const &>(*perf_query_create_info));
 	}
 }
 
 template <vkb::BindingType bindingType>
-inline std::vector<typename PhysicalDevice<bindingType>::QueueFamilyPropertiesType> const &PhysicalDevice<bindingType>::get_queue_family_properties() const
+inline std::vector<typename PhysicalDevice<bindingType>::QueueFamilyPropertiesType> const &
+    PhysicalDevice<bindingType>::get_queue_family_properties() const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -471,7 +510,8 @@ inline std::vector<typename PhysicalDevice<bindingType>::QueueFamilyPropertiesTy
 }
 
 template <vkb::BindingType bindingType>
-inline typename PhysicalDevice<bindingType>::PhysicalDeviceFeaturesType const &PhysicalDevice<bindingType>::get_requested_features() const
+inline typename PhysicalDevice<bindingType>::PhysicalDeviceFeaturesType const &
+    PhysicalDevice<bindingType>::get_requested_features() const
 {
 	return requested_features;
 }
@@ -485,21 +525,22 @@ inline bool PhysicalDevice<bindingType>::has_high_priority_graphics_queue() cons
 template <vkb::BindingType bindingType>
 inline bool PhysicalDevice<bindingType>::is_extension_supported(const std::string &requested_extension) const
 {
-	return std::ranges::find_if(device_extensions,
-	                            [requested_extension](auto &device_extension) { return std::strcmp(device_extension.extensionName, requested_extension.c_str()) == 0; }) != device_extensions.end();
+	return std::ranges::find_if(device_extensions, [requested_extension](auto &device_extension) {
+		       return std::strcmp(device_extension.extensionName, requested_extension.c_str()) == 0;
+	       }) != device_extensions.end();
 }
 
 template <vkb::BindingType bindingType>
-inline typename PhysicalDevice<bindingType>::Bool32Type PhysicalDevice<bindingType>::is_present_supported(SurfaceKHRType surface,
-                                                                                                          uint32_t       queue_family_index) const
+inline typename PhysicalDevice<bindingType>::Bool32Type
+    PhysicalDevice<bindingType>::is_present_supported(SurfaceKHRType surface, uint32_t queue_family_index) const
 {
 	return surface ? handle.getSurfaceSupportKHR(queue_family_index, surface) : false;
 }
 
 template <vkb::BindingType bindingType>
 template <typename Feature>
-inline typename PhysicalDevice<bindingType>::Bool32Type
-    PhysicalDevice<bindingType>::request_optional_feature(Bool32Type Feature::*flag, std::string const &featureName, std::string const &flagName)
+inline typename PhysicalDevice<bindingType>::Bool32Type PhysicalDevice<bindingType>::request_optional_feature(
+    Bool32Type Feature::*flag, std::string const &featureName, std::string const &flagName)
 {
 	Bool32Type supported = get_extension_features<Feature>().*flag;
 	if (supported)
@@ -515,8 +556,9 @@ inline typename PhysicalDevice<bindingType>::Bool32Type
 
 template <vkb::BindingType bindingType>
 template <typename Feature>
-inline void
-    PhysicalDevice<bindingType>::request_required_feature(Bool32Type Feature::*flag, std::string const &featureName, std::string const &flagName)
+inline void PhysicalDevice<bindingType>::request_required_feature(Bool32Type Feature::*flag,
+                                                                  std::string const   &featureName,
+                                                                  std::string const   &flagName)
 {
 	if constexpr (bindingType == BindingType::Cpp)
 	{
@@ -531,8 +573,9 @@ inline void
 
 template <vkb::BindingType bindingType>
 template <typename Feature>
-inline void
-    PhysicalDevice<bindingType>::request_required_feature_impl(vk::Bool32 Feature::*flag, std::string const &featureName, std::string const &flagName)
+inline void PhysicalDevice<bindingType>::request_required_feature_impl(vk::Bool32 Feature::*flag,
+                                                                       std::string const   &featureName,
+                                                                       std::string const   &flagName)
 {
 	if (get_extension_features_impl<Feature>().*flag)
 	{
@@ -540,7 +583,8 @@ inline void
 	}
 	else
 	{
-		throw std::runtime_error(std::string("Requested required feature <") + featureName + "::" + flagName + "> is not supported");
+		throw std::runtime_error(std::string("Requested required feature <") + featureName + "::" + flagName +
+		                         "> is not supported");
 	}
 }
 

--- a/framework/core/pipeline.cpp
+++ b/framework/core/pipeline.cpp
@@ -24,14 +24,10 @@
 
 namespace vkb
 {
-Pipeline::Pipeline(vkb::core::DeviceC &device) :
-    device{device}
+Pipeline::Pipeline(vkb::core::DeviceC &device) : device{device}
 {}
 
-Pipeline::Pipeline(Pipeline &&other) :
-    device{other.device},
-    handle{other.handle},
-    state{other.state}
+Pipeline::Pipeline(Pipeline &&other) : device{other.device}, handle{other.handle}, state{other.state}
 {
 	other.handle = VK_NULL_HANDLE;
 }
@@ -85,18 +81,21 @@ ComputePipeline::ComputePipeline(vkb::core::DeviceC             &device,
 	}
 
 	device.get_debug_utils().set_debug_name(device.get_handle(),
-	                                        VK_OBJECT_TYPE_SHADER_MODULE, reinterpret_cast<uint64_t>(stage.module),
+	                                        VK_OBJECT_TYPE_SHADER_MODULE,
+	                                        reinterpret_cast<uint64_t>(stage.module),
 	                                        shader_module->get_debug_name().c_str());
 
 	// Create specialization info from tracked state.
 	std::vector<uint8_t>                  data{};
 	std::vector<VkSpecializationMapEntry> map_entries{};
 
-	const auto specialization_constant_state = pipeline_state.get_specialization_constant_state().get_specialization_constant_state();
+	const auto specialization_constant_state =
+	    pipeline_state.get_specialization_constant_state().get_specialization_constant_state();
 
 	for (const auto specialization_constant : specialization_constant_state)
 	{
-		map_entries.push_back({specialization_constant.first, to_u32(data.size()), specialization_constant.second.size()});
+		map_entries.push_back(
+		    {specialization_constant.first, to_u32(data.size()), specialization_constant.second.size()});
 		data.insert(data.end(), specialization_constant.second.begin(), specialization_constant.second.end());
 	}
 
@@ -136,11 +135,13 @@ GraphicsPipeline::GraphicsPipeline(vkb::core::DeviceC             &device,
 	std::vector<uint8_t>                  data{};
 	std::vector<VkSpecializationMapEntry> map_entries{};
 
-	const auto specialization_constant_state = pipeline_state.get_specialization_constant_state().get_specialization_constant_state();
+	const auto specialization_constant_state =
+	    pipeline_state.get_specialization_constant_state().get_specialization_constant_state();
 
 	for (const auto specialization_constant : specialization_constant_state)
 	{
-		map_entries.push_back({specialization_constant.first, to_u32(data.size()), specialization_constant.second.size()});
+		map_entries.push_back(
+		    {specialization_constant.first, to_u32(data.size()), specialization_constant.second.size()});
 		data.insert(data.end(), specialization_constant.second.begin(), specialization_constant.second.end());
 	}
 
@@ -163,14 +164,16 @@ GraphicsPipeline::GraphicsPipeline(vkb::core::DeviceC             &device,
 		vk_create_info.codeSize = shader_module->get_binary().size() * sizeof(uint32_t);
 		vk_create_info.pCode    = shader_module->get_binary().data();
 
-		VkResult result = vkCreateShaderModule(device.get_handle(), &vk_create_info, nullptr, &stage_create_info.module);
+		VkResult result =
+		    vkCreateShaderModule(device.get_handle(), &vk_create_info, nullptr, &stage_create_info.module);
 		if (result != VK_SUCCESS)
 		{
 			throw VulkanException{result};
 		}
 
 		device.get_debug_utils().set_debug_name(device.get_handle(),
-		                                        VK_OBJECT_TYPE_SHADER_MODULE, reinterpret_cast<uint64_t>(stage_create_info.module),
+		                                        VK_OBJECT_TYPE_SHADER_MODULE,
+		                                        reinterpret_cast<uint64_t>(stage_create_info.module),
 		                                        shader_module->get_debug_name().c_str());
 
 		stage_create_info.pSpecializationInfo = &specialization_info;
@@ -186,13 +189,15 @@ GraphicsPipeline::GraphicsPipeline(vkb::core::DeviceC             &device,
 
 	VkPipelineVertexInputStateCreateInfo vertex_input_state{VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
 
-	vertex_input_state.pVertexAttributeDescriptions    = pipeline_state.get_vertex_input_state().attributes.data();
-	vertex_input_state.vertexAttributeDescriptionCount = to_u32(pipeline_state.get_vertex_input_state().attributes.size());
+	vertex_input_state.pVertexAttributeDescriptions = pipeline_state.get_vertex_input_state().attributes.data();
+	vertex_input_state.vertexAttributeDescriptionCount =
+	    to_u32(pipeline_state.get_vertex_input_state().attributes.size());
 
 	vertex_input_state.pVertexBindingDescriptions    = pipeline_state.get_vertex_input_state().bindings.data();
 	vertex_input_state.vertexBindingDescriptionCount = to_u32(pipeline_state.get_vertex_input_state().bindings.size());
 
-	VkPipelineInputAssemblyStateCreateInfo input_assembly_state{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
+	VkPipelineInputAssemblyStateCreateInfo input_assembly_state{
+	    VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
 
 	input_assembly_state.topology               = pipeline_state.get_input_assembly_state().topology;
 	input_assembly_state.primitiveRestartEnable = pipeline_state.get_input_assembly_state().primitive_restart_enable;
@@ -202,7 +207,8 @@ GraphicsPipeline::GraphicsPipeline(vkb::core::DeviceC             &device,
 	viewport_state.viewportCount = pipeline_state.get_viewport_state().viewport_count;
 	viewport_state.scissorCount  = pipeline_state.get_viewport_state().scissor_count;
 
-	VkPipelineRasterizationStateCreateInfo rasterization_state{VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
+	VkPipelineRasterizationStateCreateInfo rasterization_state{
+	    VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
 
 	rasterization_state.depthClampEnable        = pipeline_state.get_rasterization_state().depth_clamp_enable;
 	rasterization_state.rasterizerDiscardEnable = pipeline_state.get_rasterization_state().rasterizer_discard_enable;
@@ -227,7 +233,8 @@ GraphicsPipeline::GraphicsPipeline(vkb::core::DeviceC             &device,
 		multisample_state.pSampleMask = &pipeline_state.get_multisample_state().sample_mask;
 	}
 
-	VkPipelineDepthStencilStateCreateInfo depth_stencil_state{VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
+	VkPipelineDepthStencilStateCreateInfo depth_stencil_state{
+	    VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
 
 	depth_stencil_state.depthTestEnable       = pipeline_state.get_depth_stencil_state().depth_test_enable;
 	depth_stencil_state.depthWriteEnable      = pipeline_state.get_depth_stencil_state().depth_write_enable;
@@ -251,10 +258,11 @@ GraphicsPipeline::GraphicsPipeline(vkb::core::DeviceC             &device,
 
 	VkPipelineColorBlendStateCreateInfo color_blend_state{VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
 
-	color_blend_state.logicOpEnable     = pipeline_state.get_color_blend_state().logic_op_enable;
-	color_blend_state.logicOp           = pipeline_state.get_color_blend_state().logic_op;
-	color_blend_state.attachmentCount   = to_u32(pipeline_state.get_color_blend_state().attachments.size());
-	color_blend_state.pAttachments      = reinterpret_cast<const VkPipelineColorBlendAttachmentState *>(pipeline_state.get_color_blend_state().attachments.data());
+	color_blend_state.logicOpEnable   = pipeline_state.get_color_blend_state().logic_op_enable;
+	color_blend_state.logicOp         = pipeline_state.get_color_blend_state().logic_op;
+	color_blend_state.attachmentCount = to_u32(pipeline_state.get_color_blend_state().attachments.size());
+	color_blend_state.pAttachments    = reinterpret_cast<const VkPipelineColorBlendAttachmentState *>(
+        pipeline_state.get_color_blend_state().attachments.data());
 	color_blend_state.blendConstants[0] = 1.0f;
 	color_blend_state.blendConstants[1] = 1.0f;
 	color_blend_state.blendConstants[2] = 1.0f;

--- a/framework/core/pipeline_layout.cpp
+++ b/framework/core/pipeline_layout.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,8 +26,7 @@
 namespace vkb
 {
 PipelineLayout::PipelineLayout(vkb::core::DeviceC &device, const std::vector<ShaderModule *> &shader_modules) :
-    device{device},
-    shader_modules{shader_modules}
+    device{device}, shader_modules{shader_modules}
 {
 	// Collect and combine all the shader resources from each of the shader modules
 	// Collate them all into a map that is indexed by the name of the resource
@@ -82,7 +81,8 @@ PipelineLayout::PipelineLayout(vkb::core::DeviceC &device, const std::vector<Sha
 	// Create a descriptor set layout for each shader set in the shader modules
 	for (auto &shader_set_it : shader_sets)
 	{
-		descriptor_set_layouts.emplace_back(&device.get_resource_cache().request_descriptor_set_layout(shader_set_it.first, shader_modules, shader_set_it.second));
+		descriptor_set_layouts.emplace_back(&device.get_resource_cache().request_descriptor_set_layout(
+		    shader_set_it.first, shader_modules, shader_set_it.second));
 	}
 
 	// Collect all the descriptor set layout handles, maintaining set order
@@ -103,7 +103,8 @@ PipelineLayout::PipelineLayout(vkb::core::DeviceC &device, const std::vector<Sha
 	std::vector<VkPushConstantRange> push_constant_ranges;
 	for (auto &push_constant_resource : get_resources(ShaderResourceType::PushConstant))
 	{
-		push_constant_ranges.push_back({push_constant_resource.stages, push_constant_resource.offset, push_constant_resource.size});
+		push_constant_ranges.push_back(
+		    {push_constant_resource.stages, push_constant_resource.offset, push_constant_resource.size});
 	}
 
 	VkPipelineLayoutCreateInfo create_info{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
@@ -152,7 +153,8 @@ const std::vector<ShaderModule *> &PipelineLayout::get_shader_modules() const
 	return shader_modules;
 }
 
-const std::vector<ShaderResource> PipelineLayout::get_resources(const ShaderResourceType &type, VkShaderStageFlagBits stage) const
+const std::vector<ShaderResource> PipelineLayout::get_resources(const ShaderResourceType &type,
+                                                                VkShaderStageFlagBits     stage) const
 {
 	std::vector<ShaderResource> found_resources;
 
@@ -200,7 +202,8 @@ VkShaderStageFlags PipelineLayout::get_push_constant_range_stage(uint32_t size, 
 
 	for (auto &push_constant_resource : get_resources(ShaderResourceType::PushConstant))
 	{
-		if (offset >= push_constant_resource.offset && offset + size <= push_constant_resource.offset + push_constant_resource.size)
+		if (offset >= push_constant_resource.offset &&
+		    offset + size <= push_constant_resource.offset + push_constant_resource.size)
 		{
 			stages |= push_constant_resource.stages;
 		}

--- a/framework/core/pipeline_layout.h
+++ b/framework/core/pipeline_layout.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -46,7 +46,8 @@ class PipelineLayout
 
 	const std::vector<ShaderModule *> &get_shader_modules() const;
 
-	const std::vector<ShaderResource> get_resources(const ShaderResourceType &type = ShaderResourceType::All, VkShaderStageFlagBits stage = VK_SHADER_STAGE_ALL) const;
+	const std::vector<ShaderResource> get_resources(const ShaderResourceType &type  = ShaderResourceType::All,
+	                                                VkShaderStageFlagBits     stage = VK_SHADER_STAGE_ALL) const;
 
 	const std::unordered_map<uint32_t, std::vector<ShaderResource>> &get_shader_sets() const;
 

--- a/framework/core/query_pool.cpp
+++ b/framework/core/query_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2025, Broadcom Inc. and Contributors
+/* Copyright (c) 2020-2026, Broadcom Inc. and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,15 +21,12 @@
 
 namespace vkb
 {
-QueryPool::QueryPool(vkb::core::DeviceC &d, const VkQueryPoolCreateInfo &info) :
-    device{d}
+QueryPool::QueryPool(vkb::core::DeviceC &d, const VkQueryPoolCreateInfo &info) : device{d}
 {
 	VK_CHECK(vkCreateQueryPool(device.get_handle(), &info, nullptr, &handle));
 }
 
-QueryPool::QueryPool(QueryPool &&other) :
-    device{other.device},
-    handle{other.handle}
+QueryPool::QueryPool(QueryPool &&other) : device{other.device}, handle{other.handle}
 {
 	other.handle = VK_NULL_HANDLE;
 }
@@ -56,12 +53,15 @@ void QueryPool::host_reset(uint32_t first_query, uint32_t query_count)
 	vkResetQueryPoolEXT(device.get_handle(), get_handle(), first_query, query_count);
 }
 
-VkResult QueryPool::get_results(uint32_t first_query, uint32_t num_queries,
-                                size_t result_bytes, void *results, VkDeviceSize stride,
+VkResult QueryPool::get_results(uint32_t           first_query,
+                                uint32_t           num_queries,
+                                size_t             result_bytes,
+                                void              *results,
+                                VkDeviceSize       stride,
                                 VkQueryResultFlags flags)
 {
-	return vkGetQueryPoolResults(device.get_handle(), get_handle(), first_query, num_queries,
-	                             result_bytes, results, stride, flags);
+	return vkGetQueryPoolResults(
+	    device.get_handle(), get_handle(), first_query, num_queries, result_bytes, results, stride, flags);
 }
 
 }        // namespace vkb

--- a/framework/core/query_pool.h
+++ b/framework/core/query_pool.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2025, Broadcom Inc. and Contributors
+/* Copyright (c) 2020-2026, Broadcom Inc. and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -73,8 +73,11 @@ class QueryPool
 	 * @param stride The stride in bytes between results for individual queries
 	 * @param flags A bitmask of VkQueryResultFlagBits
 	 */
-	VkResult get_results(uint32_t first_query, uint32_t num_queries,
-	                     size_t result_bytes, void *results, VkDeviceSize stride,
+	VkResult get_results(uint32_t           first_query,
+	                     uint32_t           num_queries,
+	                     size_t             result_bytes,
+	                     void              *results,
+	                     VkDeviceSize       stride,
 	                     VkQueryResultFlags flags);
 
   private:

--- a/framework/core/queue.cpp
+++ b/framework/core/queue.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,7 +22,11 @@
 
 namespace vkb
 {
-Queue::Queue(vkb::core::DeviceC &device, uint32_t family_index, VkQueueFamilyProperties properties, VkBool32 can_present, uint32_t index) :
+Queue::Queue(vkb::core::DeviceC     &device,
+             uint32_t                family_index,
+             VkQueueFamilyProperties properties,
+             VkBool32                can_present,
+             uint32_t                index) :
     device{device}, family_index{family_index}, index{index}, can_present{can_present}, properties{properties}
 {
 	vkGetDeviceQueue(device.get_handle(), family_index, index, &handle);

--- a/framework/core/queue.h
+++ b/framework/core/queue.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -34,7 +34,11 @@ using CommandBufferC = CommandBuffer<vkb::BindingType::C>;
 class Queue
 {
   public:
-	Queue(vkb::core::DeviceC &device, uint32_t family_index, VkQueueFamilyProperties properties, VkBool32 can_present, uint32_t index);
+	Queue(vkb::core::DeviceC     &device,
+	      uint32_t                family_index,
+	      VkQueueFamilyProperties properties,
+	      VkBool32                can_present,
+	      uint32_t                index);
 
 	Queue(const Queue &) = default;
 

--- a/framework/core/render_pass.cpp
+++ b/framework/core/render_pass.cpp
@@ -67,12 +67,16 @@ inline void set_structure_type(VkSubpassDescription2KHR &description)
 	description.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2_KHR;
 }
 
-inline void set_pointer_next(VkSubpassDescription &subpass_description, VkSubpassDescriptionDepthStencilResolveKHR &depth_resolve, VkAttachmentReference &depth_resolve_attachment)
+inline void set_pointer_next(VkSubpassDescription                       &subpass_description,
+                             VkSubpassDescriptionDepthStencilResolveKHR &depth_resolve,
+                             VkAttachmentReference                      &depth_resolve_attachment)
 {
 	// VkSubpassDescription cannot have pNext point to a VkSubpassDescriptionDepthStencilResolveKHR containing a VkAttachmentReference
 }
 
-inline void set_pointer_next(VkSubpassDescription2KHR &subpass_description, VkSubpassDescriptionDepthStencilResolveKHR &depth_resolve, VkAttachmentReference2KHR &depth_resolve_attachment)
+inline void set_pointer_next(VkSubpassDescription2KHR                   &subpass_description,
+                             VkSubpassDescriptionDepthStencilResolveKHR &depth_resolve,
+                             VkAttachmentReference2KHR                  &depth_resolve_attachment)
 {
 	depth_resolve.pDepthStencilResolveAttachment = &depth_resolve_attachment;
 	subpass_description.pNext                    = &depth_resolve;
@@ -86,7 +90,8 @@ inline const VkAttachmentReference2KHR *get_depth_resolve_reference(const VkSubp
 
 inline const VkAttachmentReference2KHR *get_depth_resolve_reference(const VkSubpassDescription2KHR &subpass_description)
 {
-	auto description_depth_resolve = static_cast<const VkSubpassDescriptionDepthStencilResolveKHR *>(subpass_description.pNext);
+	auto description_depth_resolve =
+	    static_cast<const VkSubpassDescriptionDepthStencilResolveKHR *>(subpass_description.pNext);
 
 	const VkAttachmentReference2KHR *depth_resolve_attachment = nullptr;
 	if (description_depth_resolve)
@@ -109,7 +114,8 @@ inline VkResult create_vk_renderpass(VkDevice device, VkRenderPassCreateInfo2KHR
 }        // namespace
 
 template <typename T>
-std::vector<T> get_attachment_descriptions(const std::vector<vkb::rendering::AttachmentC> &attachments, const std::vector<LoadStoreInfo> &load_store_infos)
+std::vector<T> get_attachment_descriptions(const std::vector<vkb::rendering::AttachmentC> &attachments,
+                                           const std::vector<LoadStoreInfo>               &load_store_infos)
 {
 	std::vector<T> attachment_descriptions;
 
@@ -121,8 +127,9 @@ std::vector<T> get_attachment_descriptions(const std::vector<vkb::rendering::Att
 		attachment.format        = attachments[i].format;
 		attachment.samples       = attachments[i].samples;
 		attachment.initialLayout = attachments[i].initial_layout;
-		attachment.finalLayout =
-		    vkb::is_depth_format(attachment.format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		attachment.finalLayout   = vkb::is_depth_format(attachment.format) ?
+		                               VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL :
+		                               VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
 		if (i < load_store_infos.size())
 		{
@@ -139,7 +146,8 @@ std::vector<T> get_attachment_descriptions(const std::vector<vkb::rendering::Att
 }
 
 template <typename T_SubpassDescription, typename T_AttachmentDescription, typename T_AttachmentReference>
-void set_attachment_layouts(std::vector<T_SubpassDescription> &subpass_descriptions, std::vector<T_AttachmentDescription> &attachment_descriptions)
+void set_attachment_layouts(std::vector<T_SubpassDescription>    &subpass_descriptions,
+                            std::vector<T_AttachmentDescription> &attachment_descriptions)
 {
 	// Make the initial layout same as in the first subpass using that attachment
 	for (auto &subpass : subpass_descriptions)
@@ -249,27 +257,24 @@ void set_attachment_layouts(std::vector<T_SubpassDescription> &subpass_descripti
  * @brief Assuming there is only one depth attachment
  */
 template <typename T_SubpassDescription, typename T_AttachmentDescription>
-bool is_depth_a_dependency(std::vector<T_SubpassDescription> &subpass_descriptions, std::vector<T_AttachmentDescription> &attachment_descriptions)
+bool is_depth_a_dependency(std::vector<T_SubpassDescription>    &subpass_descriptions,
+                           std::vector<T_AttachmentDescription> &attachment_descriptions)
 {
 	// More than 1 subpass uses depth
 	if (std::ranges::count_if(subpass_descriptions,
-	                          [](auto const &subpass) {
-		                          return subpass.pDepthStencilAttachment != nullptr;
-	                          }) > 1)
+	                          [](auto const &subpass) { return subpass.pDepthStencilAttachment != nullptr; }) > 1)
 	{
 		return true;
 	}
 
 	// Otherwise check if any uses depth as an input
-	return std::ranges::any_of(
-	    subpass_descriptions,
-	    [&attachment_descriptions](auto const &subpass) {
-		    return std::ranges::any_of(
-		        std::span{subpass.pInputAttachments, subpass.inputAttachmentCount},
-		        [&attachment_descriptions](auto const &reference) {
-			        return vkb::is_depth_format(attachment_descriptions[reference.attachment].format);
-		        });
-	    });
+	return std::ranges::any_of(subpass_descriptions, [&attachment_descriptions](auto const &subpass) {
+		return std::ranges::any_of(std::span{subpass.pInputAttachments, subpass.inputAttachmentCount},
+		                           [&attachment_descriptions](auto const &reference) {
+			                           return vkb::is_depth_format(
+			                               attachment_descriptions[reference.attachment].format);
+		                           });
+	});
 
 	return false;
 }
@@ -284,24 +289,31 @@ std::vector<T> get_subpass_dependencies(const size_t subpass_count, bool depth_s
 		for (uint32_t subpass_id = 0; subpass_id < to_u32(subpass_count - 1); ++subpass_id)
 		{
 			T color_dep{};
-			color_dep.srcSubpass      = subpass_id;
-			color_dep.dstSubpass      = subpass_id + 1;
-			color_dep.srcStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-			color_dep.dstStageMask    = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-			color_dep.srcAccessMask   = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-			color_dep.dstAccessMask   = VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+			color_dep.srcSubpass   = subpass_id;
+			color_dep.dstSubpass   = subpass_id + 1;
+			color_dep.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+			color_dep.dstStageMask =
+			    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+			color_dep.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+			color_dep.dstAccessMask = VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+			                          VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 			color_dep.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 			dependencies.push_back(color_dep);
 
 			if (depth_stencil_dependency)
 			{
 				T depth_dep{};
-				depth_dep.srcSubpass      = subpass_id;
-				depth_dep.dstSubpass      = subpass_id + 1;
-				depth_dep.srcStageMask    = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-				depth_dep.dstStageMask    = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-				depth_dep.srcAccessMask   = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-				depth_dep.dstAccessMask   = VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+				depth_dep.srcSubpass = subpass_id;
+				depth_dep.dstSubpass = subpass_id + 1;
+				depth_dep.srcStageMask =
+				    VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+				depth_dep.dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+				                         VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT |
+				                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+				depth_dep.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+				depth_dep.dstAccessMask = VK_ACCESS_INPUT_ATTACHMENT_READ_BIT |
+				                          VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+				                          VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
 				depth_dep.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 				dependencies.push_back(depth_dep);
 			}
@@ -323,12 +335,20 @@ T get_attachment_reference(const uint32_t attachment, const VkImageLayout layout
 	return reference;
 }
 
-template <typename T_SubpassDescription, typename T_AttachmentDescription, typename T_AttachmentReference, typename T_SubpassDependency, typename T_RenderPassCreateInfo>
-void RenderPass::create_renderpass(const std::vector<vkb::rendering::AttachmentC> &attachments, const std::vector<LoadStoreInfo> &load_store_infos, const std::vector<SubpassInfo> &subpasses)
+template <typename T_SubpassDescription,
+          typename T_AttachmentDescription,
+          typename T_AttachmentReference,
+          typename T_SubpassDependency,
+          typename T_RenderPassCreateInfo>
+void RenderPass::create_renderpass(const std::vector<vkb::rendering::AttachmentC> &attachments,
+                                   const std::vector<LoadStoreInfo>               &load_store_infos,
+                                   const std::vector<SubpassInfo>                 &subpasses)
 {
 	if (attachments.size() != load_store_infos.size())
 	{
-		LOGW("Render Pass creation: size of attachment list and load/store info list does not match: {} vs {}", attachments.size(), load_store_infos.size());
+		LOGW("Render Pass creation: size of attachment list and load/store info list does not match: {} vs {}",
+		     attachments.size(),
+		     load_store_infos.size());
 	}
 
 	auto attachment_descriptions = get_attachment_descriptions<T_AttachmentDescription>(attachments, load_store_infos);
@@ -359,42 +379,59 @@ void RenderPass::create_renderpass(const std::vector<vkb::rendering::AttachmentC
 		// Fill color attachments references
 		for (auto o_attachment : subpass.output_attachments)
 		{
-			auto  initial_layout = attachments[o_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : attachments[o_attachment].initial_layout;
+			auto  initial_layout = attachments[o_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ?
+			                           VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL :
+			                           attachments[o_attachment].initial_layout;
 			auto &description    = attachment_descriptions[o_attachment];
 			if (!is_depth_format(description.format))
 			{
-				color_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(o_attachment, initial_layout));
+				color_attachments[i].push_back(
+				    get_attachment_reference<T_AttachmentReference>(o_attachment, initial_layout));
 			}
 		}
 
 		// Fill input attachments references
 		for (auto i_attachment : subpass.input_attachments)
 		{
-			auto initial_layout = vkb::is_depth_format(attachments[i_attachment].format) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-			input_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(i_attachment, initial_layout));
+			auto initial_layout = vkb::is_depth_format(attachments[i_attachment].format) ?
+			                          VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL :
+			                          VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			input_attachments[i].push_back(
+			    get_attachment_reference<T_AttachmentReference>(i_attachment, initial_layout));
 		}
 
 		for (auto r_attachment : subpass.color_resolve_attachments)
 		{
-			auto initial_layout = attachments[r_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : attachments[r_attachment].initial_layout;
-			color_resolve_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(r_attachment, initial_layout));
+			auto initial_layout = attachments[r_attachment].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ?
+			                          VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL :
+			                          attachments[r_attachment].initial_layout;
+			color_resolve_attachments[i].push_back(
+			    get_attachment_reference<T_AttachmentReference>(r_attachment, initial_layout));
 		}
 
 		if (!subpass.disable_depth_stencil_attachment)
 		{
 			// Assumption: depth stencil attachment appears in the list before any depth stencil resolve attachment
-			auto it = find_if(attachments.begin(), attachments.end(), [](const vkb::rendering::AttachmentC attachment) { return is_depth_format(attachment.format); });
+			auto it = find_if(attachments.begin(), attachments.end(), [](const vkb::rendering::AttachmentC attachment) {
+				return is_depth_format(attachment.format);
+			});
 			if (it != attachments.end())
 			{
 				auto i_depth_stencil = vkb::to_u32(std::distance(attachments.begin(), it));
-				auto initial_layout  = it->initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : it->initial_layout;
-				depth_stencil_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(i_depth_stencil, initial_layout));
+				auto initial_layout  = it->initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ?
+				                           VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL :
+				                           it->initial_layout;
+				depth_stencil_attachments[i].push_back(
+				    get_attachment_reference<T_AttachmentReference>(i_depth_stencil, initial_layout));
 
 				if (subpass.depth_stencil_resolve_mode != VK_RESOLVE_MODE_NONE)
 				{
 					auto i_depth_stencil_resolve = subpass.depth_stencil_resolve_attachment;
-					initial_layout               = attachments[i_depth_stencil_resolve].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : attachments[i_depth_stencil_resolve].initial_layout;
-					depth_resolve_attachments[i].push_back(get_attachment_reference<T_AttachmentReference>(i_depth_stencil_resolve, initial_layout));
+					initial_layout = attachments[i_depth_stencil_resolve].initial_layout == VK_IMAGE_LAYOUT_UNDEFINED ?
+					                     VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL :
+					                     attachments[i_depth_stencil_resolve].initial_layout;
+					depth_resolve_attachments[i].push_back(
+					    get_attachment_reference<T_AttachmentReference>(i_depth_stencil_resolve, initial_layout));
 				}
 			}
 		}
@@ -417,7 +454,8 @@ void RenderPass::create_renderpass(const std::vector<vkb::rendering::AttachmentC
 		subpass_description.pColorAttachments    = color_attachments[i].empty() ? nullptr : color_attachments[i].data();
 		subpass_description.colorAttachmentCount = to_u32(color_attachments[i].size());
 
-		subpass_description.pResolveAttachments = color_resolve_attachments[i].empty() ? nullptr : color_resolve_attachments[i].data();
+		subpass_description.pResolveAttachments =
+		    color_resolve_attachments[i].empty() ? nullptr : color_resolve_attachments[i].data();
 
 		subpass_description.pDepthStencilAttachment = nullptr;
 		if (!depth_stencil_attachments[i].empty())
@@ -470,7 +508,8 @@ void RenderPass::create_renderpass(const std::vector<vkb::rendering::AttachmentC
 
 		if (default_depth_stencil_attachment != VK_ATTACHMENT_UNUSED)
 		{
-			depth_stencil_attachments[0].push_back(get_attachment_reference<T_AttachmentReference>(default_depth_stencil_attachment, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL));
+			depth_stencil_attachments[0].push_back(get_attachment_reference<T_AttachmentReference>(
+			    default_depth_stencil_attachment, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL));
 
 			subpass_description.pDepthStencilAttachment = depth_stencil_attachments[0].data();
 		}
@@ -478,7 +517,8 @@ void RenderPass::create_renderpass(const std::vector<vkb::rendering::AttachmentC
 		subpass_descriptions.push_back(subpass_description);
 	}
 
-	set_attachment_layouts<T_SubpassDescription, T_AttachmentDescription, T_AttachmentReference>(subpass_descriptions, attachment_descriptions);
+	set_attachment_layouts<T_SubpassDescription, T_AttachmentDescription, T_AttachmentReference>(
+	    subpass_descriptions, attachment_descriptions);
 
 	color_output_count.reserve(subpass_count);
 	for (size_t i = 0; i < subpass_count; i++)
@@ -486,7 +526,8 @@ void RenderPass::create_renderpass(const std::vector<vkb::rendering::AttachmentC
 		color_output_count.push_back(to_u32(color_attachments[i].size()));
 	}
 
-	const auto &subpass_dependencies = get_subpass_dependencies<T_SubpassDependency>(subpass_count, is_depth_a_dependency(subpass_descriptions, attachment_descriptions));
+	const auto &subpass_dependencies = get_subpass_dependencies<T_SubpassDependency>(
+	    subpass_count, is_depth_a_dependency(subpass_descriptions, attachment_descriptions));
 
 	T_RenderPassCreateInfo create_info{};
 	set_structure_type(create_info);
@@ -514,25 +555,30 @@ RenderPass::RenderPass(vkb::core::DeviceC                             &device,
                        const std::vector<vkb::rendering::AttachmentC> &attachments,
                        const std::vector<LoadStoreInfo>               &load_store_infos,
                        const std::vector<SubpassInfo>                 &subpasses) :
-    VulkanResource{VK_NULL_HANDLE, &device}, subpass_count{std::max<size_t>(1, subpasses.size())},        // At least 1 subpass
+    VulkanResource{VK_NULL_HANDLE, &device},
+    subpass_count{std::max<size_t>(1, subpasses.size())},        // At least 1 subpass
     color_output_count{}
 {
 	if (device.is_extension_enabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME))
 	{
-		create_renderpass<VkSubpassDescription2KHR, VkAttachmentDescription2KHR, VkAttachmentReference2KHR, VkSubpassDependency2KHR, VkRenderPassCreateInfo2KHR>(
-		    attachments, load_store_infos, subpasses);
+		create_renderpass<VkSubpassDescription2KHR,
+		                  VkAttachmentDescription2KHR,
+		                  VkAttachmentReference2KHR,
+		                  VkSubpassDependency2KHR,
+		                  VkRenderPassCreateInfo2KHR>(attachments, load_store_infos, subpasses);
 	}
 	else
 	{
-		create_renderpass<VkSubpassDescription, VkAttachmentDescription, VkAttachmentReference, VkSubpassDependency, VkRenderPassCreateInfo>(
-		    attachments, load_store_infos, subpasses);
+		create_renderpass<VkSubpassDescription,
+		                  VkAttachmentDescription,
+		                  VkAttachmentReference,
+		                  VkSubpassDependency,
+		                  VkRenderPassCreateInfo>(attachments, load_store_infos, subpasses);
 	}
 }
 
 RenderPass::RenderPass(RenderPass &&other) :
-    VulkanResource{std::move(other)},
-    subpass_count{other.subpass_count},
-    color_output_count{other.color_output_count}
+    VulkanResource{std::move(other)}, subpass_count{other.subpass_count}, color_output_count{other.color_output_count}
 {}
 
 RenderPass::~RenderPass()

--- a/framework/core/render_pass.h
+++ b/framework/core/render_pass.h
@@ -77,8 +77,14 @@ class RenderPass : public vkb::core::VulkanResourceC<VkRenderPass>
   private:
 	size_t subpass_count;
 
-	template <typename T_SubpassDescription, typename T_AttachmentDescription, typename T_AttachmentReference, typename T_SubpassDependency, typename T_RenderPassCreateInfo>
-	void create_renderpass(const std::vector<vkb::rendering::AttachmentC> &attachments, const std::vector<LoadStoreInfo> &load_store_infos, const std::vector<SubpassInfo> &subpasses);
+	template <typename T_SubpassDescription,
+	          typename T_AttachmentDescription,
+	          typename T_AttachmentReference,
+	          typename T_SubpassDependency,
+	          typename T_RenderPassCreateInfo>
+	void create_renderpass(const std::vector<vkb::rendering::AttachmentC> &attachments,
+	                       const std::vector<LoadStoreInfo>               &load_store_infos,
+	                       const std::vector<SubpassInfo>                 &subpasses);
 
 	std::vector<uint32_t> color_output_count;
 };

--- a/framework/core/sampled_image.cpp
+++ b/framework/core/sampled_image.cpp
@@ -24,14 +24,13 @@ namespace vkb
 namespace core
 {
 SampledImage::SampledImage(const core::ImageView &image_view, Sampler *sampler) :
-    image_view{&image_view},
-    target_attachment{0},
-    render_target{nullptr},
-    sampler{sampler},
-    isDepthResolve{false}
+    image_view{&image_view}, target_attachment{0}, render_target{nullptr}, sampler{sampler}, isDepthResolve{false}
 {}
 
-SampledImage::SampledImage(uint32_t target_attachment, vkb::rendering::RenderTargetC *render_target, Sampler *sampler, bool isDepthResolve) :
+SampledImage::SampledImage(uint32_t                       target_attachment,
+                           vkb::rendering::RenderTargetC *render_target,
+                           Sampler                       *sampler,
+                           bool                           isDepthResolve) :
     image_view{nullptr},
     target_attachment{target_attachment},
     render_target{render_target},

--- a/framework/core/sampled_image.h
+++ b/framework/core/sampled_image.h
@@ -50,7 +50,10 @@ class SampledImage
 	 * @remarks If the render target is null, the default is assumed.
 	 *          If the sampler is null, a default sampler is used.
 	 */
-	SampledImage(uint32_t target_attachment, vkb::rendering::RenderTargetC *render_target = nullptr, Sampler *sampler = nullptr, bool isDepthResolve = false);
+	SampledImage(uint32_t                       target_attachment,
+	             vkb::rendering::RenderTargetC *render_target  = nullptr,
+	             Sampler                       *sampler        = nullptr,
+	             bool                           isDepthResolve = false);
 
 	SampledImage(const SampledImage &to_copy);
 	SampledImage &operator=(const SampledImage &to_copy);

--- a/framework/core/sampler_core.cpp
+++ b/framework/core/sampler_core.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -23,16 +23,13 @@ namespace vkb
 {
 namespace core
 {
-Sampler::Sampler(vkb::core::DeviceC &d, const VkSamplerCreateInfo &info) :
-    VulkanResource{VK_NULL_HANDLE, &d}
+Sampler::Sampler(vkb::core::DeviceC &d, const VkSamplerCreateInfo &info) : VulkanResource{VK_NULL_HANDLE, &d}
 {
 	VK_CHECK(vkCreateSampler(get_device().get_handle(), &info, nullptr, &get_handle()));
 }
 
-Sampler::Sampler(Sampler &&other) :
-    VulkanResource{std::move(other)}
-{
-}
+Sampler::Sampler(Sampler &&other) : VulkanResource{std::move(other)}
+{}
 
 Sampler::~Sampler()
 {

--- a/framework/core/shader_module.cpp
+++ b/framework/core/shader_module.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -31,7 +31,8 @@ ShaderModule::ShaderModule(vkb::core::DeviceC   &device,
                            const ShaderVariant  &shader_variant) :
     device{device}, stage{stage}, entry_point{entry_point}
 {
-	debug_name = fmt::format("{} [variant {:X}] [entrypoint {}]", shader_source.get_filename(), shader_variant.get_id(), entry_point);
+	debug_name = fmt::format(
+	    "{} [variant {:X}] [entrypoint {}]", shader_source.get_filename(), shader_variant.get_id(), entry_point);
 
 	// Shaders in binary SPIR-V format can be loaded directly
 	spirv = vkb::fs::read_shader_binary_u32(shader_source.get_filename());
@@ -90,7 +91,8 @@ const std::vector<uint32_t> &ShaderModule::get_binary() const
 
 void ShaderModule::set_resource_mode(const std::string &resource_name, const ShaderResourceMode &resource_mode)
 {
-	auto it = std::ranges::find_if(resources, [&resource_name](const ShaderResource &resource) { return resource.name == resource_name; });
+	auto it = std::ranges::find_if(
+	    resources, [&resource_name](const ShaderResource &resource) { return resource.name == resource_name; });
 
 	if (it != resources.end())
 	{
@@ -149,9 +151,7 @@ void ShaderVariant::clear()
 	id = 0;
 }
 
-ShaderSource::ShaderSource(const std::string &filename) :
-    filename{filename},
-    source{fs::read_text_file(filename)}
+ShaderSource::ShaderSource(const std::string &filename) : filename{filename}, source{fs::read_text_file(filename)}
 {
 	std::hash<std::string> hasher{};
 	id = hasher(std::string{this->source.cbegin(), this->source.cend()});

--- a/framework/core/swapchain.cpp
+++ b/framework/core/swapchain.cpp
@@ -25,10 +25,7 @@ namespace vkb
 {
 namespace
 {
-inline uint32_t choose_image_count(
-    uint32_t request_image_count,
-    uint32_t min_image_count,
-    uint32_t max_image_count)
+inline uint32_t choose_image_count(uint32_t request_image_count, uint32_t min_image_count, uint32_t max_image_count)
 {
 	if (max_image_count != 0)
 	{
@@ -40,9 +37,7 @@ inline uint32_t choose_image_count(
 	return request_image_count;
 }
 
-inline uint32_t choose_image_array_layers(
-    uint32_t request_image_array_layers,
-    uint32_t max_image_array_layers)
+inline uint32_t choose_image_array_layers(uint32_t request_image_array_layers, uint32_t max_image_array_layers)
 {
 	request_image_array_layers = std::min(request_image_array_layers, max_image_array_layers);
 	request_image_array_layers = std::max(request_image_array_layers, 1u);
@@ -50,11 +45,10 @@ inline uint32_t choose_image_array_layers(
 	return request_image_array_layers;
 }
 
-inline VkExtent2D choose_extent(
-    VkExtent2D        request_extent,
-    const VkExtent2D &min_image_extent,
-    const VkExtent2D &max_image_extent,
-    const VkExtent2D &current_extent)
+inline VkExtent2D choose_extent(VkExtent2D        request_extent,
+                                const VkExtent2D &min_image_extent,
+                                const VkExtent2D &max_image_extent,
+                                const VkExtent2D &current_extent)
 {
 	if (current_extent.width == 0xFFFFFFFF)
 	{
@@ -63,7 +57,11 @@ inline VkExtent2D choose_extent(
 
 	if (request_extent.width < 1 || request_extent.height < 1)
 	{
-		LOGW("(Swapchain) Image extent ({}, {}) not supported. Selecting ({}, {}).", request_extent.width, request_extent.height, current_extent.width, current_extent.height);
+		LOGW("(Swapchain) Image extent ({}, {}) not supported. Selecting ({}, {}).",
+		     request_extent.width,
+		     request_extent.height,
+		     current_extent.width,
+		     current_extent.height);
 		return current_extent;
 	}
 
@@ -76,10 +74,9 @@ inline VkExtent2D choose_extent(
 	return request_extent;
 }
 
-inline VkPresentModeKHR choose_present_mode(
-    VkPresentModeKHR                     request_present_mode,
-    const std::vector<VkPresentModeKHR> &available_present_modes,
-    const std::vector<VkPresentModeKHR> &present_mode_priority_list)
+inline VkPresentModeKHR choose_present_mode(VkPresentModeKHR                     request_present_mode,
+                                            const std::vector<VkPresentModeKHR> &available_present_modes,
+                                            const std::vector<VkPresentModeKHR> &present_mode_priority_list)
 {
 	auto present_mode_it = std::ranges::find(available_present_modes, request_present_mode);
 
@@ -97,7 +94,9 @@ inline VkPresentModeKHR choose_present_mode(
 			}
 		}
 
-		LOGW("(Swapchain) Present mode '{}' not supported. Selecting '{}'.", to_string(request_present_mode), to_string(chosen_present_mode));
+		LOGW("(Swapchain) Present mode '{}' not supported. Selecting '{}'.",
+		     to_string(request_present_mode),
+		     to_string(chosen_present_mode));
 		return chosen_present_mode;
 	}
 	else
@@ -107,15 +106,13 @@ inline VkPresentModeKHR choose_present_mode(
 	}
 }
 
-inline VkSurfaceFormatKHR choose_surface_format(
-    const VkSurfaceFormatKHR               requested_surface_format,
-    const std::vector<VkSurfaceFormatKHR> &available_surface_formats,
-    const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list)
+inline VkSurfaceFormatKHR choose_surface_format(const VkSurfaceFormatKHR               requested_surface_format,
+                                                const std::vector<VkSurfaceFormatKHR> &available_surface_formats,
+                                                const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list)
 {
 	// Try to find the requested surface format in the supported surface formats
-	auto surface_format_it = std::ranges::find_if(
-	    available_surface_formats,
-	    [&requested_surface_format](const VkSurfaceFormatKHR &surface) {
+	auto surface_format_it =
+	    std::ranges::find_if(available_surface_formats, [&requested_surface_format](const VkSurfaceFormatKHR &surface) {
 		    if (surface.format == requested_surface_format.format &&
 		        surface.colorSpace == requested_surface_format.colorSpace)
 		    {
@@ -130,11 +127,9 @@ inline VkSurfaceFormatKHR choose_surface_format(
 	{
 		for (auto &surface_format : surface_format_priority_list)
 		{
-			surface_format_it = std::ranges::find_if(
-			    available_surface_formats,
-			    [&surface_format](const VkSurfaceFormatKHR &surface) {
-				    if (surface.format == surface_format.format &&
-				        surface.colorSpace == surface_format.colorSpace)
+			surface_format_it =
+			    std::ranges::find_if(available_surface_formats, [&surface_format](const VkSurfaceFormatKHR &surface) {
+				    if (surface.format == surface_format.format && surface.colorSpace == surface_format.colorSpace)
 				    {
 					    return true;
 				    }
@@ -143,14 +138,18 @@ inline VkSurfaceFormatKHR choose_surface_format(
 			    });
 			if (surface_format_it != available_surface_formats.end())
 			{
-				LOGW("(Swapchain) Surface format ({}) not supported. Selecting ({}).", to_string(requested_surface_format), to_string(*surface_format_it));
+				LOGW("(Swapchain) Surface format ({}) not supported. Selecting ({}).",
+				     to_string(requested_surface_format),
+				     to_string(*surface_format_it));
 				return *surface_format_it;
 			}
 		}
 
 		// If nothing found, default to the first supported surface format
 		surface_format_it = available_surface_formats.begin();
-		LOGW("(Swapchain) Surface format ({}) not supported. Selecting ({}).", to_string(requested_surface_format), to_string(*surface_format_it));
+		LOGW("(Swapchain) Surface format ({}) not supported. Selecting ({}).",
+		     to_string(requested_surface_format),
+		     to_string(*surface_format_it));
 	}
 	else
 	{
@@ -160,22 +159,24 @@ inline VkSurfaceFormatKHR choose_surface_format(
 	return *surface_format_it;
 }
 
-inline VkSurfaceTransformFlagBitsKHR choose_transform(
-    VkSurfaceTransformFlagBitsKHR request_transform,
-    VkSurfaceTransformFlagsKHR    supported_transform,
-    VkSurfaceTransformFlagBitsKHR current_transform)
+inline VkSurfaceTransformFlagBitsKHR choose_transform(VkSurfaceTransformFlagBitsKHR request_transform,
+                                                      VkSurfaceTransformFlagsKHR    supported_transform,
+                                                      VkSurfaceTransformFlagBitsKHR current_transform)
 {
 	if (request_transform & supported_transform)
 	{
 		return request_transform;
 	}
 
-	LOGW("(Swapchain) Surface transform '{}' not supported. Selecting '{}'.", to_string(request_transform), to_string(current_transform));
+	LOGW("(Swapchain) Surface transform '{}' not supported. Selecting '{}'.",
+	     to_string(request_transform),
+	     to_string(current_transform));
 
 	return current_transform;
 }
 
-inline VkCompositeAlphaFlagBitsKHR choose_composite_alpha(VkCompositeAlphaFlagBitsKHR request_composite_alpha, VkCompositeAlphaFlagsKHR supported_composite_alpha)
+inline VkCompositeAlphaFlagBitsKHR choose_composite_alpha(VkCompositeAlphaFlagBitsKHR request_composite_alpha,
+                                                          VkCompositeAlphaFlagsKHR    supported_composite_alpha)
 {
 	if (request_composite_alpha & supported_composite_alpha)
 	{
@@ -192,7 +193,9 @@ inline VkCompositeAlphaFlagBitsKHR choose_composite_alpha(VkCompositeAlphaFlagBi
 	{
 		if (composite_alpha & supported_composite_alpha)
 		{
-			LOGW("(Swapchain) Composite alpha '{}' not supported. Selecting '{}.", to_string(request_composite_alpha), to_string(composite_alpha));
+			LOGW("(Swapchain) Composite alpha '{}' not supported. Selecting '{}.",
+			     to_string(request_composite_alpha),
+			     to_string(composite_alpha));
 			return composite_alpha;
 		}
 	}
@@ -211,7 +214,10 @@ inline bool validate_format_feature(VkImageUsageFlagBits image_usage, VkFormatFe
 	}
 }
 
-inline std::set<VkImageUsageFlagBits> choose_image_usage(const std::set<VkImageUsageFlagBits> &requested_image_usage_flags, VkImageUsageFlags supported_image_usage, VkFormatFeatureFlags supported_features)
+inline std::set<VkImageUsageFlagBits>
+    choose_image_usage(const std::set<VkImageUsageFlagBits> &requested_image_usage_flags,
+                       VkImageUsageFlags                     supported_image_usage,
+                       VkFormatFeatureFlags                  supported_features)
 {
 	std::set<VkImageUsageFlagBits> validated_image_usage_flags;
 	for (auto flag : requested_image_usage_flags)
@@ -229,11 +235,10 @@ inline std::set<VkImageUsageFlagBits> choose_image_usage(const std::set<VkImageU
 	if (validated_image_usage_flags.empty())
 	{
 		// Pick the first format from list of defaults, if supported
-		static const std::vector<VkImageUsageFlagBits> image_usage_flags = {
-		    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
-		    VK_IMAGE_USAGE_STORAGE_BIT,
-		    VK_IMAGE_USAGE_SAMPLED_BIT,
-		    VK_IMAGE_USAGE_TRANSFER_DST_BIT};
+		static const std::vector<VkImageUsageFlagBits> image_usage_flags = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+		                                                                    VK_IMAGE_USAGE_STORAGE_BIT,
+		                                                                    VK_IMAGE_USAGE_SAMPLED_BIT,
+		                                                                    VK_IMAGE_USAGE_TRANSFER_DST_BIT};
 
 		for (VkImageUsageFlagBits image_usage : image_usage_flags)
 		{
@@ -320,7 +325,9 @@ Swapchain::Swapchain(Swapchain &old_swapchain, const std::set<VkImageUsageFlagBi
               old_swapchain.requested_compression_fixed_rate}
 {}
 
-Swapchain::Swapchain(Swapchain &old_swapchain, const VkExtent2D &extent, const VkSurfaceTransformFlagBitsKHR transform) :
+Swapchain::Swapchain(Swapchain                          &old_swapchain,
+                     const VkExtent2D                   &extent,
+                     const VkSurfaceTransformFlagBitsKHR transform) :
     Swapchain{old_swapchain,
               old_swapchain.device,
               old_swapchain.surface,
@@ -335,7 +342,9 @@ Swapchain::Swapchain(Swapchain &old_swapchain, const VkExtent2D &extent, const V
               old_swapchain.requested_compression_fixed_rate}
 {}
 
-Swapchain::Swapchain(Swapchain &old_swapchain, const VkImageCompressionFlagsEXT requested_compression, const VkImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate) :
+Swapchain::Swapchain(Swapchain                                &old_swapchain,
+                     const VkImageCompressionFlagsEXT          requested_compression,
+                     const VkImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate) :
     Swapchain{old_swapchain,
               old_swapchain.device,
               old_swapchain.surface,
@@ -361,9 +370,17 @@ Swapchain::Swapchain(vkb::core::DeviceC                       &device,
                      const std::set<VkImageUsageFlagBits>     &image_usage_flags,
                      const VkImageCompressionFlagsEXT          requested_compression,
                      const VkImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate) :
-    Swapchain{*this, device, surface, present_mode, present_mode_priority_list, surface_format_priority_list, extent, image_count, transform, image_usage_flags}
-{
-}
+    Swapchain{*this,
+              device,
+              surface,
+              present_mode,
+              present_mode_priority_list,
+              surface_format_priority_list,
+              extent,
+              image_count,
+              transform,
+              image_usage_flags}
+{}
 
 Swapchain::Swapchain(Swapchain                                &old_swapchain,
                      vkb::core::DeviceC                       &device,
@@ -389,10 +406,12 @@ Swapchain::Swapchain(Swapchain                                &old_swapchain,
 	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(this->device.get_gpu().get_handle(), surface, &surface_capabilities);
 
 	uint32_t surface_format_count{0U};
-	VK_CHECK(vkGetPhysicalDeviceSurfaceFormatsKHR(this->device.get_gpu().get_handle(), surface, &surface_format_count, nullptr));
+	VK_CHECK(vkGetPhysicalDeviceSurfaceFormatsKHR(
+	    this->device.get_gpu().get_handle(), surface, &surface_format_count, nullptr));
 
 	std::vector<VkSurfaceFormatKHR> surface_formats(surface_format_count);
-	VK_CHECK(vkGetPhysicalDeviceSurfaceFormatsKHR(this->device.get_gpu().get_handle(), surface, &surface_format_count, surface_formats.data()));
+	VK_CHECK(vkGetPhysicalDeviceSurfaceFormatsKHR(
+	    this->device.get_gpu().get_handle(), surface, &surface_format_count, surface_formats.data()));
 
 	LOGI("Surface supports the following surface formats:");
 	for (auto &surface_format : surface_formats)
@@ -401,10 +420,12 @@ Swapchain::Swapchain(Swapchain                                &old_swapchain,
 	}
 
 	uint32_t present_mode_count{0U};
-	VK_CHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(this->device.get_gpu().get_handle(), surface, &present_mode_count, nullptr));
+	VK_CHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(
+	    this->device.get_gpu().get_handle(), surface, &present_mode_count, nullptr));
 
 	std::vector<VkPresentModeKHR> present_modes(present_mode_count);
-	VK_CHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(this->device.get_gpu().get_handle(), surface, &present_mode_count, present_modes.data()));
+	VK_CHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(
+	    this->device.get_gpu().get_handle(), surface, &present_mode_count, present_modes.data()));
 
 	LOGI("Surface supports the following present modes:");
 	for (auto &pm : present_modes)
@@ -413,20 +434,29 @@ Swapchain::Swapchain(Swapchain                                &old_swapchain,
 	}
 
 	// Choose best properties based on surface capabilities
-	properties.old_swapchain  = old_swapchain.get_handle();
-	properties.image_count    = choose_image_count(image_count, surface_capabilities.minImageCount, surface_capabilities.maxImageCount);
-	properties.extent         = choose_extent(extent, surface_capabilities.minImageExtent, surface_capabilities.maxImageExtent, surface_capabilities.currentExtent);
-	properties.surface_format = choose_surface_format(properties.surface_format, surface_formats, surface_format_priority_list);
-	properties.array_layers   = choose_image_array_layers(1U, surface_capabilities.maxImageArrayLayers);
+	properties.old_swapchain = old_swapchain.get_handle();
+	properties.image_count =
+	    choose_image_count(image_count, surface_capabilities.minImageCount, surface_capabilities.maxImageCount);
+	properties.extent = choose_extent(extent,
+	                                  surface_capabilities.minImageExtent,
+	                                  surface_capabilities.maxImageExtent,
+	                                  surface_capabilities.currentExtent);
+	properties.surface_format =
+	    choose_surface_format(properties.surface_format, surface_formats, surface_format_priority_list);
+	properties.array_layers = choose_image_array_layers(1U, surface_capabilities.maxImageArrayLayers);
 
 	VkFormatProperties format_properties;
-	vkGetPhysicalDeviceFormatProperties(this->device.get_gpu().get_handle(), properties.surface_format.format, &format_properties);
-	this->image_usage_flags = choose_image_usage(image_usage_flags, surface_capabilities.supportedUsageFlags, format_properties.optimalTilingFeatures);
+	vkGetPhysicalDeviceFormatProperties(
+	    this->device.get_gpu().get_handle(), properties.surface_format.format, &format_properties);
+	this->image_usage_flags = choose_image_usage(
+	    image_usage_flags, surface_capabilities.supportedUsageFlags, format_properties.optimalTilingFeatures);
 
-	properties.image_usage     = composite_image_flags(this->image_usage_flags);
-	properties.pre_transform   = choose_transform(transform, surface_capabilities.supportedTransforms, surface_capabilities.currentTransform);
-	properties.composite_alpha = choose_composite_alpha(VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR, surface_capabilities.supportedCompositeAlpha);
-	properties.present_mode    = choose_present_mode(present_mode, present_modes, present_mode_priority_list);
+	properties.image_usage = composite_image_flags(this->image_usage_flags);
+	properties.pre_transform =
+	    choose_transform(transform, surface_capabilities.supportedTransforms, surface_capabilities.currentTransform);
+	properties.composite_alpha =
+	    choose_composite_alpha(VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR, surface_capabilities.supportedCompositeAlpha);
+	properties.present_mode = choose_present_mode(present_mode, present_modes, present_mode_priority_list);
 
 	VkSwapchainCreateInfoKHR create_info{VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR};
 	create_info.minImageCount    = properties.image_count;
@@ -463,7 +493,8 @@ Swapchain::Swapchain(Swapchain                                &old_swapchain,
 	{
 		if (VK_IMAGE_COMPRESSION_DEFAULT_EXT != requested_compression)
 		{
-			LOGW("(Swapchain) Compression cannot be controlled because VK_EXT_image_compression_control_swapchain is not enabled")
+			LOGW("(Swapchain) Compression cannot be controlled because VK_EXT_image_compression_control_swapchain is "
+			     "not enabled")
 
 			this->requested_compression            = VK_IMAGE_COMPRESSION_DEFAULT_EXT;
 			this->requested_compression_fixed_rate = VK_IMAGE_COMPRESSION_FIXED_RATE_NONE_EXT;
@@ -488,7 +519,8 @@ Swapchain::Swapchain(Swapchain                                &old_swapchain,
 	    VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT == requested_compression)
 	{
 		// Check if fixed-rate compression was applied
-		const auto applied_compression_fixed_rate = vkb::query_applied_compression(device.get_handle(), images[0]).imageCompressionFixedRateFlags;
+		const auto applied_compression_fixed_rate =
+		    vkb::query_applied_compression(device.get_handle(), images[0]).imageCompressionFixedRateFlags;
 
 		if (applied_compression_fixed_rate != requested_compression_fixed_rate)
 		{
@@ -528,8 +560,7 @@ Swapchain::Swapchain(Swapchain &&other) :
     present_mode_priority_list{std::exchange(other.present_mode_priority_list, {})},
     surface_format_priority_list{std::exchange(other.surface_format_priority_list, {})},
     image_usage_flags{std::move(other.image_usage_flags)}
-{
-}
+{}
 
 bool Swapchain::is_valid() const
 {
@@ -548,7 +579,12 @@ VkSwapchainKHR Swapchain::get_handle() const
 
 VkResult Swapchain::acquire_next_image(uint32_t &image_index, VkSemaphore image_acquired_semaphore, VkFence fence) const
 {
-	return vkAcquireNextImageKHR(device.get_handle(), handle, std::numeric_limits<uint64_t>::max(), image_acquired_semaphore, fence, &image_index);
+	return vkAcquireNextImageKHR(device.get_handle(),
+	                             handle,
+	                             std::numeric_limits<uint64_t>::max(),
+	                             image_acquired_semaphore,
+	                             fence,
+	                             &image_index);
 }
 
 const VkExtent2D &Swapchain::get_extent() const
@@ -596,7 +632,8 @@ VkImageCompressionFlagsEXT Swapchain::get_applied_compression() const
 	return vkb::query_applied_compression(device.get_handle(), get_images()[0]).imageCompressionFlags;
 }
 
-std::vector<Swapchain::SurfaceFormatCompression> Swapchain::query_supported_fixed_rate_compression(vkb::core::DeviceC &device, const VkSurfaceKHR &surface)
+std::vector<Swapchain::SurfaceFormatCompression>
+    Swapchain::query_supported_fixed_rate_compression(vkb::core::DeviceC &device, const VkSurfaceKHR &surface)
 {
 	std::vector<SurfaceFormatCompression> surface_format_compression_list;
 
@@ -609,7 +646,8 @@ std::vector<Swapchain::SurfaceFormatCompression> Swapchain::query_supported_fixe
 
 			uint32_t surface_format_count{0U};
 
-			VK_CHECK(vkGetPhysicalDeviceSurfaceFormats2KHR(device.get_gpu().get_handle(), &surface_info, &surface_format_count, nullptr));
+			VK_CHECK(vkGetPhysicalDeviceSurfaceFormats2KHR(
+			    device.get_gpu().get_handle(), &surface_info, &surface_format_count, nullptr));
 
 			std::vector<VkSurfaceFormat2KHR> surface_formats;
 			surface_formats.resize(surface_format_count, {VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR});
@@ -622,7 +660,8 @@ std::vector<Swapchain::SurfaceFormatCompression> Swapchain::query_supported_fixe
 				surface_formats[i].pNext = &compression_properties[i];
 			}
 
-			VK_CHECK(vkGetPhysicalDeviceSurfaceFormats2KHR(device.get_gpu().get_handle(), &surface_info, &surface_format_count, surface_formats.data()));
+			VK_CHECK(vkGetPhysicalDeviceSurfaceFormats2KHR(
+			    device.get_gpu().get_handle(), &surface_info, &surface_format_count, surface_formats.data()));
 
 			surface_format_compression_list.reserve(surface_format_count);
 			for (uint32_t i = 0; i < surface_format_count; i++)
@@ -632,12 +671,14 @@ std::vector<Swapchain::SurfaceFormatCompression> Swapchain::query_supported_fixe
 		}
 		else
 		{
-			LOGW("(Swapchain) To query fixed-rate compression support, instance extension VK_KHR_get_surface_capabilities2 must be enabled")
+			LOGW("(Swapchain) To query fixed-rate compression support, instance extension "
+			     "VK_KHR_get_surface_capabilities2 must be enabled")
 		}
 	}
 	else
 	{
-		LOGW("(Swapchain) To query fixed-rate compression support, device extension VK_EXT_image_compression_control_swapchain must be enabled")
+		LOGW("(Swapchain) To query fixed-rate compression support, device extension "
+		     "VK_EXT_image_compression_control_swapchain must be enabled")
 	}
 
 	return surface_format_compression_list;

--- a/framework/core/swapchain.h
+++ b/framework/core/swapchain.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2025, Arm Limited and Contributors
+/* Copyright (c) 2019-2026, Arm Limited and Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -79,42 +79,51 @@ class Swapchain
 	 * @brief Constructor to create a swapchain by changing the compression settings
 	 *        only and preserving the configuration from the old swapchain.
 	 */
-	Swapchain(Swapchain &swapchain, const VkImageCompressionFlagsEXT requested_compression, const VkImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate);
+	Swapchain(Swapchain                                &swapchain,
+	          const VkImageCompressionFlagsEXT          requested_compression,
+	          const VkImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate);
 
 	/**
 	 * @brief Constructor to create a swapchain.
 	 */
-	Swapchain(vkb::core::DeviceC                       &device,
-	          VkSurfaceKHR                              surface,
-	          const VkPresentModeKHR                    present_mode,
-	          const std::vector<VkPresentModeKHR>      &present_mode_priority_list       = {VK_PRESENT_MODE_FIFO_KHR,
-	                                                                                        VK_PRESENT_MODE_MAILBOX_KHR},
-	          const std::vector<VkSurfaceFormatKHR>    &surface_format_priority_list     = {{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                                                        {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}},
-	          const VkExtent2D                         &extent                           = {},
-	          const uint32_t                            image_count                      = 3,
-	          const VkSurfaceTransformFlagBitsKHR       transform                        = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-	          const std::set<VkImageUsageFlagBits>     &image_usage_flags                = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_SRC_BIT},
-	          const VkImageCompressionFlagsEXT          requested_compression            = VK_IMAGE_COMPRESSION_DEFAULT_EXT,
-	          const VkImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate = VK_IMAGE_COMPRESSION_FIXED_RATE_NONE_EXT);
+	Swapchain(vkb::core::DeviceC                    &device,
+	          VkSurfaceKHR                           surface,
+	          const VkPresentModeKHR                 present_mode,
+	          const std::vector<VkPresentModeKHR>   &present_mode_priority_list = {VK_PRESENT_MODE_FIFO_KHR,
+	                                                                               VK_PRESENT_MODE_MAILBOX_KHR},
+	          const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list =
+	              {{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	               {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}},
+	          const VkExtent2D                         &extent                = {},
+	          const uint32_t                            image_count           = 3,
+	          const VkSurfaceTransformFlagBitsKHR       transform             = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
+	          const std::set<VkImageUsageFlagBits>     &image_usage_flags     = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+	                                                                             VK_IMAGE_USAGE_TRANSFER_SRC_BIT},
+	          const VkImageCompressionFlagsEXT          requested_compression = VK_IMAGE_COMPRESSION_DEFAULT_EXT,
+	          const VkImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate =
+	              VK_IMAGE_COMPRESSION_FIXED_RATE_NONE_EXT);
 
 	/**
 	 * @brief Constructor to create a swapchain from the old swapchain
 	 *        by configuring all parameters.
 	 */
-	Swapchain(Swapchain                                &old_swapchain,
-	          vkb::core::DeviceC                       &device,
-	          VkSurfaceKHR                              surface,
-	          const VkPresentModeKHR                    present_mode,
-	          const std::vector<VkPresentModeKHR>      &present_mode_priority_list       = {VK_PRESENT_MODE_FIFO_KHR, VK_PRESENT_MODE_MAILBOX_KHR},
-	          const std::vector<VkSurfaceFormatKHR>    &surface_format_priority_list     = {{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
-	                                                                                        {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}},
-	          const VkExtent2D                         &extent                           = {},
-	          const uint32_t                            image_count                      = 3,
-	          const VkSurfaceTransformFlagBitsKHR       transform                        = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-	          const std::set<VkImageUsageFlagBits>     &image_usage_flags                = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_TRANSFER_SRC_BIT},
-	          const VkImageCompressionFlagsEXT          requested_compression            = VK_IMAGE_COMPRESSION_DEFAULT_EXT,
-	          const VkImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate = VK_IMAGE_COMPRESSION_FIXED_RATE_NONE_EXT);
+	Swapchain(Swapchain                             &old_swapchain,
+	          vkb::core::DeviceC                    &device,
+	          VkSurfaceKHR                           surface,
+	          const VkPresentModeKHR                 present_mode,
+	          const std::vector<VkPresentModeKHR>   &present_mode_priority_list = {VK_PRESENT_MODE_FIFO_KHR,
+	                                                                               VK_PRESENT_MODE_MAILBOX_KHR},
+	          const std::vector<VkSurfaceFormatKHR> &surface_format_priority_list =
+	              {{VK_FORMAT_R8G8B8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR},
+	               {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}},
+	          const VkExtent2D                         &extent                = {},
+	          const uint32_t                            image_count           = 3,
+	          const VkSurfaceTransformFlagBitsKHR       transform             = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
+	          const std::set<VkImageUsageFlagBits>     &image_usage_flags     = {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+	                                                                             VK_IMAGE_USAGE_TRANSFER_SRC_BIT},
+	          const VkImageCompressionFlagsEXT          requested_compression = VK_IMAGE_COMPRESSION_DEFAULT_EXT,
+	          const VkImageCompressionFixedRateFlagsEXT requested_compression_fixed_rate =
+	              VK_IMAGE_COMPRESSION_FIXED_RATE_NONE_EXT);
 
 	Swapchain(const Swapchain &) = delete;
 
@@ -132,7 +141,9 @@ class Swapchain
 
 	VkSwapchainKHR get_handle() const;
 
-	VkResult acquire_next_image(uint32_t &image_index, VkSemaphore image_acquired_semaphore, VkFence fence = VK_NULL_HANDLE) const;
+	VkResult acquire_next_image(uint32_t   &image_index,
+	                            VkSemaphore image_acquired_semaphore,
+	                            VkFence     fence = VK_NULL_HANDLE) const;
 
 	const VkExtent2D &get_extent() const;
 
@@ -162,7 +173,8 @@ class Swapchain
 		VkImageCompressionPropertiesEXT compression_properties{VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT};
 	};
 
-	static std::vector<SurfaceFormatCompression> query_supported_fixed_rate_compression(vkb::core::DeviceC &device, const VkSurfaceKHR &surface);
+	static std::vector<SurfaceFormatCompression> query_supported_fixed_rate_compression(vkb::core::DeviceC &device,
+	                                                                                    const VkSurfaceKHR &surface);
 
   private:
 	vkb::core::DeviceC &device;
@@ -176,9 +188,7 @@ class Swapchain
 	SwapchainProperties properties;
 
 	// A list of present modes in order of priority (vector[0] has high priority, vector[size-1] has low priority)
-	std::vector<VkPresentModeKHR> present_mode_priority_list = {
-	    VK_PRESENT_MODE_FIFO_KHR,
-	    VK_PRESENT_MODE_MAILBOX_KHR};
+	std::vector<VkPresentModeKHR> present_mode_priority_list = {VK_PRESENT_MODE_FIFO_KHR, VK_PRESENT_MODE_MAILBOX_KHR};
 
 	// A list of surface formats in order of priority (vector[0] has high priority, vector[size-1] has low priority)
 	std::vector<VkSurfaceFormatKHR> surface_format_priority_list = {

--- a/framework/core/vulkan_resource.h
+++ b/framework/core/vulkan_resource.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2021-2025, Arm Limited and Contributors
- * Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2021-2026, Arm Limited and Contributors
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -46,7 +46,8 @@ class VulkanResource
 	using ResourceType = typename vkb::VulkanTypeMapping<bindingType, Handle>::Type;
 
   public:
-	using ObjectType = typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ObjectType, VkObjectType>::type;
+	using ObjectType =
+	    typename std::conditional<bindingType == vkb::BindingType::Cpp, vk::ObjectType, VkObjectType>::type;
 
 	VulkanResource(Handle handle = nullptr, Device<bindingType> *device_ = nullptr);
 
@@ -184,7 +185,8 @@ inline uint64_t VulkanResource<bindingType, Handle>::get_handle_u64() const
 }
 
 template <vkb::BindingType bindingType, typename Handle>
-inline typename VulkanResource<bindingType, Handle>::ObjectType VulkanResource<bindingType, Handle>::get_object_type() const
+inline typename VulkanResource<bindingType, Handle>::ObjectType
+    VulkanResource<bindingType, Handle>::get_object_type() const
 {
 	if constexpr (bindingType == vkb::BindingType::Cpp)
 	{
@@ -197,7 +199,8 @@ inline typename VulkanResource<bindingType, Handle>::ObjectType VulkanResource<b
 }
 
 template <vkb::BindingType bindingType, typename Handle>
-inline typename VulkanResource<bindingType, Handle>::ResourceType const &VulkanResource<bindingType, Handle>::get_resource() const
+inline typename VulkanResource<bindingType, Handle>::ResourceType const &
+    VulkanResource<bindingType, Handle>::get_resource() const
 {
 	return handle;
 }
@@ -221,7 +224,8 @@ inline void VulkanResource<bindingType, Handle>::set_debug_name(const std::strin
 
 	if (device && !debug_name.empty())
 	{
-		get_device().get_debug_utils().set_debug_name(get_device().get_handle(), get_object_type(), get_handle_u64(), debug_name.c_str());
+		get_device().get_debug_utils().set_debug_name(
+		    get_device().get_handle(), get_object_type(), get_handle_u64(), debug_name.c_str());
 	}
 }
 


### PR DESCRIPTION
## Description

Next part in limiting line length, now framework/core.

Build tested on Win11 with VS2022. Run tested on Win11 with NVidia GPU.

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making

 Note: The Samples CI runs a number of checks including:
 - [x] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
 - [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)

 If this PR contains framework changes:
 - [x] I did a full batch run using the `batch` command line argument to make sure all samples still work properly

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the readme of the folder that the sample belongs to [e.g. api samples readme](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/api/README.adoc)
- [ ] For new samples, I have added a tutorial README.md file to guide users through what they need to know to implement code using this feature. For example, see [conditional_rendering](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/conditional_rendering)
- [ ] For new samples, I have added a link to the [Antora navigation](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/antora/modules/ROOT/nav.adoc) so that the sample will be listed at the Vulkan documentation site
