### PR TITLE
Fix GUI buffer update with deferred allocation

### DIFF
--- a/framework/gui.h
+++ b/framework/gui.h
@@ -1406,7 +1406,7 @@ inline bool Gui<bindingType>::update_buffers()
 	}
 
 	bool updated = false;
-	if (!vertex_buffer->get_handle() || (vertex_buffer_size != vertex_buffer->get_size()))
+	if (!vertex_buffer || !vertex_buffer->get_handle() || (vertex_buffer_size != vertex_buffer->get_size()))
 	{
 		vertex_buffer.reset();
 		vertex_buffer = std::make_unique<vkb::core::BufferCpp>(render_context.get_device(), vertex_buffer_size,
@@ -1416,7 +1416,7 @@ inline bool Gui<bindingType>::update_buffers()
 		updated = true;
 	}
 
-	if (!index_buffer->get_handle() || (index_buffer_size != index_buffer->get_size()))
+	if (!index_buffer || !index_buffer->get_handle() || (index_buffer_size != index_buffer->get_size()))
 	{
 		index_buffer.reset();
 		index_buffer = std::make_unique<vkb::core::BufferCpp>(render_context.get_device(), index_buffer_size,


### PR DESCRIPTION
## Summary

Fixes #1508.

`Gui::update_buffers()` can be called while `explicit_update` is false. In that mode the persistent vertex and index buffers are intentionally null until the first update, but the method dereferenced both pointers before allocating them.

This change short-circuits the two conditions when the corresponding buffer is null, allowing the existing allocation and upload path to initialize both buffers.

## Reproduction

On macOS Apple Silicon (M2 Pro, macOS 26.6, Apple Clang 21, Vulkan SDK 1.4.341), an AddressSanitizer harness using the real `GuiCpp::update_buffers()` implementation and non-empty ImGui draw data reproduced a deterministic null dereference in the parent implementation:

```text
SEGV on unknown address 0x000000000028
vk::Buffer::operator!()
vkb::Gui<(vkb::BindingType)1>::update_buffers()
```

## Validation

- `cmake --build build/repro --config Debug --target framework vulkan_samples -j4` — passed
- `ctest --test-dir build/repro --output-on-failure` — no tests found in this repository configuration
- `python3 scripts/copyright.py main --fix` — passed
- `git diff --check` — passed
- `./scripts/clang_format.py main` — could not run because `clang-format` is not installed

The diff is limited to `framework/gui.h`; no public API or dependency changes are included.
