### PR TITLE
Adjust library type back to "object" when compiling locally

### DIFF
--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -155,7 +155,13 @@ function(add_project)
     endif()
 
 if(${TARGET_TYPE} STREQUAL "Sample")
-    add_library(${PROJECT_NAME} STATIC ${TARGET_FILES} ${SHADERS_GLSL} ${SHADERS_HLSL} ${SHADERS_SLANG} ${SHADERS_SPVASM})
+    if(DEFINED ENV{GITHUB_ACTIONS})
+        # The CLI variant of MSVC does have a 32-bit size limit issue, which the samples are running into e.g. in CI
+        add_library(${PROJECT_NAME} STATIC ${TARGET_FILES} ${SHADERS_GLSL} ${SHADERS_HLSL} ${SHADERS_SLANG} ${SHADERS_SPVASM})
+    else()
+        # We don't use static libraries when building locally, as that heavily increases size requirements for builds
+        add_library(${PROJECT_NAME} OBJECT ${TARGET_FILES} ${SHADERS_GLSL} ${SHADERS_HLSL} ${SHADERS_SLANG} ${SHADERS_SPVASM})
+    endif()
 elseif(${TARGET_TYPE} STREQUAL "Test")
     add_library(${PROJECT_NAME} STATIC ${TARGET_FILES} ${SHADERS_GLSL} ${SHADERS_HLSL} ${SHADERS_SLANG} ${SHADERS_SPVASM})
 endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -17,6 +17,10 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+if(DEFINED ENV{GITHUB_ACTIONS})
+    message(STATUS "Running inside GitHub CI")
+endif()
+
 # Creates a list of the subdirectories within this folder
 scan_dirs(
         DIR ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
## Description

This is a band-aid fix for excessive build sizes and does not fix the fundamental structural issues of the samples/framework.

This reverts back the library type to object when building locally (=lower build size) and sticks with static when building inside the github CI (=still works with the MSVC CLI 32-bit address space limiation).

## General Checklist:

Please ensure the following points are checked:

- [x] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Code-Style)
- [x] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/main/CONTRIBUTING.adoc#Copyright-Notice-and-License-Template)
- [x] I have commented any added functions (in line with Doxygen)
- [x] I have commented any code that could be hard to understand
- [x] My changes do not add any new compiler warnings
- [x] My changes do not add any new validation layer errors or warnings
- [x] I have used existing framework/helper functions where possible
- [x] My changes do not add any regressions
- [x] I have tested every sample to ensure everything runs correctly
- [x] This PR describes the scope and expected impact of the changes I am making
